### PR TITLE
fix(arena): stop the footer painting before the page body exists

### DIFF
--- a/components/PlatformFooter.tsx
+++ b/components/PlatformFooter.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useTheme } from '@/lib/theme';
+import { useAuth } from '@/components/AuthProvider';
 import BrandMark from '@/components/BrandMark';
 
 const DISCLOSURES = [
@@ -40,7 +41,30 @@ export default function PlatformFooter() {
   // .pf-footer), so its mark must track the real theme rather than a fixed
   // tone - the one surface in this rollout where that's actually true.
   const { theme } = useTheme();
+  const { loading: authLoading } = useAuth();
   if (pathname === '/' || pathname === '/login') return null;
+
+  /* Do not paint the page's closing chrome before the page body exists.
+   *
+   * Most routes render nothing but a small header stub until auth resolves,
+   * which takes roughly 800ms. During that window this footer - 296px, the
+   * tallest single element on the page - sat at y=132 in a 900px viewport,
+   * fully visible. The moment the real content mounted it was thrown below
+   * the fold in one frame, and because CLS scores impact fraction times
+   * distance moved, that one move was 82% of /arena's 0.365 total.
+   *
+   * Returning null here is the whole fix: with no footer in the pending
+   * window there is nothing to move, and once auth settles the footer mounts
+   * already below the fold. Mounting an element is not a layout shift, and
+   * nothing renders after the footer for its arrival to push around.
+   *
+   * Tried and rejected first: min-height on .app-content to reserve a
+   * viewport of space. It made things worse, not better - measured 0.76,
+   * roughly double the baseline - because it turned .app-content itself into
+   * a shifting element. Reserving space is the textbook CLS fix and it was
+   * the wrong one here; the problem was never missing space, it was painting
+   * the footer too early. */
+  if (authLoading) return null;
 
   return (
     <footer className="pf-footer">


### PR DESCRIPTION
## Summary

`/arena` had 0.365 Cumulative Layout Shift and 82% of it was one jump: the footer painting before the page body existed, then being thrown off screen when content arrived. Holding the footer back until auth resolves takes `/arena` to **0.068**, inside the "good" threshold. One-line behaviour change, no visual redesign.

## What changed

`PlatformFooter` returns `null` while `useAuth()` reports `loading`, alongside its existing `/` and `/login` checks. Nothing else.

## Why

QA's run flagged `/arena` CLS 0.367 and named `FOOTER.pf-footer` + `BUTTON.gchat-fab` as the sources. **Only the footer mattered** — measured with per-source attribution:

| Source | Share |
|---|---|
| `FOOTER.pf-footer` `h 296→0` | **82%** |
| `DIV.arena-ws` resizing | 18% |
| `BUTTON.gchat-fab` | **0.1%** |

The FAB was the obvious suspect — I had repositioned it during the consent-bar work — and it turned out to be irrelevant. Worth stating plainly because I nearly fixed it.

The footer never actually collapsed. Tracking container heights over time:

```
t(ms)   main.app-content   .arena-ws   footer
 200                 460          -1      296
 500                 460          -1      296
 800                2112         991      296
```

`.arena-ws` **is not in the DOM for the first ~800ms** while auth resolves. So `main.app-content` painted 460px tall and the 296px footer sat at **y=132 in a 900px viewport** — fully visible. When the workspace mounted, app-content jumped to 2112px and the footer left the viewport in one frame. `h 296→0` in the layout-shift record is the visible rect being clipped to zero, not the element shrinking. CLS scores impact fraction × distance, so one move of the tallest element across the whole viewport dominated the score.

With the footer held back there is nothing to move during the pending window, and once auth settles it mounts already below the fold. Mounting is not a layout shift, and nothing renders after the footer for its arrival to disturb.

This is not arena-specific — any route whose body waits on auth had the same shape. `/arena` just has the longest gap.

## Measurements

Three runs per configuration. Production build, `.next` deleted, exactly one server, and a sanity gate asserting the page actually rendered before measuring.

| Route | Baseline | With fix | |
|---|---|---|---|
| `/arena` | 0.3645 / 0.3705 / 0.3606 | **0.0676 / 0.0636 / 0.0676** | **−81%** |
| `/briefing` | 0.1548 / 0.1652 / 0.1580 | 0.1677 / 0.1631 / 0.1653 | unchanged |
| `/dashboard` | 0.0061 / 0.0063 / 0.0064 | 0.0068 / 0.0066 / 0.0065 | unchanged |
| `/privacy` | 0.0042 / 0.0048 / 0.0048 | 0.0048 / 0.0048 / 0.0042 | unchanged |

Baseline reproduces QA's numbers (`/arena` 0.367, `/briefing` 0.176), which is what makes the comparison trustworthy.

**Two false starts, recorded so nobody repeats them:**
- `min-height: 100vh` on `.app-content` to reserve space — measured **0.76, double the baseline**, because it turned `.app-content` itself into a shifting element. Reserving space is the textbook fix for this and it was the wrong one.
- An early run showed a perfect **0.000 on every route**, which was a stale `npm start` serving an old `.next` against freshly-built chunk hashes — HTTP 500, empty page, nothing to shift. Any CLS run without a "did the page render" assertion can produce a beautiful, meaningless zero.

## How to test (QA)

1. From the QA folder: `git fetch && git checkout fix/arena-layout-shift`, then `npm install && npm run build && npm start`.
2. Open `/arena` in a fresh tab, watching the lower half of the screen as it loads. The footer should **not** flash into view near the top and then drop away. It should simply be absent until the chart and cards arrive.
3. Scroll to the bottom of `/arena`. The footer must be fully present — brand, 7 nav links, risk disclosure, "Show full risk disclosures" toggle, copyright.
4. Repeat step 3 on `/dashboard`, `/briefing`, `/scanner`, `/privacy`. Footer complete on all five.
5. Click "Show full risk disclosures" and confirm the 6-item grid still expands.
6. Open the landing page `/` and `/login` — the footer must still be **absent** on both, as before.
7. Sign in, then reload `/arena`. Footer still correct — the auth path is the one this change touches.
8. `npm test` → 44 passing. `npx tsc --noEmit` → clean. `npm run lint` → 0 errors, 93 warnings (unchanged baseline).

## Risk level

**Low** — one early return in one presentational component. No data, no auth logic, no styling changed. Worst realistic failure is the footer appearing a few hundred milliseconds later than before, which is the intent.

The case worth checking is step 7: if `loading` never settled for some auth state, the footer would stay hidden on that path. It was verified present on all five routes signed out; signed-in is the one combination I could not cover locally.

## Screenshots (if UI change)

Not included — the change is a timing difference during load, which a static before/after cannot show. The measurement table above is the evidence. If you want it visual, `/arena` recorded at 4× slowdown shows the footer flash-and-drop on `dev` and not on this branch.
