### PR TITLE
fix(api): serve the last good ATH when CoinGecko rate-limits us

### DIFF
--- a/__tests__/apiCacheStale.test.mts
+++ b/__tests__/apiCacheStale.test.mts
@@ -1,0 +1,69 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { cachedStale } from '../lib/apiCache.ts';
+
+/* cachedStale exists so /api/ath keeps answering when CoinGecko rate-limits the
+   server's IP. The interesting behaviour is all in the failure path, which is
+   exactly the path that never runs in normal development. */
+test('cachedStale', async (t) => {
+  let n = 0;
+  const uniqueKey = () => `k${++n}`;
+
+  await t.test('first call fetches and is not stale', async () => {
+    const r = await cachedStale(uniqueKey(), 60_000, async () => 'fresh');
+    assert.equal(r.data, 'fresh');
+    assert.equal(r.stale, false);
+    assert.equal(r.ageMs, 0);
+  });
+
+  await t.test('second call inside the TTL does not re-fetch', async () => {
+    const k = uniqueKey();
+    let calls = 0;
+    const f = async () => { calls++; return 'v'; };
+    await cachedStale(k, 60_000, f);
+    const r = await cachedStale(k, 60_000, f);
+    assert.equal(calls, 1, 'fetcher should not run again inside the TTL');
+    assert.equal(r.stale, false);
+  });
+
+  await t.test('serves the last good value when the fetcher throws', async () => {
+    const k = uniqueKey();
+    await cachedStale(k, 0, async () => 'good');
+    // ttl 0 forces a re-fetch, and this one fails - the CoinGecko 429 case.
+    const r = await cachedStale(k, 0, async () => { throw new Error('CoinGecko 429'); });
+    assert.equal(r.data, 'good', 'must fall back rather than propagate');
+    assert.equal(r.stale, true);
+  });
+
+  await t.test('throws when it fails with nothing cached', async () => {
+    /* Cold start plus a failing upstream is a real failure - there is no
+       previous answer to serve, so the route has to return an error rather
+       than invent one. */
+    await assert.rejects(
+      () => cachedStale(uniqueKey(), 60_000, async () => { throw new Error('boom'); }),
+      /boom/,
+    );
+  });
+
+  await t.test('does not settle into serving stale forever', async () => {
+    /* A failure must not refresh the timestamp. If it did, one outage would
+       pin the stale value for a full TTL and recovery would be delayed long
+       after the upstream came back. */
+    const k = uniqueKey();
+    await cachedStale(k, 0, async () => 'v1');
+    await cachedStale(k, 0, async () => { throw new Error('down'); });
+    const r = await cachedStale(k, 0, async () => 'v2');
+    assert.equal(r.data, 'v2', 'should retry and pick up the recovery immediately');
+    assert.equal(r.stale, false);
+  });
+
+  await t.test('a successful fetch after a failure replaces the stale value', async () => {
+    const k = uniqueKey();
+    await cachedStale(k, 0, async () => 'old');
+    await cachedStale(k, 0, async () => { throw new Error('down'); });
+    await cachedStale(k, 0, async () => 'new');
+    const r = await cachedStale(k, 60_000, async () => { throw new Error('should not run'); });
+    assert.equal(r.data, 'new');
+    assert.equal(r.stale, false);
+  });
+});

--- a/app/api/ath/route.ts
+++ b/app/api/ath/route.ts
@@ -1,6 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { apiError } from '@/lib/apiError';
 import { rateLimit, getClientIp } from '@/lib/rateLimit';
+import { cachedStale } from '@/lib/apiCache';
+import { reportHealth, healthError } from '@/lib/apiHealth';
+
+/* All-time highs move a few times a year at most, so this is cached hard and
+   served stale rather than failed when CoinGecko is unavailable.
+   `next: { revalidate }` alone was not enough: it caches successful responses
+   only, so a 429 was re-requested on every single hit and answered 502 every
+   time. Measured on the qa service - every attempt returned
+   {"error":"CoinGecko 429"} while production, on a different instance, was
+   fine. The IP had spent its budget on a keyless public API and the route had
+   no memory of the last good answer. */
+const ATH_TTL = 6 * 60 * 60_000;
 
 const CG_IDS: Record<string, string> = {
   btc:  'bitcoin',
@@ -36,40 +48,62 @@ export async function GET(req: NextRequest) {
   const url = `https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=${ids}&per_page=50&sparkline=false`;
 
   try {
-    const r = await fetch(url, {
-      next: { revalidate: 3600 },
-      headers: { 'Accept': 'application/json' },
-    });
+    const { data: result, stale, ageMs } = await cachedStale<Record<string, AthEntry>>(
+      'ath', ATH_TTL, async () => {
+        const r = await fetch(url, {
+          cache: 'no-store',   // cachedStale owns the caching now
+          headers: { 'Accept': 'application/json' },
+        });
+        if (!r.ok) throw new Error(`CoinGecko ${r.status}`);
 
-    if (!r.ok) {
-      return NextResponse.json({ error: `CoinGecko ${r.status}` }, { status: 502 });
-    }
+        const data: Array<{
+          id: string;
+          ath: number;
+          ath_date: string;
+          ath_change_percentage: number;
+        }> = await r.json();
 
-    const data: Array<{
-      id: string;
-      ath: number;
-      ath_date: string;
-      ath_change_percentage: number;
-    }> = await r.json();
+        const cgToOur = Object.fromEntries(
+          Object.entries(CG_IDS).map(([ours, cg]) => [cg, ours])
+        );
 
-    const cgToOur = Object.fromEntries(
-      Object.entries(CG_IDS).map(([ours, cg]) => [cg, ours])
+        const out: Record<string, AthEntry> = {};
+        for (const coin of data) {
+          const ourId = cgToOur[coin.id];
+          if (ourId && coin.ath != null) {
+            out[ourId] = {
+              ath: coin.ath,
+              athDate: coin.ath_date,
+              drawdownPct: coin.ath_change_percentage,
+            };
+          }
+        }
+        /* An empty object would otherwise be cached as a perfectly good answer
+           and served for six hours. CoinGecko returning 200 with nothing usable
+           is a failure wearing a success's clothes. */
+        if (Object.keys(out).length === 0) throw new Error('CoinGecko returned no usable rows');
+        return out;
+      },
     );
 
-    const result: Record<string, AthEntry> = {};
-    for (const coin of data) {
-      const ourId = cgToOur[coin.id];
-      if (ourId && coin.ath != null) {
-        result[ourId] = {
-          ath: coin.ath,
-          athDate: coin.ath_date,
-          drawdownPct: coin.ath_change_percentage,
-        };
-      }
-    }
+    reportHealth('coingecko:ath', 'market', !stale,
+      stale ? `serving ${Math.round(ageMs / 60_000)}min-old data - upstream failing`
+            : `${Object.keys(result).length} coins`,
+      Object.keys(result).length);
 
-    return NextResponse.json(result);
+    return NextResponse.json(result, {
+      headers: {
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+        /* Debug-only. The body shape is unchanged so nothing downstream has to
+           care, but "is this stale?" is the first question when a number looks
+           wrong, and it should not require reading server logs to answer. */
+        'X-Data-Stale': stale ? `true; age=${Math.round(ageMs / 1000)}s` : 'false',
+      },
+    });
   } catch (e) {
-    return apiError('ath', e, 500, 'Request failed');
+    /* Only reached on a cold cache - no previous good value exists to fall
+       back to, so this really is a failure. */
+    reportHealth('coingecko:ath', 'market', false, healthError(e));
+    return apiError('ath', e, 502, 'Upstream unavailable');
   }
 }

--- a/lib/apiCache.ts
+++ b/lib/apiCache.ts
@@ -18,3 +18,42 @@ export async function cached<T>(key: string, ttlMs: number, fetcher: () => Promi
   store.set(key, { ts: Date.now(), data });
   return data;
 }
+
+/* Same as `cached`, but keeps serving the last good value when the fetcher
+ * fails instead of propagating the error.
+ *
+ * `cached` leaves a stale entry in place on failure but will not hand it back,
+ * so a caller gets an exception and typically turns it into a 5xx. For data
+ * that barely moves, that is the wrong trade: an all-time high from six hours
+ * ago is correct to several decimal places, while a 502 is a hole on the page.
+ *
+ * Written for /api/ath, which asks CoinGecko's keyless public API for
+ * all-time highs. That endpoint rate-limits per IP, and adding a third
+ * environment was enough to start tripping it: the qa service returned
+ * `{"error":"CoinGecko 429"}` on every attempt while production, on a
+ * different instance, was fine. Nothing was wrong with the code - the IP had
+ * simply spent its budget, and each failed request re-asked immediately
+ * because a 429 is never cached.
+ *
+ * Only use this where stale is genuinely better than absent. Prices, balances
+ * and anything a user acts on directly should fail loudly instead.
+ */
+export async function cachedStale<T>(
+  key: string, ttlMs: number, fetcher: () => Promise<T>,
+): Promise<{ data: T; stale: boolean; ageMs: number }> {
+  const hit = store.get(key) as { ts: number; data: T } | undefined;
+  const age = hit ? Date.now() - hit.ts : Infinity;
+  if (hit && age < ttlMs) return { data: hit.data, stale: false, ageMs: age };
+
+  try {
+    const data = await fetcher();
+    store.set(key, { ts: Date.now(), data });
+    return { data, stale: false, ageMs: 0 };
+  } catch (e) {
+    /* Deliberately does NOT refresh the timestamp. Every subsequent request
+       retries the upstream rather than settling into serving stale data
+       forever, so recovery is automatic once the rate limit resets. */
+    if (hit) return { data: hit.data, stale: true, ageMs: age };
+    throw e;   // nothing cached yet - the caller has to handle a real failure
+  }
+}


### PR DESCRIPTION
## Summary

`/api/ath` returned **502 on the qa service and 200 on production**, three attempts in a row, with `{"error":"CoinGecko 429"}`. Nothing was wrong with the code — CoinGecko rate-limits per IP and a third environment was enough to trip it. The route now caches for six hours and serves the last good value instead of failing.

## What changed

- **`lib/apiCache.ts`** — new `cachedStale()`: same as `cached()`, but returns the last good value when the fetcher throws rather than propagating the error. 6 new unit tests.
- **`app/api/ath/route.ts`** — uses it with a 6-hour TTL. Response shape unchanged.

## Why

The route already had `next: { revalidate: 3600 }`. **That caches successful responses only.** A 429 is never cached, so every request re-asked CoinGecko, got 429 again, and returned 502 — with no memory of the answer it had received minutes earlier.

| Host | Before |
|---|---|
| liquidity-hq.com | 200 |
| liquidity-hq-qa.onrender.com | **502** `{"error":"CoinGecko 429"}` ×3 |

Same shape as the Binance fan-out: keyless upstream, per-IP budget, no cache in front. ATH is just the first one to surface it.

**Stale is the right trade here specifically.** An all-time high moves a few times a year — a six-hour-old figure is correct to several decimal places, while a 502 is a hole on the page. `cachedStale` deliberately **does not refresh the timestamp on failure**, so every request still retries the upstream and recovery is immediate once the limit resets, rather than being pinned stale for a full TTL. There's a test for that.

**Two smaller defects fixed while in there:**

- A `200` carrying no usable rows was being cached as a good answer and would have been served for six hours. It now throws, so the previous value is kept — a success-shaped failure was the worst case, because nothing would have looked wrong.
- The route reported nothing to the API health table, so this failure was invisible until someone curled it. Now records `coingecko:ath`, including when it's serving stale.

## How to test (QA)

1. `git fetch && git checkout fix/ath-coingecko-rate-limit`, then `npm install && npm run build && npm start`.
2. `curl -D- http://localhost:3000/api/ath` — expect **200**, about 17 coins, each with `ath`, `athDate`, `drawdownPct`, and header `X-Data-Stale: false`.
3. Call it twice more. Should stay fast and identical — only the first call reaches CoinGecko.
4. Open `/scanner` and find the **Drawdown From All-Time High** card. Values should render exactly as before — this change must be invisible there.
5. `npm test` → **59 passing** (6 new). `npx tsc --noEmit` → clean. `npm run lint` → 0 errors, 93 warnings (unchanged).
6. After this reaches `qa`, `curl https://liquidity-hq-qa.onrender.com/api/ath` should return 200 rather than the 502 it gives today. If it returns 200 with `X-Data-Stale: true`, that is also a pass — it means CoinGecko is still limiting us and the fallback is doing its job.

## Risk level

**Low** — one route, one new cache helper, no change to the response shape or to any consumer.

Honest limitation: the cache is **in-memory and per-instance**, like the existing `cached()`. A restart or a cold start empties it, and on a cold start with CoinGecko still limiting, the route genuinely fails — there is no previous value to serve. That is correct behaviour rather than a bug, but it means this reduces the failure window, it does not eliminate it. A durable cache would, and is not worth it for one number.

## Screenshots (if UI change)

N/A — no visual change. Step 4 checks the card still looks identical.
