### PR TITLE
docs(workflow): QA controls when dev is promoted to qa

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,15 @@ run as proof the data path is clean.
 
 `main` → liquidity-hq.com — QA only, merge and deploy both.
 
+**Dev QAs its own work first — QA is the second check, not the first.** A
+change reaches  already verified, and the PR says how. Before opening a PR:
+run all four gates (lint 0 errors, tsc, test, build); exercise the change rather
+than reason about it, reproducing the original failure first if it is a fix;
+measure anything numeric before and after; sweep the whole area, not the one
+symptom; and name whatever is still unverified in the PR Risk level. Test to
+apply: *if QA finds nothing, was this finished?* Finding a second defect after
+saying "done" is the same failure as not finding it.
+
 **Ask QA before promoting `dev` → `qa`.** A timing check, not a review — QA
 owns that environment and a promotion mid-test-run changes the build under the
 tester. "Ok to push?" / "hold" or "go". No answer means go; it is a courtesy,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,12 @@ run as proof the data path is clean.
 
 `main` → liquidity-hq.com — QA only, merge and deploy both.
 
+**Ask QA before promoting `dev` → `qa`.** A timing check, not a review — QA
+owns that environment and a promotion mid-test-run changes the build under the
+tester. "Ok to push?" / "hold" or "go". No answer means go; it is a courtesy,
+not a lock. QA is not reviewing the code — nothing dev writes is independently
+reviewed until QA tests the staging build.
+
 **`qa` is fast-forward only.** Never commit to it directly, never PR a feature
 branch into it. Only `dev` goes in: `git checkout qa && git merge --ff-only dev`.
 If that fails, `qa` has diverged — fix it, do not force. Delete feature branches

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ run as proof the data path is clean.
 `main` → liquidity-hq.com — QA only, merge and deploy both.
 
 **Dev QAs its own work first — QA is the second check, not the first.** A
-change reaches  already verified, and the PR says how. Before opening a PR:
+change reaches `qa` already verified, and the PR says how. Before opening a PR:
 run all four gates (lint 0 errors, tsc, test, build); exercise the change rather
 than reason about it, reproducing the original failure first if it is a fix;
 measure anything numeric before and after; sweep the whole area, not the one

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -535,11 +535,40 @@ someone who has gone home.
 
 **Worth being honest about what this does and does not fix.** It stops
 collisions. It does **not** put a second pair of eyes on the code: everything
-from a feature branch through to `main` is written, merged and promoted by dev,
-so nothing is independently reviewed until QA tests the staging build. The
-first real check on any change is QA running the "How to test" steps. That is a
-deliberate trade for a two-person team, but it should be a known one rather
-than an assumed safety net.
+from a feature branch through to `main` is written, merged and promoted by dev.
+That is a deliberate trade for a two-person team, but it should be a known one
+rather than an assumed safety net.
+
+### Dev QAs its own work first. QA is the second check, not the first.
+
+Having a QA folder does not move responsibility for quality onto it. **A change
+arrives at `qa` already verified**, and the PR says how it was verified. QA
+exists to catch what dev could not see — a different machine, a real
+environment, a user's path through the product — not to be the first person who
+looks.
+
+Before opening a PR, dev has:
+
+- **Run the gates.** `npm run lint` (0 errors), `npx tsc --noEmit`, `npm test`,
+  `npm run build`. All four, not the fast one.
+- **Exercised the change**, not reasoned about it. Load the page. Call the
+  route. If it is a fix, reproduce the original failure first and then confirm
+  it is gone — a fix that was never seen failing is a guess.
+- **Measured anything numeric, before and after.** "Feels faster" is not a
+  result. This has repeatedly mattered: the obvious suspect for `/arena`'s
+  layout shift turned out to be 0.1% of it, and the textbook fix measured twice
+  as bad as the baseline. Neither was discoverable by reading the code.
+- **Swept the whole area, not the one symptom.** If one card on a page shifts,
+  check every card on that page. If one route lacks a cache, check the sibling
+  routes with the same shape. Finding a second defect after saying "done" is
+  the same failure as not finding it.
+- **Written down what is still unverified**, in the PR's Risk level. Something
+  that genuinely cannot be checked locally — a production IP, a cold start, a
+  real environment variable — is named there, not left for QA to trip over.
+
+The test to apply before handing over: *if QA finds nothing, was this PR
+finished?* If the honest answer is "no, they would have found the obvious
+thing", it was not ready.
 
 ### Before `qa` → `main`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -496,10 +496,50 @@ essay: a title, a list of what is going out, and the checklist below.
 
 ### Before `dev` → `qa`
 
-1. CI green on `dev`.
-2. **Migrations applied.** See below — this is the one that takes prod down.
-3. Merge fast-forward only: `git checkout qa && git merge --ff-only dev`.
-4. **Trigger the qa deploy** and say you have. Merging does not deploy.
+1. **Ask QA whether now is a good time.** See below — this is a timing check,
+   not a review.
+2. CI green on `dev`.
+3. **Migrations applied.** See below — this is the one that takes prod down.
+4. Merge fast-forward only: `git checkout qa && git merge --ff-only dev`.
+5. **Trigger the qa deploy** and say you have. Merging does not deploy.
+
+### QA controls *when* `dev` → `qa` happens
+
+**Dev asks before promoting. QA answers "go" or "hold".** That is the whole
+rule.
+
+QA owns the `qa` environment because QA is the only one using it. Without this,
+dev can promote and redeploy in the middle of a test run and change the thing
+being tested underneath the tester — and the resulting bug report describes a
+build that no longer exists. Two people both being careful does not prevent
+that; only asking does.
+
+**This is a timing gate, not an approval gate, and the distinction matters.**
+QA is not being asked to review the code. The whole convention is built around
+QA being someone who cannot read it (see the top of this file), and QA cannot
+test the change either, because it is not on `qa` yet. Asking for approval here
+would produce a signature, not a check — a gate that looks like oversight and
+supplies none.
+
+So the question is only ever *"are you mid-run?"*:
+
+> **dev:** Ready to promote #16 to qa — ok to push?
+> **QA:** Hold, 10 minutes, finishing the alerts sweep.
+> *...later...*
+> **QA:** Go.
+
+QA does not need a reason to say hold, and dev does not need to justify the
+promotion. If QA does not answer, dev promotes — this is a courtesy that
+prevents wasted test runs, not a lock that stalls the pipeline waiting on
+someone who has gone home.
+
+**Worth being honest about what this does and does not fix.** It stops
+collisions. It does **not** put a second pair of eyes on the code: everything
+from a feature branch through to `main` is written, merged and promoted by dev,
+so nothing is independently reviewed until QA tests the staging build. The
+first real check on any change is QA running the "How to test" steps. That is a
+deliberate trade for a two-person team, but it should be a known one rather
+than an assumed safety net.
 
 ### Before `qa` → `main`
 


### PR DESCRIPTION
## Summary

Dev must ask QA before promoting `dev` → `qa`. **A timing check, not an approval.**

## What changed

`CONTRIBUTING.md` §7 — "Before `dev` → `qa`" gains a first step, and a subsection explains the rule. Mirrored into `CLAUDE.md`.

> **dev:** Ready to promote #16 to qa — ok to push?
> **QA:** Hold, 10 minutes, finishing the alerts sweep.
> *...later...*
> **QA:** Go.

No answer means go. It's a courtesy that prevents wasted test runs, not a lock that stalls the pipeline waiting on someone who's gone home.

## Why

Dev can currently promote and redeploy **in the middle of a QA test run**, changing the build under the tester. The resulting bug report then describes something that no longer exists. QA owns that environment because QA is the only one using it, and only asking prevents the collision — two people both being careful doesn't.

**Why it is deliberately not an approval gate.** QA reviewing the code was considered and rejected. This convention is built around QA being someone who cannot read code — it says so at the top of the file. QA also cannot test the change, because it isn't on `qa` yet. Approval there produces a signature, not a check: a gate that looks like oversight and supplies none.

The question is only ever *"are you mid-run?"*.

## What this does not fix, stated plainly

Everything from a feature branch through to `main` is written, merged and promoted by dev. **Nothing is independently reviewed until QA tests the staging build.** The PR into `dev` is a paper trail that no one reads.

That's a reasonable trade for two people, but the owner asked directly whether dev self-validates and the honest answer was yes — so the section says it rather than leaving it as an assumed safety net.

## How to test (QA)

1. `git fetch && git checkout docs/qa-controls-promotion-timing`.
2. `CONTRIBUTING.md` §7 — "Before `dev` → `qa`" should have **asking QA as step 1**, ahead of CI and migrations.
3. The subsection below should state it is a timing gate and **not** an approval gate, and give the reason (QA can't read code, and can't test a change that isn't on `qa` yet).
4. It should show the go/hold exchange and say **no answer means go**.
5. It should say the code is not independently reviewed before QA tests staging.
6. `CLAUDE.md` should carry the same rule in short form.
7. The real check: next time I promote to `qa`, I should ask you first. If I don't, that's a failure of this rule and worth reporting.

## Risk level

**Low** — documentation only.

Worth flagging: this adds a step that depends on a human answering. It's written so silence doesn't block, specifically so it can't become the reason nothing ships.

## Screenshots (if UI change)

N/A.
