### PR TITLE
docs(workflow): define what happens when QA writes code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,14 @@ for someone in the QA folder, so step 1 says which branch to pull.
 handoff. QA does `git fetch && git checkout <branch>` from the PR, never
 "latest main", and reports plain pass/fail per step. Never test on the dev
 folder; never develop on the QA folder. **If this session is running in the QA
-folder and is asked to write code — rather than test, report, merge or deploy,
-which are all its job — say so instead of doing it.**
+folder and is asked to write *application* code — anything under `app/`,
+`components/` or `lib/` — say so instead of doing it.**
+
+**QA-authored code — the reverse handoff.** QA owns its own tooling and may
+write it: `qa/`, `playwright.config.ts`, test CI workflows, QA docs. Never app
+code. QA opens a PR **into `dev`** (not `main`), **dev reviews it**, dev
+merges. This is the one case where review runs QA → dev. If a fix needs an
+app-code change, QA reports it as a finding — dev writes it.
 
 **Who merges and deploys — QA, never dev.**
 Dev's job ends when the PR is open and ready for review. Dev does **not** merge

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,10 +234,40 @@ agreeing it first — several rules here assume the gap exists.
   Dev stops at "PR is open".
 - **Never develop on the QA folder.** It exists to reproduce what a fresh clone
   of that branch actually does.
-- If a Claude Code session **in the QA folder** is asked to write code changes —
-  as opposed to testing, reporting, merging or deploying, all of which are its
-  job — it must **flag that as outside the QA folder's role** instead of quietly
-  doing it.
+- If a Claude Code session **in the QA folder** is asked to write **application**
+  code — anything under `app/`, `components/` or `lib/` — it must **flag that as
+  outside the QA folder's role** instead of quietly doing it. Its own test
+  tooling is a different matter, see below.
+
+### When QA writes code — the reverse handoff
+
+QA owns its own tooling and may write it:
+
+| QA may author | QA may not author |
+|---|---|
+| `qa/` — specs, plans, fixtures | `app/`, `components/`, `lib/` |
+| `playwright.config.ts` | Anything shipped to users |
+| `.github/workflows/` test jobs | API routes, migrations |
+| QA docs and findings | |
+
+Everything else about the flow **reverses**, and that is the point — the author
+never verifies their own work:
+
+1. QA pushes a branch named per §1 and opens a PR **into `dev`**, using the
+   full template in §3. Not into `main`: test tooling reaches `main` the same
+   way everything else does, as part of a reviewed `dev` → `main` release.
+2. **Dev reviews it.** This is the only case where review runs QA → dev rather
+   than dev → QA.
+3. Dev merges it into `dev` once it passes.
+
+If QA finds that a fix needs an application-code change, that goes back to dev
+as a **finding**, not as a commit. Describe the defect and where it lives; let
+dev write it. A QA folder that starts fixing app code is no longer an
+independent check on it.
+
+This section exists because it was missing and the gap produced a real wrong
+answer: with no rule for QA-authored code, the dev session simply asserted that
+it would review such a branch — a role the document never gave it.
 
 ---
 


### PR DESCRIPTION
## Summary

The convention had no rule for QA-authored code. It said the QA folder must refuse to write code at all, while in practice QA owns the Playwright suite and its CI job. This defines the split and the reverse handoff.

## What changed

`CONTRIBUTING.md` §4 gains a **"When QA writes code"** subsection, mirrored into `CLAUDE.md`:

| QA may author | QA may not author |
|---|---|
| `qa/` — specs, plans, fixtures | `app/`, `components/`, `lib/` |
| `playwright.config.ts` | Anything shipped to users |
| `.github/workflows/` test jobs | API routes, migrations |
| QA docs and findings | |

And the flow, which reverses: QA opens a PR **into `dev`** (not `main`), **dev reviews it**, dev merges. If a fix needs application code, QA reports it as a finding rather than committing it.

The bullet above it now says "application code" instead of "code", which is what made the old rule contradict reality.

## Why

The gap produced a real wrong answer. Asked who would review QA's `test/e2e-suite-corrections` branch, I asserted that dev would — a role the document never gave me. The owner caught it. A rule that has to be invented on the spot is a missing rule.

The split is drawn at *"does a user ever run this"*. Test tooling is QA's own instrument and QA should own it. Application code is the thing QA exists to check independently, and a QA folder that fixes app code stops being an independent check on it.

## How to test (QA)

1. From the QA folder: `git fetch && git checkout docs/qa-authored-code`.
2. `CONTRIBUTING.md` §4 should have a **"When QA writes code"** subsection with a two-column table of what QA may and may not author.
3. Below the table, three numbered steps: QA opens a PR into `dev`, dev reviews, dev merges. Confirm it says `dev` and not `main`.
4. Confirm the bullet above the subsection now says "application code" rather than "code", and names `app/`, `components/`, `lib/`.
5. `CLAUDE.md` should carry the same rule in short form.
6. Sanity check it against your own `test/e2e-suite-corrections` branch — everything it touches should fall on the "may author" side. If anything does not, that is worth saying, because it means the line is drawn in the wrong place.

## Risk level

**Low** — documentation only.

Step 6 is the one that matters. This rule was written from one example; if it does not fit the work you are actually doing, better to find out now.

## Screenshots (if UI change)

N/A.
