### PR TITLE
docs(workflow): require a branch to be cut from wherever it will land

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -255,7 +255,31 @@ When in doubt: would a QA person need to look at this? If yes, write the body.
 | `dev` | liquidity-hq-dev.onrender.com | dev | **no** — trigger manually |
 | `main` | liquidity-hq.com (production) | **QA only** | **no** — trigger manually |
 
-- Feature branches are cut from `dev` and merged back via PR.
+- Feature branches are cut from `dev` and merged back into `dev` via PR.
+
+### Cut a branch from wherever it is going to land
+
+**A branch destined for `main` must be cut from `main`, not from `dev`.**
+
+Branching off `dev` and then merging that branch into `main` does not merge
+your commit — it merges *everything currently on `dev`*, including work that was
+deliberately being held back. The diff looks right locally, so nothing warns
+you.
+
+This is not hypothetical: it happened while writing this file. A `docs/` branch
+was cut from `dev` and merged to `main` to bootstrap the convention, and it
+silently carried 13 unrelated QA-scaffolding files onto `main` with it.
+
+- Normal work → cut from `dev`, merge back to `dev`. Reaches `main` later, as
+  part of a reviewed `dev` → `main` release.
+- Hotfix or anything that must land on `main` **now** → cut from `main`, and
+  merge it back into `dev` afterwards so the two do not drift.
+
+**If a merge to `main` is ever reverted**, note that the reverted commits stay
+in `main`'s history. Git treats them as already merged, so a later `dev` →
+`main` merge will **not** bring their changes back — it will look like a clean
+merge that silently does nothing. Recover them with `git revert <the-revert>` or
+a cherry-pick, not another merge.
 - `dev` is the integration branch. Dev may push and deploy the dev environment
   freely — that is what it is for.
 - `main` is **release only, and QA-owned**. Dev never merges into it. QA merges


### PR DESCRIPTION
## Summary
Adds a rule to `CONTRIBUTING.md` §6: a branch that will be merged into `main` must be cut from `main`, not from `dev`. Also documents what a reverted merge does to any future merge.

## What changed
- New subsection in §6, "Cut a branch from wherever it is going to land"
- States the branch-base rule for normal work (cut from `dev`) vs hotfixes and anything that must land on `main` now (cut from `main`, merge back to `dev` after)
- Documents the reverted-merge trap: reverted commits stay in `main`'s history, so a later `dev` → `main` merge will not bring their changes back and will report a clean merge that silently does nothing. Recovery is `git revert <the-revert>` or a cherry-pick, not another merge
- Docs only — no application code touched

## Why
Both halves come from a real failure while writing this convention, not from theory.

The `docs/git-workflow-convention` branch was cut from `dev` and merged into `main` to bootstrap the standard. Because it was cut from `dev`, that merge did not merge one commit — it merged everything sitting on `dev`, silently carrying 13 unrelated QA-scaffolding files onto `main` that had explicitly been held back. The local diff looked correct the whole time.

Fixing it by reverting the merge then created the second problem: git now treats those commits as already merged. Verified against a probe branch — merging `dev` into `main` today restores 0 of the 13 files and reports success. Anyone shipping that Playwright suite later would find it absent with no error to chase.

## How to test (QA)
1. In the QA folder: `git fetch && git checkout docs/branch-base-rule`
2. Open `CONTRIBUTING.md` and scroll to section **6. Branches and environments**
3. Confirm a subsection titled **"Cut a branch from wherever it is going to land"** appears directly under the branches table
4. Confirm it contains both parts: the branch-base rule (cut from `main` for anything landing on `main`), and the paragraph beginning **"If a merge to `main` is ever reverted"**
5. Confirm nothing outside `CONTRIBUTING.md` changed — `git diff main --stat` should list exactly one file
6. No app behaviour to check: this PR does not touch `app/`, `components/` or `lib/`, so no page needs loading

## Risk level
**Low** — documentation only. No application code, no dependency, no config. Worst case is that the wording is unclear and needs another pass; nothing can break at runtime.

## Screenshots (if UI change)
N/A — no UI change.