### PR TITLE
docs(workflow): reconcile two rules that contradicted the operational docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,10 @@ merging to `main` ships nothing until someone triggers a deploy manually
 (Render dashboard → service → Manual Deploy → Deploy latest commit). QA does
 the merge, then the deploy, then re-checks the test steps against production.
 
-`dev` branch → liquidity-hq-dev.onrender.com — dev may push and deploy this
-freely. `main` → liquidity-hq.com — QA only.
+`dev` branch → dev merges its own feature branches in and pushes freely, no
+permission needed. **Deploying the `liquidity-hq-dev` service is different —
+ask first**, it has a ~500 build-hour/month cap prod does not. Verify locally
+by default. `main` → liquidity-hq.com — QA only, merge and deploy both.
 
 **Low ceremony** — small internal chores (dep bumps, formatting, comments) may
 skip the commit body and screenshots. Branch naming and the `type(scope):`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,24 @@ the timeframe buttons. Same on ?coin=bonk. Switch to ?coin=btc — the badge
 should disappear entirely.
 ```
 
+### Trailers
+
+Commits authored with AI assistance carry these two trailers, after a blank
+line at the very end of the message:
+
+```
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_<id>
+```
+
+They are attribution and provenance, not part of the `What changed / Why /
+Test` body. Documented here because every commit in this repo already has
+them while this file described the format without them — leaving the written
+convention and the actual history disagreeing about what a commit looks like.
+
+Older commits show `Claude Opus 5 (1M context)` in the same slot. Do not go
+back and rewrite them; match the current form going forward.
+
 **Rules**
 
 - **One logical change per commit.** Do not bundle unrelated fixes. If the
@@ -256,6 +274,9 @@ When in doubt: would a QA person need to look at this? If yes, write the body.
 | `main` | liquidity-hq.com (production) | **QA only** | **no** — trigger manually |
 
 - Feature branches are cut from `dev` and merged back into `dev` via PR.
+  **Dev merges its own feature branches into `dev`** — QA ownership starts at
+  `main`, not here. Merging a feature branch into `dev` needs no permission
+  and no QA pass.
 
 ### Cut a branch from wherever it is going to land
 
@@ -280,8 +301,13 @@ in `main`'s history. Git treats them as already merged, so a later `dev` →
 `main` merge will **not** bring their changes back — it will look like a clean
 merge that silently does nothing. Recover them with `git revert <the-revert>` or
 a cherry-pick, not another merge.
-- `dev` is the integration branch. Dev may push and deploy the dev environment
-  freely — that is what it is for.
+- `dev` is the integration branch. **Pushing to the `dev` branch is always
+  fine, no need to ask. Deploying the `liquidity-hq-dev` *service* is not** —
+  ask first. That service carries a ~500 build-hour/month cap that prod does
+  not have, so a deploy spends a shared, exhaustible budget. Default to local
+  verification (`npx tsc --noEmit`, `npm run build`, `localhost:3000`) and
+  deploy dev only when something genuinely cannot be checked locally — an
+  origin IP, a real Render environment variable, a cold start.
 - `main` is **release only, and QA-owned**. Dev never merges into it. QA merges
   after every "How to test" step passes, then triggers the production deploy
   as a separate manual action (§4, "Who merges and deploys").


### PR DESCRIPTION
## Summary

The QA session found two places where `CONTRIBUTING.md` contradicts the operational docs. This fixes both, and closes a third gap it exposed: the convention never said who merges a feature branch into `dev`.

## What changed

**1. Dev environment authority.** `CONTRIBUTING.md` §6 and `CLAUDE.md` said dev *"may push and deploy the dev environment freely"*. Now they distinguish the two:
- Pushing the `dev` branch, and merging your own feature branches into it — permission-free, unchanged.
- Deploying the `liquidity-hq-dev` **service** — ask first.

**2. Commit trailers.** §2 gains a short subsection documenting the `Co-Authored-By` and `Claude-Session` trailers, where they go, and that older commits use a slightly different form that should not be rewritten.

**3. Who merges into `dev`.** §6 now states plainly that dev merges its own feature branches; QA ownership starts at `main`.

## Why

Both contradictions were found by the QA session reading the docs against each other, not by me.

| Doc | Says |
|---|---|
| `CONTRIBUTING.md:259`, `CLAUDE.md:52` | dev may *"push and deploy the dev environment freely"* |
| `OPS_ROADMAP.md:75`, `HANDOVER.md:161` | a `liquidity-hq-dev` deploy needs **explicit go-ahead** — ~500 build-hour/month cap prod does not have |

Whichever a reader hit first, the other was wrong. The cap is a shared, exhaustible budget, so the restrictive version is the correct one — but only for the *service*; pushing the branch was never the expensive part, and the old wording collapsed those into one permission.

Separately, every commit in this repo carries both trailers while the file documenting commit format never mentioned them — the written convention and the actual history disagreed about what a commit looks like.

**The third gap was not theoretical.** Because §6 never named who merges a feature branch into `dev`, I reported two open PRs as "blocked on QA" when only the one targeting `main` actually was. The owner caught it. A rule that produces a wrong answer on its first real use is worth writing down properly.

## How to test (QA)

1. From the QA folder: `git fetch && git checkout docs/reconcile-workflow-contradictions`.
2. Open `CONTRIBUTING.md` §6. It should say pushing `dev` and merging your own feature branches need no permission, and that deploying the `liquidity-hq-dev` service needs asking first, with the build-hour cap given as the reason.
3. Same section: it should state that dev merges its own feature branches into `dev`, and that QA ownership starts at `main`.
4. `CONTRIBUTING.md` §2 should have a **Trailers** subsection showing both `Co-Authored-By` and `Claude-Session`, and noting older commits differ.
5. Open `CLAUDE.md` and confirm it agrees with §6 — same split between pushing and deploying.
6. Search both files for `deploy the dev environment freely`. **Zero hits** — that phrase is what contradicted the ops docs.
7. Cross-check against `pendings/OPS_ROADMAP.md:75` and `docs/HANDOVER.md:161`. Nothing should now disagree.

## Risk level

**Low** — documentation only. No code, no config, no build output. The risk is a wrong rule going unnoticed, which is what this fixes rather than creates.

Deliberately kept off PR #1 so that one stays a single logical change and does not shift scope while it is under review. Both target `main`; either order merges cleanly, as they touch different sections.

## Screenshots (if UI change)

N/A — documentation only.
