### PR TITLE
docs(infra): record the NEXT_PUBLIC_APP_ENV trap and the QA environment

### DIFF
--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -174,10 +174,34 @@ deliberate exceptions. Set as of 2026-08-05:
 
 | Variable | Why not |
 |---|---|
-| `TELEGRAM_BOT_TOKEN` and the other `TELEGRAM_*` | **One webhook per bot.** If two services register a webhook against the same token, the last one wins and silently steals every alert from the other. That exact bug cost a day here (see `pendings/PENDING.md`). QA needs its own bot or no Telegram at all |
 | `NEXT_PUBLIC_POSTHOG_KEY` | QA test runs would land in product analytics and corrupt the numbers |
 | `LEMONSQUEEZY_WEBHOOK_SECRET` etc. | Payments. Staging has no business holding these |
 | `CRON_SECRET` | Cron routes fail **closed** without it (`lib/cronAuth.ts`), which is the desired state on staging |
+
+### Telegram on QA — currently dev's bot, safe only by accident
+
+**`TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID` and `TELEGRAM_WEBHOOK_SECRET` on the
+qa service are copies of dev's.** That is not the intended end state.
+
+Why it has not broken anything yet: registering a webhook goes through
+`/api/telegram/setup-webhook`, which is gated by `checkCronAuth`, and
+`CRON_SECRET` is **unset** on qa. `checkCronAuth` fails **closed** with no secret
+configured, so the route answers 401 and qa cannot re-register the webhook.
+Verified 2026-08-05: `GET /api/telegram/setup-webhook` on qa returns
+`{"error":"Unauthorized"}`.
+
+**So the safety property is: qa must not have `CRON_SECRET` while it shares
+dev's bot token.** Setting `CRON_SECRET` on qa without first giving it its own
+bot hands qa the ability to point dev's bot at itself, silently stealing every
+alert. That is the bug that already cost a day on this project.
+
+What qa can still do today: send outbound messages into the real dev chat during
+test runs. Noisy, not destructive. It cannot receive anything - the webhook
+points at dev - so `/start`, account linking and bot commands are untestable on
+qa either way.
+
+The fix is a dedicated QA bot; see `pendings/PENDING.md`. Until then, treat
+`CRON_SECRET` on qa as forbidden rather than merely absent.
 
 `NEXT_PUBLIC_TURNSTILE_SITE_KEY` is domain-locked. Copying dev's value is not
 enough — add `liquidity-hq-qa.onrender.com` to that widget's allowed domains in

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -124,6 +124,67 @@ Table naming convention (enforced in code, see `docs/ARCHITECTURE.md` §8): alwa
 
 ---
 
+## 4b. `NEXT_PUBLIC_APP_ENV` — a switch, not a label
+
+**It has exactly two states: `dev`, and everything else. Anything that is not
+the literal string `dev` selects production behaviour.**
+
+```ts
+// lib/tables.ts
+const p = process.env.NEXT_PUBLIC_APP_ENV === 'dev' ? 'lhq_dev_' : 'lhq_';
+```
+
+Same test in `app/api/lemonsqueezy/webhook/route.ts` (`!== 'dev'` means treat as
+production), `lib/apiHealth.ts`, and `app/api/auth/ban-reason/route.ts`.
+
+So setting it to a plausible-looking environment name — `qa`, `staging`,
+`test`, `preview` — silently gives that deployment **production table names and
+production webhook handling**. Nothing errors. It is a value that looks correct
+and is not.
+
+This is not hypothetical: the `liquidity-hq-qa` service was first created with
+`NEXT_PUBLIC_APP_ENV=qa`, which pointed it at `lhq_*` tables. Corrected to `dev`
+on 2026-08-05.
+
+**Rule: any non-production deployment sets it to `dev`, whatever the service is
+called.** It names the *data set*, not the environment. If a third value is ever
+genuinely needed, change the comparisons in all four files first — a new value
+without that is a silent switch to production.
+
+It is a `NEXT_PUBLIC_*` variable, so it is **inlined at build time**. Changing it
+requires a rebuild, not a restart.
+
+---
+
+## 4c. QA service environment variables
+
+`liquidity-hq-qa` is configured from `liquidity-hq-dev`'s values, with
+deliberate exceptions. Set as of 2026-08-05:
+
+| Variable | Value | Why |
+|---|---|---|
+| `NEXT_PUBLIC_APP_ENV` | `dev` | **Not `qa`** — see §4b |
+| `NEXT_PUBLIC_APP_URL` | `https://liquidity-hq-qa.onrender.com` | Its own URL, never dev's. Telegram webhook registration and email links build absolute URLs from this |
+| `NEXT_PUBLIC_SUPABASE_URL` / `_ANON_KEY` | dev project `wdtjhrilakoitfcezxpx` | Shares the dev database — see §1 |
+| `SUPABASE_SERVICE_ROLE_KEY` | dev project's | Server routes return empty results without it. `/api/labels` answered `{}` until it was set |
+| `AI_GLOBAL_DAILY_MAX` | `25` | Low cap. QA testing spends real xAI credit |
+| `CMC_API_KEY`, `FINNHUB_KEY`, `GROK_API_KEY` | copied from dev | Shares dev's quota |
+
+**Deliberately unset, do not "fix" these:**
+
+| Variable | Why not |
+|---|---|
+| `TELEGRAM_BOT_TOKEN` and the other `TELEGRAM_*` | **One webhook per bot.** If two services register a webhook against the same token, the last one wins and silently steals every alert from the other. That exact bug cost a day here (see `pendings/PENDING.md`). QA needs its own bot or no Telegram at all |
+| `NEXT_PUBLIC_POSTHOG_KEY` | QA test runs would land in product analytics and corrupt the numbers |
+| `LEMONSQUEEZY_WEBHOOK_SECRET` etc. | Payments. Staging has no business holding these |
+| `CRON_SECRET` | Cron routes fail **closed** without it (`lib/cronAuth.ts`), which is the desired state on staging |
+
+`NEXT_PUBLIC_TURNSTILE_SITE_KEY` is domain-locked. Copying dev's value is not
+enough — add `liquidity-hq-qa.onrender.com` to that widget's allowed domains in
+Cloudflare, or the login captcha fails on the qa host only.
+
+---
+
 ## 5. Third-Party APIs
 
 From `.env.example` — the authoritative list of what needs a key. Whether each key is actually *set* on Render (prod/dev) is not visible to an assistant; only that the app expects it.

--- a/pendings/PENDING.md
+++ b/pendings/PENDING.md
@@ -835,3 +835,29 @@ translations in either project, so choosing one silently rendered English.
 stays complete: it is the validation list, so a preference already saved as
 `tr` still resolves to English instead of erroring. Re-adding a language is a
 one-line change to `AVAILABLE_LOCALES` once its rows land.
+
+---
+
+## ⛔ OPEN — `/api/ath` is rate-limited by CoinGecko on the QA service
+
+**Found 2026-08-05** while verifying the new `qa` staging environment.
+
+| Host | `/api/ath` |
+|---|---|
+| liquidity-hq.com (prod) | **200** |
+| liquidity-hq-qa.onrender.com | **502** — `{"error":"CoinGecko 429"}`, three attempts |
+
+`app/api/ath/route.ts` calls CoinGecko's keyless public API, which rate-limits
+per IP. The QA service is a new Render instance sharing the same egress pool, so
+it arrives at a bucket that is already close to spent.
+
+**Same shape as the Binance fan-out**: a keyless public upstream, a per-IP
+limit, and no server-side cache in front of it. `lib/apiCache.ts` already exists
+and is used by `/api/funding` and `/api/proxy`; `/api/ath` does not use it. A
+`cached()` wrapper with a long TTL is the obvious fix - all-time-high prices are
+about as slow-moving as data gets, so a multi-hour cache costs nothing and
+removes almost all the requests.
+
+Not blocking QA: the ATH figure is one number on the page and it fails soft.
+Worth fixing because a third environment makes every keyless per-IP upstream in
+this app one step closer to its limit, and ATH is just the first one to show it.

--- a/pendings/PENDING.md
+++ b/pendings/PENDING.md
@@ -861,3 +861,48 @@ removes almost all the requests.
 Not blocking QA: the ATH figure is one number on the page and it fails soft.
 Worth fixing because a third environment makes every keyless per-IP upstream in
 this app one step closer to its limit, and ATH is just the first one to show it.
+
+---
+
+## ⛔ OPEN — QA needs its own Telegram bot (owner decided option B, parked)
+
+**Decided 2026-08-05, deferred to when QA needs it.**
+
+`liquidity-hq-qa` currently holds **dev's** `TELEGRAM_BOT_TOKEN`,
+`TELEGRAM_CHAT_ID` and `TELEGRAM_WEBHOOK_SECRET`, copied over when the service
+was configured from dev's environment.
+
+**It is safe today only because `CRON_SECRET` is unset on qa.** Registering a
+webhook goes through `/api/telegram/setup-webhook`, gated by `checkCronAuth`,
+which fails **closed** with no secret configured. Verified: that route returns
+`401 {"error":"Unauthorized"}` on qa.
+
+**So: do not set `CRON_SECRET` on qa until it has its own bot.** Doing so hands
+qa the ability to point dev's bot at itself and silently steal every alert —
+the same failure that already cost a day on this project (see the webhook
+hijack section above).
+
+### What option B needs, when it is picked up
+
+1. **BotFather → `/newbot`**, named `Liquidity_hq_qa_bot` to match the dev
+   naming (`Liquidity_hq_dev_bot`).
+2. On `liquidity-hq-qa`, set **all three fresh, none copied**:
+   - `TELEGRAM_BOT_TOKEN` — the new bot's
+   - `TELEGRAM_WEBHOOK_SECRET` — new random string
+   - `CRON_SECRET` — new random string, **different from dev's and prod's**.
+     Safe at this point, and required: it is what unlocks
+     `/api/telegram/setup-webhook`.
+   `TELEGRAM_CHAT_ID` can stay — it only says where alerts land, and messages
+   will visibly come from the new bot.
+3. After the redeploy, register the webhook:
+   `GET /api/telegram/setup-webhook?secret=<the new CRON_SECRET>` — expect
+   `webhook_ok: true`.
+
+**Consequence to accept deliberately:** giving qa a `CRON_SECRET` also makes
+`/api/telegram/alert`, `/api/macro-alert` and `/api/signals/track` triggerable
+there, so QA runs can fire real alerts into the chat. That is the point of
+option B, but it is a change in what a QA session can set off.
+
+**Until then**, Telegram is only half-testable on qa: outbound messages reach
+the real dev chat, inbound (`/start`, account linking, bot commands) never
+arrives because the webhook belongs to dev.


### PR DESCRIPTION
## Summary

Records how the `qa` service is actually configured, and documents a variable that silently selects production behaviour when set to anything sensible-looking.

## What changed

`docs/INFRASTRUCTURE.md`:

- **New §4b — `NEXT_PUBLIC_APP_ENV` is a switch, not a label.** It compares against the literal string `dev` in four files. Anything else means production.
- **New §4c — the qa service's variables**, what is deliberately unset and why, plus the real state of Telegram there.

`pendings/PENDING.md`:

- QA needs its own Telegram bot — option B, agreed and parked, with the steps.
- `/api/ath` is rate-limited by CoinGecko on the qa host.

## Why

**§4b exists because it already caught me.** I created the qa service with `NEXT_PUBLIC_APP_ENV=qa`, which is the obvious value and the wrong one:

```ts
const p = process.env.NEXT_PUBLIC_APP_ENV === 'dev' ? 'lhq_dev_' : 'lhq_';
```

Same `=== 'dev'` / `!== 'dev'` test in `lib/apiHealth.ts`, `app/api/lemonsqueezy/webhook/route.ts` and `app/api/auth/ban-reason/route.ts`. So `qa` gave that service **production table names and production webhook handling**, with nothing erroring. Corrected to `dev` and redeployed. A value that looks right and isn't deserves its own section.

**§4c exists because the qa configuration lived only in conversation.** The unset variables are decisions, not omissions.

**The Telegram part is a correction to my own work.** I wrote that `TELEGRAM_*` was unset on qa. It isn't — dev's token was copied across. Documenting an intention as though it were the state is exactly what this file warns against on line 5.

The real situation is safe **by accident, not design**: qa holds dev's bot token, and the only thing stopping it re-registering dev's webhook — silently stealing every alert — is that `CRON_SECRET` is unset, so `checkCronAuth` fails closed. Verified live, not inferred:

```
GET https://liquidity-hq-qa.onrender.com/api/telegram/setup-webhook
→ 401 {"error":"Unauthorized"}
```

That makes `CRON_SECRET` on qa **forbidden**, not merely absent — which is invisible in a variable list where it simply doesn't appear.

## How to test (QA)

1. `git fetch && git checkout docs/qa-env-and-app-env-trap`.
2. `docs/INFRASTRUCTURE.md` §4b — should state that any value other than `dev` means production, name the four files, and say non-production deployments use `dev`.
3. §4c — should list the qa service's variables, a second table of deliberately-unset ones, and a "Telegram on QA" subsection saying qa holds dev's token and `CRON_SECRET` must not be set until qa has its own bot.
4. Confirm §4c does **not** still claim `TELEGRAM_*` is unset.
5. `pendings/PENDING.md` — two new sections: the QA Telegram bot plan with three BotFather steps, and the `/api/ath` CoinGecko finding with the 200-vs-502 comparison.
6. Optional, confirms the claim rather than trusting it: `curl https://liquidity-hq-qa.onrender.com/api/telegram/setup-webhook` → should be `401`.

## Risk level

**Low** — documentation only, no code, no config.

Worth noting the underlying situation it describes is **Medium**: qa runs on dev's bot token, and one plausible-looking environment variable change would turn that into a live alert-hijack. The doc is what makes that visible.

## Screenshots (if UI change)

N/A.
