### PR TITLE
chore: drop the leftover Vercel references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,6 @@ yarn-error.log*
 .env*
 !.env.example
 
-# vercel
-.vercel
 
 # typescript
 *.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load its fonts, which are self-hosted from `app/fonts/`.
 
 ## Learn More
 
@@ -27,10 +27,15 @@ To learn more about Next.js, take a look at the following resources:
 - [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
 - [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
 
-## Deploy on Vercel
+## Deploy
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+Hosted on Render, not Vercel. Two services, neither auto-deploying:
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+| Branch | Service | URL |
+|---|---|---|
+| `main` | `liquidity-hq-prod` | https://liquidity-hq.com |
+| `dev` | `liquidity-hq-dev` | https://liquidity-hq-dev.onrender.com |
+
+A merge ships nothing on its own — the deploy is a separate manual step in the
+Render dashboard. See `CONTRIBUTING.md` §6 and `docs/INFRASTRUCTURE.md`.

--- a/app/api/macro-alert/route.ts
+++ b/app/api/macro-alert/route.ts
@@ -58,9 +58,11 @@ type CalEvent = {
 
 async function fetchUpcomingEvents(): Promise<CalEvent[]> {
   try {
-    const base = process.env.NEXT_PUBLIC_APP_URL
-      ?? process.env.VERCEL_URL
-      ?? 'http://localhost:3000';
+    /* This app is hosted on Render, so VERCEL_URL used to sit here and never
+       resolved. Worse than dead: Vercel sets it as a bare hostname with no
+       scheme, so had it ever been present the template below would have built
+       `myapp.vercel.app/api/econ-calendar` and thrown on fetch. */
+    const base = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
     const url = `${base}/api/econ-calendar`;
     const res = await fetch(url, { cache: 'no-store', signal: AbortSignal.timeout(10_000) });
     if (!res.ok) return [];


### PR DESCRIPTION
## Summary

Removes the leftover Vercel references from the repo. **This does not stop the Vercel deployments** — that part is a dashboard action, see below.

## What changed

- `app/api/macro-alert/route.ts` — dropped the `VERCEL_URL` fallback
- `README.md` — replaced the create-next-app "Deploy on Vercel" section with the real Render setup, and stopped claiming the app uses Geist (fonts have been self-hosted from `app/fonts/` since 2026-08-03)
- `.gitignore` — dropped the `.vercel` entry

## Why

Nothing here has ever run on Vercel. Three specifics:

- The `VERCEL_URL` fallback was **worse than dead code**. Vercel sets that variable as a bare hostname with no scheme, so had it ever been present the template would have built `myapp.vercel.app/api/econ-calendar` and thrown on fetch. It could only ever have failed.
- The README told a new reader to **deploy this project to Vercel**, which is actively wrong.
- `@sentry/vercel-edge` in `package-lock.json` is left alone — it is a transitive dependency of `@sentry/nextjs`, nothing to do with hosting.

## The part this PR cannot do

`vercel[bot]` is currently deploying this repository:

```
env=Production  creator=vercel[bot]  ref=98bac67   (main)
env=Preview     creator=vercel[bot]  ref=487c9a6
env=Preview     creator=vercel[bot]  ref=00137ea
```

So there is a **second Production deployment** running alongside Render, plus a Preview build on every branch push. That comes from the Vercel GitHub App, which is configured on vercel.com — it is not in this repository and cannot be removed by changing files here. There is no `vercel.json`, no `.vercel/` directory, and no repo webhook.

To actually stop it, one of:

1. **GitHub** → repo **Settings** → **Integrations / GitHub Apps** → **Vercel** → revoke access to this repo, or
2. **Vercel dashboard** → the project → **Settings** → **Git** → **Disconnect**, or delete the project outright.

Worth doing regardless of tidiness: a Vercel production build with no environment variables is a publicly reachable, half-working copy of the app.

## How to test (QA)

1. `git fetch && git checkout chore/drop-vercel-leftovers`.
2. Search the repo for `vercel`. The only hits should be `@sentry/vercel-edge` in `package-lock.json` and the explanatory comments added here.
3. Open `README.md` — the Deploy section should list the two Render services and say a merge does not deploy on its own. No Vercel instructions.
4. `README.md` should no longer claim the project uses Geist.
5. `npm run build` → exit 0. `npx tsc --noEmit` → clean. `npm test` → 52 passing.
6. Separately, and this is the one that matters: confirm in GitHub repo settings whether the Vercel app still has access. If it does, the bot deployments continue no matter what this PR does.

## Risk level

**Low** — the only executable change is removing an environment-variable fallback that could never have produced a valid URL. `NEXT_PUBLIC_APP_URL` is set on both Render services, and localhost remains the final fallback.

## Screenshots (if UI change)

N/A.
