### PR TITLE
fix(dashboard): stop the WebSocket fallback banning the visitor's own IP

### DIFF
--- a/components/MarketProvider.tsx
+++ b/components/MarketProvider.tsx
@@ -11,6 +11,13 @@ import { getAuthToken } from '@/lib/supabase';
 
 const WHALE_USD_THRESHOLD = 500_000; // $500k single trade = whale
 
+/* How often the REST fallback polls while the WebSocket is down, and how often
+   it retries the socket. See ws.onclose for why 5s was dangerous: restPoll
+   costs Binance request weight 80, so 5s was 960 weight/min per tab against a
+   6000/min per-IP budget, indefinitely. 30s holds it at 160. */
+const REST_FALLBACK_MS = 30_000;
+const WS_RETRY_MS      = 60_000;
+
 /* ── CVD Divergence Telegram alert ── */
 function sendCVDAlert(
   coin: string,
@@ -96,6 +103,9 @@ export default function MarketProvider({ children }: { children: React.ReactNode
   const retriesRef = useRef(0);
   const urlIdxRef = useRef(0);
   const restTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  /* Retries the socket while the REST fallback is running, so falling back is
+     temporary rather than permanent. See ws.onclose. */
+  const wsRetryRef = useRef<ReturnType<typeof setInterval> | null>(null);
   /* CVD divergence: 5-snapshot sliding window per coin */
   const cvdSnapsRef = useRef<Partial<Record<CoinId, Array<{ price: number; cvd: number }>>>>({});
   /* Whale dedup: track last seen aggTrade id per symbol */
@@ -165,6 +175,7 @@ export default function MarketProvider({ children }: { children: React.ReactNode
     ws.onopen = () => {
       retriesRef.current = 0; urlIdxRef.current = 0;
       if (restTimerRef.current) { clearInterval(restTimerRef.current); restTimerRef.current = null; }
+      if (wsRetryRef.current)  { clearInterval(wsRetryRef.current);  wsRetryRef.current = null; }
       setStore(s => ({ ...s, wsStatus: 'Live' }));
     };
 
@@ -188,10 +199,38 @@ export default function MarketProvider({ children }: { children: React.ReactNode
       urlIdxRef.current++;
       if (retriesRef.current <= 5) {
         setTimeout(() => startWSRef.current(), 2000 * retriesRef.current);
-      } else {
-        setStore(s => ({ ...s, wsStatus: 'Live · backup feed' }));
-        restPoll();
-        restTimerRef.current = setInterval(restPoll, 5000);
+        return;
+      }
+
+      /* ── REST fallback ──
+         This used to poll every 5 seconds, forever, and never retry the
+         socket. restPoll asks Binance for ticker/24hr across 45 symbols, which
+         costs request weight 80 (weight scales with symbol count: 21-100
+         symbols is the 80 band). At one call per 5s that is 960 weight per
+         minute against a 6000/minute per-IP budget - from a single tab, with
+         nothing else running, indefinitely. Two tabs, or one tab plus a normal
+         page load's other requests, and the visitor's own IP earns a Binance
+         ban within minutes. A ban returns 418 to every request from that IP,
+         including the chart's, so the whole app looks broken and the cause is
+         invisible.
+         30s holds the same fallback at 160 weight/minute. Prices come from the
+         socket whenever it is up; this path exists only while it is down, and
+         a slightly staler backup beats a banned IP. */
+      setStore(s => ({ ...s, wsStatus: 'Live · backup feed' }));
+      if (restTimerRef.current) clearInterval(restTimerRef.current);
+      restPoll();
+      restTimerRef.current = setInterval(restPoll, REST_FALLBACK_MS);
+
+      /* Falling back was permanent: after five failed reconnects nothing ever
+         opened a socket again, so a visitor who hit one bad minute stayed on
+         the REST feed for the life of the tab. Keep trying in the background;
+         ws.onopen tears both timers down when one succeeds. */
+      if (!wsRetryRef.current) {
+        wsRetryRef.current = setInterval(() => {
+          retriesRef.current = 0;
+          urlIdxRef.current  = 0;
+          startWSRef.current();
+        }, WS_RETRY_MS);
       }
     };
   }, [restPoll, updateCoin]);
@@ -1322,8 +1361,13 @@ export default function MarketProvider({ children }: { children: React.ReactNode
 
     return () => {
       intervals.forEach(clearInterval);
-      wsRef.current?.close();
+      /* Detach onclose before closing. Otherwise unmounting fires the handler
+         above, which starts the REST fallback and the socket-retry timer for a
+         provider that no longer exists - the polling then outlives the page
+         that needed it. */
+      if (wsRef.current) { wsRef.current.onclose = null; wsRef.current.close(); }
       if (restTimerRef.current) clearInterval(restTimerRef.current);
+      if (wsRetryRef.current)  clearInterval(wsRetryRef.current);
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 


### PR DESCRIPTION
## Summary

When the live price socket drops, the app fell back to polling Binance every 5 seconds — **forever**. That is enough request weight to get the visitor's own IP banned by Binance within minutes, after which the whole app looks broken. Now it polls every 30 seconds, retries the socket, and stops when the page unmounts.

## What changed

- REST fallback polls every **30s** instead of 5s
- The socket is **retried every 60s** while the fallback runs, instead of never again
- `ws.onclose` is detached before closing on unmount, so the fallback cannot outlive the page

## Why

After five failed reconnects, `ws.onclose` started `setInterval(restPoll, 5000)` and nothing ever cleared it. `restPoll` calls `ticker/24hr` for all 45 symbols, which costs **request weight 80** — weight scales with symbol count, and 21–100 symbols is the 80 band.

That is **960 weight/minute from one tab**, against Binance's 6000/minute per-IP budget, indefinitely, with nothing else running. Add a second tab or a normal page load and the visitor earns a ban. A ban returns **418 to every request from that IP**, including the chart's — so the app appears completely broken with nothing on screen explaining why.

This is not theoretical. My own IP was banned by Binance during unrelated work yesterday, with `"Way too much request weight used; IP banned until ..."`.

**Measured**, socket forced closed, 100-second window, production build:

| | ticker/24hr calls | avg gap | weight/min |
|---|---|---|---|
| Before | 16 | 6.4s | **~765** |
| After | 5 | 22.6s | **~239** |

(The averages include two startup calls; steady state is a clean 30s.)

**Two more defects in the same path, fixed here:**

- **Falling back was permanent.** After five failures nothing ever opened a socket again, so a visitor who hit one bad minute stayed on the degraded REST feed for the entire life of the tab, even after the network recovered.
- **Unmounting started the fallback.** Closing the socket during cleanup fired `onclose`, which started polling for a provider that no longer existed — the polling outlived the page that needed it.

## How to test (QA)

1. `git fetch && git checkout fix/websocket-fallback-rate-limit`, then `npm install && npm run build && npm start`.
2. Open the dashboard. Status should read **"Live"** and prices should tick normally. This is the path most users are on and it must be unaffected.
3. Now simulate an outage: DevTools → Network → **request blocking** → add `wss://stream.binance.com`, then reload.
4. Within ~30 seconds the status should change to **"Live · backup feed"**, and prices should still update — just less often.
5. In the Network tab, filter `ticker/24hr`. Requests should appear roughly **every 30 seconds, not every 5**. This is the actual fix.
6. Remove the block and wait up to a minute. The status should return to **"Live" on its own**, and `ticker/24hr` polling should stop completely. On `dev` today it never recovers.
7. Navigate away to another page. Confirm **no further** `ticker/24hr` requests are made.
8. `npm test` → 52 passing. `npx tsc --noEmit` → clean. `npm run lint` → 0 errors, 93 warnings (unchanged).

## Risk level

**Medium** — it touches the live price feed, which every page depends on. The happy path (socket connects, no fallback) is unchanged, which is why step 2 comes first.

The honest trade: fallback prices are now up to 30 seconds stale instead of 5. That is deliberate. A slightly staler backup feed beats a banned IP that breaks every Binance-backed feature at once, and this path only runs while the socket is down.

## Screenshots (if UI change)

N/A — no visual change. The status text and the request timing are the observable difference, both covered in the steps above.
