### PR TITLE
perf(api): fetch RSI once on the server instead of 276 times per visitor

### DIFF
--- a/__tests__/rsi.test.mts
+++ b/__tests__/rsi.test.mts
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { computeRSI14 } from '../lib/rsi.ts';
+
+/* computeRSI14 was moved out of MarketProvider so app/api/market/rsi could
+   share it. These lock the exact numbers the client produced before the move -
+   the risk of the refactor is not a crash, it is the value shifting by a point
+   and silently moving coins across the 30/70 badge thresholds. */
+test('computeRSI14', async (t) => {
+  await t.test('needs 15 closes to produce 14 changes', () => {
+    assert.equal(computeRSI14([]), null);
+    assert.equal(computeRSI14(Array(14).fill(100)), null);
+    assert.notEqual(computeRSI14(Array(15).fill(100)), null);
+  });
+
+  await t.test('a strictly rising series is 100', () => {
+    // No losses at all, so avgLoss is 0 and the divide-by-zero branch applies.
+    const closes = Array.from({ length: 20 }, (_, i) => 100 + i);
+    assert.equal(computeRSI14(closes), 100);
+  });
+
+  await t.test('a flat series is also 100', () => {
+    /* Every change is 0, so avgGain and avgLoss are both 0 and avgLoss === 0
+       wins. Documenting rather than endorsing: a flat market reading as
+       maximally overbought is a quirk of this formula, and anything consuming
+       rsi === 100 as a sell signal inherits it. */
+    assert.equal(computeRSI14(Array(20).fill(100)), 100);
+  });
+
+  await t.test('a strictly falling series is 0', () => {
+    const closes = Array.from({ length: 20 }, (_, i) => 100 - i);
+    assert.equal(computeRSI14(closes), 0);
+  });
+
+  await t.test('alternating equal gains and losses is 50', () => {
+    // 14 changes of +1/-1 in equal number: avgGain === avgLoss, so RSI is 50.
+    const closes = [100];
+    for (let i = 0; i < 20; i++) closes.push(closes[closes.length - 1] + (i % 2 ? -1 : 1));
+    assert.equal(computeRSI14(closes), 50);
+  });
+
+  await t.test('reads only the last 14 changes, not the whole array', () => {
+    /* The window is what makes the client's limit=16 and limit=20 requests
+       interchangeable, which the API route relies on. A long crash followed by
+       14 clean up-bars must read 100, not something dragged down by history. */
+    const crash = Array.from({ length: 40 }, (_, i) => 500 - i * 10);   // ends at 110
+    // Continues up from where the crash ended, so all 14 trailing changes are
+    // gains. Starting the recovery at a lower price instead would leave the
+    // gap itself inside the window and correctly read ~57, not 100.
+    const recovery = Array.from({ length: 14 }, (_, i) => 111 + i);
+    assert.equal(computeRSI14([...crash, ...recovery]), 100);
+  });
+
+  await t.test('returns a rounded integer', () => {
+    const closes = [100, 102, 101, 104, 103, 107, 105, 110, 108, 113,
+                    111, 116, 114, 119, 117, 122];
+    const rsi = computeRSI14(closes);
+    assert.ok(rsi !== null);
+    assert.equal(rsi, Math.round(rsi!));
+    assert.ok(rsi! >= 0 && rsi! <= 100);
+  });
+});

--- a/app/api/market/rsi/route.ts
+++ b/app/api/market/rsi/route.ts
@@ -1,0 +1,323 @@
+/**
+ * Server-side RSI aggregation for the whole coin list.
+ *
+ * GET /api/market/rsi
+ *   → { rsi: { btc: { rsi5m, rsi1h, rsi4h, rsiDaily, rsiWeekly, rsiMonthly }, ... }, ts }
+ *
+ * WHY THIS EXISTS
+ *
+ * MarketProvider used to compute these six numbers in the browser, one kline
+ * request per coin per timeframe. At 45 Binance coins plus HYPE that is 276
+ * requests fired from the visitor's own IP on every page load, out of ~495
+ * Binance requests total. Every visitor repeated all 276, and every one of
+ * them returned data that is identical for every visitor - a 1-week RSI does
+ * not differ per user.
+ *
+ * That burst is the suspected cause of the intermittent blank chart: enough
+ * concurrent requests to trip Binance's per-IP limit, after which unrelated
+ * kline calls start coming back 429 and the chart renders empty. It is worst
+ * on shared egress IPs (mobile CGNAT, office NAT, VPNs) and on anyone with
+ * two tabs open, where the same limit is being spent several times over.
+ *
+ * Moving it here makes the upstream cost fixed instead of per-visitor: the
+ * server fetches each timeframe group once per TTL and every visitor is served
+ * from that one result. Ten concurrent visitors cost the same upstream as one.
+ *
+ * TWO CACHE GROUPS, NOT ONE
+ *
+ * The client used to poll 5m RSI every 3 minutes and everything slower every
+ * 15. Collapsing that into a single cache would either make 5m RSI stale or
+ * re-fetch 230 weekly/monthly candles every 3 minutes for no benefit. So the
+ * groups are cached separately with their original cadences and merged into
+ * one response - the client can poll at the fast cadence and the slow group
+ * simply serves a warm cache most of the time.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { apiError } from '@/lib/apiError';
+import { BINANCE_SYMS, BYBIT_SYMS } from '@/lib/coins';
+import { rateLimit, getClientIp } from '@/lib/rateLimit';
+import { cached } from '@/lib/apiCache';
+import { reportHealth, healthError } from '@/lib/apiHealth';
+import { computeRSI14 } from '@/lib/rsi';
+
+export const dynamic = 'force-dynamic';
+
+/* Match the client cadences these replaced: fetch5mRSI ran every 3 min, the
+   1h/4h/1d/1w/1M pollers every 15. */
+const FAST_TTL = 3  * 60_000;
+const SLOW_TTL = 15 * 60_000;
+
+/* Binance rejects unlimited parallelism from a single IP with 418/429, and 276
+   simultaneous sockets is also more than the Render instance should hold open.
+   12 keeps a cold fill at roughly 275/12 x ~150ms, a few seconds, which only
+   one visitor per TTL window ever pays. */
+const CONCURRENCY = 12;
+
+/* Same mirror-walk as app/api/funding: api.binance.com resolves to different
+   edges by region and individual ones return 451/503 while the others are
+   healthy. Resolved once per cache fill, not per request.
+ *
+ * Spot first because that is what the client used, so the numbers this route
+ * returns are identical to the ones it replaced. The futures host is a last
+ * resort, not a preference: only fapi.binance.com is *proven* reachable from
+ * Render (app/api/funding and lib/ribbonCandles both call it in production),
+ * while nothing server-side has ever called spot from there. If spot turns out
+ * to be blocked, falling back to perp candles gives RSI that can differ by a
+ * point on a rounded 0-100 scale - worth having, but worth knowing about,
+ * which is why the health record names the source that was used.
+ *
+ * The whole group uses one endpoint, so a fallback never mixes spot and perp
+ * candles across coins within a single response. */
+const BN_ENDPOINTS = [
+  { base: 'https://api.binance.com',  klines: '/api/v3/klines',   ping: '/api/v3/ping',   label: 'spot'    },
+  { base: 'https://api1.binance.com', klines: '/api/v3/klines',   ping: '/api/v3/ping',   label: 'spot'    },
+  { base: 'https://api2.binance.com', klines: '/api/v3/klines',   ping: '/api/v3/ping',   label: 'spot'    },
+  { base: 'https://api3.binance.com', klines: '/api/v3/klines',   ping: '/api/v3/ping',   label: 'spot'    },
+  { base: 'https://fapi.binance.com', klines: '/fapi/v1/klines',  ping: '/fapi/v1/ping',  label: 'futures' },
+] as const;
+
+type Endpoint = (typeof BN_ENDPOINTS)[number];
+
+/* Binance interval string → the MarketStore field it populates. Limits are the
+   ones the client used. computeRSI14 only ever reads the last 14 changes, so
+   16 vs 20 candles produces the same number - they are kept as they were so
+   this route is a pure move, not a re-tune. */
+const BN_TIMEFRAMES = [
+  { interval: '5m', limit: 16, field: 'rsi5m'      },
+  { interval: '1h', limit: 16, field: 'rsi1h'      },
+  { interval: '4h', limit: 16, field: 'rsi4h'      },
+  { interval: '1d', limit: 20, field: 'rsiDaily'   },
+  { interval: '1w', limit: 20, field: 'rsiWeekly'  },
+  { interval: '1M', limit: 20, field: 'rsiMonthly' },
+] as const;
+
+/* HYPE has no Binance perp, so its six values come from Bybit, whose interval
+   codes are minutes-as-numbers plus D/W/M. Bybit returns newest-first. */
+const BB_TIMEFRAMES = [
+  { interval: '5',   limit: 16, field: 'rsi5m'      },
+  { interval: '60',  limit: 16, field: 'rsi1h'      },
+  { interval: '240', limit: 16, field: 'rsi4h'      },
+  { interval: 'D',   limit: 20, field: 'rsiDaily'   },
+  { interval: 'W',   limit: 20, field: 'rsiWeekly'  },
+  { interval: 'M',   limit: 20, field: 'rsiMonthly' },
+] as const;
+
+type RsiField = (typeof BN_TIMEFRAMES)[number]['field'];
+type RsiMap   = Record<string, Partial<Record<RsiField, number>>>;
+
+/* The fast group is 5m alone; the slow group is everything else. Splitting on
+   the field keeps the two lists in sync with BN_TIMEFRAMES automatically. */
+const FAST_FIELDS = new Set<RsiField>(['rsi5m']);
+
+interface Job { coin: string; field: RsiField; url: (ep: Endpoint) => string; bybit: boolean }
+
+function buildJobs(fast: boolean): Job[] {
+  const wanted = (f: RsiField) => FAST_FIELDS.has(f) === fast;
+  const jobs: Job[] = [];
+
+  for (const [coin, sym] of Object.entries(BINANCE_SYMS)) {
+    for (const tf of BN_TIMEFRAMES) {
+      if (!wanted(tf.field)) continue;
+      jobs.push({
+        coin, field: tf.field, bybit: false,
+        url: ep => `${ep.base}${ep.klines}?symbol=${sym}&interval=${tf.interval}&limit=${tf.limit}`,
+      });
+    }
+  }
+
+  const hypeSym = BYBIT_SYMS.hype;
+  if (hypeSym) {
+    for (const tf of BB_TIMEFRAMES) {
+      if (!wanted(tf.field)) continue;
+      jobs.push({
+        coin: 'hype', field: tf.field, bybit: true,
+        url: () => `https://api.bybit.com/v5/market/kline?category=linear&symbol=${hypeSym}&interval=${tf.interval}&limit=${tf.limit}`,
+      });
+    }
+  }
+
+  return jobs;
+}
+
+/* Raised when Binance answers 418 (IP banned) or 429 (rate limited). Carries
+   no data - its only job is to stop the pool, see runPool. */
+class BinanceBackoff extends Error {}
+
+/* Closes, newest last, from whichever exchange shape came back. Returns null
+   rather than throwing so one dead symbol cannot take down the batch - the
+   coin simply keeps whatever value the client already had. The one exception
+   is 418/429, which is not about this symbol at all. */
+async function fetchCloses(job: Job, ep: Endpoint): Promise<number[] | null> {
+  const ac  = new AbortController();
+  const tid = setTimeout(() => ac.abort(), 8000);
+  try {
+    const res = await fetch(job.url(ep), {
+      cache: 'no-store',
+      signal: ac.signal,
+      headers: { 'User-Agent': 'Mozilla/5.0' },
+    });
+    /* 429 is the warning, 418 is the ban that follows it. Both mean every
+       remaining request in this batch would be spent making it worse, and a
+       ban is measured in minutes to days. Distinguish from an ordinary miss
+       so runPool can stop rather than continue. */
+    if (res.status === 418 || res.status === 429) {
+      throw new BinanceBackoff(`Binance ${res.status}`);
+    }
+    if (!res.ok) return null;
+    const body = await res.json();
+
+    if (job.bybit) {
+      const list = body?.result?.list;
+      if (!Array.isArray(list)) return null;
+      return [...list].reverse().map((k: string[]) => parseFloat(k[4]));
+    }
+    if (!Array.isArray(body)) return null;
+    return body.map((k: string[]) => parseFloat(k[4]));
+  } catch (e) {
+    if (e instanceof BinanceBackoff) throw e;
+    return null;
+  } finally {
+    clearTimeout(tid);
+  }
+}
+
+/* Fixed-size worker pool. Promise.all over 276 fetches would open them all at
+   once, which is exactly the burst this route exists to stop doing.
+ *
+ * Aborts the whole batch the moment Binance returns 418/429. This matters more
+ * here than it did client-side: one banned visitor lost their own RSI, but one
+ * banned Render IP loses it for everyone at once. Spending the remaining 200
+ * requests into an active ban only extends it, so the pool stops and the
+ * partial result is cached - backing off for the TTL is the correct response
+ * to a ban, not something to retry around. */
+async function runPool(
+  jobs: Job[], ep: Endpoint, out: RsiMap,
+): Promise<{ ok: number; banned: boolean }> {
+  let next = 0;
+  let ok   = 0;
+  let banned = false;
+
+  async function worker() {
+    for (;;) {
+      if (banned) return;
+      const i = next++;
+      if (i >= jobs.length) return;
+      const job = jobs[i];
+
+      let closes: number[] | null;
+      try {
+        closes = await fetchCloses(job, ep);
+      } catch (e) {
+        if (e instanceof BinanceBackoff) { banned = true; return; }
+        continue;
+      }
+
+      /* Same guard the client applied: fewer than 15 closes cannot produce a
+         14-period RSI, and a partially-listed coin returns a short array
+         rather than an error. */
+      if (!closes || closes.length < 15) continue;
+      const rsi = computeRSI14(closes);
+      if (rsi === null) continue;
+      (out[job.coin] ??= {})[job.field] = rsi;
+      ok++;
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, jobs.length) }, worker));
+  return { ok, banned };
+}
+
+/* Pick a Binance edge that is actually answering before spending the pool on
+   it. One weight-1 probe beats discovering the host is 451 on all 276 requests.
+ *
+ * Returns null when no host answers, which is the state an active IP ban
+ * produces - every edge returns 418 because the ban is on us, not on them. The
+ * caller drops the Binance jobs entirely in that case rather than spending a
+ * pool's worth of requests re-learning it. */
+async function resolveEndpoint(): Promise<Endpoint | null> {
+  for (const ep of BN_ENDPOINTS) {
+    try {
+      const ac  = new AbortController();
+      const tid = setTimeout(() => ac.abort(), 5000);
+      const res = await fetch(`${ep.base}${ep.ping}`, {
+        cache: 'no-store', signal: ac.signal, headers: { 'User-Agent': 'Mozilla/5.0' },
+      });
+      clearTimeout(tid);
+      if (res.ok) return ep;
+    } catch { continue; }
+  }
+  return null;
+}
+
+async function buildGroup(fast: boolean): Promise<RsiMap> {
+  const out: RsiMap = {};
+  const ep = await resolveEndpoint();
+
+  /* No reachable Binance edge: run the Bybit jobs anyway so HYPE still gets
+     its RSI, and skip the 45 Binance symbols rather than firing them into a
+     wall. */
+  const allJobs = buildJobs(fast);
+  const jobs = ep ? allJobs : allJobs.filter(j => j.bybit);
+
+  const { ok, banned } = await runPool(jobs, ep ?? BN_ENDPOINTS[0], out);
+
+  /* Reported per group so a partial outage is visible: the slow group failing
+     while the fast one succeeds means Binance is rate-limiting the heavier
+     weekly/monthly calls, which is a different problem from the host being
+     unreachable. Separate source name from binance:funding for the same
+     reason that route separates its own.
+   *
+     A ban is called out explicitly because it is the one failure that needs a
+     human: it means this server's IP is spending more Binance weight than the
+     limit allows, and nothing here recovers from that by itself. */
+  reportHealth(
+    `binance:rsi-${fast ? 'fast' : 'slow'}`, 'market',
+    ok > 0 && !banned && ep !== null,
+    !ep      ? `no reachable Binance endpoint - ${ok} Bybit-only series`
+    : banned ? `418/429 on ${ep.label} after ${ok}/${allJobs.length} series - batch aborted`
+             : `${ok}/${allJobs.length} series via ${ep.label}`,
+    ok,
+  );
+
+  return out;
+}
+
+export async function GET(req: NextRequest) {
+  if (!rateLimit(`market-rsi:${getClientIp(req)}`, 30, 60_000)) {
+    return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429 });
+  }
+
+  try {
+    /* allSettled, not all: a failing slow group must still let the fast group
+       through. The client merges whatever arrives and leaves the rest at its
+       previous value, which is the same degradation the per-coin fetches had
+       when an individual symbol 429'd. */
+    const [fastRes, slowRes] = await Promise.allSettled([
+      cached('market-rsi:fast', FAST_TTL, () => buildGroup(true)),
+      cached('market-rsi:slow', SLOW_TTL, () => buildGroup(false)),
+    ]);
+
+    if (fastRes.status === 'rejected' && slowRes.status === 'rejected') {
+      reportHealth('binance:rsi', 'market', false, healthError(fastRes.reason));
+      return apiError('market-rsi', fastRes.reason, 502, 'Upstream unavailable');
+    }
+
+    const rsi: RsiMap = {};
+    for (const res of [slowRes, fastRes]) {
+      if (res.status !== 'fulfilled') continue;
+      for (const [coin, fields] of Object.entries(res.value)) {
+        Object.assign(rsi[coin] ??= {}, fields);
+      }
+    }
+
+    return NextResponse.json({ rsi, ts: Date.now() }, {
+      /* Public, visitor-independent, and already only as fresh as FAST_TTL.
+         Letting any shared cache in front of this serve it costs nothing and
+         removes the origin hit entirely for the common case. */
+      headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=600' },
+    });
+  } catch (err) {
+    return apiError('market-rsi', err, 500, 'Request failed');
+  }
+}

--- a/components/MarketProvider.tsx
+++ b/components/MarketProvider.tsx
@@ -5,6 +5,7 @@ import {
   BINANCE_SYMS, BYBIT_SYMS,
 } from '@/lib/marketStore';
 import { bybitPriceFactor } from '@/lib/coins';
+import { computeRSI14 } from '@/lib/rsi';
 import { detectPatterns } from '@/lib/patterns';
 import { getAuthToken } from '@/lib/supabase';
 
@@ -86,16 +87,8 @@ const SYM_MAP: Record<string, CoinId> = Object.fromEntries(
   Object.entries(BINANCE_SYMS).map(([id, sym]) => [sym, id as CoinId])
 );
 
-/* Helper: compute RSI14 from an array of close prices */
-function computeRSI14(closes: number[]): number | null {
-  if (closes.length < 15) return null;
-  const changes = closes.slice(1).map((c, i) => c - closes[i]);
-  const gains   = changes.slice(-14).map(c => Math.max(c, 0));
-  const losses  = changes.slice(-14).map(c => Math.max(-c, 0));
-  const avgGain = gains.reduce((a, b) => a + b, 0) / 14;
-  const avgLoss = losses.reduce((a, b) => a + b, 0) / 14;
-  return avgLoss === 0 ? 100 : Math.round(100 - (100 / (1 + avgGain / avgLoss)));
-}
+/* computeRSI14 moved to lib/rsi so app/api/market/rsi computes the identical
+   number - see that file for why two copies would drift silently. */
 
 export default function MarketProvider({ children }: { children: React.ReactNode }) {
   const [store, setStore] = useState<MarketStore>(defaultStore);
@@ -546,157 +539,44 @@ export default function MarketProvider({ children }: { children: React.ReactNode
     }));
   }, [updateCoin]);
 
-  /* ── Bybit multi-TF RSI for HYPE (1h + 4h) ── */
-  const fetchBybitMultiTFRSI = useCallback(async () => {
-    const bybitOnly = (['hype'] as CoinId[]).filter(c => BYBIT_SYMS[c] && !BINANCE_SYMS[c]);
-    await Promise.allSettled(
-      bybitOnly.flatMap(coin => {
-        const sym = BYBIT_SYMS[coin];
-        return (['60', '240'] as const).map(async (interval) => {
-          try {
-            const res = await fetch(
-              `https://api.bybit.com/v5/market/kline?category=linear&symbol=${sym}&interval=${interval}&limit=16`
-            );
-            const d = await res.json();
-            const klines: string[][] = [...(d?.result?.list ?? [])].reverse();
-            if (klines.length < 15) return;
-            const closes = klines.map(k => parseFloat(k[4]));
-            const rsi = computeRSI14(closes);
-            if (rsi === null) return;
-            updateCoin(coin, interval === '60' ? { rsi1h: rsi } : { rsi4h: rsi });
-          } catch { /* */ }
-        });
-      })
-    );
-  }, [updateCoin]);
+  /* ── RSI for every coin and timeframe, in one server call ──
+     Replaces five separate pollers - fetch5mRSI, fetchMultiTFRSI,
+     fetchBybitMultiTFRSI, fetchDailyRSI and fetchWeeklyMonthlyRSI - each of
+     which looped the whole coin list and fired one kline request per coin per
+     timeframe. That was 276 requests from the visitor's own IP on every page
+     load, all returning data identical for every visitor: a weekly RSI does
+     not differ per user.
 
-  /* ── 5-minute RSI (all coins, matches the chart's fastest timeframe) ── */
-  const fetch5mRSI = useCallback(async () => {
-    await Promise.allSettled([
-      // Binance coins
-      ...Object.entries(BINANCE_SYMS).filter(([c]) => c !== 'hype').map(async ([coin, sym]) => {
-        try {
-          const res = await fetch(
-            `https://api.binance.com/api/v3/klines?symbol=${sym}&interval=5m&limit=16`
-          );
-          const klines = await res.json();
-          if (!Array.isArray(klines) || klines.length < 15) return;
-          const closes = klines.map((k: string[]) => parseFloat(k[4]));
-          const rsi = computeRSI14(closes);
-          if (rsi !== null) updateCoin(coin as CoinId, { rsi5m: rsi });
-        } catch { /* */ }
-      }),
-      // HYPE via Bybit (5 = 5-minute interval)
-      (async () => {
-        try {
-          const res = await fetch(
-            `https://api.bybit.com/v5/market/kline?category=linear&symbol=HYPEUSDT&interval=5&limit=16`
-          );
-          const d = await res.json();
-          const klines: string[][] = [...(d?.result?.list ?? [])].reverse();
-          if (klines.length < 15) return;
-          const closes = klines.map(k => parseFloat(k[4]));
-          const rsi = computeRSI14(closes);
-          if (rsi !== null) updateCoin('hype', { rsi5m: rsi });
-        } catch { /* */ }
-      })(),
-    ]);
-  }, [updateCoin]);
+     app/api/market/rsi does that fan-out once per cache window on the server
+     and serves everyone from the one result, so this is a single request. See
+     that route for why the burst mattered - it is the suspected cause of the
+     intermittent blank chart, since tripping Binance's per-IP limit makes
+     unrelated kline calls start returning 429.
 
-  /* ── Multi-timeframe RSI (1h + 4h) ── */
-  const fetchMultiTFRSI = useCallback(async () => {
-    const binanceCoins = Object.entries(BINANCE_SYMS).filter(([c]) => c !== 'hype');
-    await Promise.allSettled(
-      binanceCoins.flatMap(([coin, sym]) =>
-        (['1h', '4h'] as const).map(async (tf) => {
-          try {
-            const res = await fetch(
-              `https://api.binance.com/api/v3/klines?symbol=${sym}&interval=${tf}&limit=16`
-            );
-            const klines = await res.json();
-            if (!Array.isArray(klines) || klines.length < 15) return;
-            const closes = klines.map((k: string[]) => parseFloat(k[4]));
-            const rsi = computeRSI14(closes);
-            if (rsi === null) return;
-            updateCoin(coin as CoinId, tf === '1h' ? { rsi1h: rsi } : { rsi4h: rsi });
-          } catch { /* */ }
-        })
-      )
-    );
-  }, [updateCoin]);
+     Polled at the old 5m cadence. The slower timeframes are cached server-side
+     at their own 15-minute TTL, so calling this every 3 minutes does not
+     re-fetch weekly and monthly candles - it just serves them warm.
 
-  /* ── Daily RSI (1D candles - all coins, runs every 15 min) ── */
-  const fetchDailyRSI = useCallback(async () => {
-    await Promise.allSettled([
-      // Binance coins
-      ...Object.entries(BINANCE_SYMS).filter(([c]) => c !== 'hype').map(async ([coin, sym]) => {
-        try {
-          const res = await fetch(
-            `https://api.binance.com/api/v3/klines?symbol=${sym}&interval=1d&limit=20`,
-            { cache: 'no-store' }
-          );
-          const klines = await res.json();
-          if (!Array.isArray(klines) || klines.length < 15) return;
-          const closes = klines.map((k: string[]) => parseFloat(k[4]));
-          const rsi = computeRSI14(closes);
-          if (rsi !== null) updateCoin(coin as CoinId, { rsiDaily: rsi });
-        } catch { /* */ }
-      }),
-      // HYPE via Bybit (D = daily interval)
-      (async () => {
-        try {
-          const res = await fetch(
-            `https://api.bybit.com/v5/market/kline?category=linear&symbol=HYPEUSDT&interval=D&limit=20`,
-            { cache: 'no-store' }
-          );
-          const d = await res.json();
-          const klines: string[][] = [...(d?.result?.list ?? [])].reverse();
-          if (klines.length < 15) return;
-          const closes = klines.map(k => parseFloat(k[4]));
-          const rsi = computeRSI14(closes);
-          if (rsi !== null) updateCoin('hype', { rsiDaily: rsi });
-        } catch { /* */ }
-      })(),
-    ]);
-  }, [updateCoin]);
-
-  /* ── Weekly + Monthly RSI (1W/1M candles - all coins, slow-moving, runs every 15 min) ── */
-  const fetchWeeklyMonthlyRSI = useCallback(async () => {
-    await Promise.allSettled([
-      // Binance coins
-      ...Object.entries(BINANCE_SYMS).filter(([c]) => c !== 'hype').flatMap(([coin, sym]) =>
-        (['1w', '1M'] as const).map(async (tf) => {
-          try {
-            const res = await fetch(
-              `https://api.binance.com/api/v3/klines?symbol=${sym}&interval=${tf}&limit=20`,
-              { cache: 'no-store' }
-            );
-            const klines = await res.json();
-            if (!Array.isArray(klines) || klines.length < 15) return;
-            const closes = klines.map((k: string[]) => parseFloat(k[4]));
-            const rsi = computeRSI14(closes);
-            if (rsi === null) return;
-            updateCoin(coin as CoinId, tf === '1w' ? { rsiWeekly: rsi } : { rsiMonthly: rsi });
-          } catch { /* */ }
-        })
-      ),
-      // HYPE via Bybit (W = weekly, M = monthly interval)
-      ...(['W', 'M'] as const).map(async (interval) => {
-        try {
-          const res = await fetch(
-            `https://api.bybit.com/v5/market/kline?category=linear&symbol=HYPEUSDT&interval=${interval}&limit=20`,
-            { cache: 'no-store' }
-          );
-          const d = await res.json();
-          const klines: string[][] = [...(d?.result?.list ?? [])].reverse();
-          if (klines.length < 15) return;
-          const closes = klines.map(k => parseFloat(k[4]));
-          const rsi = computeRSI14(closes);
-          if (rsi === null) return;
-          updateCoin('hype', interval === 'W' ? { rsiWeekly: rsi } : { rsiMonthly: rsi });
-        } catch { /* */ }
-      }),
-    ]);
+     Failure is silent and non-destructive by design: updateCoin runs only for
+     coins the response actually carried, so a partial or missing response
+     leaves the previous RSI values on screen instead of blanking the badges.
+     That matches how the per-coin version behaved when one symbol was rate
+     limited. */
+  const fetchRSI = useCallback(async () => {
+    try {
+      const res = await fetch('/api/market/rsi');
+      if (!res.ok) return;
+      const body = await res.json() as {
+        rsi?: Record<string, Partial<Record<
+          'rsi5m' | 'rsi1h' | 'rsi4h' | 'rsiDaily' | 'rsiWeekly' | 'rsiMonthly', number
+        >>>;
+      };
+      for (const [coin, fields] of Object.entries(body.rsi ?? {})) {
+        if (fields && Object.keys(fields).length > 0) {
+          updateCoin(coin as CoinId, fields);
+        }
+      }
+    } catch { /* */ }
   }, [updateCoin]);
 
   /* ── CVD + Divergence + Whale detection (all Binance coins + HYPE via Bybit) ── */
@@ -1400,16 +1280,12 @@ export default function MarketProvider({ children }: { children: React.ReactNode
     fetchLSR();
     fetchVolume();
     fetchBybitKlines();       // RSI/MA20/VWAP/POC for HYPE
-    fetchBybitMultiTFRSI();   // 1h + 4h RSI for HYPE
     fetchFNG();
     fetchCMCGlobal();
     fetchAltSeason();
     fetchMacro();
     fetchETF();
-    fetch5mRSI();
-    fetchMultiTFRSI();
-    fetchDailyRSI();
-    fetchWeeklyMonthlyRSI();
+    fetchRSI();               // all timeframes, all coins - one server call
     fetchCVD();
     fetchOrderBook();
     fetchPremiumIndex();
@@ -1428,16 +1304,14 @@ export default function MarketProvider({ children }: { children: React.ReactNode
       setInterval(fetchLSR,               5  * 60 * 1000),
       setInterval(fetchVolume,            3  * 60 * 1000),
       setInterval(fetchBybitKlines,       3  * 60 * 1000),  // same cadence as Binance klines
-      setInterval(fetchBybitMultiTFRSI,  15  * 60 * 1000),  // same as Binance multi-TF
       setInterval(fetchFNG,             24  * 60 * 60 * 1000),
       setInterval(fetchCMCGlobal,         5  * 60 * 1000),   // BTC/ETH dom - CMC, every 5m
       setInterval(fetchAltSeason,        15  * 60 * 1000),   // 90d score - slow-moving, every 15m
       setInterval(fetchMacro,            10  * 60 * 1000),
       setInterval(fetchETF,              30  * 60 * 1000),
-      setInterval(fetch5mRSI,             3  * 60 * 1000),  // same cadence as Binance klines
-      setInterval(fetchMultiTFRSI,       15  * 60 * 1000),
-      setInterval(fetchDailyRSI,         15  * 60 * 1000),  // 1D RSI - slow-moving, every 15m
-      setInterval(fetchWeeklyMonthlyRSI, 15  * 60 * 1000),  // 1W/1M RSI - slow-moving, every 15m
+      // 5m RSI's old cadence. The 1h/4h/1d/1w/1M values are cached server-side
+      // at their own 15m TTL, so this does not re-fetch them every 3 minutes.
+      setInterval(fetchRSI,               3  * 60 * 1000),
       setInterval(fetchCVD,               5  * 60 * 1000),
       setInterval(fetchOrderBook,         2  * 60 * 1000),
       setInterval(fetchPremiumIndex,     30  * 1000),        // every 30s - premium changes frequently

--- a/lib/rsi.ts
+++ b/lib/rsi.ts
@@ -1,0 +1,23 @@
+/* Windowed RSI(14).
+ *
+ * Moved here verbatim from MarketProvider.tsx so the browser and
+ * app/api/market/rsi/route.ts compute the identical number. Two copies would
+ * drift silently: the value is rounded to an integer, so a one-line difference
+ * in the averaging window shifts a coin across the 30/70 thresholds that drive
+ * the oversold/overbought badges without ever looking wrong on screen.
+ *
+ * This is the simple (non-Wilder-smoothed) variant: a flat mean of the last 14
+ * gains and losses rather than an exponential average seeded from the first 14
+ * bars. It reads slightly more reactive than TradingView's RSI. Kept as-is
+ * deliberately - every threshold, alert rule and backtest in the app was tuned
+ * against these numbers, so "correcting" it to Wilder would silently re-tune
+ * all of them. Change it only alongside those. */
+export function computeRSI14(closes: number[]): number | null {
+  if (closes.length < 15) return null;
+  const changes = closes.slice(1).map((c, i) => c - closes[i]);
+  const gains   = changes.slice(-14).map(c => Math.max(c, 0));
+  const losses  = changes.slice(-14).map(c => Math.max(-c, 0));
+  const avgGain = gains.reduce((a, b) => a + b, 0) / 14;
+  const avgLoss = losses.reduce((a, b) => a + b, 0) / 14;
+  return avgLoss === 0 ? 100 : Math.round(100 - (100 / (1 + avgGain / avgLoss)));
+}

--- a/pendings/PENDING.md
+++ b/pendings/PENDING.md
@@ -835,3 +835,50 @@ translations in either project, so choosing one silently rendered English.
 stays complete: it is the validation list, so a preference already saved as
 `tr` still resolves to English instead of erroring. Re-adding a language is a
 one-line change to `AVAILABLE_LOCALES` once its rows land.
+
+---
+
+## Binance request fan-out per page load — 46% addressed, rest outstanding
+
+**Partially fixed 2026-08-04** — PR #2, `refactor/server-side-rsi-aggregation`.
+
+The dashboard fired ~495 Binance requests from the visitor's own IP on every
+page load. Priced against Binance's 6000-weight-per-minute per-IP budget:
+
+| Call | Weight each | Count | Total | Status |
+|---|---|---|---|---|
+| RSI klines (5m/1h/4h/1d/1w/1M) | 2 | 276 | 552 | ✅ moved server-side |
+| `depth` limit=50 (`fetchOrderBook`) | 5 | 45 | 225 | ⬜ outstanding |
+| `aggTrades` limit=200 (`fetchCVD`) | 4 | 45 | 180 | ⬜ outstanding |
+| `ticker/24hr` (45 symbols) | 80 | 2 | 160 | ⬜ outstanding |
+| klines 15m (`fetchKlines`) | 2 | 45 | 90 | ⬜ outstanding |
+| `globalLongShortAccountRatio` + `topLongShortPositionRatio` | — | 90 | — | ⬜ outstanding (futures bucket) |
+
+≈**1207 weight per page load** before the fix, so roughly five loads in a
+minute earns an IP ban, after which Binance returns 418 to *every* request from
+that IP — including the ones the chart needs. **This is the blank-chart cause
+and it was reproduced**: this machine's IP was banned mid-development with
+`"Way too much request weight used; IP banned until ..."`.
+
+Now ≈655 weight per load. Still only ~5x headroom on a shared IP.
+
+**Three things worth knowing before doing the rest:**
+
+- **Spot and futures are separate limit buckets.** `api.binance.com` was banned
+  while `fapi.binance.com` answered normally throughout. That is what let the
+  new route finish via its fallback, and it is a useful diagnostic: if one
+  works and the other 418s, it is a weight ban, not an outage.
+- **Pinging while banned extends the ban.** A poll loop waiting for it to lift
+  kept it alive well past its stated expiry. Wait it out; do not poll.
+- **`fetchOrderBook` and `fetchCVD` are the next best targets** — 405 weight
+  combined, and both return per-coin data that is identical for every visitor,
+  so they cache exactly like the RSI group did. `fetchKlines` is harder: it
+  feeds VWAP/POC/value-area maths that would have to move server-side with it.
+
+**Separate issue found while measuring, not fixed:** `restPoll` polls
+`ticker/24hr` for all 45 symbols **every 5 seconds** once the WebSocket has
+failed 5 reconnects (`components/MarketProvider.tsx`, `startWS` `onclose`).
+That is weight 80 x 12/min = **960 weight/min, per tab, indefinitely** — it is
+only cleared on unmount. A user who leaves a tab open in fallback mode will ban
+their own IP within about six minutes. Worth fixing independently of the
+fan-out work; the fix is probably a slower fallback interval plus a cap.


### PR DESCRIPTION
## Summary

The RSI numbers shown across the app were being fetched by every visitor's browser, one coin and one timeframe at a time — 276 Binance requests per page load. They now come from a single cached server endpoint. The values themselves are unchanged.

## What changed

- New `GET /api/market/rsi` returns all six RSI values (5m, 1h, 4h, daily, weekly, monthly) for all 46 coins in one ~4KB response.
- `MarketProvider` replaces five separate pollers (`fetch5mRSI`, `fetchMultiTFRSI`, `fetchBybitMultiTFRSI`, `fetchDailyRSI`, `fetchWeeklyMonthlyRSI`) with one call to it.
- `computeRSI14` moved from `MarketProvider` into `lib/rsi.ts` so browser and server run identical code — two copies would drift silently, and the value is rounded to an integer, so a small difference moves coins across the 30/70 badge thresholds without ever looking wrong on screen. Locked with 8 new unit tests.
- Server caches in two groups at the cadences the client used: 5m RSI for 3 minutes, everything slower for 15. So polling every 3 minutes does not re-fetch weekly and monthly candles.
- Resilience: walks four spot hosts then falls back to `fapi.binance.com`; aborts the batch on 418/429 instead of spending the remaining requests into an active ban; skips Binance entirely when no host answers so HYPE still resolves via Bybit.

## Why

276 of the ~495 Binance requests per page load returned data that is **identical for every visitor** — a weekly RSI does not differ per user, yet every visitor re-fetched all of it.

Priced against Binance's 6000-weight-per-minute per-IP budget:

| Call | Weight each | Count | Total |
|---|---|---|---|
| `ticker/24hr` (45 symbols) | 80 | 2 | 160 |
| **RSI klines** | 2 | **276** | **552** |
| `depth` limit=50 | 5 | 45 | 225 |
| `aggTrades` limit=200 | 4 | 45 | 180 |
| klines 15m | 2 | 45 | 90 |

≈**1207 weight per page load**, so roughly five loads in a minute earns an IP ban. Binance then returns 418 to *every* request from that IP, including the ones the chart needs — the suspected cause of the intermittent blank chart.

This is not theoretical. It was reproduced during this work: the dev machine's IP was banned mid-development, with Binance returning `"Way too much request weight used; IP banned until ..."`. Shared egress IPs — mobile CGNAT, office NAT, VPNs — and anyone with two tabs open reach it sooner.

This PR removes 552 of that 1207, about **46%**. Upstream cost becomes fixed rather than per-visitor: ten concurrent visitors now cost the same upstream as one.

## How to test (QA)

1. From the QA folder: `git fetch && git checkout refactor/server-side-rsi-aggregation`, then `npm install && npm run dev`.
2. Open the dashboard. **Every coin should still show RSI values** — no blanks, no dashes where numbers used to be.
3. Compare a few coins against production (liquidity-hq.com) side by side. Values should match, or differ by at most a point or two from the minutes between the two page loads. A coin reading 50 on one and 20 on the other is a failure — report the coin.
4. Check HYPE specifically. It comes from Bybit rather than Binance and is the coin most likely to break — it should show all six RSI values like everything else.
5. Open DevTools → Network, filter `binance`, hard-refresh. Expect roughly **220 requests, not ~495**, and **no** `api.binance.com` kline requests at the 5m/1h/4h/1d/1w/1M timeframes.
6. Filter the same panel for `market/rsi`. Expect **one** request returning about 4KB. First load after starting the server may take up to ~15s; later loads should be near-instant.
7. Leave the page open for four minutes. Expect **exactly one** further `market/rsi` request — not one every few seconds.
8. `npm test` → 52 passing. `npm run lint` → 0 errors (93 pre-existing warnings, unchanged). `npx tsc --noEmit` → clean.

## Risk level

**Medium** — no auth, payment or user data is touched, and a failure degrades rather than breaks: the client only applies values the response actually carried, so a missing response leaves the previous RSI on screen instead of blanking it. But RSI feeds badges and scoring on several pages, so it is worth an actual look rather than a glance.

**One thing genuinely unverified, and QA should watch for it:** whether Render's IP can reach Binance **spot** (`api.binance.com`). Only `fapi.binance.com` is proven reachable from Render, by `/api/funding` and `lib/ribbonCandles` in production. Local testing here ran entirely through the `fapi` fallback, because the dev machine's IP was banned from spot at the time — which did prove the fallback path works, but means the spot path was never exercised against a real deployment. If spot turns out to be blocked from Render, the route still returns all 46 coins via futures candles; those can differ by a point on the rounded 0-100 scale. The health record names which source was used (`binance:rsi-fast` / `binance:rsi-slow`, detail reads `via spot` or `via futures`), so this is checkable after deploy rather than invisible.

## Screenshots (if UI change)

N/A — no visual change. The same numbers arrive by a different route.
