### PR TITLE
test(e2e): cover /scanner in the CWV spec and record its CLS as ungated

### DIFF
--- a/qa/e2e/_shared.ts
+++ b/qa/e2e/_shared.ts
@@ -122,6 +122,32 @@ export const CLS_BUDGET: Record<string, number> = {
      0.365 to 0.068 over three runs. Note it was the footer, not gchat-fab:
      per-source attribution put the FAB at 0.1% of the shift. */
   '/briefing': 0.20,  // observed 0.148, 0.153, 0.176
+
+  /* /scanner moved here from CLS_UNSTABLE on 2026-08-05, meeting the retirement
+     condition that entry set for itself ("fix the race, re-measure over >=10
+     runs, then give /scanner a real CLS_BUDGET").
+
+     The instability was real when measured, and it was measured on `dev`, which
+     had fix/scanner-layout-shift (the heatmap tile-height fix) but NOT
+     fix/scanner-card-layout-shift, which rewrote the heatmap ranking, three card
+     skeletons and PageHint. Both are now on main.
+
+     24 runs on the shipped build, production server, two batches:
+       cold  0.176 0.010 0.013 0.016 0.010 0.011 0.010 0.016 0.009 0.028 0.007 0.014
+       warm  0.008 0.007 0.007 0.008 0.012 0.010 0.028 0.007 0.011 0.012 0.016 0.011
+     Warm: min 0.007, median 0.011, mean 0.011, max 0.028.
+     The single 0.176 was run #1 against a just-started server; the second batch
+     was run to test exactly that, and reproduced nothing above 0.028. That is a
+     cold-start cost, not the ~3x race the old distribution showed.
+
+     Budget is 0.25 rather than deleting the route outright, even though the
+     median is well under CLS_GOOD, because CI always measures a cold server -
+     the webServer builds and starts immediately before the run - so 0.1 would
+     gate on the one number that legitimately varies. 0.25 clears the observed
+     cold worst case with headroom and is still ~9x tighter than the ~2.0 a
+     ceiling would have needed before the fix.
+     Lower it to CLS_GOOD (delete this line) if cold-start ever measures <0.1. */
+  '/scanner': 0.25,
 };
 
 /** The "good" CLS threshold every route not in CLS_BUDGET must meet. */
@@ -134,32 +160,19 @@ export const CLS_GOOD = 0.1;
  * visible, it just is not a pass/fail gate. Nothing here is "allowed"; it is
  * unmeasurable-by-threshold, which is a WORSE state than a bad fixed number.
  *
- * /scanner, 10 consecutive identical loads on this branch (dev, i.e. WITH
- * fix/scanner-layout-shift):
+ * EMPTY as of 2026-08-05. /scanner was the only entry and has been retired to
+ * CLS_BUDGET at 0.25 - see the note there for the 24-run distribution that
+ * justified it. The mechanism stays because the distinction it draws is a real
+ * one, and re-deriving it under pressure would be worse than keeping it.
  *
- *   0.622  0.861  1.196  1.221  1.276  1.278  1.330  1.440  1.535  1.693
- *   min 0.622   mean 1.245   max 1.693
- *
- * The same 10-run measurement on main, without the fix, was min 0.775,
- * mean 1.471, max 2.312. So the fix helps - roughly 15% off the mean and 27%
- * off the worst case - but /scanner is still 6x-17x the 0.1 "good" threshold
- * and just as non-deterministic. An earlier 3-run sample of this branch read
- * 0.432/0.691/0.454 and was reported as "fixed"; 10 runs show that was an
- * undersampled fluke. Three samples are not enough for this route.
- *
- * No budget, because a budget was tried and failed immediately: 3 samples on
- * main gave a max of 1.002, a budget of 1.10 was set from it, and the very next
- * run measured 1.195. An unsized element yields a repeatable number; a ~3x
- * spread on identical input means something races. A ceiling that survived the
- * tail would need to be ~2.0, loose enough to catch no regression worth
- * catching - and playwright.config.ts is explicit that a flaky pass is worse
- * than a fail, because it teaches everyone to re-run until green.
- *
- * To retire this entry: fix the race, re-measure over >=10 runs, then give
- * /scanner a real CLS_BUDGET, or delete it from here entirely if it gets under
- * CLS_GOOD.
+ * The bar for adding a route here, unchanged: an entry must carry a measured
+ * distribution (>=10 runs, not 3 - an earlier 3-run sample of /scanner read
+ * 0.432/0.691/0.454 and was reported as "fixed", which 10 runs disproved) AND
+ * a retirement condition saying what has to be true to remove it. Without both
+ * this becomes the place flaky tests go to be forgotten, which is the failure
+ * mode it exists to prevent.
  */
-export const CLS_UNSTABLE = new Set<string>(['/scanner']);
+export const CLS_UNSTABLE = new Set<string>([]);
 
 /**
  * Settle a page: wait for hydration, then assert the stylesheet actually

--- a/qa/e2e/_shared.ts
+++ b/qa/e2e/_shared.ts
@@ -105,6 +105,40 @@ export const CLS_BUDGET: Record<string, number> = {
 export const CLS_GOOD = 0.1;
 
 /**
+ * Routes whose CLS is too UNSTABLE to assert any number against.
+ *
+ * Still measured and attached to the report on every run - the value stays
+ * visible, it just is not a pass/fail gate. Nothing here is "allowed"; it is
+ * unmeasurable-by-threshold, which is a WORSE state than a bad fixed number.
+ *
+ * /scanner, 10 consecutive identical loads on this branch (dev, i.e. WITH
+ * fix/scanner-layout-shift):
+ *
+ *   0.622  0.861  1.196  1.221  1.276  1.278  1.330  1.440  1.535  1.693
+ *   min 0.622   mean 1.245   max 1.693
+ *
+ * The same 10-run measurement on main, without the fix, was min 0.775,
+ * mean 1.471, max 2.312. So the fix helps - roughly 15% off the mean and 27%
+ * off the worst case - but /scanner is still 6x-17x the 0.1 "good" threshold
+ * and just as non-deterministic. An earlier 3-run sample of this branch read
+ * 0.432/0.691/0.454 and was reported as "fixed"; 10 runs show that was an
+ * undersampled fluke. Three samples are not enough for this route.
+ *
+ * No budget, because a budget was tried and failed immediately: 3 samples on
+ * main gave a max of 1.002, a budget of 1.10 was set from it, and the very next
+ * run measured 1.195. An unsized element yields a repeatable number; a ~3x
+ * spread on identical input means something races. A ceiling that survived the
+ * tail would need to be ~2.0, loose enough to catch no regression worth
+ * catching - and playwright.config.ts is explicit that a flaky pass is worse
+ * than a fail, because it teaches everyone to re-run until green.
+ *
+ * To retire this entry: fix the race, re-measure over >=10 runs, then give
+ * /scanner a real CLS_BUDGET, or delete it from here entirely if it gets under
+ * CLS_GOOD.
+ */
+export const CLS_UNSTABLE = new Set<string>(['/scanner']);
+
+/**
  * Settle a page: wait for hydration, then assert the stylesheet actually
  * applied.
  *

--- a/qa/e2e/perf.spec.ts
+++ b/qa/e2e/perf.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { settle, CLS_BUDGET, CLS_GOOD } from './_shared';
+import { settle, CLS_BUDGET, CLS_GOOD, CLS_UNSTABLE } from './_shared';
 
 // Core Web Vitals + third-party request volume.
 //
@@ -7,7 +7,13 @@ import { settle, CLS_BUDGET, CLS_GOOD } from './_shared';
 // measurement - no network latency, no Render cold start. Budgets are set
 // loose enough that only a real regression trips them.
 
-const KEY_ROUTES = ['/', '/login', '/arena', '/dashboard', '/markets', '/briefing'];
+// /scanner was missing from this list until 2026-08-05, and it is by far the
+// worst route in the app for layout shift - CLS 0.622-1.693 over 10 identical
+// loads even WITH fix/scanner-layout-shift, up to 17x the "good" threshold. A
+// Core Web Vitals spec that skips the worst offender is not doing its job, and
+// this one did for its whole existence. If you add a route to the app, add it
+// here too; the cost is a few seconds per run.
+const KEY_ROUTES = ['/', '/login', '/arena', '/dashboard', '/markets', '/briefing', '/scanner'];
 
 test.describe('performance', () => {
   test.beforeEach(({ }, testInfo) => {
@@ -15,7 +21,7 @@ test.describe('performance', () => {
   });
 
   for (const route of KEY_ROUTES) {
-    test(`${route} stays within CLS and LCP budget`, async ({ page }) => {
+    test(`${route} stays within CLS and LCP budget`, async ({ page }, testInfo) => {
       await settle(page, route);
 
       const vitals = await page.evaluate(() => new Promise<{ lcp: number; cls: number }>(resolve => {
@@ -34,22 +40,42 @@ test.describe('performance', () => {
         setTimeout(() => resolve({ lcp: Math.round(lcp), cls: +cls.toFixed(3) }), 1200);
       }));
 
-      // Audit §3.2 claimed 0.000 everywhere. That was wrong - /arena and
-      // /briefing both shift visibly during load (see CLS_BUDGET in _shared.ts
-      // for the measurements and which element moves). Those two are held to a
-      // documented known-bad budget; every other route is held to the real
-      // 0.1 "good" threshold.
-      const budget = CLS_BUDGET[route] ?? CLS_GOOD;
-      const known = route in CLS_BUDGET;
-      expect(
-        vitals.cls,
-        known
-          ? `${route} CLS ${vitals.cls} exceeded its known-bad budget of ${budget}. ` +
-            `This route already fails the 0.1 "good" threshold; it just got worse. ` +
-            `Do NOT raise the budget - see CLS_BUDGET in qa/e2e/_shared.ts.`
-          : `${route} CLS regressed to ${vitals.cls} (budget ${budget}). Content is ` +
-            `jumping during load.`,
-      ).toBeLessThan(budget);
+      // Record every measurement, asserted or not, so the number reaches the
+      // report even for routes too unstable to gate on.
+      testInfo.attach(`cls-${route.replace(/\W+/g, '_') || 'root'}.txt`, {
+        body: `${route}  CLS=${vitals.cls}  LCP=${vitals.lcp}ms`,
+        contentType: 'text/plain',
+      });
+
+      // Audit §3.2 claimed 0.000 everywhere. That was wrong - see CLS_BUDGET
+      // and CLS_UNSTABLE in _shared.ts for what actually shifts and by how
+      // much. Known-bad routes get a documented budget; the rest are held to
+      // the real 0.1 "good" threshold.
+      if (CLS_UNSTABLE.has(route)) {
+        // Measured and reported, deliberately NOT asserted. /scanner's CLS
+        // varies ~3x across identical loads, so any threshold either flakes or
+        // is too loose to catch anything. This is a worse state than a bad
+        // fixed number, not a pass - see CLS_UNSTABLE for the distribution and
+        // what has to happen before it becomes a real assertion again.
+        testInfo.annotations.push({
+          type: 'known-issue',
+          description:
+            `${route} CLS ${vitals.cls} - non-deterministic (0.622-1.693 over 10 runs), ` +
+            `not gated. See CLS_UNSTABLE in qa/e2e/_shared.ts.`,
+        });
+      } else {
+        const budget = CLS_BUDGET[route] ?? CLS_GOOD;
+        const known = route in CLS_BUDGET;
+        expect(
+          vitals.cls,
+          known
+            ? `${route} CLS ${vitals.cls} exceeded its known-bad budget of ${budget}. ` +
+              `This route already fails the 0.1 "good" threshold; it just got worse. ` +
+              `Do NOT raise the budget - see CLS_BUDGET in qa/e2e/_shared.ts.`
+            : `${route} CLS regressed to ${vitals.cls} (budget ${budget}). Content is ` +
+              `jumping during load.`,
+        ).toBeLessThan(budget);
+      }
 
       // Measured 84-720ms locally. 2500ms is Google's "good" bar - generous
       // headroom so this only fires on a genuine regression.

--- a/qa/e2e/perf.spec.ts
+++ b/qa/e2e/perf.spec.ts
@@ -7,12 +7,19 @@ import { settle, CLS_BUDGET, CLS_GOOD, CLS_UNSTABLE } from './_shared';
 // measurement - no network latency, no Render cold start. Budgets are set
 // loose enough that only a real regression trips them.
 
-// /scanner was missing from this list until 2026-08-05, and it is by far the
-// worst route in the app for layout shift - CLS 0.622-1.693 over 10 identical
-// loads even WITH fix/scanner-layout-shift, up to 17x the "good" threshold. A
+// /scanner was missing from this list until 2026-08-05, and at the time it was
+// added it was by far the worst route in the app for layout shift - CLS
+// 0.622-1.693 over 10 identical loads even WITH fix/scanner-layout-shift. A
 // Core Web Vitals spec that skips the worst offender is not doing its job, and
-// this one did for its whole existence. If you add a route to the app, add it
-// here too; the cost is a few seconds per run.
+// this one did for its whole existence.
+// It now measures 0.007-0.028 warm over 24 runs and carries a real 0.25 budget
+// (see CLS_BUDGET). Worth noting WHY it looked non-deterministic: the route was
+// only ever measured on a build missing fix/scanner-card-layout-shift, so the
+// spread was a genuine race that has since been fixed - not observer noise. The
+// lesson that survives is the sampling one: 3 runs called it fixed, 10 runs
+// disproved that.
+// If you add a route to the app, add it here too; the cost is a few seconds per
+// run.
 const KEY_ROUTES = ['/', '/login', '/arena', '/dashboard', '/markets', '/briefing', '/scanner'];
 
 test.describe('performance', () => {
@@ -52,16 +59,19 @@ test.describe('performance', () => {
       // much. Known-bad routes get a documented budget; the rest are held to
       // the real 0.1 "good" threshold.
       if (CLS_UNSTABLE.has(route)) {
-        // Measured and reported, deliberately NOT asserted. /scanner's CLS
-        // varies ~3x across identical loads, so any threshold either flakes or
-        // is too loose to catch anything. This is a worse state than a bad
-        // fixed number, not a pass - see CLS_UNSTABLE for the distribution and
-        // what has to happen before it becomes a real assertion again.
+        // Measured and reported, deliberately NOT asserted, for a route whose
+        // CLS varies so much that any threshold either flakes or is too loose to
+        // catch anything. That is a WORSE state than a bad fixed number, not a
+        // pass - the annotation exists so it cannot be mistaken for one.
+        // CLS_UNSTABLE is currently EMPTY (/scanner was retired to a real budget
+        // on 2026-08-05), so this branch does not run today. Kept because the
+        // distinction is real and re-deriving it mid-incident would be worse.
         testInfo.annotations.push({
           type: 'known-issue',
           description:
-            `${route} CLS ${vitals.cls} - non-deterministic (0.622-1.693 over 10 runs), ` +
-            `not gated. See CLS_UNSTABLE in qa/e2e/_shared.ts.`,
+            `${route} CLS ${vitals.cls} - non-deterministic, not gated. ` +
+            `See CLS_UNSTABLE in qa/e2e/_shared.ts for the distribution and the ` +
+            `retirement condition.`,
         });
       } else {
         const budget = CLS_BUDGET[route] ?? CLS_GOOD;


### PR DESCRIPTION
## Summary

Adds `/scanner` to the Core Web Vitals spec, which never measured it, and records its CLS rather than gating on a number it could not hold.

## What changed

- `/scanner` joins `KEY_ROUTES` in `qa/e2e/perf.spec.ts`.
- Every route's CLS and LCP is now attached to the report, asserted or not.
- New `CLS_UNSTABLE` set in `qa/e2e/_shared.ts`; `/scanner` is measured and annotated as a known issue instead of gated.

## Why

The spec measured six routes and skipped the worst one, so `/scanner` was invisible to the suite for its entire existence — including while `fix/scanner-layout-shift` was written and merged against it.

Ten identical loads, measured when this branch was cut:

```
0.622 0.861 1.196 1.221 1.276 1.278 1.330 1.440 1.535 1.693
min 0.622   mean 1.245   max 1.693
```

No budget was set, because one was tried and failed immediately: three samples on `main` gave a max of 1.002, a budget of 1.10 was set from it, and the very next run measured 1.195. A ~3x spread on identical input means something races rather than merely being unsized.

## ⚠️ This branch is partly superseded by release PR #18

`fix/scanner-card-layout-shift` (17d3dc9) lands in that release and changes the picture substantially. Measured against staging at `9e06e18`:

| Build | min | mean | max |
|---|---|---|---|
| `main`, no fixes | 0.775 | 1.471 | 2.312 |
| `dev`, + layout-shift fix | 0.622 | 1.245 | 1.693 |
| release, + card fix | 0.022 | 0.117 | 0.199 |

At 0.022–0.199 the route is bounded enough to carry a real `CLS_BUDGET` (~0.25) rather than being ungated.

**Suggested handling:** merge this for the `/scanner` coverage and the always-attach reporting, both of which stand on their own — then let me follow up with a commit that swaps `CLS_UNSTABLE` for a real budget once the release is on `main` and I have re-measured on a local build. Alternatively hold this until then and I will submit it as one commit. Either is fine; the coverage gap is the part worth fixing quickly, since nothing currently measures that route at all.

Note the two independent `/scanner` measurements taken by QA and dev differ in absolute value (2.312 → 0.199 vs 0.98 → 0.061) because the shifts are data-arrival dependent and network timing moves when data lands. Same direction, ~10x improvement either way.

## How to test (QA)

1. `git fetch && git checkout test/e2e-scanner-coverage`
2. `npm ci`, then `npx playwright install --with-deps chromium`
3. Ensure `.env.local` carries `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` for the dev project — without them `/login` specs fail and `/api/ops/*` answers 500 where the security specs assert 401
4. `npx playwright test qa/e2e/perf.spec.ts --project=desktop` — expect **8 passed**, including a `/scanner` test
5. `npm run test:e2e:report`, open the `/scanner` test, confirm a `known-issue` annotation quoting its CLS and a `cls-_scanner.txt` attachment
6. Confirm `/arena` is asserted against the strict 0.1 threshold, not a budget
7. `npx tsc --noEmit` clean, `npm run lint` 0 errors

## Risk level

**Low** — test tooling only, no application code. Worst case is a noisier report, not a user-facing defect.
