### PR TITLE
Release 2026-08-05: RSI aggregation, arena + scanner CLS, WebSocket IP-ban fix, ATH cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,20 @@
 name: CI
 
 on:
+  # qa matters most of the three. It is the only branch that deploys itself
+  # (Render auto-deploy is on for liquidity-hq-qa), so before this it was also
+  # the only branch that could ship to a live environment with nothing checked
+  # first - the exact inverse of what you want. A push to qa now has to pass
+  # lint, typecheck, unit tests and a build like everywhere else.
   push:
-    branches: [dev, main]
+    branches: [dev, qa, main]
   # Also on PRs, or CI only ever runs AFTER a merge - which is the one moment
   # it cannot help. The convention makes the PR the review point (CONTRIBUTING
   # section 4), so the checks have to be green before the merge button, not
   # after. Covers PRs from any branch, including QA-authored ones, which a
   # push trigger limited to [dev, main] never sees.
   pull_request:
-    branches: [dev, main]
+    branches: [dev, qa, main]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,13 @@ name: CI
 on:
   push:
     branches: [dev, main]
+  # Also on PRs, or CI only ever runs AFTER a merge - which is the one moment
+  # it cannot help. The convention makes the PR the review point (CONTRIBUTING
+  # section 4), so the checks have to be green before the merge button, not
+  # after. Covers PRs from any branch, including QA-authored ones, which a
+  # push trigger limited to [dev, main] never sees.
+  pull_request:
+    branches: [dev, main]
 
 jobs:
   build:
@@ -24,7 +31,7 @@ jobs:
       # Runs first because it is the fastest of the four steps.
       #
       # Fails on errors only. Warnings are printed but do not block - there are
-      # ~131 of them, a pre-existing React Compiler backlog documented in
+      # 93 of them, a pre-existing React Compiler backlog documented in
       # eslint.config.mjs. Deliberately no --max-warnings=0: it would either
       # force a 67-file refactor of live code today, or be set to a number
       # nobody maintains.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,59 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  e2e:
+    name: E2E (Playwright)
+    runs-on: ubuntu-latest
+    # Only after lint/typecheck/unit/build are green. A broken build would
+    # produce 216 browser failures that all say "the build is broken", which
+    # buries the one line that actually explains it.
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      # Chromium only. Firefox and WebKit roughly triple install time, and this
+      # app ships as a Chromium-based PWA plus a Capacitor Android shell, so
+      # neither engine reflects a real user.
+      #
+      # Note playwright.config.ts pins `browserName: 'chromium'` on the mobile
+      # project. devices['iPhone 13'] defaults to WebKit, and without that pin
+      # every mobile test fails here with "Executable doesn't exist at
+      # .../webkit-2336" - which is what happened the first time this suite ran.
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      # playwright.config.ts's webServer runs `npm run build && npm start` on
+      # port 3100, so CI and local exercise the same production build.
+      #
+      # The NEXT_PUBLIC_* vars are inlined AT BUILD TIME, which is why they are
+      # set on this step rather than only at run time. Without them AuthProvider
+      # builds no Supabase client, /login never renders its form, and
+      # /api/ops/* throws "supabaseUrl is required" and answers 500 instead of
+      # the 401 the security specs assert.
+      #
+      # These point at the DEV Supabase project, never prod, and carry the anon
+      # key only - never the service-role key. The anon key is public by design
+      # and the dev project holds no real user data.
+      - name: Run E2E
+        run: npm run test:e2e
+        env:
+          CI: true
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
+          NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ secrets.E2E_TURNSTILE_SITE_KEY }}
+
+      # Uploaded on failure too - that is the run you actually need to read.
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: qa/e2e-report/
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,11 @@
 name: CI
 
 on:
-  # qa matters most of the three. It is the only branch that deploys itself
-  # (Render auto-deploy is on for liquidity-hq-qa), so before this it was also
-  # the only branch that could ship to a live environment with nothing checked
-  # first - the exact inverse of what you want. A push to qa now has to pass
-  # lint, typecheck, unit tests and a build like everywhere else.
+  # qa is the branch QA tests against, so a broken merge into it costs QA a
+  # wasted test run and a false bug report before anyone looks at CI. Checking
+  # it here is cheaper than that. Note the qa Render service does NOT
+  # auto-deploy - a merge into qa is not live until someone triggers it - so
+  # this is a gate on the branch, not a last line of defence before users.
   push:
     branches: [dev, qa, main]
   # Also on PRs, or CI only ever runs AFTER a merge - which is the one moment

--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,6 @@ yarn-error.log*
 .env*
 !.env.example
 
-# vercel
-.vercel
 
 # typescript
 *.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load its fonts, which are self-hosted from `app/fonts/`.
 
 ## Learn More
 
@@ -27,10 +27,15 @@ To learn more about Next.js, take a look at the following resources:
 - [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
 - [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
 
-## Deploy on Vercel
+## Deploy
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+Hosted on Render, not Vercel. Two services, neither auto-deploying:
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+| Branch | Service | URL |
+|---|---|---|
+| `main` | `liquidity-hq-prod` | https://liquidity-hq.com |
+| `dev` | `liquidity-hq-dev` | https://liquidity-hq-dev.onrender.com |
+
+A merge ships nothing on its own — the deploy is a separate manual step in the
+Render dashboard. See `CONTRIBUTING.md` §6 and `docs/INFRASTRUCTURE.md`.

--- a/__tests__/apiCacheStale.test.mts
+++ b/__tests__/apiCacheStale.test.mts
@@ -1,0 +1,69 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { cachedStale } from '../lib/apiCache.ts';
+
+/* cachedStale exists so /api/ath keeps answering when CoinGecko rate-limits the
+   server's IP. The interesting behaviour is all in the failure path, which is
+   exactly the path that never runs in normal development. */
+test('cachedStale', async (t) => {
+  let n = 0;
+  const uniqueKey = () => `k${++n}`;
+
+  await t.test('first call fetches and is not stale', async () => {
+    const r = await cachedStale(uniqueKey(), 60_000, async () => 'fresh');
+    assert.equal(r.data, 'fresh');
+    assert.equal(r.stale, false);
+    assert.equal(r.ageMs, 0);
+  });
+
+  await t.test('second call inside the TTL does not re-fetch', async () => {
+    const k = uniqueKey();
+    let calls = 0;
+    const f = async () => { calls++; return 'v'; };
+    await cachedStale(k, 60_000, f);
+    const r = await cachedStale(k, 60_000, f);
+    assert.equal(calls, 1, 'fetcher should not run again inside the TTL');
+    assert.equal(r.stale, false);
+  });
+
+  await t.test('serves the last good value when the fetcher throws', async () => {
+    const k = uniqueKey();
+    await cachedStale(k, 0, async () => 'good');
+    // ttl 0 forces a re-fetch, and this one fails - the CoinGecko 429 case.
+    const r = await cachedStale(k, 0, async () => { throw new Error('CoinGecko 429'); });
+    assert.equal(r.data, 'good', 'must fall back rather than propagate');
+    assert.equal(r.stale, true);
+  });
+
+  await t.test('throws when it fails with nothing cached', async () => {
+    /* Cold start plus a failing upstream is a real failure - there is no
+       previous answer to serve, so the route has to return an error rather
+       than invent one. */
+    await assert.rejects(
+      () => cachedStale(uniqueKey(), 60_000, async () => { throw new Error('boom'); }),
+      /boom/,
+    );
+  });
+
+  await t.test('does not settle into serving stale forever', async () => {
+    /* A failure must not refresh the timestamp. If it did, one outage would
+       pin the stale value for a full TTL and recovery would be delayed long
+       after the upstream came back. */
+    const k = uniqueKey();
+    await cachedStale(k, 0, async () => 'v1');
+    await cachedStale(k, 0, async () => { throw new Error('down'); });
+    const r = await cachedStale(k, 0, async () => 'v2');
+    assert.equal(r.data, 'v2', 'should retry and pick up the recovery immediately');
+    assert.equal(r.stale, false);
+  });
+
+  await t.test('a successful fetch after a failure replaces the stale value', async () => {
+    const k = uniqueKey();
+    await cachedStale(k, 0, async () => 'old');
+    await cachedStale(k, 0, async () => { throw new Error('down'); });
+    await cachedStale(k, 0, async () => 'new');
+    const r = await cachedStale(k, 60_000, async () => { throw new Error('should not run'); });
+    assert.equal(r.data, 'new');
+    assert.equal(r.stale, false);
+  });
+});

--- a/__tests__/rsi.test.mts
+++ b/__tests__/rsi.test.mts
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { computeRSI14 } from '../lib/rsi.ts';
+
+/* computeRSI14 was moved out of MarketProvider so app/api/market/rsi could
+   share it. These lock the exact numbers the client produced before the move -
+   the risk of the refactor is not a crash, it is the value shifting by a point
+   and silently moving coins across the 30/70 badge thresholds. */
+test('computeRSI14', async (t) => {
+  await t.test('needs 15 closes to produce 14 changes', () => {
+    assert.equal(computeRSI14([]), null);
+    assert.equal(computeRSI14(Array(14).fill(100)), null);
+    assert.notEqual(computeRSI14(Array(15).fill(100)), null);
+  });
+
+  await t.test('a strictly rising series is 100', () => {
+    // No losses at all, so avgLoss is 0 and the divide-by-zero branch applies.
+    const closes = Array.from({ length: 20 }, (_, i) => 100 + i);
+    assert.equal(computeRSI14(closes), 100);
+  });
+
+  await t.test('a flat series is also 100', () => {
+    /* Every change is 0, so avgGain and avgLoss are both 0 and avgLoss === 0
+       wins. Documenting rather than endorsing: a flat market reading as
+       maximally overbought is a quirk of this formula, and anything consuming
+       rsi === 100 as a sell signal inherits it. */
+    assert.equal(computeRSI14(Array(20).fill(100)), 100);
+  });
+
+  await t.test('a strictly falling series is 0', () => {
+    const closes = Array.from({ length: 20 }, (_, i) => 100 - i);
+    assert.equal(computeRSI14(closes), 0);
+  });
+
+  await t.test('alternating equal gains and losses is 50', () => {
+    // 14 changes of +1/-1 in equal number: avgGain === avgLoss, so RSI is 50.
+    const closes = [100];
+    for (let i = 0; i < 20; i++) closes.push(closes[closes.length - 1] + (i % 2 ? -1 : 1));
+    assert.equal(computeRSI14(closes), 50);
+  });
+
+  await t.test('reads only the last 14 changes, not the whole array', () => {
+    /* The window is what makes the client's limit=16 and limit=20 requests
+       interchangeable, which the API route relies on. A long crash followed by
+       14 clean up-bars must read 100, not something dragged down by history. */
+    const crash = Array.from({ length: 40 }, (_, i) => 500 - i * 10);   // ends at 110
+    // Continues up from where the crash ended, so all 14 trailing changes are
+    // gains. Starting the recovery at a lower price instead would leave the
+    // gap itself inside the window and correctly read ~57, not 100.
+    const recovery = Array.from({ length: 14 }, (_, i) => 111 + i);
+    assert.equal(computeRSI14([...crash, ...recovery]), 100);
+  });
+
+  await t.test('returns a rounded integer', () => {
+    const closes = [100, 102, 101, 104, 103, 107, 105, 110, 108, 113,
+                    111, 116, 114, 119, 117, 122];
+    const rsi = computeRSI14(closes);
+    assert.ok(rsi !== null);
+    assert.equal(rsi, Math.round(rsi!));
+    assert.ok(rsi! >= 0 && rsi! <= 100);
+  });
+});

--- a/app/api/ath/route.ts
+++ b/app/api/ath/route.ts
@@ -1,6 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { apiError } from '@/lib/apiError';
 import { rateLimit, getClientIp } from '@/lib/rateLimit';
+import { cachedStale } from '@/lib/apiCache';
+import { reportHealth, healthError } from '@/lib/apiHealth';
+
+/* All-time highs move a few times a year at most, so this is cached hard and
+   served stale rather than failed when CoinGecko is unavailable.
+   `next: { revalidate }` alone was not enough: it caches successful responses
+   only, so a 429 was re-requested on every single hit and answered 502 every
+   time. Measured on the qa service - every attempt returned
+   {"error":"CoinGecko 429"} while production, on a different instance, was
+   fine. The IP had spent its budget on a keyless public API and the route had
+   no memory of the last good answer. */
+const ATH_TTL = 6 * 60 * 60_000;
 
 const CG_IDS: Record<string, string> = {
   btc:  'bitcoin',
@@ -36,40 +48,62 @@ export async function GET(req: NextRequest) {
   const url = `https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=${ids}&per_page=50&sparkline=false`;
 
   try {
-    const r = await fetch(url, {
-      next: { revalidate: 3600 },
-      headers: { 'Accept': 'application/json' },
-    });
+    const { data: result, stale, ageMs } = await cachedStale<Record<string, AthEntry>>(
+      'ath', ATH_TTL, async () => {
+        const r = await fetch(url, {
+          cache: 'no-store',   // cachedStale owns the caching now
+          headers: { 'Accept': 'application/json' },
+        });
+        if (!r.ok) throw new Error(`CoinGecko ${r.status}`);
 
-    if (!r.ok) {
-      return NextResponse.json({ error: `CoinGecko ${r.status}` }, { status: 502 });
-    }
+        const data: Array<{
+          id: string;
+          ath: number;
+          ath_date: string;
+          ath_change_percentage: number;
+        }> = await r.json();
 
-    const data: Array<{
-      id: string;
-      ath: number;
-      ath_date: string;
-      ath_change_percentage: number;
-    }> = await r.json();
+        const cgToOur = Object.fromEntries(
+          Object.entries(CG_IDS).map(([ours, cg]) => [cg, ours])
+        );
 
-    const cgToOur = Object.fromEntries(
-      Object.entries(CG_IDS).map(([ours, cg]) => [cg, ours])
+        const out: Record<string, AthEntry> = {};
+        for (const coin of data) {
+          const ourId = cgToOur[coin.id];
+          if (ourId && coin.ath != null) {
+            out[ourId] = {
+              ath: coin.ath,
+              athDate: coin.ath_date,
+              drawdownPct: coin.ath_change_percentage,
+            };
+          }
+        }
+        /* An empty object would otherwise be cached as a perfectly good answer
+           and served for six hours. CoinGecko returning 200 with nothing usable
+           is a failure wearing a success's clothes. */
+        if (Object.keys(out).length === 0) throw new Error('CoinGecko returned no usable rows');
+        return out;
+      },
     );
 
-    const result: Record<string, AthEntry> = {};
-    for (const coin of data) {
-      const ourId = cgToOur[coin.id];
-      if (ourId && coin.ath != null) {
-        result[ourId] = {
-          ath: coin.ath,
-          athDate: coin.ath_date,
-          drawdownPct: coin.ath_change_percentage,
-        };
-      }
-    }
+    reportHealth('coingecko:ath', 'market', !stale,
+      stale ? `serving ${Math.round(ageMs / 60_000)}min-old data - upstream failing`
+            : `${Object.keys(result).length} coins`,
+      Object.keys(result).length);
 
-    return NextResponse.json(result);
+    return NextResponse.json(result, {
+      headers: {
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+        /* Debug-only. The body shape is unchanged so nothing downstream has to
+           care, but "is this stale?" is the first question when a number looks
+           wrong, and it should not require reading server logs to answer. */
+        'X-Data-Stale': stale ? `true; age=${Math.round(ageMs / 1000)}s` : 'false',
+      },
+    });
   } catch (e) {
-    return apiError('ath', e, 500, 'Request failed');
+    /* Only reached on a cold cache - no previous good value exists to fall
+       back to, so this really is a failure. */
+    reportHealth('coingecko:ath', 'market', false, healthError(e));
+    return apiError('ath', e, 502, 'Upstream unavailable');
   }
 }

--- a/app/api/macro-alert/route.ts
+++ b/app/api/macro-alert/route.ts
@@ -58,9 +58,11 @@ type CalEvent = {
 
 async function fetchUpcomingEvents(): Promise<CalEvent[]> {
   try {
-    const base = process.env.NEXT_PUBLIC_APP_URL
-      ?? process.env.VERCEL_URL
-      ?? 'http://localhost:3000';
+    /* This app is hosted on Render, so VERCEL_URL used to sit here and never
+       resolved. Worse than dead: Vercel sets it as a bare hostname with no
+       scheme, so had it ever been present the template below would have built
+       `myapp.vercel.app/api/econ-calendar` and thrown on fetch. */
+    const base = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
     const url = `${base}/api/econ-calendar`;
     const res = await fetch(url, { cache: 'no-store', signal: AbortSignal.timeout(10_000) });
     if (!res.ok) return [];

--- a/app/api/market/rsi/route.ts
+++ b/app/api/market/rsi/route.ts
@@ -1,0 +1,323 @@
+/**
+ * Server-side RSI aggregation for the whole coin list.
+ *
+ * GET /api/market/rsi
+ *   → { rsi: { btc: { rsi5m, rsi1h, rsi4h, rsiDaily, rsiWeekly, rsiMonthly }, ... }, ts }
+ *
+ * WHY THIS EXISTS
+ *
+ * MarketProvider used to compute these six numbers in the browser, one kline
+ * request per coin per timeframe. At 45 Binance coins plus HYPE that is 276
+ * requests fired from the visitor's own IP on every page load, out of ~495
+ * Binance requests total. Every visitor repeated all 276, and every one of
+ * them returned data that is identical for every visitor - a 1-week RSI does
+ * not differ per user.
+ *
+ * That burst is the suspected cause of the intermittent blank chart: enough
+ * concurrent requests to trip Binance's per-IP limit, after which unrelated
+ * kline calls start coming back 429 and the chart renders empty. It is worst
+ * on shared egress IPs (mobile CGNAT, office NAT, VPNs) and on anyone with
+ * two tabs open, where the same limit is being spent several times over.
+ *
+ * Moving it here makes the upstream cost fixed instead of per-visitor: the
+ * server fetches each timeframe group once per TTL and every visitor is served
+ * from that one result. Ten concurrent visitors cost the same upstream as one.
+ *
+ * TWO CACHE GROUPS, NOT ONE
+ *
+ * The client used to poll 5m RSI every 3 minutes and everything slower every
+ * 15. Collapsing that into a single cache would either make 5m RSI stale or
+ * re-fetch 230 weekly/monthly candles every 3 minutes for no benefit. So the
+ * groups are cached separately with their original cadences and merged into
+ * one response - the client can poll at the fast cadence and the slow group
+ * simply serves a warm cache most of the time.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { apiError } from '@/lib/apiError';
+import { BINANCE_SYMS, BYBIT_SYMS } from '@/lib/coins';
+import { rateLimit, getClientIp } from '@/lib/rateLimit';
+import { cached } from '@/lib/apiCache';
+import { reportHealth, healthError } from '@/lib/apiHealth';
+import { computeRSI14 } from '@/lib/rsi';
+
+export const dynamic = 'force-dynamic';
+
+/* Match the client cadences these replaced: fetch5mRSI ran every 3 min, the
+   1h/4h/1d/1w/1M pollers every 15. */
+const FAST_TTL = 3  * 60_000;
+const SLOW_TTL = 15 * 60_000;
+
+/* Binance rejects unlimited parallelism from a single IP with 418/429, and 276
+   simultaneous sockets is also more than the Render instance should hold open.
+   12 keeps a cold fill at roughly 275/12 x ~150ms, a few seconds, which only
+   one visitor per TTL window ever pays. */
+const CONCURRENCY = 12;
+
+/* Same mirror-walk as app/api/funding: api.binance.com resolves to different
+   edges by region and individual ones return 451/503 while the others are
+   healthy. Resolved once per cache fill, not per request.
+ *
+ * Spot first because that is what the client used, so the numbers this route
+ * returns are identical to the ones it replaced. The futures host is a last
+ * resort, not a preference: only fapi.binance.com is *proven* reachable from
+ * Render (app/api/funding and lib/ribbonCandles both call it in production),
+ * while nothing server-side has ever called spot from there. If spot turns out
+ * to be blocked, falling back to perp candles gives RSI that can differ by a
+ * point on a rounded 0-100 scale - worth having, but worth knowing about,
+ * which is why the health record names the source that was used.
+ *
+ * The whole group uses one endpoint, so a fallback never mixes spot and perp
+ * candles across coins within a single response. */
+const BN_ENDPOINTS = [
+  { base: 'https://api.binance.com',  klines: '/api/v3/klines',   ping: '/api/v3/ping',   label: 'spot'    },
+  { base: 'https://api1.binance.com', klines: '/api/v3/klines',   ping: '/api/v3/ping',   label: 'spot'    },
+  { base: 'https://api2.binance.com', klines: '/api/v3/klines',   ping: '/api/v3/ping',   label: 'spot'    },
+  { base: 'https://api3.binance.com', klines: '/api/v3/klines',   ping: '/api/v3/ping',   label: 'spot'    },
+  { base: 'https://fapi.binance.com', klines: '/fapi/v1/klines',  ping: '/fapi/v1/ping',  label: 'futures' },
+] as const;
+
+type Endpoint = (typeof BN_ENDPOINTS)[number];
+
+/* Binance interval string → the MarketStore field it populates. Limits are the
+   ones the client used. computeRSI14 only ever reads the last 14 changes, so
+   16 vs 20 candles produces the same number - they are kept as they were so
+   this route is a pure move, not a re-tune. */
+const BN_TIMEFRAMES = [
+  { interval: '5m', limit: 16, field: 'rsi5m'      },
+  { interval: '1h', limit: 16, field: 'rsi1h'      },
+  { interval: '4h', limit: 16, field: 'rsi4h'      },
+  { interval: '1d', limit: 20, field: 'rsiDaily'   },
+  { interval: '1w', limit: 20, field: 'rsiWeekly'  },
+  { interval: '1M', limit: 20, field: 'rsiMonthly' },
+] as const;
+
+/* HYPE has no Binance perp, so its six values come from Bybit, whose interval
+   codes are minutes-as-numbers plus D/W/M. Bybit returns newest-first. */
+const BB_TIMEFRAMES = [
+  { interval: '5',   limit: 16, field: 'rsi5m'      },
+  { interval: '60',  limit: 16, field: 'rsi1h'      },
+  { interval: '240', limit: 16, field: 'rsi4h'      },
+  { interval: 'D',   limit: 20, field: 'rsiDaily'   },
+  { interval: 'W',   limit: 20, field: 'rsiWeekly'  },
+  { interval: 'M',   limit: 20, field: 'rsiMonthly' },
+] as const;
+
+type RsiField = (typeof BN_TIMEFRAMES)[number]['field'];
+type RsiMap   = Record<string, Partial<Record<RsiField, number>>>;
+
+/* The fast group is 5m alone; the slow group is everything else. Splitting on
+   the field keeps the two lists in sync with BN_TIMEFRAMES automatically. */
+const FAST_FIELDS = new Set<RsiField>(['rsi5m']);
+
+interface Job { coin: string; field: RsiField; url: (ep: Endpoint) => string; bybit: boolean }
+
+function buildJobs(fast: boolean): Job[] {
+  const wanted = (f: RsiField) => FAST_FIELDS.has(f) === fast;
+  const jobs: Job[] = [];
+
+  for (const [coin, sym] of Object.entries(BINANCE_SYMS)) {
+    for (const tf of BN_TIMEFRAMES) {
+      if (!wanted(tf.field)) continue;
+      jobs.push({
+        coin, field: tf.field, bybit: false,
+        url: ep => `${ep.base}${ep.klines}?symbol=${sym}&interval=${tf.interval}&limit=${tf.limit}`,
+      });
+    }
+  }
+
+  const hypeSym = BYBIT_SYMS.hype;
+  if (hypeSym) {
+    for (const tf of BB_TIMEFRAMES) {
+      if (!wanted(tf.field)) continue;
+      jobs.push({
+        coin: 'hype', field: tf.field, bybit: true,
+        url: () => `https://api.bybit.com/v5/market/kline?category=linear&symbol=${hypeSym}&interval=${tf.interval}&limit=${tf.limit}`,
+      });
+    }
+  }
+
+  return jobs;
+}
+
+/* Raised when Binance answers 418 (IP banned) or 429 (rate limited). Carries
+   no data - its only job is to stop the pool, see runPool. */
+class BinanceBackoff extends Error {}
+
+/* Closes, newest last, from whichever exchange shape came back. Returns null
+   rather than throwing so one dead symbol cannot take down the batch - the
+   coin simply keeps whatever value the client already had. The one exception
+   is 418/429, which is not about this symbol at all. */
+async function fetchCloses(job: Job, ep: Endpoint): Promise<number[] | null> {
+  const ac  = new AbortController();
+  const tid = setTimeout(() => ac.abort(), 8000);
+  try {
+    const res = await fetch(job.url(ep), {
+      cache: 'no-store',
+      signal: ac.signal,
+      headers: { 'User-Agent': 'Mozilla/5.0' },
+    });
+    /* 429 is the warning, 418 is the ban that follows it. Both mean every
+       remaining request in this batch would be spent making it worse, and a
+       ban is measured in minutes to days. Distinguish from an ordinary miss
+       so runPool can stop rather than continue. */
+    if (res.status === 418 || res.status === 429) {
+      throw new BinanceBackoff(`Binance ${res.status}`);
+    }
+    if (!res.ok) return null;
+    const body = await res.json();
+
+    if (job.bybit) {
+      const list = body?.result?.list;
+      if (!Array.isArray(list)) return null;
+      return [...list].reverse().map((k: string[]) => parseFloat(k[4]));
+    }
+    if (!Array.isArray(body)) return null;
+    return body.map((k: string[]) => parseFloat(k[4]));
+  } catch (e) {
+    if (e instanceof BinanceBackoff) throw e;
+    return null;
+  } finally {
+    clearTimeout(tid);
+  }
+}
+
+/* Fixed-size worker pool. Promise.all over 276 fetches would open them all at
+   once, which is exactly the burst this route exists to stop doing.
+ *
+ * Aborts the whole batch the moment Binance returns 418/429. This matters more
+ * here than it did client-side: one banned visitor lost their own RSI, but one
+ * banned Render IP loses it for everyone at once. Spending the remaining 200
+ * requests into an active ban only extends it, so the pool stops and the
+ * partial result is cached - backing off for the TTL is the correct response
+ * to a ban, not something to retry around. */
+async function runPool(
+  jobs: Job[], ep: Endpoint, out: RsiMap,
+): Promise<{ ok: number; banned: boolean }> {
+  let next = 0;
+  let ok   = 0;
+  let banned = false;
+
+  async function worker() {
+    for (;;) {
+      if (banned) return;
+      const i = next++;
+      if (i >= jobs.length) return;
+      const job = jobs[i];
+
+      let closes: number[] | null;
+      try {
+        closes = await fetchCloses(job, ep);
+      } catch (e) {
+        if (e instanceof BinanceBackoff) { banned = true; return; }
+        continue;
+      }
+
+      /* Same guard the client applied: fewer than 15 closes cannot produce a
+         14-period RSI, and a partially-listed coin returns a short array
+         rather than an error. */
+      if (!closes || closes.length < 15) continue;
+      const rsi = computeRSI14(closes);
+      if (rsi === null) continue;
+      (out[job.coin] ??= {})[job.field] = rsi;
+      ok++;
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, jobs.length) }, worker));
+  return { ok, banned };
+}
+
+/* Pick a Binance edge that is actually answering before spending the pool on
+   it. One weight-1 probe beats discovering the host is 451 on all 276 requests.
+ *
+ * Returns null when no host answers, which is the state an active IP ban
+ * produces - every edge returns 418 because the ban is on us, not on them. The
+ * caller drops the Binance jobs entirely in that case rather than spending a
+ * pool's worth of requests re-learning it. */
+async function resolveEndpoint(): Promise<Endpoint | null> {
+  for (const ep of BN_ENDPOINTS) {
+    try {
+      const ac  = new AbortController();
+      const tid = setTimeout(() => ac.abort(), 5000);
+      const res = await fetch(`${ep.base}${ep.ping}`, {
+        cache: 'no-store', signal: ac.signal, headers: { 'User-Agent': 'Mozilla/5.0' },
+      });
+      clearTimeout(tid);
+      if (res.ok) return ep;
+    } catch { continue; }
+  }
+  return null;
+}
+
+async function buildGroup(fast: boolean): Promise<RsiMap> {
+  const out: RsiMap = {};
+  const ep = await resolveEndpoint();
+
+  /* No reachable Binance edge: run the Bybit jobs anyway so HYPE still gets
+     its RSI, and skip the 45 Binance symbols rather than firing them into a
+     wall. */
+  const allJobs = buildJobs(fast);
+  const jobs = ep ? allJobs : allJobs.filter(j => j.bybit);
+
+  const { ok, banned } = await runPool(jobs, ep ?? BN_ENDPOINTS[0], out);
+
+  /* Reported per group so a partial outage is visible: the slow group failing
+     while the fast one succeeds means Binance is rate-limiting the heavier
+     weekly/monthly calls, which is a different problem from the host being
+     unreachable. Separate source name from binance:funding for the same
+     reason that route separates its own.
+   *
+     A ban is called out explicitly because it is the one failure that needs a
+     human: it means this server's IP is spending more Binance weight than the
+     limit allows, and nothing here recovers from that by itself. */
+  reportHealth(
+    `binance:rsi-${fast ? 'fast' : 'slow'}`, 'market',
+    ok > 0 && !banned && ep !== null,
+    !ep      ? `no reachable Binance endpoint - ${ok} Bybit-only series`
+    : banned ? `418/429 on ${ep.label} after ${ok}/${allJobs.length} series - batch aborted`
+             : `${ok}/${allJobs.length} series via ${ep.label}`,
+    ok,
+  );
+
+  return out;
+}
+
+export async function GET(req: NextRequest) {
+  if (!rateLimit(`market-rsi:${getClientIp(req)}`, 30, 60_000)) {
+    return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429 });
+  }
+
+  try {
+    /* allSettled, not all: a failing slow group must still let the fast group
+       through. The client merges whatever arrives and leaves the rest at its
+       previous value, which is the same degradation the per-coin fetches had
+       when an individual symbol 429'd. */
+    const [fastRes, slowRes] = await Promise.allSettled([
+      cached('market-rsi:fast', FAST_TTL, () => buildGroup(true)),
+      cached('market-rsi:slow', SLOW_TTL, () => buildGroup(false)),
+    ]);
+
+    if (fastRes.status === 'rejected' && slowRes.status === 'rejected') {
+      reportHealth('binance:rsi', 'market', false, healthError(fastRes.reason));
+      return apiError('market-rsi', fastRes.reason, 502, 'Upstream unavailable');
+    }
+
+    const rsi: RsiMap = {};
+    for (const res of [slowRes, fastRes]) {
+      if (res.status !== 'fulfilled') continue;
+      for (const [coin, fields] of Object.entries(res.value)) {
+        Object.assign(rsi[coin] ??= {}, fields);
+      }
+    }
+
+    return NextResponse.json({ rsi, ts: Date.now() }, {
+      /* Public, visitor-independent, and already only as fresh as FAST_TTL.
+         Letting any shared cache in front of this serve it costs nothing and
+         removes the origin hit entirely for the common case. */
+      headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=600' },
+    });
+  } catch (err) {
+    return apiError('market-rsi', err, 500, 'Request failed');
+  }
+}

--- a/components/AccumulationTracker.tsx
+++ b/components/AccumulationTracker.tsx
@@ -98,7 +98,21 @@ export default function AccumulationTracker() {
       </div>
 
       {rows.length === 0 ? (
-        <div style={{ padding: '10px 14px 12px', fontSize: 'var(--fs-caption)', color: 'var(--txt3)' }}>
+        /* minHeight holds the space the rows will occupy.
+
+           Without it this card was 72px while prices were still arriving and
+           277px once they had, and all five cards below it moved 205px down
+           the page at that moment.
+
+           Measured rather than guessed: with the reservation the empty card
+           sat at 222px against a loaded 277px, so 245 closes the remaining
+           55px. Sized to the typical loaded height rather than a maximum -
+           over-reserving would leave a visible gap on a genuinely empty
+           result, which is a real state here (no coin scores >= 45). */
+        <div style={{
+          padding: '10px 14px 12px', fontSize: 'var(--fs-caption)', color: 'var(--txt3)',
+          minHeight: 245,
+        }}>
           {t('ACCUMULATION_TRACKER_EMPTY')}
         </div>
       ) : (

--- a/components/CoinHeatmap.tsx
+++ b/components/CoinHeatmap.tsx
@@ -1,9 +1,14 @@
 'use client';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useMarket, COINS, CoinId } from '@/lib/marketStore';
 import { withAlpha } from '@/lib/color';
 import Tip from '@/components/Tip';
 import { useLabels } from '@/lib/labels';
+
+/* How often the heatmap re-ranks itself. See the effect in the component. */
+const RERANK_MS = 60_000;
+/* If a feed never reports, rank anyway rather than sitting in declared order. */
+const FIRST_RANK_TIMEOUT_MS = 12_000;
 
 type Cat = 'all' | 'majors' | 'alts' | 'defi' | 'meme';
 
@@ -38,6 +43,8 @@ export default function CoinHeatmap() {
   const { t } = useLabels();
   const { store } = useMarket();
   const [cat, setCat] = useState<Cat>('all');
+  /* Frozen tile order per category - see the comment above the effect below. */
+  const [order, setOrder] = useState<Partial<Record<Cat, CoinId[]>>>({});
 
   const CAT_LABELS: Record<Cat, string> = {
     all: t('COIN_HEATMAP_CAT_ALL'),
@@ -49,20 +56,72 @@ export default function CoinHeatmap() {
 
   const entries = [...(CAT[cat] as CoinId[])].map(c => ({ c, coin: store.coins[c] }));
 
-  /* Hold the declared order until every tile has a number to be ranked by.
+  /* Rank on a schedule, never on a price tick.
    *
-   * Sorting on `change ?? -999` ranks the not-yet-loaded coins dead last, so
-   * each one leapt from the bottom of the grid to its real position the moment
-   * its price arrived. XAU and SPX are the worst of it - they come from the
-   * slowest feeds, so they were still travelling the height of the grid two
-   * seconds in, and every jump reflowed the tiles around them.
+   * This grid used to re-sort every time any price moved. Prices arrive
+   * continuously, so tiles swapped places continuously - 63% of /scanner's
+   * layout shift came from this one component reordering itself, and it never
+   * settled, because there is always another tick. It is also unpleasant to
+   * use: tiles move under the cursor while you are reading them.
    *
-   * Waiting costs one ordering change instead of one per coin, and only while
-   * the page is filling. Once loaded this sorts exactly as before. */
-  const coins = entries.sort((a, b) => (b.coin?.change ?? -999) - (a.coin?.change ?? -999));
+   * Two rules replace it. Rank once the category has data for every coin (or
+   * after FIRST_RANK_TIMEOUT_MS, so a permanently-missing feed cannot stop it
+   * forever), then re-rank every RERANK_MS. Between those moments the ORDER is
+   * frozen while prices, colours and percentages keep updating live inside
+   * each tile.
+   *
+   * Waiting for complete data before the first rank is the part that took two
+   * attempts. Ranking at 80% coverage put the late-arriving 20% wherever their
+   * missing value sorted them and then held that for a full minute - measured
+   * a coin sitting 16.7% out of position. Partial data ranked confidently is
+   * worse than no ranking at all, because it looks authoritative. */
+  const withData = entries.filter(e => e.coin?.change != null).length;
+  const complete = withData === entries.length;
 
-  const positiveCount = coins.filter(x => x.coin?.change != null && x.coin.change >= 0).length;
-  const negativeCount = coins.filter(x => x.coin?.change != null && x.coin.change < 0).length;
+  const [rankTick, setRankTick] = useState(0);
+  const [rankedOnce, setRankedOnce] = useState(false);
+
+  /* Fallback so an incomplete category still ranks eventually. */
+  useEffect(() => {
+    if (rankedOnce) return;
+    const id = setTimeout(() => setRankedOnce(true), FIRST_RANK_TIMEOUT_MS);
+    return () => clearTimeout(id);
+  }, [rankedOnce]);
+
+  useEffect(() => {
+    const id = setInterval(() => setRankTick(n => n + 1), RERANK_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  /* Recomputes when the category changes, when the data first becomes complete
+     (or times out), and on the timer - never simply because a price moved. */
+  useEffect(() => {
+    if (!complete && !rankedOnce) return;
+    if (complete) setRankedOnce(true);
+    setOrder(prev => ({
+      ...prev,
+      [cat]: [...(CAT[cat] as CoinId[])]
+        .map(c => ({ c, coin: store.coins[c] }))
+        .sort((x, y) => (y.coin?.change ?? -999) - (x.coin?.change ?? -999))
+        .map(e => e.c),
+    }));
+    // store.coins is read inside but is deliberately not a dependency -
+    // reacting to it is the jitter this exists to prevent.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [complete, rankedOnce, cat, rankTick]);
+
+  /* Until the ranking exists, render placeholders rather than the unranked
+     tiles. Showing real tiles in declared order and then re-ordering them is a
+     genuine layout shift - it was 51% of what remained. Placeholders are keyed
+     by index, so when the ranking lands React replaces them outright instead of
+     moving 50 identified nodes around, and the real tiles mount already in
+     their final position. Same geometry, so nothing around the grid moves
+     either. Costs about a second of dashes on a cold load, which is honest -
+     the ranking genuinely is not known yet. */
+  const ranked = order[cat];
+  const coins  = ranked ? ranked.map(c => ({ c, coin: store.coins[c] })) : null;
+  const positiveCount = coins?.filter(x => x.coin?.change != null && x.coin.change >= 0).length ?? 0;
+  const negativeCount = coins?.filter(x => x.coin?.change != null && x.coin.change < 0).length ?? 0;
 
   return (
     <div style={{
@@ -115,7 +174,18 @@ export default function CoinHeatmap() {
         gridTemplateColumns: 'repeat(auto-fill, minmax(100px, 1fr))',
         gap: 4, padding: '0 12px 12px',
       }}>
-        {coins.map(({ c, coin }) => {
+        {!coins && Array.from({ length: entries.length }).map((_, i) => (
+          <div key={`ph-${i}`} aria-hidden="true" style={{
+            background: 'rgba(255,255,255,0.04)', borderRadius: 8, padding: '10px 8px',
+            display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 3,
+            border: '0.5px solid rgba(255,255,255,0.04)',
+          }}>
+            <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 800, color: '#333' }}>-</span>
+            <span style={{ fontSize: 'var(--fs-caption)', color: '#2a2a2a' }}>-</span>
+            <span style={{ fontSize: 'var(--fs-label)', fontWeight: 700, color: '#333', lineHeight: 1 }}>-</span>
+          </div>
+        ))}
+        {coins?.map(({ c, coin }) => {
           const chg = coin?.change ?? null;
           const { bg, text } = changeColor(chg);
           const sign = chg == null ? '' : chg >= 0 ? '+' : '';

--- a/components/CoinHeatmap.tsx
+++ b/components/CoinHeatmap.tsx
@@ -47,13 +47,19 @@ export default function CoinHeatmap() {
     meme: t('COIN_HEATMAP_CAT_MEME'),
   };
 
-  const coins = [...(CAT[cat] as CoinId[])]
-    .map(c => ({ c, coin: store.coins[c] }))
-    .sort((a, b) => {
-      const ca = a.coin?.change ?? -999;
-      const cb = b.coin?.change ?? -999;
-      return cb - ca;
-    });
+  const entries = [...(CAT[cat] as CoinId[])].map(c => ({ c, coin: store.coins[c] }));
+
+  /* Hold the declared order until every tile has a number to be ranked by.
+   *
+   * Sorting on `change ?? -999` ranks the not-yet-loaded coins dead last, so
+   * each one leapt from the bottom of the grid to its real position the moment
+   * its price arrived. XAU and SPX are the worst of it - they come from the
+   * slowest feeds, so they were still travelling the height of the grid two
+   * seconds in, and every jump reflowed the tiles around them.
+   *
+   * Waiting costs one ordering change instead of one per coin, and only while
+   * the page is filling. Once loaded this sorts exactly as before. */
+  const coins = entries.sort((a, b) => (b.coin?.change ?? -999) - (a.coin?.change ?? -999));
 
   const positiveCount = coins.filter(x => x.coin?.change != null && x.coin.change >= 0).length;
   const negativeCount = coins.filter(x => x.coin?.change != null && x.coin.change < 0).length;
@@ -129,11 +135,15 @@ export default function CoinHeatmap() {
               <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 800, color: text, letterSpacing: '.04em' }}>
                 {c.toUpperCase()}
               </span>
-              {coin?.price != null && (
-                <span style={{ fontSize: 'var(--fs-caption)', color: withAlpha(text, 'aa'), fontVariantNumeric: 'tabular-nums' }}>
-                  ${fmtPrice(coin.price)}
-                </span>
-              )}
+              {/* Always rendered, even with no price yet. Conditionally
+                  mounting this line made every tile two lines tall until its
+                  price arrived and three lines after, so the whole grid grew
+                  in steps as coins reported in - and each step pushed the two
+                  cards below the heatmap down the page. A dash holds the
+                  slot; the tile is the same height from first paint. */}
+              <span style={{ fontSize: 'var(--fs-caption)', color: withAlpha(text, 'aa'), fontVariantNumeric: 'tabular-nums' }}>
+                {coin?.price != null ? `$${fmtPrice(coin.price)}` : '-'}
+              </span>
               <span style={{
                 fontSize: 'var(--fs-label)', fontWeight: 700, color: text,
                 fontVariantNumeric: 'tabular-nums', lineHeight: 1,

--- a/components/DrawdownChart.tsx
+++ b/components/DrawdownChart.tsx
@@ -35,6 +35,12 @@ function fmtPrice(p: number): string {
   return '$' + p.toFixed(7);
 }
 
+/* /api/ath covers 17 coins (CG_IDS in app/api/ath/route.ts), and every one of
+   them ends up as a row here, so the loading skeleton renders the same count.
+   Kept as a constant rather than inlined so the link between the two is
+   visible: if that map grows, this follows. */
+const SKELETON_ROWS = 17;
+
 export default function DrawdownChart() {
   const { t } = useLabels();
   const { store } = useMarket();
@@ -83,10 +89,20 @@ export default function DrawdownChart() {
 
       {/* Loading / error states */}
       {!ath && !err && (
-        <div style={{ padding: '10px 14px 12px', display: 'flex', flexDirection: 'column', gap: 10 }} role="status" aria-live="polite">
+        /* One skeleton row per coin this card will actually show, shaped like a
+           real row (label line + bar). Five generic bars reserved ~120px where
+           the loaded card needs ~650, so the card grew by 454px the moment the
+           data landed and shoved everything below it down the page - the
+           single largest card-growth on /scanner. A skeleton that does not
+           match the shape it is standing in for is decoration, not a
+           placeholder. */
+        <div style={{ padding: '10px 14px 12px', display: 'flex', flexDirection: 'column', gap: 7 }} role="status" aria-live="polite">
           <span className="sr-only">{t('DRAWDOWN_CHART_LOADING_SR')}</span>
-          {[0, 1, 2, 3, 4].map(i => (
-            <SkeletonBar key={i} height={12} radius={4} style={{ opacity: 1 - i * 0.12 }} />
+          {Array.from({ length: SKELETON_ROWS }).map((_, i) => (
+            <div key={i} style={{ display: 'flex', flexDirection: 'column', gap: 3, opacity: Math.max(0.25, 1 - i * 0.05) }}>
+              <SkeletonBar width="45%" height={11} radius={4} />
+              <SkeletonBar height={10} radius={4} />
+            </div>
           ))}
         </div>
       )}

--- a/components/MarketProvider.tsx
+++ b/components/MarketProvider.tsx
@@ -11,6 +11,13 @@ import { getAuthToken } from '@/lib/supabase';
 
 const WHALE_USD_THRESHOLD = 500_000; // $500k single trade = whale
 
+/* How often the REST fallback polls while the WebSocket is down, and how often
+   it retries the socket. See ws.onclose for why 5s was dangerous: restPoll
+   costs Binance request weight 80, so 5s was 960 weight/min per tab against a
+   6000/min per-IP budget, indefinitely. 30s holds it at 160. */
+const REST_FALLBACK_MS = 30_000;
+const WS_RETRY_MS      = 60_000;
+
 /* ── CVD Divergence Telegram alert ── */
 function sendCVDAlert(
   coin: string,
@@ -96,6 +103,9 @@ export default function MarketProvider({ children }: { children: React.ReactNode
   const retriesRef = useRef(0);
   const urlIdxRef = useRef(0);
   const restTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  /* Retries the socket while the REST fallback is running, so falling back is
+     temporary rather than permanent. See ws.onclose. */
+  const wsRetryRef = useRef<ReturnType<typeof setInterval> | null>(null);
   /* CVD divergence: 5-snapshot sliding window per coin */
   const cvdSnapsRef = useRef<Partial<Record<CoinId, Array<{ price: number; cvd: number }>>>>({});
   /* Whale dedup: track last seen aggTrade id per symbol */
@@ -165,6 +175,7 @@ export default function MarketProvider({ children }: { children: React.ReactNode
     ws.onopen = () => {
       retriesRef.current = 0; urlIdxRef.current = 0;
       if (restTimerRef.current) { clearInterval(restTimerRef.current); restTimerRef.current = null; }
+      if (wsRetryRef.current)  { clearInterval(wsRetryRef.current);  wsRetryRef.current = null; }
       setStore(s => ({ ...s, wsStatus: 'Live' }));
     };
 
@@ -188,10 +199,38 @@ export default function MarketProvider({ children }: { children: React.ReactNode
       urlIdxRef.current++;
       if (retriesRef.current <= 5) {
         setTimeout(() => startWSRef.current(), 2000 * retriesRef.current);
-      } else {
-        setStore(s => ({ ...s, wsStatus: 'Live · backup feed' }));
-        restPoll();
-        restTimerRef.current = setInterval(restPoll, 5000);
+        return;
+      }
+
+      /* ── REST fallback ──
+         This used to poll every 5 seconds, forever, and never retry the
+         socket. restPoll asks Binance for ticker/24hr across 45 symbols, which
+         costs request weight 80 (weight scales with symbol count: 21-100
+         symbols is the 80 band). At one call per 5s that is 960 weight per
+         minute against a 6000/minute per-IP budget - from a single tab, with
+         nothing else running, indefinitely. Two tabs, or one tab plus a normal
+         page load's other requests, and the visitor's own IP earns a Binance
+         ban within minutes. A ban returns 418 to every request from that IP,
+         including the chart's, so the whole app looks broken and the cause is
+         invisible.
+         30s holds the same fallback at 160 weight/minute. Prices come from the
+         socket whenever it is up; this path exists only while it is down, and
+         a slightly staler backup beats a banned IP. */
+      setStore(s => ({ ...s, wsStatus: 'Live · backup feed' }));
+      if (restTimerRef.current) clearInterval(restTimerRef.current);
+      restPoll();
+      restTimerRef.current = setInterval(restPoll, REST_FALLBACK_MS);
+
+      /* Falling back was permanent: after five failed reconnects nothing ever
+         opened a socket again, so a visitor who hit one bad minute stayed on
+         the REST feed for the life of the tab. Keep trying in the background;
+         ws.onopen tears both timers down when one succeeds. */
+      if (!wsRetryRef.current) {
+        wsRetryRef.current = setInterval(() => {
+          retriesRef.current = 0;
+          urlIdxRef.current  = 0;
+          startWSRef.current();
+        }, WS_RETRY_MS);
       }
     };
   }, [restPoll, updateCoin]);
@@ -1322,8 +1361,13 @@ export default function MarketProvider({ children }: { children: React.ReactNode
 
     return () => {
       intervals.forEach(clearInterval);
-      wsRef.current?.close();
+      /* Detach onclose before closing. Otherwise unmounting fires the handler
+         above, which starts the REST fallback and the socket-retry timer for a
+         provider that no longer exists - the polling then outlives the page
+         that needed it. */
+      if (wsRef.current) { wsRef.current.onclose = null; wsRef.current.close(); }
       if (restTimerRef.current) clearInterval(restTimerRef.current);
+      if (wsRetryRef.current)  clearInterval(wsRetryRef.current);
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/components/MarketProvider.tsx
+++ b/components/MarketProvider.tsx
@@ -5,6 +5,7 @@ import {
   BINANCE_SYMS, BYBIT_SYMS,
 } from '@/lib/marketStore';
 import { bybitPriceFactor } from '@/lib/coins';
+import { computeRSI14 } from '@/lib/rsi';
 import { detectPatterns } from '@/lib/patterns';
 import { getAuthToken } from '@/lib/supabase';
 
@@ -86,16 +87,8 @@ const SYM_MAP: Record<string, CoinId> = Object.fromEntries(
   Object.entries(BINANCE_SYMS).map(([id, sym]) => [sym, id as CoinId])
 );
 
-/* Helper: compute RSI14 from an array of close prices */
-function computeRSI14(closes: number[]): number | null {
-  if (closes.length < 15) return null;
-  const changes = closes.slice(1).map((c, i) => c - closes[i]);
-  const gains   = changes.slice(-14).map(c => Math.max(c, 0));
-  const losses  = changes.slice(-14).map(c => Math.max(-c, 0));
-  const avgGain = gains.reduce((a, b) => a + b, 0) / 14;
-  const avgLoss = losses.reduce((a, b) => a + b, 0) / 14;
-  return avgLoss === 0 ? 100 : Math.round(100 - (100 / (1 + avgGain / avgLoss)));
-}
+/* computeRSI14 moved to lib/rsi so app/api/market/rsi computes the identical
+   number - see that file for why two copies would drift silently. */
 
 export default function MarketProvider({ children }: { children: React.ReactNode }) {
   const [store, setStore] = useState<MarketStore>(defaultStore);
@@ -546,157 +539,44 @@ export default function MarketProvider({ children }: { children: React.ReactNode
     }));
   }, [updateCoin]);
 
-  /* ── Bybit multi-TF RSI for HYPE (1h + 4h) ── */
-  const fetchBybitMultiTFRSI = useCallback(async () => {
-    const bybitOnly = (['hype'] as CoinId[]).filter(c => BYBIT_SYMS[c] && !BINANCE_SYMS[c]);
-    await Promise.allSettled(
-      bybitOnly.flatMap(coin => {
-        const sym = BYBIT_SYMS[coin];
-        return (['60', '240'] as const).map(async (interval) => {
-          try {
-            const res = await fetch(
-              `https://api.bybit.com/v5/market/kline?category=linear&symbol=${sym}&interval=${interval}&limit=16`
-            );
-            const d = await res.json();
-            const klines: string[][] = [...(d?.result?.list ?? [])].reverse();
-            if (klines.length < 15) return;
-            const closes = klines.map(k => parseFloat(k[4]));
-            const rsi = computeRSI14(closes);
-            if (rsi === null) return;
-            updateCoin(coin, interval === '60' ? { rsi1h: rsi } : { rsi4h: rsi });
-          } catch { /* */ }
-        });
-      })
-    );
-  }, [updateCoin]);
+  /* ── RSI for every coin and timeframe, in one server call ──
+     Replaces five separate pollers - fetch5mRSI, fetchMultiTFRSI,
+     fetchBybitMultiTFRSI, fetchDailyRSI and fetchWeeklyMonthlyRSI - each of
+     which looped the whole coin list and fired one kline request per coin per
+     timeframe. That was 276 requests from the visitor's own IP on every page
+     load, all returning data identical for every visitor: a weekly RSI does
+     not differ per user.
 
-  /* ── 5-minute RSI (all coins, matches the chart's fastest timeframe) ── */
-  const fetch5mRSI = useCallback(async () => {
-    await Promise.allSettled([
-      // Binance coins
-      ...Object.entries(BINANCE_SYMS).filter(([c]) => c !== 'hype').map(async ([coin, sym]) => {
-        try {
-          const res = await fetch(
-            `https://api.binance.com/api/v3/klines?symbol=${sym}&interval=5m&limit=16`
-          );
-          const klines = await res.json();
-          if (!Array.isArray(klines) || klines.length < 15) return;
-          const closes = klines.map((k: string[]) => parseFloat(k[4]));
-          const rsi = computeRSI14(closes);
-          if (rsi !== null) updateCoin(coin as CoinId, { rsi5m: rsi });
-        } catch { /* */ }
-      }),
-      // HYPE via Bybit (5 = 5-minute interval)
-      (async () => {
-        try {
-          const res = await fetch(
-            `https://api.bybit.com/v5/market/kline?category=linear&symbol=HYPEUSDT&interval=5&limit=16`
-          );
-          const d = await res.json();
-          const klines: string[][] = [...(d?.result?.list ?? [])].reverse();
-          if (klines.length < 15) return;
-          const closes = klines.map(k => parseFloat(k[4]));
-          const rsi = computeRSI14(closes);
-          if (rsi !== null) updateCoin('hype', { rsi5m: rsi });
-        } catch { /* */ }
-      })(),
-    ]);
-  }, [updateCoin]);
+     app/api/market/rsi does that fan-out once per cache window on the server
+     and serves everyone from the one result, so this is a single request. See
+     that route for why the burst mattered - it is the suspected cause of the
+     intermittent blank chart, since tripping Binance's per-IP limit makes
+     unrelated kline calls start returning 429.
 
-  /* ── Multi-timeframe RSI (1h + 4h) ── */
-  const fetchMultiTFRSI = useCallback(async () => {
-    const binanceCoins = Object.entries(BINANCE_SYMS).filter(([c]) => c !== 'hype');
-    await Promise.allSettled(
-      binanceCoins.flatMap(([coin, sym]) =>
-        (['1h', '4h'] as const).map(async (tf) => {
-          try {
-            const res = await fetch(
-              `https://api.binance.com/api/v3/klines?symbol=${sym}&interval=${tf}&limit=16`
-            );
-            const klines = await res.json();
-            if (!Array.isArray(klines) || klines.length < 15) return;
-            const closes = klines.map((k: string[]) => parseFloat(k[4]));
-            const rsi = computeRSI14(closes);
-            if (rsi === null) return;
-            updateCoin(coin as CoinId, tf === '1h' ? { rsi1h: rsi } : { rsi4h: rsi });
-          } catch { /* */ }
-        })
-      )
-    );
-  }, [updateCoin]);
+     Polled at the old 5m cadence. The slower timeframes are cached server-side
+     at their own 15-minute TTL, so calling this every 3 minutes does not
+     re-fetch weekly and monthly candles - it just serves them warm.
 
-  /* ── Daily RSI (1D candles - all coins, runs every 15 min) ── */
-  const fetchDailyRSI = useCallback(async () => {
-    await Promise.allSettled([
-      // Binance coins
-      ...Object.entries(BINANCE_SYMS).filter(([c]) => c !== 'hype').map(async ([coin, sym]) => {
-        try {
-          const res = await fetch(
-            `https://api.binance.com/api/v3/klines?symbol=${sym}&interval=1d&limit=20`,
-            { cache: 'no-store' }
-          );
-          const klines = await res.json();
-          if (!Array.isArray(klines) || klines.length < 15) return;
-          const closes = klines.map((k: string[]) => parseFloat(k[4]));
-          const rsi = computeRSI14(closes);
-          if (rsi !== null) updateCoin(coin as CoinId, { rsiDaily: rsi });
-        } catch { /* */ }
-      }),
-      // HYPE via Bybit (D = daily interval)
-      (async () => {
-        try {
-          const res = await fetch(
-            `https://api.bybit.com/v5/market/kline?category=linear&symbol=HYPEUSDT&interval=D&limit=20`,
-            { cache: 'no-store' }
-          );
-          const d = await res.json();
-          const klines: string[][] = [...(d?.result?.list ?? [])].reverse();
-          if (klines.length < 15) return;
-          const closes = klines.map(k => parseFloat(k[4]));
-          const rsi = computeRSI14(closes);
-          if (rsi !== null) updateCoin('hype', { rsiDaily: rsi });
-        } catch { /* */ }
-      })(),
-    ]);
-  }, [updateCoin]);
-
-  /* ── Weekly + Monthly RSI (1W/1M candles - all coins, slow-moving, runs every 15 min) ── */
-  const fetchWeeklyMonthlyRSI = useCallback(async () => {
-    await Promise.allSettled([
-      // Binance coins
-      ...Object.entries(BINANCE_SYMS).filter(([c]) => c !== 'hype').flatMap(([coin, sym]) =>
-        (['1w', '1M'] as const).map(async (tf) => {
-          try {
-            const res = await fetch(
-              `https://api.binance.com/api/v3/klines?symbol=${sym}&interval=${tf}&limit=20`,
-              { cache: 'no-store' }
-            );
-            const klines = await res.json();
-            if (!Array.isArray(klines) || klines.length < 15) return;
-            const closes = klines.map((k: string[]) => parseFloat(k[4]));
-            const rsi = computeRSI14(closes);
-            if (rsi === null) return;
-            updateCoin(coin as CoinId, tf === '1w' ? { rsiWeekly: rsi } : { rsiMonthly: rsi });
-          } catch { /* */ }
-        })
-      ),
-      // HYPE via Bybit (W = weekly, M = monthly interval)
-      ...(['W', 'M'] as const).map(async (interval) => {
-        try {
-          const res = await fetch(
-            `https://api.bybit.com/v5/market/kline?category=linear&symbol=HYPEUSDT&interval=${interval}&limit=20`,
-            { cache: 'no-store' }
-          );
-          const d = await res.json();
-          const klines: string[][] = [...(d?.result?.list ?? [])].reverse();
-          if (klines.length < 15) return;
-          const closes = klines.map(k => parseFloat(k[4]));
-          const rsi = computeRSI14(closes);
-          if (rsi === null) return;
-          updateCoin('hype', interval === 'W' ? { rsiWeekly: rsi } : { rsiMonthly: rsi });
-        } catch { /* */ }
-      }),
-    ]);
+     Failure is silent and non-destructive by design: updateCoin runs only for
+     coins the response actually carried, so a partial or missing response
+     leaves the previous RSI values on screen instead of blanking the badges.
+     That matches how the per-coin version behaved when one symbol was rate
+     limited. */
+  const fetchRSI = useCallback(async () => {
+    try {
+      const res = await fetch('/api/market/rsi');
+      if (!res.ok) return;
+      const body = await res.json() as {
+        rsi?: Record<string, Partial<Record<
+          'rsi5m' | 'rsi1h' | 'rsi4h' | 'rsiDaily' | 'rsiWeekly' | 'rsiMonthly', number
+        >>>;
+      };
+      for (const [coin, fields] of Object.entries(body.rsi ?? {})) {
+        if (fields && Object.keys(fields).length > 0) {
+          updateCoin(coin as CoinId, fields);
+        }
+      }
+    } catch { /* */ }
   }, [updateCoin]);
 
   /* ── CVD + Divergence + Whale detection (all Binance coins + HYPE via Bybit) ── */
@@ -1400,16 +1280,12 @@ export default function MarketProvider({ children }: { children: React.ReactNode
     fetchLSR();
     fetchVolume();
     fetchBybitKlines();       // RSI/MA20/VWAP/POC for HYPE
-    fetchBybitMultiTFRSI();   // 1h + 4h RSI for HYPE
     fetchFNG();
     fetchCMCGlobal();
     fetchAltSeason();
     fetchMacro();
     fetchETF();
-    fetch5mRSI();
-    fetchMultiTFRSI();
-    fetchDailyRSI();
-    fetchWeeklyMonthlyRSI();
+    fetchRSI();               // all timeframes, all coins - one server call
     fetchCVD();
     fetchOrderBook();
     fetchPremiumIndex();
@@ -1428,16 +1304,14 @@ export default function MarketProvider({ children }: { children: React.ReactNode
       setInterval(fetchLSR,               5  * 60 * 1000),
       setInterval(fetchVolume,            3  * 60 * 1000),
       setInterval(fetchBybitKlines,       3  * 60 * 1000),  // same cadence as Binance klines
-      setInterval(fetchBybitMultiTFRSI,  15  * 60 * 1000),  // same as Binance multi-TF
       setInterval(fetchFNG,             24  * 60 * 60 * 1000),
       setInterval(fetchCMCGlobal,         5  * 60 * 1000),   // BTC/ETH dom - CMC, every 5m
       setInterval(fetchAltSeason,        15  * 60 * 1000),   // 90d score - slow-moving, every 15m
       setInterval(fetchMacro,            10  * 60 * 1000),
       setInterval(fetchETF,              30  * 60 * 1000),
-      setInterval(fetch5mRSI,             3  * 60 * 1000),  // same cadence as Binance klines
-      setInterval(fetchMultiTFRSI,       15  * 60 * 1000),
-      setInterval(fetchDailyRSI,         15  * 60 * 1000),  // 1D RSI - slow-moving, every 15m
-      setInterval(fetchWeeklyMonthlyRSI, 15  * 60 * 1000),  // 1W/1M RSI - slow-moving, every 15m
+      // 5m RSI's old cadence. The 1h/4h/1d/1w/1M values are cached server-side
+      // at their own 15m TTL, so this does not re-fetch them every 3 minutes.
+      setInterval(fetchRSI,               3  * 60 * 1000),
       setInterval(fetchCVD,               5  * 60 * 1000),
       setInterval(fetchOrderBook,         2  * 60 * 1000),
       setInterval(fetchPremiumIndex,     30  * 1000),        // every 30s - premium changes frequently

--- a/components/PageHint.tsx
+++ b/components/PageHint.tsx
@@ -10,24 +10,44 @@ interface Props {
 
 export default function PageHint({ pageKey, title, body }: Props) {
   const key = `lhq_hint_${pageKey}`;
-  const [show, setShow] = useState(false);
+  /* Three states, not two: 'pending' matters.
+   *
+   * This used to start at "hidden", then flip to "shown" after reading
+   * localStorage on mount. For a first-time visitor that inserted ~62px at the
+   * very top of the page a beat after paint, pushing every card below it down
+   * - about 7% of /scanner's layout shift, and it applied to every page this
+   * component is on.
+   *
+   * Rendering an invisible spacer during 'pending' means the space is already
+   * reserved when the answer arrives: the hint fades in where the gap was, or
+   * the gap collapses for a returning visitor who dismissed it. The collapse
+   * is a shift too, but it happens for people who have seen the hint before
+   * and are scrolling past it, and it is one frame rather than a reflow of
+   * everything below. */
+  const [state, setState] = useState<'pending' | 'show' | 'hide'>('pending');
   const { t } = useLabels();
 
   useEffect(() => {
     try {
-      if (!localStorage.getItem(key)) setShow(true);
-    } catch {}
+      setState(localStorage.getItem(key) ? 'hide' : 'show');
+    } catch {
+      setState('show');
+    }
   }, [key]);
 
-  if (!show) return null;
+  if (state === 'hide') return null;
 
   function dismiss() {
     try { localStorage.setItem(key, '1'); } catch {}
-    setShow(false);
+    setState('hide');
   }
 
   return (
     <div style={{
+      /* Invisible but occupying its full height until the localStorage read
+         resolves, so the hint arrives in space that was already reserved
+         rather than inserting itself and pushing the page down. */
+      visibility: state === 'pending' ? 'hidden' : 'visible',
       display: 'flex',
       alignItems: 'flex-start',
       gap: 10,

--- a/components/PlatformFooter.tsx
+++ b/components/PlatformFooter.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useTheme } from '@/lib/theme';
+import { useAuth } from '@/components/AuthProvider';
 import BrandMark from '@/components/BrandMark';
 
 const DISCLOSURES = [
@@ -40,7 +41,30 @@ export default function PlatformFooter() {
   // .pf-footer), so its mark must track the real theme rather than a fixed
   // tone - the one surface in this rollout where that's actually true.
   const { theme } = useTheme();
+  const { loading: authLoading } = useAuth();
   if (pathname === '/' || pathname === '/login') return null;
+
+  /* Do not paint the page's closing chrome before the page body exists.
+   *
+   * Most routes render nothing but a small header stub until auth resolves,
+   * which takes roughly 800ms. During that window this footer - 296px, the
+   * tallest single element on the page - sat at y=132 in a 900px viewport,
+   * fully visible. The moment the real content mounted it was thrown below
+   * the fold in one frame, and because CLS scores impact fraction times
+   * distance moved, that one move was 82% of /arena's 0.365 total.
+   *
+   * Returning null here is the whole fix: with no footer in the pending
+   * window there is nothing to move, and once auth settles the footer mounts
+   * already below the fold. Mounting an element is not a layout shift, and
+   * nothing renders after the footer for its arrival to push around.
+   *
+   * Tried and rejected first: min-height on .app-content to reserve a
+   * viewport of space. It made things worse, not better - measured 0.76,
+   * roughly double the baseline - because it turned .app-content itself into
+   * a shifting element. Reserving space is the textbook CLS fix and it was
+   * the wrong one here; the problem was never missing space, it was painting
+   * the footer too early. */
+  if (authLoading) return null;
 
   return (
     <footer className="pf-footer">

--- a/components/SignalAccuracy.tsx
+++ b/components/SignalAccuracy.tsx
@@ -88,10 +88,13 @@ export default function SignalAccuracy() {
 
       {/* Loading / error */}
       {!data && !err && (
-        <div style={{ padding: '10px 14px 12px', display: 'flex', flexDirection: 'column', gap: 10 }} role="status" aria-live="polite">
+        /* Four thin bars reserved ~90px where the loaded card needs ~420, so it
+           grew by 270px on arrival and pushed everything below it. Taller bars
+           at the real row count reserve roughly the right space instead. */
+        <div style={{ padding: '10px 14px 12px', display: 'flex', flexDirection: 'column', gap: 9 }} role="status" aria-live="polite">
           <span className="sr-only">{t('SIGNAL_ACCURACY_SR_COMPUTING')}</span>
-          {[0, 1, 2, 3].map(i => (
-            <SkeletonBar key={i} height={14} radius={4} style={{ opacity: 1 - i * 0.15 }} />
+          {Array.from({ length: 8 }).map((_, i) => (
+            <SkeletonBar key={i} height={36} radius={6} style={{ opacity: Math.max(0.25, 1 - i * 0.09) }} />
           ))}
         </div>
       )}

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -66,10 +66,15 @@ directory genuinely exists and is populated — it is not a dead reference.
 **npm scripts** (that's all of them):
 
 ```bash
-npm run dev            # next dev
-npm run build          # next build
-npm start              # next start
-npm run labels:regen   # refresh lib/labelDefaults.en.json from a running dev server
+npm run dev              # next dev
+npm run build            # next build
+npm start                # next start
+npm run lint             # eslint . - 0 errors, ~93 warnings (documented backlog)
+npm test                 # node --test __tests__/*.test.mts - 44 assertions
+npm run test:e2e         # playwright test - builds + boots the app on port 3100 itself
+npm run test:e2e:ui      # same, in Playwright's UI mode
+npm run test:e2e:report  # open the HTML report from the last e2e run
+npm run labels:regen     # refresh lib/labelDefaults.en.json from a running dev server
 ```
 
 **MCP servers wired up and used regularly:**
@@ -86,8 +91,33 @@ live logged-in session, and it has been crashing.
 **Plugins/skills present** in `.claude/skills` (design, frontend, security, testing
 helpers) and a `caveman` output-style plugin. Skills are directory-scoped to the project.
 
-**No CI. No test runner.** No `.github/workflows`, no Jest/Vitest/Playwright. All
-verification is manual and rigor-tiered per `docs/QA_TEST_PLAN.md`.
+**Testing & CI** — corrected 2026-08-05. This section previously read *"No CI. No test
+runner. No `.github/workflows`, no Jest/Vitest/Playwright."* All three of those now exist;
+the claim was already stale when written up as audit §7.2.
+
+| Layer | What | Where |
+|---|---|---|
+| CI | GitHub Actions, on push to `dev` and `main`. Job `build`: lint → typecheck → test → build. Job `e2e`: Playwright, `needs: build` | `.github/workflows/ci.yml` |
+| Unit | `node --test`, 4 files, 44 assertions | `__tests__/*.test.mts` |
+| E2E | Playwright, 216 tests × desktop 1440×900 + iPhone 13, against a **production** build on port 3100 | `qa/e2e/*.spec.ts`, `playwright.config.ts` |
+| Lint | ESLint via CLI — `next lint` no longer exists in Next 16, and `next build` stopped linting | `eslint.config.mjs` |
+
+Two things about the E2E suite that will bite otherwise:
+
+- **It needs `.env.local`.** `NEXT_PUBLIC_*` is inlined at build time and the config builds
+  the app itself, so without `NEXT_PUBLIC_SUPABASE_URL` / `_ANON_KEY` the login specs fail
+  and `/api/ops/*` returns 500 instead of 401 — which reads as a security regression and
+  is not.
+- **Baselines only ratchet down.** `qa/e2e/_shared.ts` holds known-failing counts so CI is
+  green on today's code while still blocking regressions. Never raise one to make a build
+  pass.
+
+Manual verification is still rigor-tiered per `qa/QA_TEST_PLAN.md` (**moved from `docs/`
+on 2026-08-04** — §4's table below still points at the old path).
+
+Current state: `pendings/QA_AUDIT_2026-08-04.md` (the sweep) and
+`pendings/QA_E2E_FINDINGS_2026-08-05.md` (first execution of the suite, and **two
+corrections to that audit** — its CLS and tap-target numbers are both wrong).
 
 ---
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -72,6 +72,14 @@ const eslintConfig = defineConfig([
     'node_modules/**',
     'public/**',
     'supabase/**',
+    // Playwright's generated HTML report and per-test artefacts. Both are
+    // gitignored, so CI's fresh checkout never sees them - but locally, one
+    // `npm run test:e2e` leaves a bundled copy of Playwright's own report UI on
+    // disk, and the next `npm run lint` fails inside it with
+    // `React Hook "T.useState" is called in function "te"`. That is a lint
+    // error in vendored, minified third-party code that no one can act on.
+    'qa/e2e-report/**',
+    'test-results/**',
   ]),
 ]);
 

--- a/lib/apiCache.ts
+++ b/lib/apiCache.ts
@@ -18,3 +18,42 @@ export async function cached<T>(key: string, ttlMs: number, fetcher: () => Promi
   store.set(key, { ts: Date.now(), data });
   return data;
 }
+
+/* Same as `cached`, but keeps serving the last good value when the fetcher
+ * fails instead of propagating the error.
+ *
+ * `cached` leaves a stale entry in place on failure but will not hand it back,
+ * so a caller gets an exception and typically turns it into a 5xx. For data
+ * that barely moves, that is the wrong trade: an all-time high from six hours
+ * ago is correct to several decimal places, while a 502 is a hole on the page.
+ *
+ * Written for /api/ath, which asks CoinGecko's keyless public API for
+ * all-time highs. That endpoint rate-limits per IP, and adding a third
+ * environment was enough to start tripping it: the qa service returned
+ * `{"error":"CoinGecko 429"}` on every attempt while production, on a
+ * different instance, was fine. Nothing was wrong with the code - the IP had
+ * simply spent its budget, and each failed request re-asked immediately
+ * because a 429 is never cached.
+ *
+ * Only use this where stale is genuinely better than absent. Prices, balances
+ * and anything a user acts on directly should fail loudly instead.
+ */
+export async function cachedStale<T>(
+  key: string, ttlMs: number, fetcher: () => Promise<T>,
+): Promise<{ data: T; stale: boolean; ageMs: number }> {
+  const hit = store.get(key) as { ts: number; data: T } | undefined;
+  const age = hit ? Date.now() - hit.ts : Infinity;
+  if (hit && age < ttlMs) return { data: hit.data, stale: false, ageMs: age };
+
+  try {
+    const data = await fetcher();
+    store.set(key, { ts: Date.now(), data });
+    return { data, stale: false, ageMs: 0 };
+  } catch (e) {
+    /* Deliberately does NOT refresh the timestamp. Every subsequent request
+       retries the upstream rather than settling into serving stale data
+       forever, so recovery is automatic once the rate limit resets. */
+    if (hit) return { data: hit.data, stale: true, ageMs: age };
+    throw e;   // nothing cached yet - the caller has to handle a real failure
+  }
+}

--- a/lib/rsi.ts
+++ b/lib/rsi.ts
@@ -1,0 +1,23 @@
+/* Windowed RSI(14).
+ *
+ * Moved here verbatim from MarketProvider.tsx so the browser and
+ * app/api/market/rsi/route.ts compute the identical number. Two copies would
+ * drift silently: the value is rounded to an integer, so a one-line difference
+ * in the averaging window shifts a coin across the 30/70 thresholds that drive
+ * the oversold/overbought badges without ever looking wrong on screen.
+ *
+ * This is the simple (non-Wilder-smoothed) variant: a flat mean of the last 14
+ * gains and losses rather than an exponential average seeded from the first 14
+ * bars. It reads slightly more reactive than TradingView's RSI. Kept as-is
+ * deliberately - every threshold, alert rule and backtest in the app was tuned
+ * against these numbers, so "correcting" it to Wilder would silently re-tune
+ * all of them. Change it only alongside those. */
+export function computeRSI14(closes: number[]): number | null {
+  if (closes.length < 15) return null;
+  const changes = closes.slice(1).map((c, i) => c - closes[i]);
+  const gains   = changes.slice(-14).map(c => Math.max(c, 0));
+  const losses  = changes.slice(-14).map(c => Math.max(-c, 0));
+  const avgGain = gains.reduce((a, b) => a + b, 0) / 14;
+  const avgLoss = losses.reduce((a, b) => a + b, 0) / 14;
+  return avgLoss === 0 ? 100 : Math.round(100 - (100 / (1 + avgGain / avgLoss)));
+}

--- a/pendings/PENDING.md
+++ b/pendings/PENDING.md
@@ -835,3 +835,51 @@ translations in either project, so choosing one silently rendered English.
 stays complete: it is the validation list, so a preference already saved as
 `tr` still resolves to English instead of erroring. Re-adding a language is a
 one-line change to `AVAILABLE_LOCALES` once its rows land.
+
+---
+
+## ⛔ OPEN — /scanner has ~0.98 CLS, and the audit's 0.000 figure is wrong
+
+**Found 2026-08-05** while fixing `/arena`'s layout shift (PR #5).
+
+`pendings/QA_AUDIT_2026-08-04.md` §0 and §3.2 report **"Cumulative Layout Shift
+0.000 on every page measured"**. That is not true of at least three routes.
+Measured on a production build, `.next` deleted, one server, three runs each,
+with a gate asserting the page actually rendered first:
+
+| Route | Measured CLS | Google's threshold |
+|---|---|---|
+| `/scanner` | **0.79 – 1.25** (median ~0.98) | poor above 0.25 |
+| `/arena` | 0.365 | fixed to 0.068 in PR #5 |
+| `/briefing` | 0.16 | needs improvement |
+| `/dashboard` | 0.006 | good |
+| `/privacy` | 0.005 | good |
+
+`/scanner` is roughly **10x the "poor" threshold** on a core feature page, and
+it is the one route nobody has reported. It is **not** caused by the `/arena`
+footer fix - baseline and fixed builds both measure ~1.0.
+
+Its shape is different from `/arena`'s, which is why the same fix will not
+work. `/arena` was one dominant jump (82% from a single element). `/scanner`
+produces **23 to 34 separate shifts per load**, and the run-to-run spread
+(0.79 to 1.25) is itself a signal: the page's layout depends on how much
+market data has arrived, so the shifts are data-dependent rather than a single
+fixed mistake.
+
+**Do not plan from audit §8's ordering until §3.2 is corrected** - that
+priority list was built on the assumption that layout stability was already
+perfect, so it ranks SEO and contrast work above a route that is currently the
+worst Core Web Vital in the product.
+
+**Two measurement traps found the hard way, worth repeating:**
+
+- **A stale `npm start` serving an old `.next` against newly-built chunk hashes
+  returns HTTP 500, renders an empty page, and reports a perfect CLS 0.000.**
+  Any CLS measurement without a "did the page actually render" assertion can
+  produce a beautiful, meaningless zero. Kill the old server and delete
+  `.next` between configurations.
+- **Attribution beats intuition.** `/arena`'s shift was blamed on the Ask AI
+  FAB by two separate readings, including mine. Per-source attribution put the
+  FAB at **0.1%** and the footer at 82%. Separately, the textbook fix -
+  reserving space with `min-height` - measured *double* the baseline. Measure
+  before and after every attempt; do not reason about which is likely.

--- a/pendings/PENDING.md
+++ b/pendings/PENDING.md
@@ -835,3 +835,50 @@ translations in either project, so choosing one silently rendered English.
 stays complete: it is the validation list, so a preference already saved as
 `tr` still resolves to English instead of erroring. Re-adding a language is a
 one-line change to `AVAILABLE_LOCALES` once its rows land.
+
+---
+
+## Binance request fan-out per page load — 46% addressed, rest outstanding
+
+**Partially fixed 2026-08-04** — PR #2, `refactor/server-side-rsi-aggregation`.
+
+The dashboard fired ~495 Binance requests from the visitor's own IP on every
+page load. Priced against Binance's 6000-weight-per-minute per-IP budget:
+
+| Call | Weight each | Count | Total | Status |
+|---|---|---|---|---|
+| RSI klines (5m/1h/4h/1d/1w/1M) | 2 | 276 | 552 | ✅ moved server-side |
+| `depth` limit=50 (`fetchOrderBook`) | 5 | 45 | 225 | ⬜ outstanding |
+| `aggTrades` limit=200 (`fetchCVD`) | 4 | 45 | 180 | ⬜ outstanding |
+| `ticker/24hr` (45 symbols) | 80 | 2 | 160 | ⬜ outstanding |
+| klines 15m (`fetchKlines`) | 2 | 45 | 90 | ⬜ outstanding |
+| `globalLongShortAccountRatio` + `topLongShortPositionRatio` | — | 90 | — | ⬜ outstanding (futures bucket) |
+
+≈**1207 weight per page load** before the fix, so roughly five loads in a
+minute earns an IP ban, after which Binance returns 418 to *every* request from
+that IP — including the ones the chart needs. **This is the blank-chart cause
+and it was reproduced**: this machine's IP was banned mid-development with
+`"Way too much request weight used; IP banned until ..."`.
+
+Now ≈655 weight per load. Still only ~5x headroom on a shared IP.
+
+**Three things worth knowing before doing the rest:**
+
+- **Spot and futures are separate limit buckets.** `api.binance.com` was banned
+  while `fapi.binance.com` answered normally throughout. That is what let the
+  new route finish via its fallback, and it is a useful diagnostic: if one
+  works and the other 418s, it is a weight ban, not an outage.
+- **Pinging while banned extends the ban.** A poll loop waiting for it to lift
+  kept it alive well past its stated expiry. Wait it out; do not poll.
+- **`fetchOrderBook` and `fetchCVD` are the next best targets** — 405 weight
+  combined, and both return per-coin data that is identical for every visitor,
+  so they cache exactly like the RSI group did. `fetchKlines` is harder: it
+  feeds VWAP/POC/value-area maths that would have to move server-side with it.
+
+**Separate issue found while measuring, not fixed:** `restPoll` polls
+`ticker/24hr` for all 45 symbols **every 5 seconds** once the WebSocket has
+failed 5 reconnects (`components/MarketProvider.tsx`, `startWS` `onclose`).
+That is weight 80 x 12/min = **960 weight/min, per tab, indefinitely** — it is
+only cleared on unmount. A user who leaves a tab open in fallback mode will ban
+their own IP within about six minutes. Worth fixing independently of the
+fan-out work; the fix is probably a slower fallback interval plus a cap.

--- a/pendings/QA_E2E_FINDINGS_2026-08-05.md
+++ b/pendings/QA_E2E_FINDINGS_2026-08-05.md
@@ -1,0 +1,219 @@
+# QA — first execution of the E2E suite, 2026-08-05
+
+**Run by:** the QA session. **No application code was modified.** Everything
+below is either a finding handed to the development session, or a change to
+test infrastructure (`qa/e2e/*`, `playwright.config.ts`, `eslint.config.mjs`,
+`.github/workflows/ci.yml`), which QA owns.
+
+The Playwright suite committed in `81aea13` had **never been executed** — it
+typechecked and linted clean, which is not the same thing. Running it found
+three defects in the suite itself and two errors in
+`pendings/QA_AUDIT_2026-08-04.md`.
+
+**Method.** Four full runs against a production build (`npm run build` +
+`npm start`, port 3100), plus two standalone harnesses written specifically to
+check the suite's own numbers from a separate process. Where this document
+disagrees with the audit, the disagreement was reproduced by **two independent
+harnesses** before being written down — audit §4.3 is a worked example of why
+one harness is not enough.
+
+---
+
+## 0. Scoreboard
+
+| | Before | After |
+|---|---|---|
+| E2E tests that had ever run | **0 of 216** | 216 |
+| Mobile project | **never launched** | 108 tests running |
+| Suite result | n/a | 174 passed / 3 failed → **0 failed** after corrections |
+| Wall clock | n/a | ~32 min, 1 worker |
+| `npx tsc --noEmit` | clean | clean |
+| `npm run lint` | 0 errors | 0 errors, 93 warnings |
+
+---
+
+## 1. 🔴 Corrections to the 2026-08-04 audit
+
+No application code changed between the audit and these measurements. Both
+items below are therefore **errors in the audit, not regressions in the app.**
+
+### 1.1 CLS is not 0.000 — `/arena` is 0.367, in the "poor" band
+
+Audit **§3.2** states *"CLS = 0.000 on every page measured"* and names `/arena`
+and `/briefing` among those pages. Both fail Google's 0.1 "good" threshold, and
+`/arena` is past the 0.25 "poor" boundary.
+
+Reproduced on three consecutive suite runs and once more by a standalone
+harness with shift attribution:
+
+| Route | CLS | Dominant shift |
+|---|---|---|
+| `/arena` | **0.367** | `t=763ms  v=0.3031` — `FOOTER.pf-footer` + `BUTTON.gchat-fab` |
+| `/briefing` | 0.148 – 0.176 | `t=652ms  v=0.0933` — five `DIV.card` (`.mb-brief-card`) |
+| `/dashboard` | 0.006 | — (passes; included as a control) |
+
+**One late shift at 763 ms is 83% of `/arena`'s total.** The footer and the
+Grok chat FAB paint after the main content and push the page down.
+
+`/dashboard` measuring 0.006 on the identical harness is the reason this is
+read as real product behaviour rather than an over-eager observer.
+
+**Why the audit missed it:** most likely its measurement window closed before
+the shifts landed. This suite waits 2500 ms for hydration and *then* reads
+`layout-shift` entries with `buffered: true`, so it sees shifts a short window
+misses.
+
+**Fix direction** (dev session's call): reserve space for the footer and the
+FAB so they do not reflow content in, or defer their mount until after LCP.
+
+**Repro:** `npm run build && PORT=3100 npm start`, then load `/arena` with a
+`PerformanceObserver` on `layout-shift`.
+
+### 1.2 Tap targets under 24px are 213, not 159 — and `/playbook` is the worst route
+
+Audit **§4.1** reports 159 and says *"~85% of the 159 come from one shared
+footer component"*. Measured at **the audit's own 375×812 viewport**: **213**.
+
+The gap is exact and fully explained. §4.1's table lists `button.pb-star` on
+`/playbook` as a **single row** (`16 × 13`). There are **55 of them**:
+
+```
+213 − 55 + 1 = 159
+```
+
+Composition at 375×812:
+
+| Count | Element | Note |
+|---|---|---|
+| 84 | `a.pf-footer-bottom-link` | counted per instance by the audit |
+| **55** | `button.pb-star` — "★" `16×13` | `/playbook`; audit counted this as 1 |
+| 28 | `button.pf-footer-expand` | counted per instance by the audit |
+| 27 | `a.consent-link` | cookie consent bar — **absent from the audit entirely** |
+| 12 | `a` (no class) | incl. "Refund Policy", "Full disclaimer" |
+| 5 | `button` (no class) | the `14×16` "×" close controls |
+| 1 | `div` · 1 `button.st-toggle` | |
+
+Viewport is **not** a factor: 213 at 375×812 vs 217 at iPhone 13's real
+390×844, a difference of 4.
+
+**This reorders audit §8.** Its plan ranks "fix `.pf-footer-*`" third on the
+claim that it clears ~135 of 159 (85%).
+
+| Target | Real share of 213 |
+|---|---|
+| `.pf-footer-*` (both elements) | 112 — **53%** |
+| `/playbook` `button.pb-star` | 55 — **26%** |
+| `a.consent-link` | 27 — 13% |
+
+`button.pb-star` at `16×13` is **under half** the WCAG 2.2 AA floor, and it is a
+primary control (favourite a play), not footer fine print. It is a single
+component fixed once, affecting 55 targets.
+
+`BASELINE.tapTargetsUnder24` in `qa/e2e/_shared.ts` has been corrected 159 → **217**
+with an inline explanation. Note the baseline tracks **390×844** (the suite's
+`devices['iPhone 13']` mobile project), not the audit's 375×812 — setting it to
+213 from the audit's viewport was a mistake made once already here, and it
+surfaced as a 213-vs-217 failure. **That comment must not be read as precedent for
+raising a baseline** — it documents a corrected measurement of unchanged code.
+The only legitimate future change to that number is downward.
+
+---
+
+## 2. 🟡 Defects in the E2E suite itself — found by running it, all fixed
+
+These are why "typechecks and lints clean" is not evidence a test suite works.
+
+| # | Defect | Symptom | Fix |
+|---|---|---|---|
+| 2.1 | `browserName` not pinned on the `mobile` project | **All 108 mobile tests failed in ~2 ms** with `browserType.launch: Executable doesn't exist at ...\webkit-2336\Playwright.exe` | pin `browserName: 'chromium'` |
+| 2.2 | `page.getAttribute()` on a possibly-absent element | `/ops/login is not indexable` hung for the full **120 s** timeout and reported as a product failure | `count()` first, then read |
+| 2.3 | Per-test timeout too tight for CI | 32-route sweeps take ~90 s locally against a 120 s cap — 75% of budget before CI's slower hardware | raise to 240 s |
+| 2.4 | ESLint scanned Playwright's generated report | after any `npm run test:e2e`, `npm run lint` failed inside minified vendored code | ignore `qa/e2e-report/**`, `test-results/**` |
+
+**2.1 is the significant one.** The mobile project silently defaulted to WebKit
+because `devices['iPhone 13']` carries `defaultBrowserType: 'webkit'`, and this
+repo deliberately installs Chromium only. Mobile is where all 213 tap-target
+findings and the 375px overflow assertions live — **none of those assertions had
+ever executed.** The failure mode is nasty: 108 red tests that look like 108
+product bugs, caused by one missing config line.
+
+---
+
+## 3. CLS budgets — new mechanism in `_shared.ts`
+
+`/arena` and `/briefing` cannot be fixed from a QA session, and leaving the
+suite permanently red trains everyone to ignore it — the same dynamic that
+turned 93 lint warnings into a backlog nobody owns.
+
+They are therefore held to documented known-bad budgets, exactly as the
+existing tap-target and h1 baselines are, while **every other route keeps the
+strict 0.1 threshold**:
+
+```ts
+export const CLS_BUDGET: Record<string, number> = {
+  '/arena': 0.40,     // worst observed 0.367
+  '/briefing': 0.20,  // observed 0.148, 0.153, 0.176
+};
+```
+
+A route that reaches < 0.1 should be **deleted from the map**, not lowered — it
+then falls back to the strict threshold automatically.
+
+---
+
+## 4. CI — the `e2e` job
+
+Added to `.github/workflows/ci.yml`, `needs: build`, Chromium only, report
+uploaded as an artifact on pass *and* fail (retention 14 days).
+
+Cost: roughly +6–8 min per push. `needs: build` means it does not run at all if
+lint, typecheck, unit tests or the build already failed.
+
+### ⚠️ Requires 3 repo secrets before it can pass — owner action
+
+`E2E_SUPABASE_URL`, `E2E_SUPABASE_ANON_KEY`, `E2E_TURNSTILE_SITE_KEY`.
+
+Point them at the **dev** Supabase project (`wdtjhrilakoitfcezxpx`), **anon key
+only, never the service-role key, never prod.**
+
+These are set on the *run* step because `NEXT_PUBLIC_*` is **inlined at build
+time** and `playwright.config.ts`'s `webServer` performs the build. Without
+them, `AuthProvider` constructs no Supabase client, `/login` never renders its
+form, and `/api/ops/*` throws `supabaseUrl is required` and answers **500 where
+the security specs assert 401** — three failures that look like security
+regressions and are not. This was observed directly during run 1.
+
+---
+
+## 5. Still open
+
+| Item | Owner | Note |
+|---|---|---|
+| **BOLA / IDOR** | **owner + QA** | Unchanged since the audit. `security.spec.ts` still carries a `test.fixme`. Needs `E2E_TOKEN_A` / `E2E_TOKEN_B` for the two test accounts. **The largest untested area in the product.** |
+| 3 CI secrets above | owner | job cannot go green without them |
+| Leaked-password protection | owner | 2 Supabase toggles, audit §2.2 |
+| Stray `C:\Users\Dominic\package-lock.json` | owner | still hijacking Next's workspace root; printed on every build of this run |
+| `/arena` + `/briefing` CLS | dev | §1.1 |
+| `/playbook` `button.pb-star` | dev | §1.2 — 55 targets, one component |
+| Audit §3.2 and §4.1 text | dev/QA | now known wrong; correct them in place per `HANDOVER.md`'s "code wins, then fix the file" rule |
+| `HANDOVER.md` §3 | dev/QA | still says *"No CI. No test runner… no Playwright."* All three exist. Flagged as audit §7.2 and still true. |
+
+---
+
+## 6. Reproducing
+
+```bash
+npm ci
+npx playwright install --with-deps chromium
+npm run test:e2e          # config builds and boots the app on 3100 itself
+npm run test:e2e:report   # open the HTML report
+```
+
+Requires a `.env.local` with at least `NEXT_PUBLIC_SUPABASE_URL` and
+`NEXT_PUBLIC_SUPABASE_ANON_KEY` pointing at the dev project, for the reason in
+§4.
+
+The two standalone verification harnesses (viewport comparison, CLS attribution,
+tap-target histogram) were written in the session scratchpad and are **not
+committed** — they exist to check the suite from outside itself, and are
+described in enough detail above to rebuild in ~20 minutes.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,7 +15,15 @@ const PORT = Number(process.env.E2E_PORT ?? 3100);
 export default defineConfig({
   testDir: './qa/e2e',
   // Each spec sweeps ~32 routes; the default 30s is not enough on a cold start.
-  timeout: 120_000,
+  //
+  // 240s, not 120s. Measured 2026-08-04: a 32-route sweep (a11y, seo) takes
+  // ~90s on this dev machine, i.e. 75% of a 120s budget before CI is even
+  // involved. A GitHub ubuntu-latest runner is slower, so 120s would have
+  // turned every sweep test into a timeout the first time it ran in CI - and a
+  // timeout reads as a product failure, not as "the budget was too tight".
+  // The per-route cost is settle()'s deliberate 2500ms hydration wait; that
+  // wait is load-bearing for measurement accuracy, so the budget moves, not it.
+  timeout: 240_000,
   expect: { timeout: 10_000 },
 
   // A flaky pass is worse than a fail - it teaches everyone to re-run until
@@ -43,7 +51,16 @@ export default defineConfig({
     { name: 'desktop', use: { ...devices['Desktop Chrome'], viewport: { width: 1440, height: 900 } } },
     // Real iPhone metrics + touch + mobile UA. The app is an installable PWA,
     // so 375px is a primary target, not an edge case.
-    { name: 'mobile', use: { ...devices['iPhone 13'] } },
+    //
+    // browserName MUST stay pinned to chromium. devices['iPhone 13'] carries
+    // `defaultBrowserType: 'webkit'`, so without this the whole mobile project
+    // silently tries to launch WebKit - which this repo deliberately does not
+    // install (E2E_PLAN.md §3.3: Chromium only, the app ships as a
+    // Chromium-based PWA + Capacitor Android shell). That mistake made all 71
+    // mobile tests fail in ~2ms with "Executable doesn't exist at
+    // ...webkit-2336", which reads like 71 product bugs rather than one config
+    // line.
+    { name: 'mobile', use: { ...devices['iPhone 13'], browserName: 'chromium' } },
   ],
 
   // Playwright builds and boots the app itself so CI and local behave the same.

--- a/qa/E2E_PLAN.md
+++ b/qa/E2E_PLAN.md
@@ -1,12 +1,30 @@
 # E2E test suite + CI job — implementation plan
 
-**Written 2026-08-04 by the QA session.** The spec files and
-`playwright.config.ts` are already written and committed-ready. What remains is
-three shared-file changes and two decisions, listed below.
+**Written 2026-08-04. Largely CARRIED OUT on 2026-08-05** — see
+`pendings/QA_E2E_FINDINGS_2026-08-05.md` for what executing it actually found.
+This file is kept for its reasoning (§1 in particular); read the status table
+below before trusting any individual section.
 
-**Nothing here has been executed.** `npm install` was not run, `package.json`
-and `.github/workflows/ci.yml` were not modified — those are shared files the
-development session owns, and this needs to land as one coherent commit.
+| § | Item | Status |
+|---|---|---|
+| 1 | Why Playwright and not a hosted service | still the standing decision |
+| 2 | What exists | accurate, but the baselines it quotes are **superseded** — see below |
+| 3.1 | `package.json` scripts + devDependency | **done** |
+| 3.2 | `.gitignore` entries | **done** |
+| 3.3 | CI `e2e` job | **done** — `ci.yml`, `needs: build` |
+| 4.1 | Supabase env in CI | **decided: option A.** Needs 3 repo secrets — owner action, see the findings doc §4 |
+| 4.2 | Turnstile in CI | unchanged, still correct |
+| 5 | BOLA / IDOR | **still open. Still the biggest gap.** |
+| 6 | Suggested sequence | steps 1–5 done, step 6 outstanding |
+
+⚠️ **The baseline numbers quoted in §2 below are wrong.** Executing the suite
+showed tap targets are **217** (at the suite's 390×844), not 159, and that
+`/arena` and `/briefing` fail CLS where audit §3.2 claimed 0.000 everywhere.
+`qa/e2e/_shared.ts` is authoritative; the reasoning is in the findings doc §1.
+
+Executing it also found three defects in the suite itself — most importantly
+the mobile project silently defaulting to WebKit, so **all 108 mobile tests had
+never run**. "Typechecks and lints clean" was not evidence the suite worked.
 
 ---
 
@@ -45,11 +63,17 @@ Revisit if real users arrive and cross-browser/real-device coverage is needed.
 `qa/e2e/_shared.ts` exports `BASELINE`, the known-failing counts from the audit:
 
 ```ts
-tapTargetsUnder24:   159   // §4.1
+tapTargetsUnder24:   217   // §4.1 - CORRECTED 2026-08-05 from 159; see below
 controlsWithoutName:   4   // §4.2
 pagesWithoutH1:       13   // §6.4
 pagesWithCanonical:    0   // §6.2 - inverted, must only go UP
 ```
+
+The tap-target figure was corrected **upward**, which the rule below otherwise
+forbids. That was legitimate exactly once, because 159 was a mis-measurement of
+unchanged code rather than a number the app later regressed past: audit §4.1
+counted `/playbook`'s 55 `button.pb-star` controls as one table row. It is not
+precedent. `_shared.ts` carries the full reasoning inline.
 
 Every spec passes on today's code. A spec fails only when a count gets **worse**.
 When something is fixed, lower the baseline in the same commit — that is the ratchet.

--- a/qa/e2e/_shared.ts
+++ b/qa/e2e/_shared.ts
@@ -23,8 +23,37 @@ export const ROUTES = [
  * Full detail + file:line for each: pendings/QA_AUDIT_2026-08-04.md
  */
 export const BASELINE = {
-  /** §4.1 - tap targets under the WCAG 2.2 AA 24px floor, mobile, all routes. */
-  tapTargetsUnder24: 159,
+  /**
+   * §4.1 - tap targets under the WCAG 2.2 AA 24px floor, mobile, all routes.
+   *
+   * 217, CORRECTED UP from 159 on 2026-08-05. This is NOT a ratchet violation
+   * and is NOT precedent for raising a baseline - read this before citing it.
+   *
+   * The number must match the viewport THIS SUITE runs at: the mobile project
+   * is devices['iPhone 13'], which is 390x844. At the audit's 375x812 the count
+   * is 213. Setting the baseline from the audit's viewport instead of the
+   * suite's is a mistake that was made once already and showed up as a 213-vs-
+   * 217 failure - if you re-measure, re-measure at 390x844.
+   *
+   * The audit's 159 was an undercount of unchanged code, not a number the app
+   * has since regressed past. §4.1's table lists `button.pb-star` on /playbook
+   * as a single row; there are 55 of them, each 16x13. The audit counted the
+   * footer links per instance (84 + 28 across ~30 routes) but collapsed the
+   * stars to one. 213 - 55 + 1 = 159 reproduces the old figure exactly.
+   *
+   * Verified 2026-08-05 by two independent harnesses: 213 at the audit's own
+   * 375x812 and 217 at iPhone 13's real 390x844 - a difference of 4, so
+   * viewport is not what explains the gap from 159. Composition at 375x812:
+   *   84 a.pf-footer-bottom-link · 55 button.pb-star · 28 button.pf-footer-expand
+   *   27 a.consent-link · 12 a · 5 button · 1 div · 1 button.st-toggle
+   *
+   * This also reorders audit §8: the footer is 112/213 (53%), not the ~85% it
+   * claims, and /playbook's stars are 26% on their own.
+   *
+   * The only legitimate reason to change this number again is DOWNWARD, when a
+   * fix lands.
+   */
+  tapTargetsUnder24: 217,
   /** §4.2 - controls whose only label is a placeholder. */
   controlsWithoutName: 4,
   /** §6.4 - pages with no <h1>, desktop. */
@@ -32,6 +61,40 @@ export const BASELINE = {
   /** §6.2 - pages emitting <link rel="canonical">. Target is ALL of them. */
   pagesWithCanonical: 0,
 } as const;
+
+/**
+ * Routes whose CLS is known-bad, with the budget each is held to.
+ *
+ * Every other route is held to the strict < 0.1 "good" threshold. These two are
+ * listed because they FAIL it today, measured 2026-08-05 - which contradicts
+ * audit §3.2's claim of "CLS = 0.000 on every page measured", a claim that
+ * named both of these routes. No app code changed between the audit and the
+ * measurement, so §3.2 is wrong, not stale.
+ *
+ * Confirmed by two independent harnesses across three runs, with shift
+ * attribution:
+ *
+ *   /arena     0.367  - one 0.3031 shift at t=763ms from FOOTER.pf-footer +
+ *                       BUTTON.gchat-fab lands late and pushes the page. That
+ *                       single shift is 83% of the route's total.
+ *   /briefing  0.148-0.176 across runs - 0.0933 at t=652ms from five DIV.card
+ *                       (.mb-brief-card) elements resizing after data arrives.
+ *
+ * /dashboard measured 0.006 on the same harness, which is why these are read
+ * as real product behaviour rather than an observer artefact.
+ *
+ * Budgets carry a little headroom over the worst observed value so normal
+ * run-to-run variance is not reported as a regression. Lower them when the
+ * shifts are fixed; a route that reaches < 0.1 should be deleted from this map
+ * entirely so it falls back to the strict threshold.
+ */
+export const CLS_BUDGET: Record<string, number> = {
+  '/arena': 0.40,     // worst observed 0.367
+  '/briefing': 0.20,  // observed 0.148, 0.153, 0.176
+};
+
+/** The "good" CLS threshold every route not in CLS_BUDGET must meet. */
+export const CLS_GOOD = 0.1;
 
 /**
  * Settle a page: wait for hydration, then assert the stylesheet actually

--- a/qa/e2e/_shared.ts
+++ b/qa/e2e/_shared.ts
@@ -89,7 +89,15 @@ export const BASELINE = {
  * entirely so it falls back to the strict threshold.
  */
 export const CLS_BUDGET: Record<string, number> = {
-  '/arena': 0.40,     // worst observed 0.367
+  /* /arena was here at 0.40. Removed 2026-08-05, per the rule above: the shift
+     was fixed, so the route goes back to the strict threshold rather than
+     keeping a budget it now passes by 6x.
+     PlatformFooter was painting before the page body existed - main.app-content
+     rendered 460px tall while auth resolved, so the 296px footer sat at y=132
+     in a 900px viewport and was thrown off screen when .arena-ws finally
+     mounted. Holding the footer back until auth settles took the route from
+     0.365 to 0.068 over three runs. Note it was the footer, not gchat-fab:
+     per-source attribution put the FAB at 0.1% of the shift. */
   '/briefing': 0.20,  // observed 0.148, 0.153, 0.176
 };
 

--- a/qa/e2e/perf.spec.ts
+++ b/qa/e2e/perf.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { settle } from './_shared';
+import { settle, CLS_BUDGET, CLS_GOOD } from './_shared';
 
 // Core Web Vitals + third-party request volume.
 //
@@ -34,9 +34,22 @@ test.describe('performance', () => {
         setTimeout(() => resolve({ lcp: Math.round(lcp), cls: +cls.toFixed(3) }), 1200);
       }));
 
-      // Measured 0.000 on every page in the audit. 0.1 is the "good" threshold;
-      // anything above means content is jumping during load.
-      expect(vitals.cls, `${route} CLS regressed to ${vitals.cls}`).toBeLessThan(0.1);
+      // Audit §3.2 claimed 0.000 everywhere. That was wrong - /arena and
+      // /briefing both shift visibly during load (see CLS_BUDGET in _shared.ts
+      // for the measurements and which element moves). Those two are held to a
+      // documented known-bad budget; every other route is held to the real
+      // 0.1 "good" threshold.
+      const budget = CLS_BUDGET[route] ?? CLS_GOOD;
+      const known = route in CLS_BUDGET;
+      expect(
+        vitals.cls,
+        known
+          ? `${route} CLS ${vitals.cls} exceeded its known-bad budget of ${budget}. ` +
+            `This route already fails the 0.1 "good" threshold; it just got worse. ` +
+            `Do NOT raise the budget - see CLS_BUDGET in qa/e2e/_shared.ts.`
+          : `${route} CLS regressed to ${vitals.cls} (budget ${budget}). Content is ` +
+            `jumping during load.`,
+      ).toBeLessThan(budget);
 
       // Measured 84-720ms locally. 2500ms is Google's "good" bar - generous
       // headroom so this only fires on a genuine regression.

--- a/qa/e2e/seo.spec.ts
+++ b/qa/e2e/seo.spec.ts
@@ -89,7 +89,14 @@ test.describe('seo', () => {
 
   test('/ops/login is not indexable', async ({ page, request }) => {
     await settle(page, '/ops/login');
-    const robotsMeta = await page.getAttribute('meta[name="robots"]', 'content');
+    // count() first, then read. page.getAttribute() WAITS for the locator, so
+    // on a page with no robots meta - which is precisely the known gap this
+    // test documents - it does not return null, it hangs until the 120s test
+    // timeout and reports as a failure. Absent must be a value, not a stall.
+    const hasRobotsMeta = (await page.locator('meta[name="robots"]').count()) > 0;
+    const robotsMeta = hasRobotsMeta
+      ? await page.getAttribute('meta[name="robots"]', 'content')
+      : null;
     const robotsTxt = await (await request.get('/robots.txt')).text();
     const blocked = /noindex/i.test(robotsMeta ?? '') || /Disallow:\s*\/ops/i.test(robotsTxt);
     // Known gap as of the audit - internal admin login is currently crawlable.


### PR DESCRIPTION
## Summary

**Release candidate — everything currently on `qa`, ready for QA testing.**

Five user-facing fixes and the CI/test-suite work. Live on staging now: **https://liquidity-hq-qa.onrender.com** (`qa` = `9e06e18`).

This PR is the handoff. When every section below passes, **QA merges it and deploys production.**

## What changed

| # | Change | Measured |
|---|---|---|
| 1 | **RSI fetched once on the server** instead of per visitor | 276 Binance requests → **1** |
| 2 | **`/arena` layout shift** — footer no longer paints before the page body | 0.365 → **0.068** |
| 3 | **`/scanner` layout shift** — heatmap ranking + 4 cards reserving space | 0.98 → **0.061** |
| 4 | **WebSocket fallback** no longer gets the visitor's IP banned by Binance | 765 → **239** weight/min |
| 5 | **`/api/ath`** serves the last good value when CoinGecko rate-limits | 502 → 200 |
| — | CI now runs on `qa` and on pull requests; Vercel leftovers removed; Playwright suite fixed | — |

## Why

Two of these are user-visible breakage, not polish:

- **#4 was actively harming users.** Once the price WebSocket gave up reconnecting, the app polled Binance every 5 seconds forever — 960 request-weight per minute from a single tab against a 6000/min per-IP budget. A visitor who left a tab open earned themselves a Binance ban in about six minutes, after which *every* Binance-backed feature returned 418 and the app looked completely broken with nothing explaining why.
- **#1 is the suspected cause of the intermittent blank chart.** 276 of ~495 Binance requests per page load returned data identical for every visitor. That burst is roughly 1207 weight per load, so about five reloads in a minute earned the same ban.

**#3 was the worst Core Web Vital in the product** and nobody had reported it — the audit recorded 0.000 everywhere, which was wrong.

## How to test (QA)

Test on **https://liquidity-hq-qa.onrender.com**, or locally on the `qa` branch. Free tier — if the first request is slow or times out, retry once.

**A. `/scanner` — the biggest change**
1. Cold-load `/scanner`. The MARKET HEATMAP shows placeholder tiles (dashes) for about a second, then fills in. Tiles must **not** appear and then visibly rearrange.
2. Confirm the grid is ordered by 24h change, biggest gainer first.
3. Leave it two minutes. Tiles stay put. One quiet re-rank is expected; constant shuffling is not.
4. Watch the cards below the heatmap while it loads — they should not jump down the page.
5. Category filter — All / Major / Alts / DeFi / Meme. Each re-ranks on switch, tile heights stay uniform.

**B. `/arena`**
6. Cold-load `/arena` watching the lower half. The footer should **not** flash into view near the top and then drop away.
7. Scroll to the bottom — footer complete, 7 links.

**C. RSI (site-wide)**
8. On the dashboard, confirm every coin shows RSI values — no blanks where numbers used to be.
9. Compare a few against production. Within a point or two is fine; a coin reading 50 here and 20 on prod is a failure — report which coin.
10. Check **HYPE** specifically. It comes from Bybit, not Binance, and fails independently of everything else.

**D. WebSocket fallback**
11. Dashboard status should read **"Live"**. This is the path most users are on.
12. DevTools → Network → request blocking → add `wss://stream.binance.com`, reload. Within ~30s the status becomes **"Live · backup feed"** and prices still update.
13. Filter Network for `ticker/24hr` — roughly every **30 seconds**, not every 5. This is the fix.
14. Remove the block, wait up to a minute — status returns to **"Live"** on its own and polling stops.

**E. General regression**
15. Load `/dashboard`, `/markets`, `/alerts`, `/settings`, `/login`. All render, no console errors.
16. `/api/ath` returns 200. If it returns 200 with header `X-Data-Stale: true`, that is also a pass — CoinGecko is limiting us and the fallback is working.

**F. If everything passes**
17. Merge this PR into `main`.
18. **Deploy production manually** — Render → `liquidity-hq-prod` → Manual Deploy → Deploy latest commit. Merging does not deploy.
19. Re-run sections A–E against liquidity-hq.com.
20. Tag it: `git tag -a v2026.08.05 -m "RSI aggregation, arena + scanner CLS, WebSocket fallback, ATH cache"` and push.

## Risk level

**Medium** — no auth, payments or migrations, and no schema change, so there is nothing to roll back but the build. But it touches the live price feed (#1, #4), which every page depends on, and five components on `/scanner`.

Rollback if needed: Render → `liquidity-hq-prod` → Deploys → *Rollback to this deploy*. Safe here because no migration ships with this release.

**Known limitations, stated rather than discovered:**

- **`/scanner` CLS varies** with how fast market data arrives — runs ranged 0.023 to 0.241. 0.061 is a median of 8, not a floor.
- **`/api/ath` on a cold instance with CoinGecko still limiting will still fail** — there is no previous value to serve. The fix shrinks the failure window, it does not close it.
- **Spot vs futures for RSI is unverified in production.** Only `fapi.binance.com` is proven reachable from Render. After deploy, check the API health row `binance:rsi-fast` — the detail reads `via spot` or `via futures`. If futures, values are correct but sourced from perp candles and can differ by a point.
- **Lint is 94 warnings**, up from 93. One documented `eslint-disable` in the heatmap, in the existing React Compiler backlog. 0 errors.

## Screenshots (if UI change)

None — every change here is load-time behaviour, which a still image cannot show. Steps A1, B6 and D13 are where the difference is visible.
