### PR TITLE
perf(api): move the Binance market fan-out to the server

### DIFF
--- a/app/api/market/snapshot/route.ts
+++ b/app/api/market/snapshot/route.ts
@@ -1,0 +1,265 @@
+/**
+ * Server-side market snapshot: 24h ticker, 15m kline metrics, long/short ratios.
+ *
+ * GET /api/market/snapshot
+ *   → { ticker: {...}, klines: {...}, lsr: {...}, ts }
+ *
+ * WHY THIS EXISTS
+ *
+ * Measured on a real /dashboard load, this is what the browser used to ask
+ * Binance for directly, per visitor:
+ *
+ *   aggTrades                     45 req   180 weight
+ *   ticker/24hr (45 symbols)       2 req   160 weight
+ *   fapi/v1/klines                45 req    90 weight
+ *   globalLongShortAccountRatio   46 req    46 weight
+ *   topLongShortPositionRatio     45 req    45 weight
+ *   everything else               10 req    33 weight
+ *   ------------------------------------------------
+ *   TOTAL                        193 req   554 weight
+ *
+ * This route takes the three biggest that are safe to move — ticker, klines and
+ * the two ratio endpoints — which is 138 of those requests and 341 of that
+ * weight, and serves them to every visitor from one cached result.
+ *
+ * The point is not that any single visitor was close to Binance's limit. It is
+ * that the cost was per-visitor and therefore unbounded: two tabs doubled it,
+ * ten visitors multiplied it by ten, and Binance rate-limits by IP, which on
+ * mobile CGNAT or an office NAT is shared. Once an IP is limited Binance
+ * returns 418 to everything from it, including the chart's own calls, so the
+ * app appears completely broken with nothing on screen explaining why. Doing it
+ * here makes the upstream cost fixed instead.
+ *
+ * WHAT IS DELIBERATELY LEFT IN THE BROWSER
+ *
+ * `aggTrades` (45 requests, 180 weight — the single largest remaining item)
+ * stays client-side on purpose. It does two jobs: a pure CVD sum, which would
+ * move happily, and whale detection, which dispatches a `whale-trade` DOM event
+ * for each new large trade and dedupes against a per-client `lastAggId`. Moving
+ * it would need a server→client push channel and a shared notion of "already
+ * seen", i.e. a different design rather than a relocation. It is a known
+ * remainder, not an oversight.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { apiError } from '@/lib/apiError';
+import { BINANCE_SYMS } from '@/lib/coins';
+import { rateLimit, getClientIp } from '@/lib/rateLimit';
+import { cached } from '@/lib/apiCache';
+import { reportHealth, healthError } from '@/lib/apiHealth';
+import { computeKlineMetrics, type KlineMetrics } from '@/lib/klineMetrics';
+
+export const dynamic = 'force-dynamic';
+
+/* Cadences the client used, kept so nothing gets fresher or staler than it was:
+   fetchVolume ran every 3 minutes, fetchLSR every 5. */
+const KLINES_TTL = 3 * 60_000;
+const TICKER_TTL = 3 * 60_000;
+const LSR_TTL    = 5 * 60_000;
+
+/* 45 symbols x 2 ratio endpoints is 90 requests. Unbounded parallelism is what
+   this route exists to stop doing, and it is also more sockets than the Render
+   instance should hold open at once. */
+const CONCURRENCY = 12;
+
+/* Same mirror-walk as /api/funding and /api/market/rsi: individual Binance
+   edges return 451/503 by region while the others are healthy. Resolved once
+   per cache fill rather than per request. */
+const SPOT_HOSTS    = ['https://api.binance.com', 'https://api1.binance.com', 'https://api2.binance.com'];
+const FUTURES_HOSTS = ['https://fapi.binance.com', 'https://fapi1.binance.com', 'https://fapi2.binance.com'];
+
+const SYMS = Object.entries(BINANCE_SYMS).filter(([c]) => c !== 'hype');
+
+interface TickerEntry { price: number; change: number; high: number; low: number; vol24: number }
+interface LsrEntry {
+  bnLongRatio?: number; bnShortRatio?: number;
+  bnWhaleLongRatio?: number; bnWhaleShortRatio?: number;
+}
+
+/** 418 = IP banned, 429 = rate limited. Neither is about the symbol asked for. */
+class BinanceBackoff extends Error {}
+
+async function get(url: string, timeoutMs = 8000): Promise<unknown | null> {
+  const ac = new AbortController();
+  const tid = setTimeout(() => ac.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      cache: 'no-store', signal: ac.signal, headers: { 'User-Agent': 'Mozilla/5.0' },
+    });
+    if (res.status === 418 || res.status === 429) throw new BinanceBackoff(`Binance ${res.status}`);
+    if (!res.ok) return null;
+    return await res.json();
+  } catch (e) {
+    if (e instanceof BinanceBackoff) throw e;
+    return null;
+  } finally {
+    clearTimeout(tid);
+  }
+}
+
+/* Cheap probe so a dead edge is found once, not 90 times.
+ *
+ * Swallows BinanceBackoff deliberately. A 418 on the ping means this IP is
+ * banned, which is a reason to report "no reachable host" and return an empty
+ * section - not to throw and take the other two sections down with it. Letting
+ * it propagate is what made the ticker come back empty *and* rejected while
+ * klines and ratios were fine. */
+async function resolveHost(hosts: readonly string[], pingPath: string): Promise<string | null> {
+  for (const h of hosts) {
+    try {
+      const ok = await get(`${h}${pingPath}`, 5000);
+      if (ok !== null) return h;
+    } catch { /* banned or rate-limited on this edge - try the next */ }
+  }
+  return null;
+}
+
+/* Fixed-size worker pool that stops the moment Binance signals a limit -
+   spending the remaining requests into an active ban only extends it. */
+async function pool<T>(items: T[], limit: number, work: (item: T) => Promise<void>): Promise<boolean> {
+  let next = 0, banned = false;
+  const worker = async () => {
+    for (;;) {
+      if (banned) return;
+      const i = next++;
+      if (i >= items.length) return;
+      try { await work(items[i]); }
+      catch (e) { if (e instanceof BinanceBackoff) { banned = true; return; } }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return banned;
+}
+
+async function buildTicker(): Promise<Record<string, TickerEntry>> {
+  const out: Record<string, TickerEntry> = {};
+  const byCoin = Object.fromEntries(SYMS.map(([c, s]) => [s, c]));
+
+  const absorb = (arr: unknown) => {
+    if (!Array.isArray(arr)) return;
+    for (const d of arr as Record<string, string>[]) {
+      const coin = byCoin[d.symbol];
+      if (!coin) continue;
+      out[coin] = {
+        price:  parseFloat(d.lastPrice || '0'),
+        change: parseFloat(d.priceChangePercent || '0'),
+        high:   parseFloat(d.highPrice || '0'),
+        low:    parseFloat(d.lowPrice || '0'),
+        vol24:  parseFloat(d.quoteVolume || '0'),
+      };
+    }
+  };
+
+  /* Spot first: one batched call for all 45 symbols, exactly as the client
+     did. Weight 80 either way - the saving is that it happens once per TTL
+     rather than once per visitor. */
+  const spot = await resolveHost(SPOT_HOSTS, '/api/v3/ping');
+  if (spot) {
+    const batch = encodeURIComponent(JSON.stringify(SYMS.map(([, s]) => s)));
+    absorb(await get(`${spot}/api/v3/ticker/24hr?symbols=${batch}`));
+  }
+
+  /* Futures fallback. Spot and futures are separate rate-limit buckets, and in
+     practice they fail independently - this was found with spot returning 418
+     for a banned IP while futures answered normally on the same machine and
+     the same second. Without this, one banned bucket meant no 24h volume
+     anywhere in the app.
+     The futures endpoint takes no `symbols` array, so this asks for everything
+     (weight 40) and filters. Perp volume is not identical to spot volume for
+     the same pair, so this is a degraded answer rather than an equal one -
+     which is why it is a fallback and not the default. */
+  const source = Object.keys(out).length > 0 ? 'spot' : 'futures';
+  if (Object.keys(out).length === 0) {
+    const fut = await resolveHost(FUTURES_HOSTS, '/fapi/v1/ping');
+    if (fut) absorb(await get(`${fut}/fapi/v1/ticker/24hr`));
+  }
+
+  reportHealth('binance:ticker', 'market', Object.keys(out).length > 0,
+    `${Object.keys(out).length} coins via ${source}`);
+  return out;
+}
+
+async function buildKlines(): Promise<Record<string, KlineMetrics>> {
+  /* Futures klines, with spot as fallback - the client preferred fapi because
+     its taker buy/sell split is the one perp traders act on. */
+  const fut  = await resolveHost(FUTURES_HOSTS, '/fapi/v1/ping');
+  const spot = fut ? null : await resolveHost(SPOT_HOSTS, '/api/v3/ping');
+  const out: Record<string, KlineMetrics> = {};
+  if (!fut && !spot) { reportHealth('binance:klines', 'market', false, 'no reachable host'); return out; }
+
+  const banned = await pool(SYMS, CONCURRENCY, async ([coin, sym]) => {
+    const url = fut
+      ? `${fut}/fapi/v1/klines?symbol=${sym}&interval=15m&limit=100`
+      : `${spot}/api/v3/klines?symbol=${sym}&interval=15m&limit=100`;
+    const raw = await get(url);
+    if (!Array.isArray(raw)) return;
+    const m = computeKlineMetrics(raw as string[][]);
+    if (m) out[coin] = m;
+  });
+
+  reportHealth('binance:klines', 'market', Object.keys(out).length > 0 && !banned,
+    banned ? `418/429 after ${Object.keys(out).length}/${SYMS.length}`
+           : `${Object.keys(out).length}/${SYMS.length} via ${fut ? 'futures' : 'spot'}`);
+  return out;
+}
+
+async function buildLsr(): Promise<Record<string, LsrEntry>> {
+  const host = await resolveHost(FUTURES_HOSTS, '/fapi/v1/ping');
+  const out: Record<string, LsrEntry> = {};
+  if (!host) { reportHealth('binance:lsr', 'market', false, 'no reachable futures host'); return out; }
+
+  const banned = await pool(SYMS, CONCURRENCY, async ([coin, sym]) => {
+    const [g, w] = await Promise.all([
+      get(`${host}/futures/data/globalLongShortAccountRatio?symbol=${sym}&period=5m&limit=1`),
+      get(`${host}/futures/data/topLongShortPositionRatio?symbol=${sym}&period=5m&limit=1`),
+    ]);
+    const gi = Array.isArray(g) ? (g[0] as Record<string, string>) : null;
+    const wi = Array.isArray(w) ? (w[0] as Record<string, string>) : null;
+    const e: LsrEntry = {};
+    if (gi) { e.bnLongRatio = parseFloat(gi.longAccount || '0.5'); e.bnShortRatio = parseFloat(gi.shortAccount || '0.5'); }
+    if (wi) { e.bnWhaleLongRatio = parseFloat(wi.longAccount || '0.5'); e.bnWhaleShortRatio = parseFloat(wi.shortAccount || '0.5'); }
+    if (Object.keys(e).length) out[coin] = e;
+  });
+
+  reportHealth('binance:lsr', 'market', Object.keys(out).length > 0 && !banned,
+    banned ? `418/429 after ${Object.keys(out).length}/${SYMS.length}` : `${Object.keys(out).length}/${SYMS.length}`);
+  return out;
+}
+
+export async function GET(req: NextRequest) {
+  if (!rateLimit(`market-snapshot:${getClientIp(req)}`, 30, 60_000)) {
+    return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429 });
+  }
+
+  try {
+    /* Three independent caches with their original cadences, merged into one
+       response. allSettled, not all: a failing kline fill must not take the
+       ticker down with it - the client merges whatever arrives and leaves the
+       rest at its previous value, which is how the per-coin version behaved
+       when one symbol failed. */
+    const [t, k, l] = await Promise.allSettled([
+      cached('mkt:ticker', TICKER_TTL, buildTicker),
+      cached('mkt:klines', KLINES_TTL, buildKlines),
+      cached('mkt:lsr',    LSR_TTL,    buildLsr),
+    ]);
+
+    if (t.status === 'rejected' && k.status === 'rejected' && l.status === 'rejected') {
+      reportHealth('binance:snapshot', 'market', false, healthError(t.reason));
+      return apiError('market-snapshot', t.reason, 502, 'Upstream unavailable');
+    }
+
+    return NextResponse.json({
+      ticker: t.status === 'fulfilled' ? t.value : {},
+      klines: k.status === 'fulfilled' ? k.value : {},
+      lsr:    l.status === 'fulfilled' ? l.value : {},
+      ts: Date.now(),
+    }, {
+      /* Public and visitor-independent, and already only as fresh as the
+         shortest TTL. Letting any shared cache in front of this serve it
+         removes the origin hit for the common case. */
+      headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=600' },
+    });
+  } catch (e) {
+    return apiError('market-snapshot', e, 500, 'Request failed');
+  }
+}

--- a/components/KLineProChart.tsx
+++ b/components/KLineProChart.tsx
@@ -1087,8 +1087,9 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
               // the US, and crypto-exchange API hosts are on common ad/privacy
               // blocklists, so a whole class of users would only ever see an
               // empty chart. Meanwhile the app already had the right answer
-              // elsewhere: MarketProvider's fetchKlines tries futures then spot.
-              // The chart just never got the same treatment.
+              // elsewhere: app/api/market/snapshot tries futures then spot (this
+              // used to live in MarketProvider.fetchKlines). The chart just never
+              // got the same treatment.
               //
               // Futures is also the better default on its own merits - this is a
               // perp-trading app, and fapi's candles are the ones the funding,

--- a/components/MarketProvider.tsx
+++ b/components/MarketProvider.tsx
@@ -99,6 +99,13 @@ const SYM_MAP: Record<string, CoinId> = Object.fromEntries(
 
 export default function MarketProvider({ children }: { children: React.ReactNode }) {
   const [store, setStore] = useState<MarketStore>(defaultStore);
+  /* Mirror of `store` for callbacks that must read the CURRENT value without
+     depending on it. fetchSnapshot needs to know whether a coin already has a
+     price before deciding to seed one; depending on `store` would rebuild the
+     callback on every price tick and re-arm its interval. Written in the effect
+     below rather than during render - a ref write during render is its own
+     violation (react-hooks/refs). */
+  const storeRef = useRef<MarketStore>(defaultStore);
   const wsRef = useRef<WebSocket | null>(null);
   const retriesRef = useRef(0);
   const urlIdxRef = useRef(0);
@@ -118,6 +125,8 @@ export default function MarketProvider({ children }: { children: React.ReactNode
   /* Liquidation cascade: rolling event buffer + per-coin cooldown */
   const liqBufferRef    = useRef<Array<{ coin: string; side: 'LONG' | 'SHORT'; usd: number; ts: number }>>([]);
   const cascadeCooldown = useRef<Record<string, number>>({});
+
+  useEffect(() => { storeRef.current = store; }, [store]);
 
   const updateCoin = useCallback((id: CoinId, patch: Partial<MarketStore['coins'][CoinId]>) => {
     setStore(s => ({
@@ -333,150 +342,75 @@ export default function MarketProvider({ children }: { children: React.ReactNode
           });
         } catch { /* */ }
       }),
-      // Binance global account ratio (5m) + top trader position ratio - Binance-listed coins only
-      ...Object.entries(BINANCE_SYMS).map(async ([coin, sym]) => {
-        try {
-          const [globalRes, whaleRes] = await Promise.all([
-            fetch(`https://fapi.binance.com/futures/data/globalLongShortAccountRatio?symbol=${sym}&period=5m&limit=1`),
-            fetch(`https://fapi.binance.com/futures/data/topLongShortPositionRatio?symbol=${sym}&period=5m&limit=1`),
-          ]);
-          const [globalArr, whaleArr] = await Promise.all([globalRes.json(), whaleRes.json()]);
-          const g = Array.isArray(globalArr) ? globalArr[0] : null;
-          const w = Array.isArray(whaleArr)  ? whaleArr[0]  : null;
-          updateCoin(coin as CoinId, {
-            ...(g ? { bnLongRatio:       parseFloat(g.longAccount  || '0.5'),
-                       bnShortRatio:      parseFloat(g.shortAccount || '0.5') } : {}),
-            ...(w ? { bnWhaleLongRatio:  parseFloat(w.longAccount  || '0.5'),
-                       bnWhaleShortRatio: parseFloat(w.shortAccount || '0.5') } : {}),
-          });
-        } catch { /* */ }
-      }),
+      // The Binance half of this - two ratio requests per coin, 91 requests
+      // in total - moved to app/api/market/snapshot. Bybit stays here: it is
+      // one request per coin against a different provider with its own limit,
+      // and it is the only source for the Bybit-only coins.
     ]);
   }, [updateCoin]);
 
-  /* fetchKlines is declared before fetchVolume, which calls it. It used to sit
-     after, so fetchVolume closed over a const declared later - what
-     react-hooks/immutability means by "accessed before it is declared". Safe only
-     because fetchVolume is never invoked during render; moving it earlier removes
-     the dependency on that being true. */
-  const fetchKlines = useCallback(async (coin: CoinId, sym: string) => {
+  /* ── 24h ticker, 15m kline metrics and long/short ratios, in one call ──
+     Replaces fetchKlines (one kline request per coin), fetchVolume (a
+     45-symbol ticker/24hr batch plus a fetchKlines per coin) and the Binance
+     half of fetchLSR (two ratio requests per coin).
+
+     Measured on a real /dashboard load, those were 138 of the 193 Binance
+     requests the browser made, and 341 of the 554 request-weight. Every one
+     returned data identical for every visitor. Now one request.
+
+     app/api/market/snapshot fans out once per cache window on the server and
+     serves everyone from the result, so the upstream cost is fixed rather
+     than per-visitor. See that route for why that mattered: Binance limits by
+     IP, and a limited IP gets 418 on everything including the chart.
+
+     Polled at fetchVolume's old 3-minute cadence. The ratios are cached
+     server-side at their own 5-minute TTL, so this does not re-fetch them
+     more often than before.
+
+     Failure is silent and non-destructive: updateCoin runs only for coins the
+     response actually carried, so a partial or missing response leaves the
+     previous values on screen rather than blanking them. */
+  const fetchSnapshot = useCallback(async () => {
     try {
-      // Use futures klines (fapi) - more accurate taker buy/sell for perp traders
-      // Falls back to spot if futures endpoint fails (e.g. no perp for that symbol)
-      const futuresUrl = `https://fapi.binance.com/fapi/v1/klines?symbol=${sym}&interval=15m&limit=100`;
-      const spotUrl    = `https://api.binance.com/api/v3/klines?symbol=${sym}&interval=15m&limit=100`;
-      let raw = await fetch(futuresUrl);
-      if (!raw.ok) raw = await fetch(spotUrl);
-      const klines = await raw.json();
-      if (!Array.isArray(klines) || klines.length < 15) return;
+      const res = await fetch('/api/market/snapshot');
+      if (!res.ok) return;
+      const body = await res.json() as {
+        ticker?: Record<string, { price: number; change: number; high: number; low: number; vol24: number }>;
+        klines?: Record<string, Record<string, unknown>>;
+        lsr?: Record<string, Record<string, number>>;
+      };
+      /* vol24 always; price only as a FIRST paint.
 
-      const closes = klines.map((k: string[]) => parseFloat(k[4]));
-      const highs  = klines.map((k: string[]) => parseFloat(k[2]));
-      const lows   = klines.map((k: string[]) => parseFloat(k[3]));
-      const vols   = klines.map((k: string[]) => parseFloat(k[7])); // quote volume
+         The socket owns price, change, high and low - they arrive live and are
+         correct to the second. Applying the cached ticker on every poll would
+         overwrite a live price with one up to three minutes old, which on
+         screen is a visible tick backwards.
 
-      /* Volume ratio */
-      const current = vols[vols.length - 2];
-      const avg = vols.slice(0, -1).reduce((a: number, b: number) => a + b, 0) / (vols.length - 1);
-
-      /* MA20 */
-      const ma20Slice = closes.slice(-20);
-      const ma20 = ma20Slice.reduce((a: number, b: number) => a + b, 0) / ma20Slice.length;
-
-      /* RSI14 */
-      const rsi14 = computeRSI14(closes);
-
-      /* ── Volume Profile / POC ── */
-      const allPrices = [...highs, ...lows];
-      const minP = Math.min(...allPrices);
-      const maxP = Math.max(...allPrices);
-      const range = maxP - minP;
-      const BUCKETS = 60;
-      const bSize = range / BUCKETS;
-      const buckets = new Array<number>(BUCKETS).fill(0);
-
-      klines.forEach((k: string[], i: number) => {
-        const h = highs[i], l = lows[i], v = vols[i];
-        const lo = Math.max(0, Math.floor((l - minP) / bSize));
-        const hi = Math.min(BUCKETS - 1, Math.floor((h - minP) / bSize));
-        const span = Math.max(1, hi - lo + 1);
-        for (let b = lo; b <= hi; b++) buckets[b] += v / span;
-      });
-
-      // POC = bucket with max volume
-      let maxVol = 0, pocBucket = 0;
-      buckets.forEach((v, i) => { if (v > maxVol) { maxVol = v; pocBucket = i; } });
-      const poc = minP + (pocBucket + 0.5) * bSize;
-
-      // Value Area: expand from POC to capture 70% of total volume
-      const totalVol = buckets.reduce((a, b) => a + b, 0);
-      let lo = pocBucket, hi = pocBucket, captured = buckets[pocBucket];
-      while (captured < totalVol * 0.70 && (lo > 0 || hi < BUCKETS - 1)) {
-        const addLo = lo > 0 ? buckets[lo - 1] : 0;
-        const addHi = hi < BUCKETS - 1 ? buckets[hi + 1] : 0;
-        if (addLo >= addHi && lo > 0) { lo--; captured += buckets[lo]; }
-        else if (hi < BUCKETS - 1)    { hi++; captured += buckets[hi]; }
-        else                           { lo--; captured += buckets[lo]; }
+         But before the socket connects there is no price at all, which is what
+         restPoll() was doing on mount: one ticker/24hr call for 45 symbols,
+         request weight 80, purely to fill the gap for a second or two. Seeding
+         from data already in this response removes that call entirely. The
+         null check is what keeps it a seed rather than a stomp - once a coin
+         has any price, the socket owns it and this never touches it again.
+         restPoll still exists for the socket-down fallback path. */
+      for (const [coin, v] of Object.entries(body.ticker ?? {})) {
+        if (!v) continue;
+        const id = coin as CoinId;
+        const patch: Partial<CoinData> = {};
+        if (v.vol24 != null) patch.vol24 = v.vol24;
+        if (storeRef.current.coins[id]?.price == null && v.price) {
+          patch.price = v.price; patch.change = v.change; patch.high = v.high; patch.low = v.low;
+        }
+        if (Object.keys(patch).length) updateCoin(id, patch);
       }
-      const val = minP + lo * bSize;
-      const vah = minP + (hi + 1) * bSize;
-
-      /* ── Taker Buy/Sell ratio (last 8 candles ≈ 2h) ──
-         k[9] = taker buy base volume, k[5] = total base volume
-         Smaller window = reacts faster to recent momentum shifts
-         takerBuyRatio > 0.55 = buyers hitting asks (aggression = bullish)
-         takerBuyRatio < 0.45 = sellers hitting bids (aggression = bearish) */
-      let totalBuyVol = 0, totalBaseVol = 0;
-      klines.slice(-8).forEach((k: string[]) => {
-        totalBuyVol  += parseFloat(k[9]);   // taker buy base vol
-        totalBaseVol += parseFloat(k[5]);   // total base vol
-      });
-      const takerBuyRatio = totalBaseVol > 0 ? totalBuyVol / totalBaseVol : null;
-
-      /* ── VWAP - use BASE volume (k[5]) for standard formula ── */
-      // quoteVol (k[7]) biases the average; base vol gives true VWAP
-      let sumTPV = 0, sumVol = 0;
-      klines.forEach((k: string[], i: number) => {
-        const tp       = (highs[i] + lows[i] + closes[i]) / 3;
-        const baseVol  = parseFloat(k[5]);                      // BTC (base) volume
-        sumTPV += tp * baseVol;
-        sumVol += baseVol;
-      });
-      const vwap = sumVol > 0 ? sumTPV / sumVol : null;
-
-      // Chart pattern detection from last 25 candles OHLC
-      const patternCandles = klines.slice(-25).map((k: string[]) => ({
-        o: parseFloat(k[1]), h: parseFloat(k[2]), l: parseFloat(k[3]), c: parseFloat(k[4]),
-      }));
-      const patterns = detectPatterns(patternCandles);
-      const chartPattern = patterns.length > 0 ? patterns.join('; ') : null;
-
-      updateCoin(coin, { volRatio: avg > 0 ? current / avg : 1, ma20, rsi14, poc, vah, val, vwap, takerBuyRatio, chartPattern });
+      for (const [coin, m] of Object.entries(body.klines ?? {})) {
+        if (m && Object.keys(m).length) updateCoin(coin as CoinId, m as Partial<CoinData>);
+      }
+      for (const [coin, r] of Object.entries(body.lsr ?? {})) {
+        if (r && Object.keys(r).length) updateCoin(coin as CoinId, r as Partial<CoinData>);
+      }
     } catch { /* */ }
   }, [updateCoin]);
-
-  /* ── Binance volume + klines ── */
-  const fetchVolume = useCallback(async () => {
-    const binanceCoins = Object.entries(BINANCE_SYMS).filter(([c]) => c !== 'hype');
-    const syms = binanceCoins.map(([, s]) => s);
-    try {
-      const batch = encodeURIComponent(JSON.stringify(syms));
-      const res = await fetch(`https://api.binance.com/api/v3/ticker/24hr?symbols=${batch}`);
-      const arr = await res.json();
-      if (!Array.isArray(arr)) return;
-      arr.forEach((d: Record<string, string>) => {
-        const id = SYM_MAP[d.symbol];
-        if (!id) return;
-        updateCoin(id, { vol24: parseFloat(d.quoteVolume || '0') });
-        fetchKlines(id, d.symbol);
-      });
-    } catch {
-      binanceCoins.forEach(([coin, sym], i) => {
-        setTimeout(() => fetchKlines(coin as CoinId, sym), i * 300);
-      });
-    }
-  }, [updateCoin]); // eslint-disable-line react-hooks/exhaustive-deps
-
 
   /* ── Bybit klines for Bybit-only coins (HYPE, PEPE, BONK, XAU, SPX, …) ── */
   // Bybit kline format (newest-first): [startTime, open, high, low, close, volume, turnover]
@@ -1313,11 +1247,10 @@ export default function MarketProvider({ children }: { children: React.ReactNode
 
   /* ── Initialise on mount ── */
   useEffect(() => {
-    restPoll(); // immediate prices before WS connects
     startWS();
     fetchBybit();
     fetchLSR();
-    fetchVolume();
+    fetchSnapshot();
     fetchBybitKlines();       // RSI/MA20/VWAP/POC for HYPE
     fetchFNG();
     fetchCMCGlobal();
@@ -1341,7 +1274,7 @@ export default function MarketProvider({ children }: { children: React.ReactNode
     const intervals = [
       setInterval(fetchBybit,             8  * 60 * 1000),
       setInterval(fetchLSR,               5  * 60 * 1000),
-      setInterval(fetchVolume,            3  * 60 * 1000),
+      setInterval(fetchSnapshot,          3  * 60 * 1000),
       setInterval(fetchBybitKlines,       3  * 60 * 1000),  // same cadence as Binance klines
       setInterval(fetchFNG,             24  * 60 * 60 * 1000),
       setInterval(fetchCMCGlobal,         5  * 60 * 1000),   // BTC/ETH dom - CMC, every 5m

--- a/lib/klineMetrics.ts
+++ b/lib/klineMetrics.ts
@@ -1,0 +1,125 @@
+import { computeRSI14 } from './rsi';
+import { detectPatterns } from './patterns';
+
+/* Everything MarketProvider used to derive from a coin's 15-minute candles,
+ * lifted out verbatim so app/api/market/snapshot can compute it once on the
+ * server instead of every visitor computing it in their own browser.
+ *
+ * Pure: klines in, numbers out. No fetching, no React, no store. That is the
+ * whole reason it can live in both places without drifting - the previous
+ * version of this problem (computeRSI14) was two copies of the same maths, and
+ * a one-line difference there would have moved coins across the 30/70 badge
+ * thresholds silently.
+ *
+ * Binance kline array indices, since they are otherwise unreadable:
+ *   [1] open  [2] high  [3] low  [4] close
+ *   [5] base volume     [7] quote volume     [9] taker buy base volume
+ */
+
+export interface KlineMetrics {
+  volRatio: number;
+  ma20: number;
+  rsi14: number | null;
+  poc: number;
+  vah: number;
+  val: number;
+  vwap: number | null;
+  takerBuyRatio: number | null;
+  chartPattern: string | null;
+}
+
+/** Volume-profile resolution. 60 buckets over the high-low range. */
+const BUCKETS = 60;
+/** Value area = the price band holding this share of traded volume. */
+const VALUE_AREA_SHARE = 0.70;
+/** Taker buy/sell window: 8 candles at 15m is about two hours. */
+const TAKER_WINDOW = 8;
+/** Pattern detection reads the most recent candles only. */
+const PATTERN_WINDOW = 25;
+
+/** Needs at least 15 closes for RSI14; fewer and the whole set is unreliable. */
+export const MIN_KLINES = 15;
+
+export function computeKlineMetrics(klines: string[][]): KlineMetrics | null {
+  if (!Array.isArray(klines) || klines.length < MIN_KLINES) return null;
+
+  const closes = klines.map(k => parseFloat(k[4]));
+  const highs  = klines.map(k => parseFloat(k[2]));
+  const lows   = klines.map(k => parseFloat(k[3]));
+  const vols   = klines.map(k => parseFloat(k[7]));   // quote volume
+
+  /* Volume ratio: the last CLOSED candle against the average of everything
+     before it. Index -2, not -1, because the final candle is still forming and
+     would always look low. */
+  const current = vols[vols.length - 2];
+  const avg = vols.slice(0, -1).reduce((a, b) => a + b, 0) / (vols.length - 1);
+
+  const ma20Slice = closes.slice(-20);
+  const ma20 = ma20Slice.reduce((a, b) => a + b, 0) / ma20Slice.length;
+
+  const rsi14 = computeRSI14(closes);
+
+  /* ── Volume profile: POC and value area ── */
+  const allPrices = [...highs, ...lows];
+  const minP = Math.min(...allPrices);
+  const maxP = Math.max(...allPrices);
+  const bSize = (maxP - minP) / BUCKETS;
+  const buckets = new Array<number>(BUCKETS).fill(0);
+
+  klines.forEach((_k, i) => {
+    const h = highs[i], l = lows[i], v = vols[i];
+    const lo = Math.max(0, Math.floor((l - minP) / bSize));
+    const hi = Math.min(BUCKETS - 1, Math.floor((h - minP) / bSize));
+    const span = Math.max(1, hi - lo + 1);
+    for (let b = lo; b <= hi; b++) buckets[b] += v / span;
+  });
+
+  let maxVol = 0, pocBucket = 0;
+  buckets.forEach((v, i) => { if (v > maxVol) { maxVol = v; pocBucket = i; } });
+  const poc = minP + (pocBucket + 0.5) * bSize;
+
+  /* Expand outward from the POC, always taking the heavier neighbour, until
+     VALUE_AREA_SHARE of volume is inside. */
+  const totalVol = buckets.reduce((a, b) => a + b, 0);
+  let lo = pocBucket, hi = pocBucket, captured = buckets[pocBucket];
+  while (captured < totalVol * VALUE_AREA_SHARE && (lo > 0 || hi < BUCKETS - 1)) {
+    const addLo = lo > 0 ? buckets[lo - 1] : 0;
+    const addHi = hi < BUCKETS - 1 ? buckets[hi + 1] : 0;
+    if (addLo >= addHi && lo > 0) { lo--; captured += buckets[lo]; }
+    else if (hi < BUCKETS - 1)    { hi++; captured += buckets[hi]; }
+    else                           { lo--; captured += buckets[lo]; }
+  }
+  const val = minP + lo * bSize;
+  const vah = minP + (hi + 1) * bSize;
+
+  /* Taker buy/sell aggression over the recent window.
+     >0.55 = buyers lifting offers, <0.45 = sellers hitting bids. */
+  let totalBuyVol = 0, totalBaseVol = 0;
+  klines.slice(-TAKER_WINDOW).forEach(k => {
+    totalBuyVol  += parseFloat(k[9]);
+    totalBaseVol += parseFloat(k[5]);
+  });
+  const takerBuyRatio = totalBaseVol > 0 ? totalBuyVol / totalBaseVol : null;
+
+  /* VWAP on BASE volume, not quote. Quote volume biases the average toward
+     high-price candles and does not give a true VWAP. */
+  let sumTPV = 0, sumVol = 0;
+  klines.forEach((k, i) => {
+    const tp = (highs[i] + lows[i] + closes[i]) / 3;
+    const baseVol = parseFloat(k[5]);
+    sumTPV += tp * baseVol;
+    sumVol += baseVol;
+  });
+  const vwap = sumVol > 0 ? sumTPV / sumVol : null;
+
+  const patternCandles = klines.slice(-PATTERN_WINDOW).map(k => ({
+    o: parseFloat(k[1]), h: parseFloat(k[2]), l: parseFloat(k[3]), c: parseFloat(k[4]),
+  }));
+  const patterns = detectPatterns(patternCandles);
+
+  return {
+    volRatio: avg > 0 ? current / avg : 1,
+    ma20, rsi14, poc, vah, val, vwap, takerBuyRatio,
+    chartPattern: patterns.length > 0 ? patterns.join('; ') : null,
+  };
+}


### PR DESCRIPTION
## Summary

The browser asked Binance for market data **coin by coin, per visitor** — measured at **193 requests / 554 request-weight** on every `/dashboard` load. Now **56 / 214**. One cached server route replaces three client fan-outs.

## What changed

- **New `app/api/market/snapshot`** — 24h ticker, 15m kline metrics, long/short ratios, in one cached response (~21KB, ~10ms warm)
- **New `lib/klineMetrics.ts`** — the 9 values `fetchKlines` derived (volRatio, ma20, rsi14, poc, vah, val, vwap, takerBuyRatio, chartPattern), lifted out pure so browser and server can't drift
- **`MarketProvider`** — `fetchKlines`, `fetchVolume` and the Binance half of `fetchLSR` replaced by one `fetchSnapshot`

## Measured, same probe before and after

| Endpoint | Before | After |
|---|---|---|
| `aggTrades` | 45 req / 180 w | 45 / 180 — *left deliberately* |
| `ticker/24hr` | 2 / **160** | 0 / 0 |
| `fapi/v1/klines` | 45 / **90** | 0 / 0 |
| `globalLongShortAccountRatio` | 46 / 46 | 1 / 1 |
| `topLongShortPositionRatio` | 45 / 45 | 0 / 0 |
| **TOTAL** | **193 / 554** | **56 / 214** |

## Why

The problem was never that one visitor came close to Binance's limit. It's that the cost was **per-visitor and therefore unbounded** — two tabs doubled it, ten visitors multiplied it by ten. Binance limits by **IP**, which on mobile CGNAT or an office NAT is shared. A limited IP gets **418 on everything**, including the chart's own calls, so the app looks completely broken with nothing explaining why.

## Three things running it turned up that reading the code would not

**1. Spot and futures are separate rate-limit buckets.** The ticker section came back empty while klines and ratios were fine — this machine was 418 on `api.binance.com` and answering normally on `fapi.binance.com` in the same second. `resolveHost` was letting that 418 throw, taking the whole section down instead of returning empty. Now swallowed, and the ticker **falls back to the futures endpoint** so 24h volume survives a banned spot bucket.

**2. My first version would have made prices tick backwards.** It applied `price/change/high/low` from the cached ticker. The original `fetchVolume` took **only `vol24`** — price is owned by the WebSocket. Applying it would have overwritten a live price with one up to three minutes old on every poll.

**3. That fix enabled a further one.** Prices are now seeded from the snapshot *only when a coin has none yet*, which let `restPoll`'s mount call go entirely — one more `ticker/24hr` batch at weight 80.

**Verified the socket still wins:** prices at t=2s came from the seed, **333 socket frames** arrived over the next 15 seconds, and displayed prices **had changed** by t=17s.

## What is deliberately left

`aggTrades` — 45 requests, 180 weight, the largest remaining item. It does two jobs: a CVD sum that would move happily, and **whale detection**, which dispatches a DOM event per new large trade and dedupes against a per-client `lastAggId`. Moving it needs a server→client push channel and a shared notion of "already seen" — a different design, not a relocation. Known remainder, not an oversight.

## How to test (QA)

1. Open the dashboard on staging. Every coin should show a price within a second or two, **and then keep ticking**. Frozen prices after first paint is the failure this PR could plausibly cause — watch for 30 seconds.
2. Confirm **24h volume**, **RSI**, **MA20** and **VWAP** are present on the coin cards.
3. Confirm the **long/short ratio** bars are populated.
4. DevTools → Network, filter `binance`, hard-refresh. Expect roughly **56 requests, not ~193**, and **no per-coin kline or ratio requests**.
5. Filter for `market/snapshot` — **one** request, about 21KB.
6. Leave the page four minutes — expect **exactly one** more `market/snapshot`.
7. Check `/scanner` and `/arena` still render their data — they read the same store.
8. `npm test` → 59 passing. `npx tsc --noEmit` → clean. `npm run lint` → 0 errors.

## Risk level

**Medium** — this is the market data path that every page reads. No auth, no payments, no migration.

**Honest limitations:**

- **Spot reachability from Render is still unverified**, same open question as the RSI route. If spot is blocked there, `vol24` comes from the futures fallback — perp volume is not identical to spot volume for the same pair. The health record says which was used (`binance:ticker`, detail reads `via spot` or `via futures`).
- **The cache is in-memory per-instance.** A restart empties it; the first visitor after that pays the fill.
- **Lint is 94 warnings**, unchanged from `dev`. 0 errors.

## Screenshots (if UI change)

N/A — no visual change intended. Step 1 is the check that matters: same numbers, arriving differently.
