### PR TITLE
docs(workflow): document the qa staging branch and its Render service

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,55 @@
+<!--
+  Auto-filled on every PR. Full rules: CONTRIBUTING.md section 3.
+  Delete the italic prompts as you replace them. Do not delete the headings -
+  "How to test (QA)" in particular is the dev to QA handoff, not documentation.
+-->
+
+## Summary
+
+*One or two sentences, plain language. What would you tell someone who has not been following this work?*
+
+## What changed
+
+*Bullets. User-facing terms first, technical detail after if it is needed at all.*
+
+-
+
+## Why
+
+*The problem this solves. If it is a bug, what was actually wrong - not "it was broken".*
+
+## How to test (QA)
+
+*Numbered steps someone who cannot read code can follow, each with an expected result. Step 1 is normally where to test:*
+
+*- The `qa` staging environment: https://liquidity-hq-qa.onrender.com (once this is merged to `qa` and deployed)*
+*- Or locally on the `qa` branch: `git fetch && git checkout qa && git pull`*
+*- Or this branch directly, if the change is not on `qa` yet: `git fetch && git checkout <branch>`*
+
+*Name the viewport and theme if the change is visual. Say what a failure looks like, not only a pass.*
+
+1.
+2.
+3.
+
+## Risk level
+
+*Low / Medium / High, and one line on what breaks if this is wrong.*
+
+- **Low** — isolated, no shared code, easy to eyeball
+- **Medium** — touches a shared component or a data path used elsewhere
+- **High** — auth, payments, alert delivery, migrations, anything that fails silently or affects money or user data
+
+## Checklist
+
+- [ ] `npm run lint` — 0 errors
+- [ ] `npx tsc --noEmit` — clean
+- [ ] `npm test` — passing
+- [ ] `npm run build` — exit 0
+- [ ] **Database migration?** If yes, say which file, and confirm it is applied to dev/qa **before** this merges — see CONTRIBUTING.md section 7
+- [ ] **New environment variable?** If yes, list it here and say which services still need it set. A var that exists only on dev is a broken deploy waiting to happen
+- [ ] Anything I could not verify is stated in the PR, not left for QA to discover
+
+## Screenshots (if UI change)
+
+*Before and after. "N/A - no visual change" is a valid answer; leaving it blank is not.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,10 +55,23 @@ merging to `main` ships nothing until someone triggers a deploy manually
 (Render dashboard → service → Manual Deploy → Deploy latest commit). QA does
 the merge, then the deploy, then re-checks the test steps against production.
 
+**Flow is `dev` → `qa` → `main`.**
+
 `dev` branch → dev merges its own feature branches in and pushes freely, no
 permission needed. **Deploying the `liquidity-hq-dev` service is different —
 ask first**, it has a ~500 build-hour/month cap prod does not. Verify locally
-by default. `main` → liquidity-hq.com — QA only, merge and deploy both.
+by default.
+
+`qa` branch → **liquidity-hq-qa.onrender.com, the only branch that
+auto-deploys.** Merge `dev` → `qa` and a build starts, no dashboard step. Free
+plan, so it sleeps when idle and the first request after that is slow. Uses the
+**dev** Supabase (`wdtjhrilakoitfcezxpx`) — a known compromise, since Supabase's
+free plan caps the account at two active projects and dev + prod already take
+both. **It must never point at prod Supabase (`qdpwhnvmhqgzijuwopso`) — hard
+rule.** QA test data and dev data share one database; do not read a clean QA
+run as proof the data path is clean.
+
+`main` → liquidity-hq.com — QA only, merge and deploy both.
 
 **Low ceremony** — small internal chores (dep bumps, formatting, comments) may
 skip the commit body and screenshots. Branch naming and the `type(scope):`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,13 +33,14 @@ One logical change per commit. Never `fix bug` / `update stuff` / `wip`.
 for someone in the QA folder, so step 1 says which branch to pull.
 
 **Two folders** — dev folder writes code, QA folder tests it; the PR is the
-handoff. **QA tests on the `qa` staging environment —
-https://liquidity-hq-qa.onrender.com — not a local checkout**, and reports plain
-pass/fail per step. Never test on `main`; it does not have the change yet.
-Local checkout (`git fetch && git checkout <branch>` from the PR) is the
-exception, for changes not yet on `qa` and for QA's own test tooling. When every
-step passes, **QA merges `qa` → `main`**, not the feature branch. Never test on
-the dev folder; never develop on the QA folder. **If this session is running in the QA
+handoff. **QA tests the `qa` branch** — either on the staging URL
+(https://liquidity-hq-qa.onrender.com) or on **localhost, provided the QA folder
+is checked out on `qa`**. Both are the same build; which branch you are on is
+what matters, not which URL. Say which one a result came from. Never test on
+`main` — it does not have the change yet. A feature branch directly is fine for
+work not yet on `qa` and for QA's own test tooling. Reports are plain pass/fail
+per step. When every step passes, **QA merges `qa` → `main`**, not the feature
+branch. Never test on the dev folder; never develop on the QA folder. **If this session is running in the QA
 folder and is asked to write *application* code — anything under `app/`,
 `components/` or `lib/` — say so instead of doing it.**
 
@@ -50,9 +51,13 @@ merges. This is the one case where review runs QA → dev. If a fix needs an
 app-code change, QA reports it as a finding — dev writes it.
 
 **Who merges and deploys — QA, never dev.**
-Dev's job ends when the PR is open and ready for review. Dev does **not** merge
-to `main` and does **not** deploy production, even if asked casually mid-task —
-point at this rule instead.
+**QA is the only one who merges `qa` → `main`, and the only one who deploys
+production.** Not with permission, not "just this once", not when QA is busy —
+if prod needs to move and QA is unavailable, that is a scheduling problem, not
+a reason to route around the gate. Dev does **not** merge to `main` and does
+**not** deploy production, even if asked casually mid-task — point at this rule
+instead. Dev's authority stops at `dev` and `qa`: it may merge its own feature
+branches into `dev`, may merge `dev` → `qa`, and may deploy nothing.
 
 Merging is **not** the deploy. Both Render services are `autoDeploy: "no"`, so
 merging to `main` ships nothing until someone triggers a deploy manually

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,36 @@ run as proof the data path is clean.
 
 `main` → liquidity-hq.com — QA only, merge and deploy both.
 
+**`qa` is fast-forward only.** Never commit to it directly, never PR a feature
+branch into it. Only `dev` goes in: `git checkout qa && git merge --ff-only dev`.
+If that fails, `qa` has diverged — fix it, do not force. Delete feature branches
+once merged; only `main`, `dev`, `qa` and open-PR branches should exist.
+
+**A hotfix skips `qa`, so it skips testing.** Cut from `main`, then merge back
+into **both `dev` and `qa`** or the next release reverts it. Say in the PR what
+was not verified.
+
+**Migrations — the thing that takes prod down.** Apply the migration *before*
+the deploy that needs it, never after. Prefer additive (add, backfill, then
+switch code); dropping in the same release as the code change leaves no safe
+rollback. Always High risk. **`qa` shares the dev database, so applying a
+migration "to qa" applies it to dev for everyone** — there is no isolated place
+to try one.
+
+**Environment variables.** If a PR adds one, the PR says so and lists which
+services still need it. Set it on prod *before* the release deploy.
+`NEXT_PUBLIC_*` are inlined at build time — setting one after a build does
+nothing until the next build. Never copy a prod secret to `qa`/`dev`.
+
+**When prod breaks — roll back first, diagnose second.** Render dashboard →
+`liquidity-hq-prod` → Deploys → *Rollback to this deploy*. That reverts the
+build, not git. **If a destructive migration shipped, there is no recovery
+path** — prod Supabase is on the free plan and has no backups.
+
+**Tag `main` after a successful prod deploy** — `git tag -a v2026.08.05 -m "..."`.
+Date-based. Without it, "what is in production?" is only answerable from the
+Render dashboard.
+
 **Low ceremony** — small internal chores (dep bumps, formatting, comments) may
 skip the commit body and screenshots. Branch naming and the `type(scope):`
 prefix are non-negotiable on everything.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,9 +71,10 @@ permission needed. **Deploying the `liquidity-hq-dev` service is different —
 ask first**, it has a ~500 build-hour/month cap prod does not. Verify locally
 by default.
 
-`qa` branch → **liquidity-hq-qa.onrender.com, the only branch that
-auto-deploys.** Merge `dev` → `qa` and a build starts, no dashboard step. Free
-plan, so it sleeps when idle and the first request after that is slow. Uses the
+`qa` branch → liquidity-hq-qa.onrender.com, the staging environment QA tests
+against. **Does not auto-deploy** — merge `dev` → `qa`, then trigger the deploy
+manually, and say you have done it. Whoever merges also deploys. Free plan, so
+it sleeps when idle and the first request after that is slow. Uses the
 **dev** Supabase (`wdtjhrilakoitfcezxpx`) — a known compromise, since Supabase's
 free plan caps the account at two active projects and dev + prod already take
 both. **It must never point at prod Supabase (`qdpwhnvmhqgzijuwopso`) — hard

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,9 +33,13 @@ One logical change per commit. Never `fix bug` / `update stuff` / `wip`.
 for someone in the QA folder, so step 1 says which branch to pull.
 
 **Two folders** — dev folder writes code, QA folder tests it; the PR is the
-handoff. QA does `git fetch && git checkout <branch>` from the PR, never
-"latest main", and reports plain pass/fail per step. Never test on the dev
-folder; never develop on the QA folder. **If this session is running in the QA
+handoff. **QA tests on the `qa` staging environment —
+https://liquidity-hq-qa.onrender.com — not a local checkout**, and reports plain
+pass/fail per step. Never test on `main`; it does not have the change yet.
+Local checkout (`git fetch && git checkout <branch>` from the PR) is the
+exception, for changes not yet on `qa` and for QA's own test tooling. When every
+step passes, **QA merges `qa` → `main`**, not the feature branch. Never test on
+the dev folder; never develop on the QA folder. **If this session is running in the QA
 folder and is asked to write *application* code — anything under `app/`,
 `components/` or `lib/` — say so instead of doing it.**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,14 +179,33 @@ dev is done. Dev does **not** merge to `main` and does **not** deploy — see
 
 ### QA folder — when testing a PR
 
-1. ```
-   git fetch && git checkout <branch-name>
-   ```
-   The **exact branch from the PR**. Never assume "latest `main`" — the change
-   under test is not on `main` yet, and testing `main` will silently pass.
+1. **Test on the `qa` staging environment, not a local checkout.**
+
+   https://liquidity-hq-qa.onrender.com
+
+   That is the point of the `qa` branch: dev merges `dev` → `qa`, it deploys
+   itself, and QA gets a real running build with no setup. Testing a branch you
+   built locally tests your machine as much as the change.
+
+   Confirm you are looking at the right build before reporting anything — the
+   commit `qa` is on should contain the change under test. If it does not, say
+   so and stop; that is a finding about the handoff, not about the code.
+
+   **Never test on `main`.** The change is not there yet, so it will silently
+   pass.
+
+   *Exception:* a change that has not reached `qa` yet, or QA's own test
+   tooling, still gets the local route —
+   `git fetch && git checkout <branch-name>`, the exact branch from the PR.
 2. Run the "How to test" steps **literally, in order**. Do not improvise a
    different path; if the steps are wrong or impossible, that itself is the
    finding and belongs in the report.
+
+   Two things about this environment will otherwise be reported as bugs and are
+   not: it runs on Render's **free plan**, so the first request after it has
+   been idle is slow and can time out — retry once. And it shares the **dev**
+   database, so data you did not create may already be there, and dev may
+   change it underneath you mid-test.
 3. Report as a PR comment (or directly to the user) in **plain pass/fail per
    step**:
 
@@ -198,8 +217,13 @@ dev is done. Dev does **not** merge to `main` and does **not** deploy — see
 4. If the QA folder has no `CLAUDE.md` / `CONTRIBUTING.md`, it has not pulled
    since this convention landed. **Pull `main` first**, then check out the
    feature branch, so both folders are working to the same standard.
-5. **When every step passes, QA merges the branch into `main`** and then
-   deploys — both steps, in that order. See below.
+5. **When every step passes, QA merges `qa` into `main`** and then deploys —
+   both steps, in that order. See below.
+
+   `qa` → `main`, not the feature branch → `main`. By the time QA is testing,
+   the change is already on `dev` and `qa`; merging the original feature branch
+   straight into `main` would skip whatever else `qa` was validated with, and
+   ship a combination nobody tested.
 
 ### Who merges and deploys
 
@@ -216,7 +240,7 @@ Merging is not the deploy. Both Render services are configured
 So **merging to `main` ships nothing on its own.** Production keeps serving the
 previous build until someone triggers a deploy. QA must do both:
 
-1. Merge the approved branch into `main` and push.
+1. Merge **`qa`** into `main` and push — not the original feature branch.
 2. **Trigger the deploy manually** — Render dashboard → `liquidity-hq-prod` →
    *Manual Deploy* → *Deploy latest commit*.
 3. Confirm the deploy reaches `live` and re-check the "How to test" steps

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,8 @@ back and rewrite them; match the current form going forward.
 
 ## 3. Pull request template
 
-Every PR description uses this structure:
+This lives in `.github/pull_request_template.md`, so GitHub fills it in for you
+on every PR — you edit rather than remember. The structure:
 
 ```markdown
 ## Summary
@@ -146,6 +147,11 @@ Low / Medium / High — <one line on what could break if this goes wrong>
 ## Screenshots (if UI change)
 <before/after>
 ```
+
+The file also carries a **checklist** the prose version never had: the four
+build gates, plus the two questions that cause silent production failures —
+does this add a migration, and does this add an environment variable. Both are
+covered in §7.
 
 **Rules**
 
@@ -183,9 +189,9 @@ dev is done. Dev does **not** merge to `main` and does **not** deploy — see
 
    https://liquidity-hq-qa.onrender.com
 
-   That is the point of the `qa` branch: dev merges `dev` → `qa`, it deploys
-   itself, and QA gets a real running build with no setup. Testing a branch you
-   built locally tests your machine as much as the change.
+   That is the point of the `qa` branch: dev merges `dev` → `qa`, deploys it,
+   and QA gets a real running build with no setup. Testing a branch you built
+   locally tests your machine as much as the change.
 
    Confirm you are looking at the right build before reporting anything — the
    commit `qa` is on should contain the change under test. If it does not, say
@@ -424,9 +430,42 @@ was cut from `dev` and merged to `main` to bootstrap the convention, and it
 silently carried 13 unrelated QA-scaffolding files onto `main` with it.
 
 - Normal work → cut from `dev`, merge back to `dev`. Reaches `main` later, as
-  part of a reviewed `dev` → `main` release.
-- Hotfix or anything that must land on `main` **now** → cut from `main`, and
-  merge it back into `dev` afterwards so the two do not drift.
+  part of a reviewed `dev` → `qa` → `main` release.
+- Hotfix or anything that must land on `main` **now** → cut from `main`, then
+  merge it back into **both `dev` and `qa`** afterwards, or the next release
+  silently reverts it. Merging into `dev` alone is not enough now that `qa`
+  exists.
+
+**A hotfix skips `qa`, which means it skips testing.** That is the trade you
+are making by calling something a hotfix, so make it deliberately: test it
+locally, keep it as small as you can defend, and say in the PR what was *not*
+verified. "Urgent" is a reason to shorten the queue, not a reason to pretend
+the risk is lower than it is.
+
+### `qa` is fast-forward only
+
+**Never commit directly to `qa`, and never open a PR against it from a feature
+branch.** The only thing that goes into `qa` is `dev`:
+
+```
+git checkout qa && git merge --ff-only dev && git push
+```
+
+If that command fails, `qa` has diverged and something has gone in the wrong
+way. Fix the divergence rather than forcing the merge — a `qa` that is not a
+prefix of `dev` means "tested on qa" no longer tells you anything about what is
+on `dev`, and the whole `dev` → `qa` → `main` model stops meaning what it says.
+
+After a release lands on `main`, `qa` keeps whatever it had; the next promotion
+fast-forwards it again from `dev`. Nothing needs resetting.
+
+### Delete the branch when it merges
+
+Once a feature branch is merged, delete it locally and on the remote. A branch
+list that still shows a dozen merged branches makes the two or three that
+matter impossible to find, and it is not obvious from the name which are live.
+`main`, `dev`, `qa` and anything with an open PR are the only branches that
+should exist.
 
 **If a merge to `main` is ever reverted**, note that the reverted commits stay
 in `main`'s history. Git treats them as already merged, so a later `dev` →
@@ -443,5 +482,125 @@ a cherry-pick, not another merge.
 - `main` is **release only, and QA-owned**. Dev never merges into it. QA merges
   after every "How to test" step passes, then triggers the production deploy
   as a separate manual action (§4, "Who merges and deploys").
-- Neither service auto-deploys. A merge is not a release; the deploy is always
+- **No** service auto-deploys. A merge is not a release; the deploy is always
   a deliberate second step.
+
+---
+
+## 7. Promoting a release
+
+The two merges that actually reach users — `dev` → `qa` and `qa` → `main` — get
+a PR like everything else. They are the merges with the highest blast radius,
+so they are the wrong place to skip the paper trail. A promotion PR needs no
+essay: a title, a list of what is going out, and the checklist below.
+
+### Before `dev` → `qa`
+
+1. CI green on `dev`.
+2. **Migrations applied.** See below — this is the one that takes prod down.
+3. Merge fast-forward only: `git checkout qa && git merge --ff-only dev`.
+4. **Trigger the qa deploy** and say you have. Merging does not deploy.
+
+### Before `qa` → `main`
+
+1. Every "How to test" step passed, on `qa` — not on a feature branch, not on
+   `dev`.
+2. CI green on `qa`.
+3. **Migrations already applied to production.** Before the deploy, never after.
+4. **Every environment variable the release needs exists on
+   `liquidity-hq-prod`.** Check, do not assume.
+5. Nothing unresolved that you would not want a user to find first.
+
+Then merge, deploy, and re-check the steps against production rather than
+against `qa`. A pass on staging is evidence, not proof: prod has different data,
+different environment variables and a different Supabase project.
+
+### Database migrations
+
+142 migration files exist and **nothing in this workflow used to mention them**,
+which is how a deploy ships code that reads a column the database does not have.
+Rules:
+
+- **Apply the migration before the deploy that needs it, never after.** New code
+  against an old schema is an outage; old code against a new schema is usually
+  fine. That asymmetry is why the order is fixed.
+- **Prefer additive migrations.** Add a column, backfill, then switch the code
+  over. Dropping or renaming in the same release as the code change leaves no
+  safe moment to roll back to.
+- A migration is **High risk** in §3 terms, always. It gets the full PR body and
+  the file named in it.
+- **`qa` shares the dev database.** Applying a migration "to qa" applies it to
+  dev, for everyone, immediately. There is no isolated place to try one — the
+  closest thing is a local Supabase, and if you are about to do something
+  destructive, that is where to do it.
+- Applied through the Supabase MCP (`apply_migration`), per
+  `docs/HANDOVER.md` §5.
+
+### Environment variables
+
+A variable that exists on one service and not another is a deploy that builds
+and then fails at runtime, usually in a way that fails soft and goes unnoticed.
+It has already happened here twice, with `CRON_SECRET` and
+`NEXT_PUBLIC_SENTRY_DSN`.
+
+- If a PR adds or renames a variable, **the PR says so**, and lists which
+  services still need it. That is a checklist item in the PR template.
+- Set it on `liquidity-hq-prod` **before** the release deploy, not after.
+- `NEXT_PUBLIC_*` variables are **inlined at build time**. Setting one after a
+  build does nothing until the next build — a rebuild is required, not a
+  restart.
+- Never copy a production secret onto `qa` or `dev`. If staging needs a key,
+  provision a separate one.
+
+### Tagging
+
+Tag `main` after a successful production deploy:
+
+```
+git tag -a v2026.08.05 -m "RSI aggregation, arena + scanner CLS, WebSocket fallback"
+git push origin v2026.08.05
+```
+
+Date-based, because this ships continuously and has no versioned API for semver
+to describe. There are **no tags at all** right now, which means the only way to
+answer "what is in production?" is to read the commit hash off the Render
+dashboard and hope it matches something. One command per release fixes that.
+
+---
+
+## 8. When production breaks
+
+**Roll back first, diagnose second.** A production incident is not the moment to
+work out what went wrong — get users onto something that works, then find out.
+
+### Rolling back a deploy
+
+Render keeps previous deploys. Dashboard → `liquidity-hq-prod` → **Deploys** →
+find the last known-good one → **Rollback to this deploy**. It redeploys that
+build; it does not touch git, so `main` still has the bad commit and someone
+must revert or fix it forward afterwards.
+
+This is fast and safe **as long as no migration shipped with the bad release.**
+
+### Rolling back when a migration shipped
+
+You mostly cannot, and this is worth understanding before you need it.
+
+Rolling the *code* back is easy. Rolling the *schema* back is not: a dropped
+column has taken its data with it, and **the production Supabase project is on
+the free plan, so there are no backups to restore from.** Not "backups we have
+not tested" — none.
+
+So the recovery path for a destructive migration is currently: there isn't one.
+That is the single strongest argument for Supabase Pro, and it is why §7 says
+prefer additive migrations. An additive migration is nearly always safe to leave
+in place while you roll the code back.
+
+### Afterwards
+
+- Say what happened in `pendings/PENDING.md`, including what was tried and did
+  not work. A fix nobody can find is a fix that gets re-invented.
+- If the release passed QA and still broke production, the interesting question
+  is what `qa` could not have caught — different data, a missing environment
+  variable, a cold start, real traffic. That gap is the actual finding, and it
+  belongs in the QA test plan so it is covered next time.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,9 +194,26 @@ dev is done. Dev does **not** merge to `main` and does **not** deploy — see
    **Never test on `main`.** The change is not there yet, so it will silently
    pass.
 
-   *Exception:* a change that has not reached `qa` yet, or QA's own test
-   tooling, still gets the local route —
-   `git fetch && git checkout <branch-name>`, the exact branch from the PR.
+   **Testing locally is equally valid — as long as the QA folder is on the
+   `qa` branch:**
+
+   ```
+   git fetch && git checkout qa && git pull
+   npm install && npm run build && npm start
+   ```
+
+   Same code, no cold start, and the browser devtools are right there. Use it
+   whenever the staging service is asleep or the test needs the Network tab, a
+   throttled connection, or a device emulator. What matters is **which branch
+   you are on**, not which URL you point at — a local run on `qa` and the
+   staging URL are the same build.
+
+   Say which one a result came from when reporting. "Fails on localhost, passes
+   on staging" is itself a finding worth having.
+
+   *Also fine on a feature branch directly:* a change that has not reached `qa`
+   yet, or QA's own test tooling, still gets
+   `git fetch && git checkout <branch-name>` — the exact branch from the PR.
 2. Run the "How to test" steps **literally, in order**. Do not improvise a
    different path; if the steps are wrong or impossible, that itself is the
    finding and belongs in the report.
@@ -227,15 +244,23 @@ dev is done. Dev does **not** merge to `main` and does **not** deploy — see
 
 ### Who merges and deploys
 
-**QA owns the merge to `main` and the deploy. Dev never does either.**
+**QA is the only one who merges `qa` → `main`, and the only one who deploys
+production. Dev never does either.** Not with permission, not "just this once",
+not when QA is busy. If production needs to move and QA is unavailable, that is
+a scheduling problem, not a reason to route around the rule — the whole value
+of the gate is that it is never the person who wrote the code.
 
-Merging is not the deploy. Both Render services are configured
+Dev's authority stops at `dev` and `qa`. Dev may merge its own feature branches
+into `dev`, may merge `dev` → `qa`, and may deploy nothing.
+
+Merging is not the deploy. Both permanent Render services are configured
 `autoDeploy: "no"` / `autoDeployTrigger: "off"`:
 
-| Service | Branch | Auto-deploy |
-|---|---|---|
-| `liquidity-hq-prod` → liquidity-hq.com | `main` | **no** |
-| `liquidity-hq-dev` → liquidity-hq-dev.onrender.com | `dev` | **no** |
+| Service | Branch | Auto-deploy | Who deploys |
+|---|---|---|---|
+| `liquidity-hq-prod` → liquidity-hq.com | `main` | **no** | **QA only** |
+| `liquidity-hq-qa` → liquidity-hq-qa.onrender.com | `qa` | **yes** | nobody — it deploys itself |
+| `liquidity-hq-dev` → liquidity-hq-dev.onrender.com | `dev` | **no** | dev, ask first |
 
 So **merging to `main` ships nothing on its own.** Production keeps serving the
 previous build until someone triggers a deploy. QA must do both:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,6 +271,14 @@ previous build until someone triggers a deploy. QA must do both:
 3. Confirm the deploy reaches `live` and re-check the "How to test" steps
    against production, not just the branch.
 
+**None of this is enforced by GitHub.** Branch protection needs GitHub Pro on a
+private repo, and this repo has neither, so nothing technically stops anyone
+pushing straight to `main` or merging their own work. Checked, not assumed - the
+API returns *"Upgrade to GitHub Pro or make this repository public to enable
+this feature"* for `main`, `qa` and `dev` alike. Every rule here is therefore a
+convention people choose to follow, which is worth knowing: the cost of
+breaking one is paid later and by someone else, not caught at push time.
+
 This is a deliberate safety property, not an oversight: a merge can be reviewed
 and corrected before it reaches users. Do not turn auto-deploy on without
 agreeing it first — several rules here assume the gap exists.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -297,16 +297,56 @@ When in doubt: would a QA person need to look at this? If yes, write the body.
 
 ## 6. Branches and environments
 
+The flow is `dev` → `qa` → `main`.
+
 | Branch | Environment | Who pushes | Deploys automatically? |
 |---|---|---|---|
 | `<type>/<description>` | none | dev | n/a |
 | `dev` | liquidity-hq-dev.onrender.com | dev | **no** — trigger manually |
+| `qa` | **liquidity-hq-qa.onrender.com** | dev merges `dev` → `qa` | **yes** — on every push |
 | `main` | liquidity-hq.com (production) | **QA only** | **no** — trigger manually |
 
 - Feature branches are cut from `dev` and merged back into `dev` via PR.
   **Dev merges its own feature branches into `dev`** — QA ownership starts at
   `main`, not here. Merging a feature branch into `dev` needs no permission
   and no QA pass.
+
+### The `qa` staging environment
+
+`qa` is the only branch that deploys on its own. Merge `dev` → `qa` and a
+build starts; no dashboard step. That is deliberate — QA should be able to get
+a testable environment without waiting on dev, which is the whole reason the
+branch exists.
+
+| | |
+|---|---|
+| **URL** | https://liquidity-hq-qa.onrender.com |
+| **Render service** | `liquidity-hq-qa` (`srv-d9p42ke1egvs73f8car0`), free plan, Singapore |
+| **Database** | Supabase `liquidity-hq-dev` (`wdtjhrilakoitfcezxpx`) |
+| **Auto-deploy** | **yes**, on every push to `qa` |
+
+**It shares the dev database, and that is a known compromise, not the design.**
+The intent was a separate `liquidity-hq-qa` Supabase project. Supabase's free
+plan caps a *user* at two active projects across every org they own, and
+`liquidity-hq-dev` and `liquidity-hq-prod` already use both. Deleting two
+unrelated paused projects did not free a slot — the cap counts active projects
+only — and a new org does not help either, because the limit follows the
+account, not the org. Revisit when the org moves to Pro; a separate project or
+a real Supabase branch is the right answer and this is the stopgap.
+
+What that costs you in practice: QA test accounts and dev's own data live in
+the same database, so each can see and overwrite the other's rows. Do not read
+a clean QA run as proof the data path is clean.
+
+**What it must never do is point at production Supabase**
+(`qdpwhnvmhqgzijuwopso`). That is a hard rule. A staging environment that can
+write to production data is worse than having no staging environment, because
+it looks safe.
+
+**Free plan means it sleeps.** The service spins down after inactivity, so the
+first request after an idle period is slow and can time out. That is the tier,
+not a bug — retry once before reporting it. It also shares the ~500
+build-hour/month cap noted above.
 
 ### Cut a branch from wherever it is going to land
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -253,13 +253,13 @@ of the gate is that it is never the person who wrote the code.
 Dev's authority stops at `dev` and `qa`. Dev may merge its own feature branches
 into `dev`, may merge `dev` → `qa`, and may deploy nothing.
 
-Merging is not the deploy. Both permanent Render services are configured
+Merging is not the deploy. **No** Render service auto-deploys; all three are
 `autoDeploy: "no"` / `autoDeployTrigger: "off"`:
 
 | Service | Branch | Auto-deploy | Who deploys |
 |---|---|---|---|
 | `liquidity-hq-prod` → liquidity-hq.com | `main` | **no** | **QA only** |
-| `liquidity-hq-qa` → liquidity-hq-qa.onrender.com | `qa` | **yes** | nobody — it deploys itself |
+| `liquidity-hq-qa` → liquidity-hq-qa.onrender.com | `qa` | **no** | whoever merged `dev` → `qa` |
 | `liquidity-hq-dev` → liquidity-hq-dev.onrender.com | `dev` | **no** | dev, ask first |
 
 So **merging to `main` ships nothing on its own.** Production keeps serving the
@@ -360,7 +360,7 @@ The flow is `dev` → `qa` → `main`.
 |---|---|---|---|
 | `<type>/<description>` | none | dev | n/a |
 | `dev` | liquidity-hq-dev.onrender.com | dev | **no** — trigger manually |
-| `qa` | **liquidity-hq-qa.onrender.com** | dev merges `dev` → `qa` | **yes** — on every push |
+| `qa` | **liquidity-hq-qa.onrender.com** | dev merges `dev` → `qa` | **no** — trigger manually |
 | `main` | liquidity-hq.com (production) | **QA only** | **no** — trigger manually |
 
 - Feature branches are cut from `dev` and merged back into `dev` via PR.
@@ -370,17 +370,22 @@ The flow is `dev` → `qa` → `main`.
 
 ### The `qa` staging environment
 
-`qa` is the only branch that deploys on its own. Merge `dev` → `qa` and a
-build starts; no dashboard step. That is deliberate — QA should be able to get
-a testable environment without waiting on dev, which is the whole reason the
-branch exists.
+Merging `dev` → `qa` does **not** deploy. Like prod and dev, this service is
+`autoDeploy: no`, so the branch moving and the environment moving are two
+separate acts. **Whoever merges `dev` → `qa` also triggers the deploy** —
+normally dev, since getting a build in front of QA is part of the handoff. QA
+may trigger it too, for a re-deploy or after a config change.
+
+Render dashboard → `liquidity-hq-qa` → *Manual Deploy* → *Deploy latest
+commit*. Say in the PR or the handoff message that you have done it, otherwise
+QA tests the previous build and neither of you finds out for a while.
 
 | | |
 |---|---|
 | **URL** | https://liquidity-hq-qa.onrender.com |
 | **Render service** | `liquidity-hq-qa` (`srv-d9p42ke1egvs73f8car0`), free plan, Singapore |
 | **Database** | Supabase `liquidity-hq-dev` (`wdtjhrilakoitfcezxpx`) |
-| **Auto-deploy** | **yes**, on every push to `qa` |
+| **Auto-deploy** | **no** — merge, then trigger manually |
 
 **It shares the dev database, and that is a known compromise, not the design.**
 The intent was a separate `liquidity-hq-qa` Supabase project. Supabase's free

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -34,10 +34,10 @@ calculators, trade journal, and an internal-only `/ops` admin console.
 | Local checkout | `C:\Users\Dominic\Documents\VS code\liquidity-hunter-hq\liquidity-hq` |
 | Prod site | https://liquidity-hq.com (also `liquidity-hq.onrender.com`) |
 | Dev site | https://liquidity-hq-dev.onrender.com |
-| **QA / staging site** | **https://liquidity-hq-qa.onrender.com** — branch `qa`, **auto-deploys** |
+| **QA / staging site** | **https://liquidity-hq-qa.onrender.com** — branch `qa`, deploy manually |
 | Render prod service | `srv-d8aluf6l51nc73e1ijp0` — branch `main` |
 | Render dev service | `srv-d8prs6po3t8c739aepdg` — branch `dev` |
-| Render **qa** service | `srv-d9p42ke1egvs73f8car0` — branch `qa`, free plan, auto-deploy ON |
+| Render **qa** service | `srv-d9p42ke1egvs73f8car0` — branch `qa`, free plan, auto-deploy OFF |
 | Supabase **prod** | project `liquidity-hq-prod`, ref `qdpwhnvmhqgzijuwopso` — tables `lhq_*` |
 | Supabase **dev** | project `liquidity-hq-dev`, ref `wdtjhrilakoitfcezxpx` — tables `lhq_dev_*` |
 | Supabase **qa** | none of its own — the qa service shares the **dev** project. Free plan caps the account at 2 active projects |

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -34,10 +34,13 @@ calculators, trade journal, and an internal-only `/ops` admin console.
 | Local checkout | `C:\Users\Dominic\Documents\VS code\liquidity-hunter-hq\liquidity-hq` |
 | Prod site | https://liquidity-hq.com (also `liquidity-hq.onrender.com`) |
 | Dev site | https://liquidity-hq-dev.onrender.com |
+| **QA / staging site** | **https://liquidity-hq-qa.onrender.com** — branch `qa`, **auto-deploys** |
 | Render prod service | `srv-d8aluf6l51nc73e1ijp0` — branch `main` |
 | Render dev service | `srv-d8prs6po3t8c739aepdg` — branch `dev` |
+| Render **qa** service | `srv-d9p42ke1egvs73f8car0` — branch `qa`, free plan, auto-deploy ON |
 | Supabase **prod** | project `liquidity-hq-prod`, ref `qdpwhnvmhqgzijuwopso` — tables `lhq_*` |
 | Supabase **dev** | project `liquidity-hq-dev`, ref `wdtjhrilakoitfcezxpx` — tables `lhq_dev_*` |
+| Supabase **qa** | none of its own — the qa service shares the **dev** project. Free plan caps the account at 2 active projects |
 | Error tracking | GlitchTip — `app.glitchtip.com/liquidityhq/issues`, project id `25983` |
 | Analytics / replay | PostHog |
 | Email | Brevo (SMTP relay + transactional API) |

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -8,15 +8,18 @@ This file exists because the codebase alone doesn't tell the whole story. `docs/
 
 ## 1. Hosting — Render
 
-Three services, one Render account, org workspace shared with unrelated projects (`n8n workflows` is also used by other automations, not exclusive to LHQ).
+Four services, one Render account, org workspace shared with unrelated projects (`n8n workflows` is also used by other automations, not exclusive to LHQ).
 
 | Service | Render ID | Plan | Region | Branch | URL | Purpose |
 |---|---|---|---|---|---|---|
 | `liquidity-hq-prod` | `srv-d8aluf6l51nc73e1ijp0` | starter | Singapore | `main` | `liquidity-hq.onrender.com` | Production. `npm install; npm run build` → `npm start`. |
-| `liquidity-hq-dev` | `srv-d8prs6po3t8c739aepdg` | free | Singapore | `dev` | `liquidity-hq-dev.onrender.com` | Staging. Free plan — spins down after inactivity, first request after idle is slow/can fail. |
+| `liquidity-hq-dev` | `srv-d8prs6po3t8c739aepdg` | free | Singapore | `dev` | `liquidity-hq-dev.onrender.com` | Dev integration. Free plan — spins down after inactivity, first request after idle is slow/can fail. |
+| `liquidity-hq-qa` | `srv-d9p42ke1egvs73f8car0` | free | Singapore | `qa` | `liquidity-hq-qa.onrender.com` | **Staging — the environment QA tests against.** The ONLY service with auto-deploy ON: every push to `qa` builds and ships by itself. Uses the **dev** Supabase project (free plan caps the account at 2 active projects, so it has none of its own). Free plan, so it sleeps when idle. |
 | `n8n-workflows` | `srv-d6e4fkq4d50c73b8dpk0` | starter | Singapore | n/a (Docker image `n8nio/n8n:latest`) | `n8n-workflows-6ig6.onrender.com` | Self-hosted n8n instance, 5GB persistent disk. Shared across projects, not LHQ-exclusive. |
 
-Both `liquidity-hq-prod` and `liquidity-hq-dev` have `autoDeploy: no` — pushing to `main`/`dev` does **not** auto-deploy. Deploys are triggered manually (via Render dashboard, the `mcp__render__trigger_deploy` tool, or `git push` if that ever changes).
+`liquidity-hq-prod` and `liquidity-hq-dev` have `autoDeploy: no` — pushing to `main`/`dev` does **not** auto-deploy. Deploys are triggered manually (via Render dashboard, the `mcp__render__trigger_deploy` tool, or `git push` if that ever changes).
+
+**`liquidity-hq-qa` is the exception and the only one: `autoDeploy: yes`.** Pushing to `qa` deploys with no human step, which is the point — QA should not have to wait on dev to get a testable build. It also means a bad merge into `qa` is live in minutes, so CI runs on `qa` too (`.github/workflows/ci.yml`).
 
 `render.yaml` in this repo has **no cron job definitions** — Render's own Cron Jobs feature is not used anywhere for this project (it has no free tier, unlike the alternatives below).
 

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -14,12 +14,12 @@ Four services, one Render account, org workspace shared with unrelated projects 
 |---|---|---|---|---|---|---|
 | `liquidity-hq-prod` | `srv-d8aluf6l51nc73e1ijp0` | starter | Singapore | `main` | `liquidity-hq.onrender.com` | Production. `npm install; npm run build` → `npm start`. |
 | `liquidity-hq-dev` | `srv-d8prs6po3t8c739aepdg` | free | Singapore | `dev` | `liquidity-hq-dev.onrender.com` | Dev integration. Free plan — spins down after inactivity, first request after idle is slow/can fail. |
-| `liquidity-hq-qa` | `srv-d9p42ke1egvs73f8car0` | free | Singapore | `qa` | `liquidity-hq-qa.onrender.com` | **Staging — the environment QA tests against.** The ONLY service with auto-deploy ON: every push to `qa` builds and ships by itself. Uses the **dev** Supabase project (free plan caps the account at 2 active projects, so it has none of its own). Free plan, so it sleeps when idle. |
+| `liquidity-hq-qa` | `srv-d9p42ke1egvs73f8car0` | free | Singapore | `qa` | `liquidity-hq-qa.onrender.com` | **Staging — the environment QA tests against.** `autoDeploy: no`, like the other two: merging `dev` → `qa` moves the branch, not the environment. Uses the **dev** Supabase project (free plan caps the account at 2 active projects, so it has none of its own). Free plan, so it sleeps when idle. |
 | `n8n-workflows` | `srv-d6e4fkq4d50c73b8dpk0` | starter | Singapore | n/a (Docker image `n8nio/n8n:latest`) | `n8n-workflows-6ig6.onrender.com` | Self-hosted n8n instance, 5GB persistent disk. Shared across projects, not LHQ-exclusive. |
 
-`liquidity-hq-prod` and `liquidity-hq-dev` have `autoDeploy: no` — pushing to `main`/`dev` does **not** auto-deploy. Deploys are triggered manually (via Render dashboard, the `mcp__render__trigger_deploy` tool, or `git push` if that ever changes).
+All three LHQ services have `autoDeploy: no` — pushing to `main`/`dev` does **not** auto-deploy. Deploys are triggered manually (via Render dashboard, the `mcp__render__trigger_deploy` tool, or `git push` if that ever changes).
 
-**`liquidity-hq-qa` is the exception and the only one: `autoDeploy: yes`.** Pushing to `qa` deploys with no human step, which is the point — QA should not have to wait on dev to get a testable build. It also means a bad merge into `qa` is live in minutes, so CI runs on `qa` too (`.github/workflows/ci.yml`).
+`liquidity-hq-qa` is the same: `autoDeploy: no`. **No service in this project auto-deploys.** Whoever merges `dev` → `qa` triggers the qa deploy — normally dev, as part of handing the build to QA. CI runs on `qa` as well (`.github/workflows/ci.yml`), so a merge is checked even though it does not ship by itself.
 
 `render.yaml` in this repo has **no cron job definitions** — Render's own Cron Jobs feature is not used anywhere for this project (it has no free tier, unlike the alternatives below).
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,5 +1,14 @@
+# NOT the source of truth. All three services were created and are configured
+# through the Render dashboard/API, and this file is not applied as a Blueprint.
+# Two things it says are already false of the live services:
+#   - the "auto-deploys" comments below are wrong. liquidity-hq and
+#     liquidity-hq-dev both have autoDeploy: no; deploys are manual.
+#   - liquidity-hq-qa (branch `qa`, the staging environment QA tests against,
+#     and the only service with auto-deploy actually ON) is missing entirely.
+# Kept as a rough record of build/start commands. Read docs/INFRASTRUCTURE.md
+# section 1 for what is really deployed.
 services:
-  # ── Production - auto-deploys from main ─────────────────────────────────────
+  # ── Production - deploys from main (MANUAL trigger, not automatic) ──────────
   - type: web
     name: liquidity-hq
     runtime: node

--- a/render.yaml
+++ b/render.yaml
@@ -3,8 +3,8 @@
 # Two things it says are already false of the live services:
 #   - the "auto-deploys" comments below are wrong. liquidity-hq and
 #     liquidity-hq-dev both have autoDeploy: no; deploys are manual.
-#   - liquidity-hq-qa (branch `qa`, the staging environment QA tests against,
-#     and the only service with auto-deploy actually ON) is missing entirely.
+#   - liquidity-hq-qa (branch `qa`, the staging environment QA tests against)
+#     is missing entirely.
 # Kept as a rough record of build/start commands. Read docs/INFRASTRUCTURE.md
 # section 1 for what is really deployed.
 services:


### PR DESCRIPTION
## Summary

`qa` is now a real staging environment, not just a branch. Merging `dev` → `qa` auto-deploys to https://liquidity-hq-qa.onrender.com with no dashboard step. This documents it.

## What changed

`CONTRIBUTING.md` §6 and `CLAUDE.md`:

- Branch table gains a `qa` row — the **only** branch that auto-deploys
- New subsection with the staging URL, Render service id, Supabase project, and the two limitations below
- The flow is stated as `dev` → `qa` → `main`

## What was actually built

| | |
|---|---|
| Branch | `qa`, cut from `dev` at `172e1b4` |
| Render service | `liquidity-hq-qa` (`srv-d9p42ke1egvs73f8car0`), **free plan**, Singapore |
| URL | https://liquidity-hq-qa.onrender.com — **verified live, HTTP 200** |
| Auto-deploy | **yes**, on every push to `qa` |
| Database | Supabase `liquidity-hq-dev` (`wdtjhrilakoitfcezxpx`) |

**Production isolation verified, not assumed.** I pulled the 17 JS chunks the QA site serves and grepped them: **1 references the dev Supabase ref, 0 reference the production ref** (`qdpwhnvmhqgzijuwopso`).

## Two limitations, recorded rather than left to be discovered

**It shares the dev database.** A separate `liquidity-hq-qa` project was attempted and rejected — Supabase's free plan caps an *account* at two active projects across every org it owns, and dev + prod already use both. Deleting two unrelated paused projects did not free a slot (the cap counts *active* projects), and a new org does not help either, because the limit follows the account rather than the org. So QA test data and dev data now share one database and can overwrite each other. **A clean QA run is therefore not proof the data path is clean**, and nobody would guess that from the URL.

**It sleeps.** Free plan spins down when idle, so the first request afterwards is slow or times out. That is the tier, not a defect — it will otherwise get reported as one.

## How to test (QA)

1. `git fetch && git checkout docs/qa-staging-environment`.
2. `CONTRIBUTING.md` §6 — the branch table should have four rows, and `qa` should be the only one marked as deploying automatically.
3. The subsection below it should give the staging URL, the Render service id, which Supabase project it uses, and why it is shared.
4. `CLAUDE.md` should say the same in short form, including the never-point-at-prod rule and the prod project ref.
5. Open https://liquidity-hq-qa.onrender.com — it should load. If it is slow or times out on the first hit, that is the free tier waking up; retry once.
6. The real test: merge `dev` into `qa` and push. A build should start on its own in the Render dashboard, with no manual trigger.

## Risk level

**Low** for this PR — documentation only. The infrastructure it describes already exists and is verified.

Worth stating plainly: the environment itself is **Medium** risk to rely on, because of the shared database. It is fine for testing UI, routing and behaviour. It is not a trustworthy test of anything data-isolation-shaped.

## Screenshots (if UI change)

N/A.
