### PR TITLE
docs(workflow): carry PR #4 the last step onto main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,10 @@ merging to `main` ships nothing until someone triggers a deploy manually
 (Render dashboard → service → Manual Deploy → Deploy latest commit). QA does
 the merge, then the deploy, then re-checks the test steps against production.
 
-`dev` branch → liquidity-hq-dev.onrender.com — dev may push and deploy this
-freely. `main` → liquidity-hq.com — QA only.
+`dev` branch → dev merges its own feature branches in and pushes freely, no
+permission needed. **Deploying the `liquidity-hq-dev` service is different —
+ask first**, it has a ~500 build-hour/month cap prod does not. Verify locally
+by default. `main` → liquidity-hq.com — QA only, merge and deploy both.
 
 **Low ceremony** — small internal chores (dep bumps, formatting, comments) may
 skip the commit body and screenshots. Branch naming and the `type(scope):`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,24 @@ the timeframe buttons. Same on ?coin=bonk. Switch to ?coin=btc — the badge
 should disappear entirely.
 ```
 
+### Trailers
+
+Commits authored with AI assistance carry these two trailers, after a blank
+line at the very end of the message:
+
+```
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_<id>
+```
+
+They are attribution and provenance, not part of the `What changed / Why /
+Test` body. Documented here because every commit in this repo already has
+them while this file described the format without them — leaving the written
+convention and the actual history disagreeing about what a commit looks like.
+
+Older commits show `Claude Opus 5 (1M context)` in the same slot. Do not go
+back and rewrite them; match the current form going forward.
+
 **Rules**
 
 - **One logical change per commit.** Do not bundle unrelated fixes. If the
@@ -256,6 +274,9 @@ When in doubt: would a QA person need to look at this? If yes, write the body.
 | `main` | liquidity-hq.com (production) | **QA only** | **no** — trigger manually |
 
 - Feature branches are cut from `dev` and merged back into `dev` via PR.
+  **Dev merges its own feature branches into `dev`** — QA ownership starts at
+  `main`, not here. Merging a feature branch into `dev` needs no permission
+  and no QA pass.
 
 ### Cut a branch from wherever it is going to land
 
@@ -280,8 +301,13 @@ in `main`'s history. Git treats them as already merged, so a later `dev` →
 `main` merge will **not** bring their changes back — it will look like a clean
 merge that silently does nothing. Recover them with `git revert <the-revert>` or
 a cherry-pick, not another merge.
-- `dev` is the integration branch. Dev may push and deploy the dev environment
-  freely — that is what it is for.
+- `dev` is the integration branch. **Pushing to the `dev` branch is always
+  fine, no need to ask. Deploying the `liquidity-hq-dev` *service* is not** —
+  ask first. That service carries a ~500 build-hour/month cap that prod does
+  not have, so a deploy spends a shared, exhaustible budget. Default to local
+  verification (`npx tsc --noEmit`, `npm run build`, `localhost:3000`) and
+  deploy dev only when something genuinely cannot be checked locally — an
+  origin IP, a real Render environment variable, a cold start.
 - `main` is **release only, and QA-owned**. Dev never merges into it. QA merges
   after every "How to test" step passes, then triggers the production deploy
   as a separate manual action (§4, "Who merges and deploys").


### PR DESCRIPTION
## Summary

PR #4's content never reached `main`. This carries it the last step. Nothing new — it is #4's already-reviewed commit.

## Why

I stacked #4 on top of #1 so the two would not conflict on `CONTRIBUTING.md`. That worked, but had a consequence I failed to flag: merging #4 landed it on `docs/branch-base-rule`, and `main` had already taken #1 by then. So #4's changes ended up one branch short of `main`. My mistake in how I set it up, not anything you did wrong.

Confirmed on `main` right now: `CONTRIBUTING.md` has #1's "Cut a branch from wherever it is going to land" section, but **no Trailers section**, and `CLAUDE.md` still lacks the dev-deploy correction.

## How to test (QA)

1. Merge this PR.
2. On `main`, open `CONTRIBUTING.md` §2 — there should be a **Trailers** subsection showing `Co-Authored-By` and `Claude-Session`.
3. §6 should say pushing the `dev` branch needs no permission but deploying the `liquidity-hq-dev` service does, and that dev merges its own feature branches.
4. `CLAUDE.md` should agree with §6.
5. Search both files for the phrase `deploy the dev environment freely` — zero hits.
6. Confirm #1's "Cut a branch from wherever it is going to land" section is still intact.

## Risk level

**Low** — documentation only, already reviewed as #4.

## Screenshots (if UI change)

N/A.
