### PR TITLE
ci: run CI on the qa branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,20 @@
 name: CI
 
 on:
+  # qa matters most of the three. It is the only branch that deploys itself
+  # (Render auto-deploy is on for liquidity-hq-qa), so before this it was also
+  # the only branch that could ship to a live environment with nothing checked
+  # first - the exact inverse of what you want. A push to qa now has to pass
+  # lint, typecheck, unit tests and a build like everywhere else.
   push:
-    branches: [dev, main]
+    branches: [dev, qa, main]
   # Also on PRs, or CI only ever runs AFTER a merge - which is the one moment
   # it cannot help. The convention makes the PR the review point (CONTRIBUTING
   # section 4), so the checks have to be green before the merge button, not
   # after. Covers PRs from any branch, including QA-authored ones, which a
   # push trigger limited to [dev, main] never sees.
   pull_request:
-    branches: [dev, main]
+    branches: [dev, qa, main]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,11 @@
 name: CI
 
 on:
-  # qa matters most of the three. It is the only branch that deploys itself
-  # (Render auto-deploy is on for liquidity-hq-qa), so before this it was also
-  # the only branch that could ship to a live environment with nothing checked
-  # first - the exact inverse of what you want. A push to qa now has to pass
-  # lint, typecheck, unit tests and a build like everywhere else.
+  # qa is the branch QA tests against, so a broken merge into it costs QA a
+  # wasted test run and a false bug report before anyone looks at CI. Checking
+  # it here is cheaper than that. Note the qa Render service does NOT
+  # auto-deploy - a merge into qa is not live until someone triggers it - so
+  # this is a gate on the branch, not a last line of defence before users.
   push:
     branches: [dev, qa, main]
   # Also on PRs, or CI only ever runs AFTER a merge - which is the one moment


### PR DESCRIPTION
## Summary

CI now runs on the `qa` branch, not just `dev` and `main`.

## What changed

`.github/workflows/ci.yml` — `push` and `pull_request` triggers go from `[dev, main]` to `[dev, qa, main]`.

## Why

`qa` is the branch QA tests against, and it was the only branch CI ignored. A broken merge into `qa` costs QA a wasted test run and a false bug report before anyone thinks to look at CI — which is more expensive than the check.

Note this is a gate on the branch, not a last line of defence before users: the `qa` Render service does **not** auto-deploy (verified `autoDeploy: "no"`), so a merge into `qa` is not live until someone triggers it.

## How to test (QA)

1. `git fetch && git checkout ci/run-on-qa-branch`, confirm `.github/workflows/ci.yml` line 4–13 lists `[dev, qa, main]` for both `push` and `pull_request`.
2. After this merges, push any commit to `qa` and confirm the CI workflow appears in the Actions tab for it.
3. Open a PR targeting `qa` and confirm CI runs on the PR too.
4. Both jobs should appear — `Lint + typecheck + test + build`, then `E2E (Playwright)`.

## Risk level

**Low** — one line in a workflow file, no application code. It adds a check where there was none; it cannot make anything fail that was passing.

The E2E job will still fail until the three repo secrets exist (`E2E_SUPABASE_URL`, `E2E_SUPABASE_ANON_KEY`, `E2E_TURNSTILE_SITE_KEY`). That is pre-existing and unrelated to this change.

## Screenshots (if UI change)

N/A.
