### PR TITLE
Release 2026-08-05.2: Binance fan-out, tap targets, four QA defects, contrast 270 -> 0

### DIFF
--- a/__tests__/contrastTokens.test.mts
+++ b/__tests__/contrastTokens.test.mts
@@ -72,9 +72,34 @@ test('design token contrast', async (t) => {
   await t.test('sanity: the ratio maths matches known WCAG values', () => {
     assert.equal(Math.round(ratio('#ffffff', '#000000')), 21);
     assert.equal(Math.round(ratio('#000000', '#000000')), 1);
-    // The brand blue pair this branch deliberately leaves failing.
+    // The pair that forced --accent-solid to exist.
     assert.ok(Math.abs(ratio('#ffffff', '#1a7aff') - 3.98) < 0.02,
-      'white on --accent should still measure ~3.98:1');
+      'white on the undarkened brand blue should measure ~3.98:1');
+  });
+
+  await t.test('the two accent tokens each cover their own direction', () => {
+    /* The whole reason there are two. A single blue cannot do both jobs on a
+       dark theme: darkening enough for white text to pass ON it drops it below
+       AA when used AS text on the near-black backgrounds. Assert both ends so
+       nobody "simplifies" this back into one token. */
+    const accent = token('accent');
+    const solid = token('accent-solid');
+
+    const onSolid = ratio('#ffffff', solid);
+    assert.ok(onSolid >= AA,
+      `white on --accent-solid ${solid} = ${onSolid.toFixed(2)}:1, needs ${AA}:1`);
+
+    for (const [surface, bg] of Object.entries(SURFACES)) {
+      const r = ratio(accent, bg);
+      assert.ok(r >= AA,
+        `--accent ${accent} as TEXT on ${surface} ${bg} = ${r.toFixed(2)}:1`);
+    }
+
+    /* And the trap itself: --accent-solid must NOT be used as text on --bg0.
+       If this ever stops holding, the two tokens have converged and one of the
+       two directions is silently failing again. */
+    assert.ok(ratio(solid, SURFACES['--bg0']) < AA,
+      'if --accent-solid passes as text too, re-check whether both tokens are still needed');
   });
 
   for (const name of ['txt', 'txt2', 'txt3', 'txt-dim']) {

--- a/__tests__/contrastTokens.test.mts
+++ b/__tests__/contrastTokens.test.mts
@@ -1,0 +1,117 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+/* Guards the design tokens against WCAG 2.2 SC 1.4.3 (AA, 4.5:1 for normal
+   text) without needing a browser.
+
+   This exists because the previous --txt3 fix was verified against --bg1/--bg2
+   only and shipped at 4.46:1 on --bg4 and 4.32:1 on #191b1e - two surfaces
+   nobody thought to check. A colour that "passes" is a claim about a specific
+   pair, and the only way to keep that claim true as surfaces are added is to
+   assert every pair. Parsing the values out of globals.css rather than
+   duplicating them here means editing a token re-runs the check.
+
+   Not covered here, deliberately: anything blended at runtime (opacity,
+   color-mix) or painted over a gradient/image. Those need a real renderer -
+   axe against the running app - and were the source of most of the failures
+   this test is the aftermath of. Passing this file is necessary, not
+   sufficient. */
+
+const CSS = fs.readFileSync(new URL('../app/globals.css', import.meta.url), 'utf8');
+
+function token(name: string, scope?: string): string {
+  const haystack = scope
+    ? CSS.slice(CSS.indexOf(scope), CSS.indexOf(scope) + 1200)
+    : CSS;
+  const m = haystack.match(new RegExp('--' + name + ':\\s*(#[0-9a-fA-F]{6})'));
+  assert.ok(m, `token --${name} not found${scope ? ' in ' + scope : ''}`);
+  return m![1].toLowerCase();
+}
+
+/** WCAG 2.x relative luminance. */
+function luminance(hex: string): number {
+  const c = [1, 3, 5].map(i => {
+    const v = parseInt(hex.slice(i, i + 2), 16) / 255;
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2];
+}
+
+function ratio(fg: string, bg: string): number {
+  const a = luminance(fg), b = luminance(bg);
+  return (Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05);
+}
+
+const AA = 4.5;
+
+/* The declared surface tokens. Every text token must clear AA on all of them,
+   because any of them can host any text tier. */
+const SURFACES: Record<string, string> = {
+  '--bg0': token('bg0'),
+  '--bg1': token('bg1'),
+  '--bg2': token('bg2'),
+  '--bg3': token('bg3'),
+  '--bg4': token('bg4'),
+};
+
+/* Surfaces that are NOT tokens - one-off card backgrounds found by running axe
+   against the built app. Only asserted for the tokens actually observed on
+   them, because that is all the measurement established.
+   Known gap, recorded rather than papered over: --txt2 is 4.31:1 on #191b1e.
+   Nothing renders --txt2 there today, so it is not a live defect, but moving
+   any secondary text onto that card would create one. Fixing it means
+   relightening --txt2 app-wide, which is a visible typography change and the
+   owner's call - not something to slip into a contrast pass. If that surface
+   ever gains secondary text, raise --txt2 to >= #7e8298 and add it below. */
+const MEASURED_PAIRS: { surface: string; tokens: string[] }[] = [
+  { surface: '#191b1e', tokens: ['txt', 'txt3', 'txt-dim'] },
+];
+
+test('design token contrast', async (t) => {
+  await t.test('sanity: the ratio maths matches known WCAG values', () => {
+    assert.equal(Math.round(ratio('#ffffff', '#000000')), 21);
+    assert.equal(Math.round(ratio('#000000', '#000000')), 1);
+    // The brand blue pair this branch deliberately leaves failing.
+    assert.ok(Math.abs(ratio('#ffffff', '#1a7aff') - 3.98) < 0.02,
+      'white on --accent should still measure ~3.98:1');
+  });
+
+  for (const name of ['txt', 'txt2', 'txt3', 'txt-dim']) {
+    const fg = token(name);
+    await t.test(`--${name} (${fg}) clears AA on every app surface`, () => {
+      for (const [surface, bg] of Object.entries(SURFACES)) {
+        const r = ratio(fg, bg);
+        assert.ok(r >= AA,
+          `--${name} ${fg} on ${surface} ${bg} = ${r.toFixed(2)}:1, needs ${AA}:1`);
+      }
+    });
+  }
+
+  await t.test('tokens clear AA on the measured non-token card surfaces', () => {
+    for (const { surface, tokens } of MEASURED_PAIRS) {
+      for (const name of tokens) {
+        const fg = token(name);
+        const r = ratio(fg, surface);
+        assert.ok(r >= AA, `--${name} ${fg} on ${surface} = ${r.toFixed(2)}:1`);
+      }
+    }
+  });
+
+  await t.test('.lp-root overrides also clear AA on the landing surfaces', () => {
+    /* .lp-root re-declares the palette to force dark mode regardless of the
+       saved theme, which is how it silently reverted the :root AA fix for the
+       first page every visitor sees. */
+    const fg = token('txt3', '.lp-root {');
+    for (const bg of ['#050505', '#0e0e12', '#0a0c10']) {
+      const r = ratio(fg, bg);
+      assert.ok(r >= AA, `.lp-root --txt3 ${fg} on ${bg} = ${r.toFixed(2)}:1`);
+    }
+  });
+
+  await t.test('--txt-dim is the neutral it claims to be, not a tinted grey', () => {
+    const v = token('txt-dim');
+    assert.equal(v.slice(1, 3), v.slice(3, 5), 'r and g should match');
+    assert.equal(v.slice(3, 5), v.slice(5, 7), 'g and b should match');
+  });
+});

--- a/__tests__/labelsFallback.test.mts
+++ b/__tests__/labelsFallback.test.mts
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import DEFAULTS from '../lib/labelDefaults.en.json' with { type: 'json' };
+
+/* Guards the §1.4 defect QA found: /api/labels answers `200 {}` on any DB
+   error, and LabelsProvider used to apply that unconditionally - replacing
+   every seeded English default, so t()'s `map[key] ?? key` rendered the whole
+   UI as raw keys.
+   The provider itself is a React component and not unit-testable here without
+   a renderer, so this pins the two pure decisions it makes. If either of these
+   fails, the provider logic has drifted from what the comment there claims. */
+
+const defaults = DEFAULTS as Record<string, string>;
+
+/** Mirrors the guard in LabelsProvider.fetchLabels. */
+function isUsablePayload(data: unknown): boolean {
+  return !!data && typeof data === 'object' && !Array.isArray(data)
+    && Object.keys(data as object).length > 0;
+}
+
+/** Mirrors how the provider applies a payload over the seeded defaults. */
+function applyPayload(
+  current: Record<string, string>, data: unknown,
+): Record<string, string> {
+  if (!isUsablePayload(data)) return current;
+  return { ...defaults, ...(data as Record<string, string>) };
+}
+
+test('label payload guard', async (t) => {
+  await t.test('the seed is not empty, or none of this matters', () => {
+    assert.ok(Object.keys(defaults).length > 100,
+      'labelDefaults.en.json should carry the full English snapshot');
+  });
+
+  await t.test('an empty object is rejected - the exact prod failure mode', () => {
+    assert.equal(isUsablePayload({}), false);
+    const after = applyPayload(defaults, {});
+    assert.deepEqual(after, defaults, 'defaults must survive a fail-open 200 {}');
+  });
+
+  await t.test('null, undefined and arrays are rejected', () => {
+    for (const bad of [null, undefined, [], ['a'], 'string', 0]) {
+      assert.equal(isUsablePayload(bad), false, String(bad) + ' should be rejected');
+      assert.deepEqual(applyPayload(defaults, bad), defaults);
+    }
+  });
+
+  await t.test('a real payload is applied', () => {
+    const key = Object.keys(defaults)[0];
+    const after = applyPayload(defaults, { [key]: 'TRANSLATED' });
+    assert.equal(after[key], 'TRANSLATED');
+  });
+
+  await t.test('a PARTIAL payload degrades to English, never to raw keys', () => {
+    /* The PostgREST db-max-rows case app/api/labels warns about, and any
+       half-translated locale. Before the fix these keys resolved to
+       `map[key] ?? key` and rendered as NAV_SIGN_IN on screen. */
+    const keys = Object.keys(defaults);
+    const partial = { [keys[0]]: 'UNO' };
+    const after = applyPayload(defaults, partial);
+    assert.equal(after[keys[0]], 'UNO', 'provided key uses the payload');
+    assert.equal(after[keys[1]], defaults[keys[1]], 'missing key falls back to English');
+    assert.equal(Object.keys(after).length, keys.length,
+      'no key may go missing - a missing key is a raw key on screen');
+  });
+});

--- a/app/alerts/page.tsx
+++ b/app/alerts/page.tsx
@@ -506,7 +506,7 @@ export default function AlertsPage() {
 
   const stepStyle: React.CSSProperties = { display: 'flex', gap: 12, marginBottom: 16 };
   const numStyle: React.CSSProperties = {
-    width: 24, height: 24, borderRadius: '50%', background: 'var(--accent)',
+    width: 24, height: 24, borderRadius: '50%', background: 'var(--accent-solid)',
     display: 'flex', alignItems: 'center', justifyContent: 'center',
     fontSize: 'var(--fs-caption)', fontWeight: 700, color: '#fff', flexShrink: 0, marginTop: 1,
   };

--- a/app/api/market/snapshot/route.ts
+++ b/app/api/market/snapshot/route.ts
@@ -1,0 +1,265 @@
+/**
+ * Server-side market snapshot: 24h ticker, 15m kline metrics, long/short ratios.
+ *
+ * GET /api/market/snapshot
+ *   → { ticker: {...}, klines: {...}, lsr: {...}, ts }
+ *
+ * WHY THIS EXISTS
+ *
+ * Measured on a real /dashboard load, this is what the browser used to ask
+ * Binance for directly, per visitor:
+ *
+ *   aggTrades                     45 req   180 weight
+ *   ticker/24hr (45 symbols)       2 req   160 weight
+ *   fapi/v1/klines                45 req    90 weight
+ *   globalLongShortAccountRatio   46 req    46 weight
+ *   topLongShortPositionRatio     45 req    45 weight
+ *   everything else               10 req    33 weight
+ *   ------------------------------------------------
+ *   TOTAL                        193 req   554 weight
+ *
+ * This route takes the three biggest that are safe to move — ticker, klines and
+ * the two ratio endpoints — which is 138 of those requests and 341 of that
+ * weight, and serves them to every visitor from one cached result.
+ *
+ * The point is not that any single visitor was close to Binance's limit. It is
+ * that the cost was per-visitor and therefore unbounded: two tabs doubled it,
+ * ten visitors multiplied it by ten, and Binance rate-limits by IP, which on
+ * mobile CGNAT or an office NAT is shared. Once an IP is limited Binance
+ * returns 418 to everything from it, including the chart's own calls, so the
+ * app appears completely broken with nothing on screen explaining why. Doing it
+ * here makes the upstream cost fixed instead.
+ *
+ * WHAT IS DELIBERATELY LEFT IN THE BROWSER
+ *
+ * `aggTrades` (45 requests, 180 weight — the single largest remaining item)
+ * stays client-side on purpose. It does two jobs: a pure CVD sum, which would
+ * move happily, and whale detection, which dispatches a `whale-trade` DOM event
+ * for each new large trade and dedupes against a per-client `lastAggId`. Moving
+ * it would need a server→client push channel and a shared notion of "already
+ * seen", i.e. a different design rather than a relocation. It is a known
+ * remainder, not an oversight.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { apiError } from '@/lib/apiError';
+import { BINANCE_SYMS } from '@/lib/coins';
+import { rateLimit, getClientIp } from '@/lib/rateLimit';
+import { cached } from '@/lib/apiCache';
+import { reportHealth, healthError } from '@/lib/apiHealth';
+import { computeKlineMetrics, type KlineMetrics } from '@/lib/klineMetrics';
+
+export const dynamic = 'force-dynamic';
+
+/* Cadences the client used, kept so nothing gets fresher or staler than it was:
+   fetchVolume ran every 3 minutes, fetchLSR every 5. */
+const KLINES_TTL = 3 * 60_000;
+const TICKER_TTL = 3 * 60_000;
+const LSR_TTL    = 5 * 60_000;
+
+/* 45 symbols x 2 ratio endpoints is 90 requests. Unbounded parallelism is what
+   this route exists to stop doing, and it is also more sockets than the Render
+   instance should hold open at once. */
+const CONCURRENCY = 12;
+
+/* Same mirror-walk as /api/funding and /api/market/rsi: individual Binance
+   edges return 451/503 by region while the others are healthy. Resolved once
+   per cache fill rather than per request. */
+const SPOT_HOSTS    = ['https://api.binance.com', 'https://api1.binance.com', 'https://api2.binance.com'];
+const FUTURES_HOSTS = ['https://fapi.binance.com', 'https://fapi1.binance.com', 'https://fapi2.binance.com'];
+
+const SYMS = Object.entries(BINANCE_SYMS).filter(([c]) => c !== 'hype');
+
+interface TickerEntry { price: number; change: number; high: number; low: number; vol24: number }
+interface LsrEntry {
+  bnLongRatio?: number; bnShortRatio?: number;
+  bnWhaleLongRatio?: number; bnWhaleShortRatio?: number;
+}
+
+/** 418 = IP banned, 429 = rate limited. Neither is about the symbol asked for. */
+class BinanceBackoff extends Error {}
+
+async function get(url: string, timeoutMs = 8000): Promise<unknown | null> {
+  const ac = new AbortController();
+  const tid = setTimeout(() => ac.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      cache: 'no-store', signal: ac.signal, headers: { 'User-Agent': 'Mozilla/5.0' },
+    });
+    if (res.status === 418 || res.status === 429) throw new BinanceBackoff(`Binance ${res.status}`);
+    if (!res.ok) return null;
+    return await res.json();
+  } catch (e) {
+    if (e instanceof BinanceBackoff) throw e;
+    return null;
+  } finally {
+    clearTimeout(tid);
+  }
+}
+
+/* Cheap probe so a dead edge is found once, not 90 times.
+ *
+ * Swallows BinanceBackoff deliberately. A 418 on the ping means this IP is
+ * banned, which is a reason to report "no reachable host" and return an empty
+ * section - not to throw and take the other two sections down with it. Letting
+ * it propagate is what made the ticker come back empty *and* rejected while
+ * klines and ratios were fine. */
+async function resolveHost(hosts: readonly string[], pingPath: string): Promise<string | null> {
+  for (const h of hosts) {
+    try {
+      const ok = await get(`${h}${pingPath}`, 5000);
+      if (ok !== null) return h;
+    } catch { /* banned or rate-limited on this edge - try the next */ }
+  }
+  return null;
+}
+
+/* Fixed-size worker pool that stops the moment Binance signals a limit -
+   spending the remaining requests into an active ban only extends it. */
+async function pool<T>(items: T[], limit: number, work: (item: T) => Promise<void>): Promise<boolean> {
+  let next = 0, banned = false;
+  const worker = async () => {
+    for (;;) {
+      if (banned) return;
+      const i = next++;
+      if (i >= items.length) return;
+      try { await work(items[i]); }
+      catch (e) { if (e instanceof BinanceBackoff) { banned = true; return; } }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return banned;
+}
+
+async function buildTicker(): Promise<Record<string, TickerEntry>> {
+  const out: Record<string, TickerEntry> = {};
+  const byCoin = Object.fromEntries(SYMS.map(([c, s]) => [s, c]));
+
+  const absorb = (arr: unknown) => {
+    if (!Array.isArray(arr)) return;
+    for (const d of arr as Record<string, string>[]) {
+      const coin = byCoin[d.symbol];
+      if (!coin) continue;
+      out[coin] = {
+        price:  parseFloat(d.lastPrice || '0'),
+        change: parseFloat(d.priceChangePercent || '0'),
+        high:   parseFloat(d.highPrice || '0'),
+        low:    parseFloat(d.lowPrice || '0'),
+        vol24:  parseFloat(d.quoteVolume || '0'),
+      };
+    }
+  };
+
+  /* Spot first: one batched call for all 45 symbols, exactly as the client
+     did. Weight 80 either way - the saving is that it happens once per TTL
+     rather than once per visitor. */
+  const spot = await resolveHost(SPOT_HOSTS, '/api/v3/ping');
+  if (spot) {
+    const batch = encodeURIComponent(JSON.stringify(SYMS.map(([, s]) => s)));
+    absorb(await get(`${spot}/api/v3/ticker/24hr?symbols=${batch}`));
+  }
+
+  /* Futures fallback. Spot and futures are separate rate-limit buckets, and in
+     practice they fail independently - this was found with spot returning 418
+     for a banned IP while futures answered normally on the same machine and
+     the same second. Without this, one banned bucket meant no 24h volume
+     anywhere in the app.
+     The futures endpoint takes no `symbols` array, so this asks for everything
+     (weight 40) and filters. Perp volume is not identical to spot volume for
+     the same pair, so this is a degraded answer rather than an equal one -
+     which is why it is a fallback and not the default. */
+  const source = Object.keys(out).length > 0 ? 'spot' : 'futures';
+  if (Object.keys(out).length === 0) {
+    const fut = await resolveHost(FUTURES_HOSTS, '/fapi/v1/ping');
+    if (fut) absorb(await get(`${fut}/fapi/v1/ticker/24hr`));
+  }
+
+  reportHealth('binance:ticker', 'market', Object.keys(out).length > 0,
+    `${Object.keys(out).length} coins via ${source}`);
+  return out;
+}
+
+async function buildKlines(): Promise<Record<string, KlineMetrics>> {
+  /* Futures klines, with spot as fallback - the client preferred fapi because
+     its taker buy/sell split is the one perp traders act on. */
+  const fut  = await resolveHost(FUTURES_HOSTS, '/fapi/v1/ping');
+  const spot = fut ? null : await resolveHost(SPOT_HOSTS, '/api/v3/ping');
+  const out: Record<string, KlineMetrics> = {};
+  if (!fut && !spot) { reportHealth('binance:klines', 'market', false, 'no reachable host'); return out; }
+
+  const banned = await pool(SYMS, CONCURRENCY, async ([coin, sym]) => {
+    const url = fut
+      ? `${fut}/fapi/v1/klines?symbol=${sym}&interval=15m&limit=100`
+      : `${spot}/api/v3/klines?symbol=${sym}&interval=15m&limit=100`;
+    const raw = await get(url);
+    if (!Array.isArray(raw)) return;
+    const m = computeKlineMetrics(raw as string[][]);
+    if (m) out[coin] = m;
+  });
+
+  reportHealth('binance:klines', 'market', Object.keys(out).length > 0 && !banned,
+    banned ? `418/429 after ${Object.keys(out).length}/${SYMS.length}`
+           : `${Object.keys(out).length}/${SYMS.length} via ${fut ? 'futures' : 'spot'}`);
+  return out;
+}
+
+async function buildLsr(): Promise<Record<string, LsrEntry>> {
+  const host = await resolveHost(FUTURES_HOSTS, '/fapi/v1/ping');
+  const out: Record<string, LsrEntry> = {};
+  if (!host) { reportHealth('binance:lsr', 'market', false, 'no reachable futures host'); return out; }
+
+  const banned = await pool(SYMS, CONCURRENCY, async ([coin, sym]) => {
+    const [g, w] = await Promise.all([
+      get(`${host}/futures/data/globalLongShortAccountRatio?symbol=${sym}&period=5m&limit=1`),
+      get(`${host}/futures/data/topLongShortPositionRatio?symbol=${sym}&period=5m&limit=1`),
+    ]);
+    const gi = Array.isArray(g) ? (g[0] as Record<string, string>) : null;
+    const wi = Array.isArray(w) ? (w[0] as Record<string, string>) : null;
+    const e: LsrEntry = {};
+    if (gi) { e.bnLongRatio = parseFloat(gi.longAccount || '0.5'); e.bnShortRatio = parseFloat(gi.shortAccount || '0.5'); }
+    if (wi) { e.bnWhaleLongRatio = parseFloat(wi.longAccount || '0.5'); e.bnWhaleShortRatio = parseFloat(wi.shortAccount || '0.5'); }
+    if (Object.keys(e).length) out[coin] = e;
+  });
+
+  reportHealth('binance:lsr', 'market', Object.keys(out).length > 0 && !banned,
+    banned ? `418/429 after ${Object.keys(out).length}/${SYMS.length}` : `${Object.keys(out).length}/${SYMS.length}`);
+  return out;
+}
+
+export async function GET(req: NextRequest) {
+  if (!rateLimit(`market-snapshot:${getClientIp(req)}`, 30, 60_000)) {
+    return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429 });
+  }
+
+  try {
+    /* Three independent caches with their original cadences, merged into one
+       response. allSettled, not all: a failing kline fill must not take the
+       ticker down with it - the client merges whatever arrives and leaves the
+       rest at its previous value, which is how the per-coin version behaved
+       when one symbol failed. */
+    const [t, k, l] = await Promise.allSettled([
+      cached('mkt:ticker', TICKER_TTL, buildTicker),
+      cached('mkt:klines', KLINES_TTL, buildKlines),
+      cached('mkt:lsr',    LSR_TTL,    buildLsr),
+    ]);
+
+    if (t.status === 'rejected' && k.status === 'rejected' && l.status === 'rejected') {
+      reportHealth('binance:snapshot', 'market', false, healthError(t.reason));
+      return apiError('market-snapshot', t.reason, 502, 'Upstream unavailable');
+    }
+
+    return NextResponse.json({
+      ticker: t.status === 'fulfilled' ? t.value : {},
+      klines: k.status === 'fulfilled' ? k.value : {},
+      lsr:    l.status === 'fulfilled' ? l.value : {},
+      ts: Date.now(),
+    }, {
+      /* Public and visitor-independent, and already only as fresh as the
+         shortest TTL. Letting any shared cache in front of this serve it
+         removes the origin hit for the common case. */
+      headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=600' },
+    });
+  } catch (e) {
+    return apiError('market-snapshot', e, 500, 'Request failed');
+  }
+}

--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -1577,7 +1577,7 @@ function ArenaContent() {
                 disabled={alertSaving || !alertPrice}
                 style={{
                   width: '100%', fontSize: 'var(--fs-body)', fontWeight: 700, color: '#fff',
-                  background: 'var(--accent)', border: 'none', borderRadius: 10, padding: '12px 18px',
+                  background: 'var(--accent-solid)', border: 'none', borderRadius: 10, padding: '12px 18px',
                   cursor: alertSaving || !alertPrice ? 'default' : 'pointer',
                   opacity: alertSaving || !alertPrice ? 0.5 : 1, transition: 'opacity .15s',
                 }}

--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -1222,6 +1222,12 @@ function ArenaContent() {
             onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.stopPropagation(); enableNotifications(); } }}
             title={notifEnabled ? t('ARENA_ALERTS_ON_TITLE') : t('ARENA_ALERTS_ENABLE_TITLE')}
             style={{
+              /* 28x20 before - WCAG 2.2 SC 2.5.8 wants 24 in both axes, and a
+                 notification toggle is a standalone control so the inline
+                 exception does not apply. Grown via minHeight and centring so
+                 the bell glyph and the pill border look unchanged. */
+              minWidth: 24, minHeight: 24,
+              display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
               padding: '3px 7px', borderRadius: 7, border: '0.5px solid',
               background: notifEnabled ? '#152b1e' : 'transparent',
               borderColor: notifEnabled ? '#266038' : 'rgba(255,255,255,0.08)',

--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -1198,7 +1198,7 @@ function ArenaContent() {
             </span>
           )}
           {sqzCount === 0 && flushCount === 0 && (
-            <span style={{ fontSize: 'var(--fs-caption)', color: '#333' }}>All neutral</span>
+            <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)' }}>All neutral</span>
           )}
           {/* Coin Health grade badge */}
           {(() => {
@@ -1231,7 +1231,7 @@ function ArenaContent() {
               padding: '3px 7px', borderRadius: 7, border: '0.5px solid',
               background: notifEnabled ? '#152b1e' : 'transparent',
               borderColor: notifEnabled ? '#266038' : 'rgba(255,255,255,0.08)',
-              color: notifEnabled ? '#7de0a4' : '#444',
+              color: notifEnabled ? '#7de0a4' : 'var(--txt-dim)',
               fontSize: 'var(--fs-caption)', cursor: 'pointer', flexShrink: 0, lineHeight: 1,
             }}
           >
@@ -1241,7 +1241,7 @@ function ArenaContent() {
               {!notifEnabled && <line x1="2" y1="2" x2="22" y2="22" />}
             </svg>
           </div>
-          <span style={{ fontSize: 'var(--fs-caption)', color: '#333', flexShrink: 0 }}>{scannerOpen ? '▲' : '▼'}</span>
+          <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)', flexShrink: 0 }}>{scannerOpen ? '▲' : '▼'}</span>
         </button>
 
         {/* ── Flyout panel (appears on hover / click) ── */}
@@ -1920,7 +1920,10 @@ function ArenaContent() {
             <span style={{ opacity: 0.8, letterSpacing: '0.01em' }}>{t('ARENA_ANTICHOP_LABEL')}</span>
           </Tip>
         </button>
-        <span style={{ fontSize: 'var(--fs-caption)', opacity: 0.35 }}>
+        {/* opacity 0.35 computed to #55565b = 2.75:1. This hint explains what
+            the anti-chop toggle beside it actually does, so it has to be
+            readable; --txt-dim carries the same de-emphasis at 5.80:1. */}
+        <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)' }}>
           {antiChopEnabled
             ? t('ARENA_ANTICHOP_ON_HINT')
             : t('ARENA_ANTICHOP_OFF_HINT')}
@@ -2048,10 +2051,10 @@ function ArenaContent() {
       {history.length > 0 && (
         <div style={{ marginTop: 20 }}>
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
-            <div style={{ fontSize: 'var(--fs-micro)', fontWeight: 600, letterSpacing: '.08em', textTransform: 'uppercase', color: '#444' }}>{t('ARENA_SESSION_HISTORY_HEADER')}</div>
+            <div style={{ fontSize: 'var(--fs-micro)', fontWeight: 600, letterSpacing: '.08em', textTransform: 'uppercase', color: 'var(--txt-dim)' }}>{t('ARENA_SESSION_HISTORY_HEADER')}</div>
             <button
               onClick={() => { setHistory([]); setDetailIdx(null); try { sessionStorage.removeItem(ARENA_HIST_KEY); } catch {} }}
-              style={{ fontSize: 'var(--fs-caption)', color: '#444', background: 'none', border: 'none', cursor: 'pointer', padding: '2px 6px' }}
+              style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)', background: 'none', border: 'none', cursor: 'pointer', padding: '2px 6px' }}
             >{t('ARENA_SESSION_HISTORY_CLEAR_BUTTON')}</button>
           </div>
 
@@ -2073,7 +2076,7 @@ function ArenaContent() {
                 </div>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                   <div className="arena-hist-conf">{h.confidence}%</div>
-                  <span style={{ fontSize: 'var(--fs-caption)', color: '#444' }}>{detailIdx === i ? '▲' : '▼'}</span>
+                  <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)' }}>{detailIdx === i ? '▲' : '▼'}</span>
                 </div>
               </div>
 

--- a/app/briefing/page.tsx
+++ b/app/briefing/page.tsx
@@ -384,7 +384,7 @@ export default function MorningBriefing() {
       <div className="card" style={{ marginBottom: 10 }}>
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
           <div className="lbl" style={{ margin: 0 }}>{t('BRIEFING_TOP3_TITLE')}</div>
-          <Link href="/arena" style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', textDecoration: 'none' }}>
+          <Link href="/arena" style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', textDecoration: 'none', display: 'inline-flex', alignItems: 'center', minHeight: 24 }}>
             {t('BRIEFING_SEE_ALL_ARENA')}
           </Link>
         </div>
@@ -697,7 +697,7 @@ export default function MorningBriefing() {
           <div className="card" style={{ marginBottom: 10 }}>
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: shown.length > 0 ? 10 : 0 }}>
               <div className="lbl" style={{ margin: 0 }}>{t('BRIEFING_NOTABLE_SIGNALS_TITLE')}</div>
-              <Link href="/scanner" style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', textDecoration: 'none' }}>
+              <Link href="/scanner" style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', textDecoration: 'none', display: 'inline-flex', alignItems: 'center', minHeight: 24 }}>
                 {t('BRIEFING_FULL_SCANNER_LINK')}
               </Link>
             </div>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -322,7 +322,7 @@ function EdgeSignals() {
 
   // ── Squeeze score ──
   const sq = computeSqueezeScore(d);
-  const sqCol = sq.dir === 'SHORT_SQ' ? 'var(--green)' : sq.dir === 'LONG_LIQ' ? 'var(--red)' : '#606060';
+  const sqCol = sq.dir === 'SHORT_SQ' ? 'var(--green)' : sq.dir === 'LONG_LIQ' ? 'var(--red)' : 'var(--txt-dim)';
 
   const vwapCard = (
     <div className="edge-card">

--- a/app/econ-calendar/page.tsx
+++ b/app/econ-calendar/page.tsx
@@ -4,6 +4,7 @@ import { useNow } from '@/lib/useNow';
 import LoadingState from '@/components/LoadingState';
 import { useLabels } from '@/lib/labels';
 import type { LabelKey } from '@/lib/labelKeys';
+import { econImpactKey, type EconImpact } from '@/lib/classify';
 
 type CalEvent = {
   name: string; type: string; isoDate: string; impact: string;
@@ -59,10 +60,14 @@ function calcDelta(actual?: string, estimate?: string): { text: string; positive
   return { text: (d >= 0 ? '+' : '') + d.toFixed(2) + unit, positive: d >= 0 };
 }
 
-const IMPACT_CFG = {
+/* Keyed by econImpactKey, never by the raw feed string - the feed says 'high'
+   and 'med' in lowercase, so indexing this map directly missed on every row and
+   painted the whole calendar in the LOW style. See lib/classify.ts.
+   LOW's colour also failed AA on its own (#6b7280 = 3.77:1). */
+const IMPACT_CFG: Record<EconImpact, { color: string; bg: string; border: string; accent: string }> = {
   HIGH:   { color: '#f87171', bg: 'rgba(248,113,113,0.14)', border: 'rgba(248,113,113,0.35)', accent: '#f87171' },
   MEDIUM: { color: '#fbbf24', bg: 'rgba(251,191,36,0.12)',  border: 'rgba(251,191,36,0.3)',   accent: '#fbbf24' },
-  LOW:    { color: '#6b7280', bg: 'rgba(107,114,128,0.10)', border: 'rgba(107,114,128,0.25)', accent: 'rgba(107,114,128,0.4)' },
+  LOW:    { color: 'var(--txt-dim)', bg: 'rgba(107,114,128,0.10)', border: 'rgba(107,114,128,0.25)', accent: 'rgba(107,114,128,0.4)' },
 };
 
 const COLS = '68px 72px 1fr 90px 95px 82px 72px 70px';
@@ -120,7 +125,7 @@ export default function EconCalendarPage() {
 
       {/* Next event banner */}
       {next && (() => {
-        const ic  = IMPACT_CFG[next.impact as keyof typeof IMPACT_CFG] ?? IMPACT_CFG.LOW;
+        const ic  = IMPACT_CFG[econImpactKey(next.impact)];
         const ctObj = countdown(next.isoDate);
         const ct  = formatCountdown(ctObj, t);
         const released = ctObj.released;
@@ -185,7 +190,7 @@ export default function EconCalendarPage() {
 
               {/* Rows */}
               {dayEvents.map((e, i) => {
-                const ic      = IMPACT_CFG[e.impact as keyof typeof IMPACT_CFG] ?? IMPACT_CFG.LOW;
+                const ic      = IMPACT_CFG[econImpactKey(e.impact)];
                 const isPast  = new Date(e.isoDate).getTime() < now;
                 const isNext  = next?.isoDate === e.isoDate && next?.name === e.name;
                 const delta   = calcDelta(e.actual, e.estimate);

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -22,7 +22,7 @@ export default function GlobalError({
           <p style={{ color: '#9ca3af', marginBottom: '1.5rem' }}>An unexpected error occurred.</p>
           <button
             onClick={reset}
-            style={{ padding: '0.5rem 1.5rem', background: '#1a7aff', color: '#fff', border: 'none', borderRadius: '0.5rem', cursor: 'pointer', fontSize: 'var(--fs-card-title)' }}
+            style={{ padding: '0.5rem 1.5rem', background: 'var(--accent-solid)', color: '#fff', border: 'none', borderRadius: '0.5rem', cursor: 'pointer', fontSize: 'var(--fs-card-title)' }}
           >
             Try again
           </button>

--- a/app/globals.css
+++ b/app/globals.css
@@ -54,6 +54,18 @@
 
   /* Electric blue - CTAs and interactive elements only */
   --accent:     #1a7aff;
+  /* The SAME brand blue, darkened, for one job: a filled surface carrying white
+     text. White on #1a7aff is 3.98:1 and fails AA - it was the last 20 contrast
+     failures in the app (primary CTA, active nav pill, consent Accept, plan
+     badges). #1668e3 takes that pair to 5.09:1.
+     A second token rather than a darker --accent, because darkening the token
+     itself trades one failure for another: --accent is also used AS TEXT on the
+     near-black backgrounds (links, funding badges, .reasoning-link), where
+     #1a7aff is 5.06:1 and #1668e3 would be 3.95:1. One value cannot satisfy
+     both directions on a dark theme.
+     Rule: --accent for text, borders, glows and rgba tints; --accent-solid
+     wherever the blue is the background under white text. */
+  --accent-solid: #1668e3;
   --accent-2:   #5aa3ff;
   --accent-dim: rgba(26,122,255,0.12);
   --accent-bg:  rgba(26,122,255,0.07);
@@ -813,7 +825,7 @@ body[data-rpm-level="high"]::before {
   border: 0.5px solid transparent; white-space: nowrap;
 }
 .desktop-nav-item:hover { color: var(--txt); background: rgba(90,150,255,0.07); }
-.desktop-nav-item.on { color: #ffffff; background: var(--accent); font-weight: 600; }
+.desktop-nav-item.on { color: #ffffff; background: var(--accent-solid); font-weight: 600; }
 
 @media (min-width: 768px) {
   .hamburger   { display: none !important; }
@@ -1505,7 +1517,7 @@ body.ticker-on .breaking-alert { top: calc(84px + var(--banner-h)); }
   min-height: 30px; letter-spacing: 0; white-space: nowrap;
   transition: background 0.15s, border-color 0.15s, color 0.15s;
 }
-.ncard-ask-btn:hover { background: var(--accent); border-color: var(--accent); color: #fff; box-shadow: none; }
+.ncard-ask-btn:hover { background: var(--accent-solid); border-color: var(--accent); color: #fff; box-shadow: none; }
 .ncard-ask-spark { font-size: 0.8em; line-height: 1; }
 /* Secondary action - neutral, not accent-colored, so it doesn't compete with
    Ask LiquidityAI for attention as the primary CTA. */
@@ -3566,7 +3578,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 
 /* Chat FAB - solid accent in light mode so it's visible */
 [data-theme="light"] .gchat-fab {
-  background: var(--accent);
+  background: var(--accent-solid);
   border-color: transparent;
   box-shadow: 0 4px 20px rgba(0,82,204,0.22), 0 1px 4px rgba(0,0,0,0.10);
   color: #fff;
@@ -3655,7 +3667,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .login-email-input:focus { border-color: var(--purple-bdr); }
 .login-email-btn {
   width: 100%; padding: 11px 16px; border-radius: 12px;
-  background: var(--accent); border: 0.5px solid var(--accent);
+  background: var(--accent-solid); border: 0.5px solid var(--accent);
   color: #fff; font-size: var(--fs-label); font-weight: 600; cursor: pointer;
   transition: all 0.15s; font-family: inherit; letter-spacing: -0.1px;
   display: flex; align-items: center; justify-content: center; gap: 8px;
@@ -3831,7 +3843,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   display: inline-flex; align-items: center; justify-content: center;
   transition: filter 0.15s, background 0.15s;
 }
-.consent-accept  { background: var(--accent); border: 0.5px solid var(--accent); color: #fff; }
+.consent-accept  { background: var(--accent-solid); border: 0.5px solid var(--accent); color: #fff; }
 .consent-decline { background: var(--bg4); border: 0.5px solid var(--txt3); color: var(--txt); }
 .consent-accept:hover  { filter: brightness(1.08); }
 .consent-decline:hover { filter: brightness(1.25); }
@@ -4138,6 +4150,7 @@ body.landing {
   --bdr2: rgba(255,255,255,0.14);
 
   --accent:     #1a7aff;
+  --accent-solid: #1668e3; /* AA fix, mirrors :root - see note there */
   --accent-2:   #5aa3ff;
   --accent-dim: rgba(26,122,255,0.12);
   --accent-bg:  rgba(26,122,255,0.07);
@@ -4263,7 +4276,7 @@ body.landing {
 .lp-nav-actions { display: flex; align-items: center; gap: 10px; }
 .lp-btn-ghost  { font-size: var(--fs-label); font-weight: 500; color: var(--txt2); padding: 6px 14px; border-radius: var(--radius-chip); text-decoration: none; transition: color .15s, background .15s; min-height: 36px; display: inline-flex; align-items: center; }
 .lp-btn-ghost:hover { color: var(--txt); background: rgba(255,255,255,.05); }
-.lp-btn-primary { font-size: var(--fs-label); font-weight: 600; color: #fff; background: var(--accent); padding: 7px 16px; border-radius: var(--radius-chip); text-decoration: none; transition: opacity .15s; min-height: 36px; display: inline-flex; align-items: center; }
+.lp-btn-primary { font-size: var(--fs-label); font-weight: 600; color: #fff; background: var(--accent-solid); padding: 7px 16px; border-radius: var(--radius-chip); text-decoration: none; transition: opacity .15s; min-height: 36px; display: inline-flex; align-items: center; }
 .lp-btn-primary:hover { opacity: .85; }
 .lp-lang-short { display: none; }
 
@@ -4302,7 +4315,7 @@ body.landing {
 .lp-h1-accent   { font-family: Georgia, 'Times New Roman', serif; font-style: italic; font-weight: 400; color: var(--accent-2); }
 .lp-hero-sub    { font-size: var(--fs-caption); color: var(--txt2); line-height: 1.65; max-width: 520px; margin: 0; }
 .lp-hero-ctas   { display: flex; gap: 12px; flex-wrap: wrap; justify-content: center; }
-.lp-cta-primary { font-size: var(--fs-card-title); font-weight: 700; color: #fff; background: var(--accent); padding: 13px 28px; border-radius: var(--radius-card); text-decoration: none; transition: opacity .15s; }
+.lp-cta-primary { font-size: var(--fs-card-title); font-weight: 700; color: #fff; background: var(--accent-solid); padding: 13px 28px; border-radius: var(--radius-card); text-decoration: none; transition: opacity .15s; }
 .lp-cta-primary:hover { opacity: .88; }
 .lp-cta-ghost   { font-size: var(--fs-card-title); font-weight: 600; color: var(--txt2); background: rgba(255,255,255,.06); border: 1px solid var(--bdr); padding: 13px 28px; border-radius: var(--radius-card); text-decoration: none; transition: background .15s, color .15s; }
 .lp-cta-ghost:hover { background: rgba(255,255,255,.1); color: var(--txt); }
@@ -4343,7 +4356,7 @@ body.landing {
 .lp-step          { flex: 1; padding: 0 28px; text-align: center; }
 .lp-step:first-child { padding-left: 0; }
 .lp-step:last-child  { padding-right: 0; }
-.lp-step-num      { width: 40px; height: 40px; border-radius: 50%; background: var(--accent); color: #fff; font-size: var(--fs-data); font-weight: 800; display: flex; align-items: center; justify-content: center; margin: 0 auto 14px; }
+.lp-step-num      { width: 40px; height: 40px; border-radius: 50%; background: var(--accent-solid); color: #fff; font-size: var(--fs-data); font-weight: 800; display: flex; align-items: center; justify-content: center; margin: 0 auto 14px; }
 .lp-step h3       { font-size: var(--fs-card-title); font-weight: 700; margin: 0 0 8px; }
 .lp-step p        { font-size: var(--fs-label); color: var(--txt2); line-height: 1.6; margin: 0; }
 .lp-step-arrow    { font-size: 1.25rem; color: var(--txt3); margin-top: 10px; flex-shrink: 0; align-self: center; }
@@ -4352,7 +4365,7 @@ body.landing {
 .lp-pricing         { display: flex; gap: 20px; align-items: flex-start; justify-content: center; flex-wrap: wrap; }
 .lp-plan            { flex: 1; min-width: 280px; max-width: 380px; border-radius: var(--radius-card); padding: 28px; border: 1px solid var(--bdr); background: var(--bg2); position: relative; }
 .lp-plan-pro        { border-color: rgba(26,122,255,.3); background: var(--bg2); }
-.lp-plan-badge      { position: absolute; top: -12px; left: 50%; transform: translateX(-50%); font-size: var(--fs-micro); font-weight: 700; letter-spacing: .08em; text-transform: uppercase; background: var(--accent); color: #fff; padding: 3px 14px; border-radius: var(--radius-chip); white-space: nowrap; }
+.lp-plan-badge      { position: absolute; top: -12px; left: 50%; transform: translateX(-50%); font-size: var(--fs-micro); font-weight: 700; letter-spacing: .08em; text-transform: uppercase; background: var(--accent-solid); color: #fff; padding: 3px 14px; border-radius: var(--radius-chip); white-space: nowrap; }
 .lp-plan-header     { margin-bottom: 24px; }
 .lp-plan-name       { font-size: var(--fs-label); font-weight: 700; color: var(--txt2); letter-spacing: .06em; text-transform: uppercase; margin-bottom: 6px; }
 .lp-plan-price      { font-size: 3rem; font-weight: 900; letter-spacing: -.04em; line-height: 1; margin-bottom: 6px; }
@@ -4366,7 +4379,7 @@ body.landing {
 .lp-plan-cta        { display: block; text-align: center; padding: 12px; border-radius: var(--radius-card); font-size: var(--fs-label); font-weight: 700; text-decoration: none; transition: opacity .15s; }
 .lp-plan-cta-free   { background: rgba(255,255,255,.07); border: 0.5px solid var(--bdr); color: var(--txt); }
 .lp-plan-cta-free:hover { background: rgba(255,255,255,.12); }
-.lp-plan-cta-pro    { background: var(--accent); color: #fff; }
+.lp-plan-cta-pro    { background: var(--accent-solid); color: #fff; }
 .lp-plan-cta-pro:hover { opacity: .85; }
 
 /* ── LP FINAL CTA ────────────────────────────────────────────────────── */
@@ -4605,7 +4618,7 @@ html[lang="ar"] .lp-h1-accent {
 .obw-seg-track { height: 3px; background: var(--bdr); overflow: hidden; }
 .obw-seg-fill {
   display: block; height: 100%; width: 0;
-  background: var(--accent);
+  background: var(--accent-solid);
   transition: width 0.45s cubic-bezier(0.16,1,0.3,1);
 }
 .obw-seg.is-done .obw-seg-fill   { width: 100%; opacity: 0.45; }
@@ -4688,7 +4701,7 @@ html[lang="ar"] .lp-h1-accent {
   display: flex; align-items: center; justify-content: center; transition: all 0.15s;
 }
 .obw-row.is-selected .obw-ind,
-.obw-tile.is-selected .obw-ind { border-color: var(--accent); background: var(--accent); }
+.obw-tile.is-selected .obw-ind { border-color: var(--accent); background: var(--accent-solid); }
 
 /* Account-size 2x2 grid tiles */
 .obw-grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-2); }
@@ -4751,7 +4764,7 @@ html[lang="ar"] .lp-h1-accent {
 }
 .obw-btn-back { flex-shrink: 0; background: transparent; border: 1px solid var(--bdr); color: var(--txt2); }
 .obw-btn-back:hover { border-color: var(--bdr2); color: var(--txt); }
-.obw-btn-next { flex: 1; border: 1px solid var(--accent); background: var(--accent); color: #fff; }
+.obw-btn-next { flex: 1; border: 1px solid var(--accent); background: var(--accent-solid); color: #fff; }
 .obw-btn-next:hover:not(:disabled) { background: var(--accent-2); border-color: var(--accent-2); }
 .obw-btn-next:disabled { background: var(--bg2); border-color: var(--bdr); color: var(--txt3); cursor: not-allowed; }
 .obw-skip {

--- a/app/globals.css
+++ b/app/globals.css
@@ -24,8 +24,29 @@
      uppercase micro-labels (.mr-factor-k / .dash-section / .edge-card-label
      / .csb-header-row) actually sit on. Sits close to --txt2 by necessity - on a
      near-black bg, AA-passing muted text can't stay much dimmer than secondary
-     text; differentiate those two tiers by weight/size/tracking, not color. */
-  --txt3: #767d92;
+     text; differentiate those two tiers by weight/size/tracking, not color.
+     Nudged again to #7b8297. #767d92 cleared AA on --bg0/--bg1/--bg2 but not on
+     the lighter card surfaces it also lands on: 4.46:1 on --bg4 (#14161a,
+     .av-rail-panel) and 4.32:1 on #191b1e (.csb2-sig). Both measured, not
+     assumed - the earlier value was picked against --bg1/--bg2 only, which is
+     how it shipped under AA on two surfaces nobody checked. #7b8297 is 4.56:1
+     on the worst of them and higher everywhere else. Visually a few points of
+     lightness; if a new surface lighter than #191b1e appears, re-measure rather
+     than trusting this comment. */
+  --txt3: #7b8297;
+
+  /* Dimmed body text, AA-safe. Exists because ~54 call sites had hardcoded
+     #333 / #444 / #555 / #606060 inline - four arbitrary greys used
+     interchangeably for the same "de-emphasised caption" job, none of them
+     legible: they measured 1.54:1 to 3.20:1 and accounted for 152 of the app's
+     265 contrast failures. That included real data (prices, scores, funding
+     rates) and table column headers, not just decoration.
+     #8a8a8a is 5.80:1 on --bg0 and 5.23:1 on --bg4, so it clears AA on every
+     surface in the app. Deliberately neutral grey rather than reusing --txt3's
+     blue-grey, because these sites also carry the "neutral / no signal"
+     semantic that sits beside --green and --red (squeeze direction, funding
+     bias, EMA pass state) and should not read as tinted. */
+  --txt-dim: #8a8a8a;
 
   /* Borders - neutral white hairline, no indigo tint */
   --bdr:  rgba(255,255,255,0.08);
@@ -601,7 +622,11 @@ body::after {
   background: var(--txt3); opacity: 0.5; }
 .mr-scale { display: flex; justify-content: space-between; margin-top: 4px;
   font-family: var(--font-mono), monospace; font-size: var(--fs-micro); color: var(--txt3); }
-.mr-scale-good { opacity: 0.85; }
+/* No opacity here. --txt3 is tuned to sit just above the 4.5:1 line, so any
+   multiplier on top of it lands under - 0.85 blended this to #656b7e = 3.79:1.
+   Same trap as .pf-footer-bottom-note and .st-locked-list; if this label needs
+   to read as secondary, do it with weight or size, not alpha. */
+.mr-scale-good { font-weight: 600; }
 .mr-factors { display: grid; grid-template-columns: repeat(5, 1fr); gap: 8px; }
 .mr-factor { border: 0.5px solid var(--bdr); border-radius: 8px; padding: 8px 9px; background: var(--bg2);
   min-width: 0; }
@@ -1209,18 +1234,24 @@ body.ticker-on .breaking-alert { top: calc(84px + var(--banner-h)); }
 .arena-quick-btn { background: rgba(52,211,153,0.08) !important; border-color: rgba(52,211,153,0.3) !important; color: #34d399 !important; }
 .arena-quick-btn:not(:disabled):hover { box-shadow: 0 4px 20px rgba(52,211,153,0.15) !important; border-color: #34d399 !important; }
 /* Deep button - locked state (not signed in) */
+/* "Locked" styling for the Quick/Deep Research buttons when signed out.
+   Was #8a6020 under opacity 0.75, which computed to #694a1b = 2.4:1 - the
+   worst-contrast interactive control in the app. It gets no exemption either:
+   the button is NOT disabled when signed out (see app/arena - `disabled` is
+   only set for loading and quota), it is a live control that navigates to
+   /login, so WCAG 1.4.3's carve-out for inactive components does not apply.
+   Locked-ness is carried by the amber hue, the dimmer background and the
+   padlock, none of which need alpha to read. #c8891e is 6.42:1. */
 .arena-deep-locked {
-  opacity: 0.75 !important;
   background: rgba(217, 119, 6, 0.06) !important;
   border-color: rgba(217, 119, 6, 0.28) !important;
-  color: #8a6020 !important; box-shadow: none !important; cursor: pointer !important;
+  color: #c8891e !important; box-shadow: none !important; cursor: pointer !important;
 }
 .arena-deep-locked:not(:disabled):hover {
-  opacity: 1 !important;
   background: rgba(217, 119, 6, 0.1) !important;
   border-color: rgba(217, 119, 6, 0.5) !important;
   box-shadow: 0 4px 16px rgba(217, 119, 6, 0.12) !important;
-  color: #c8891e !important;
+  color: #e8a838 !important;
 }
 /* Cache banner */
 
@@ -3302,10 +3333,18 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 
 /* Locked "Sign in to continue" feature list - opacity alone conveys the
    disabled state, but 0.35 over a light card blends var(--txt2) down to
-   near-invisible grey-on-white (AUTH note in AUDIT.md item #11). Dark
-   theme's near-white --txt2 survives the same opacity fine, so only the
-   light-theme value needs raising. */
-.st-locked-list { opacity: 0.35; }
+   near-invisible grey-on-white (AUTH note in AUDIT.md item #11).
+   The rest of that note - "dark theme's near-white --txt2 survives the same
+   opacity fine" - was wrong, and measurement is why: --txt2 is #7a7e94, not
+   near-white, and 0.35 of it over --bg0 computes to #2f313a = 1.55:1. It read
+   as fine because the text is short and the reader already knew what it said.
+   No alpha fixes it either: --txt2 at FULL opacity is only 5.05:1, so any
+   multiplier at all drops it under AA. Hence colour, not opacity, in dark.
+   These are feature names telling a signed-out visitor what they get by
+   signing in - the pitch, not a disabled control, so the 1.4.3 exemption for
+   inactive components does not apply. Light theme keeps its 0.6 over a white
+   card, where the base colour has the headroom to absorb it. */
+.st-locked-list { color: var(--txt2); }
 [data-theme="light"] .st-locked-list { opacity: 0.6; }
 
 /* ── Coin multi-select dropdown (replaces the full chip-grid watchlist picker) ── */
@@ -4093,7 +4132,7 @@ body.landing {
 
   --txt:  #e8eaf0;
   --txt2: #7a7e94;
-  --txt3: #767d92; /* AA fix, mirrors :root - see note there (audit P2-1) */
+  --txt3: #7b8297; /* AA fix, mirrors :root - see note there (audit P2-1) */
 
   --bdr:  rgba(255,255,255,0.08);
   --bdr2: rgba(255,255,255,0.14);
@@ -4191,7 +4230,14 @@ body.landing {
   --bg1:    #0e0e12;
   --txt:    #f2f2f7;
   --txt2:   #8e8e93;
-  --txt3:   #48484a;
+  /* Was #48484a = 2.23:1 on this block's own --bg0 (#050505) and 2.14:1 on the
+     pricing cards. This scope re-declares --txt3 to force the dark palette
+     regardless of saved theme, and in doing so it silently reverted the :root
+     AA fix for every visitor on the landing page - the first page anyone sees.
+     17 of the app's contrast failures came from this one line: the footer
+     brand copy, all four footer column titles, and the plan price/sub text.
+     #7c7c82 is 4.92:1 on #050505 and 4.73:1 on the #0a0c10 plan cards. */
+  --txt3:   #7c7c82;
   --bdr:    rgba(255,255,255,0.07);
   --accent: #1a7aff;
   display: flex; flex-direction: column; min-height: 100vh; color: var(--txt); background: var(--bg0); font-family: inherit;
@@ -4400,7 +4446,9 @@ body.landing {
 .pf-footer-divider-label {
   font-family: var(--font-mono, monospace);
   font-size: var(--fs-label); font-weight: 600; letter-spacing: 0.12em;
-  color: var(--accent); opacity: 0.6; white-space: nowrap;
+  /* --accent at 0.6 alpha computed to #124c9d = 2.44:1. --accent-2 is the
+     lighter tint of the same blue and needs no alpha to sit back: 7.89:1. */
+  color: var(--accent-2); white-space: nowrap;
 }
 .pf-footer-divider-line { flex: 1; height: 1px; background: var(--bdr); }
 .pf-footer-disclaimer {
@@ -4437,7 +4485,12 @@ body.landing {
   padding-top: 18px; border-top: 1px solid var(--bdr);
   font-size: var(--fs-caption); color: var(--txt3);
 }
-.pf-footer-bottom-note { opacity: 0.8; font-style: italic; max-width: 700px; text-align: right; }
+/* opacity: 0.8 removed - it blended --txt3 down to #606577 = 3.47:1, and the
+   Disclaimer / Terms / Privacy links nested inside inherited it, so one
+   declaration cost 24 failures across all six app routes. This is the site's
+   legal notice; it is the last text that should be hard to read. Italic and
+   the smaller caption size already carry the de-emphasis. */
+.pf-footer-bottom-note { font-style: italic; max-width: 700px; text-align: right; }
 .pf-footer-bottom-link { color: var(--txt3); text-decoration: underline; text-underline-offset: 2px; }
 .pf-footer-bottom-link:hover { color: var(--txt); }
 @media (max-width: 900px) { .pf-footer-grid { grid-template-columns: repeat(2, 1fr); } }
@@ -4460,7 +4513,11 @@ body.landing {
 .lp-footer-col a:hover { color: var(--accent-2); }
 .lp-footer-bottom   { max-width: 1100px; margin: 36px auto 0; padding-top: 20px; border-top: 0.5px solid var(--bdr); display: flex; flex-direction: column; gap: 10px; }
 .lp-footer-copy     { font-size: var(--fs-caption); color: var(--txt3); }
-.lp-footer-ack      { font-size: var(--fs-caption); color: var(--txt3); opacity: 0.75; line-height: 1.65; }
+/* Third instance of the same trap (see .pf-footer-bottom-note, .mr-scale-good,
+   .st-locked-list): opacity multiplied on top of a --txt3 that is already tuned
+   to sit just above 4.5:1. 0.75 computed to #58585d = 2.88:1 on the landing
+   footer, and this is the risk-acknowledgement copy. */
+.lp-footer-ack      { font-size: var(--fs-caption); color: var(--txt3); line-height: 1.65; }
 
 /* ── LP RESPONSIVE ───────────────────────────────────────────────────── */
 @media (max-width: 900px) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -1167,7 +1167,15 @@ body.ticker-on .breaking-alert { top: calc(84px + var(--banner-h)); }
 .cat-time  { background: var(--green-bg);  color: var(--green); }
 .cat-trap  { background: var(--red-bg);    color: var(--red); }
 .cat-psych { background: var(--amber-bg);  color: var(--amber); }
-.pb-star   { background: none; border: none; cursor: pointer; font-size: var(--fs-label); color: var(--txt3); padding: 0 2px; line-height: 1; }
+/* 24x24 minimum is WCAG 2.2 AA (SC 2.5.8 Target Size). This was 16x13 - the
+   glyph's own size, with 2px of side padding and nothing vertical - and there
+   are 55 of them on /playbook, which made it the single largest accessibility
+   failure in the app by count.
+   Sized with min-width/min-height and centred rather than by growing the font,
+   so the star looks identical and only its hit area changes. */
+.pb-star   { background: none; border: none; cursor: pointer; font-size: var(--fs-label); color: var(--txt3); line-height: 1;
+             min-width: 24px; min-height: 24px; padding: 0 2px;
+             display: inline-flex; align-items: center; justify-content: center; }
 .pb-star.on { color: #fbbf24; }
 
 /* ── CLUSTER TRACKER (legacy) ── */
@@ -3204,14 +3212,35 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 }
 .st-checkbox-item:last-child { border-bottom: none; padding-bottom: 0; }
 .st-toggle-label { font-size: var(--fs-label); color: var(--txt2); font-weight: 500; }
+/* The visible track stays 38x21 - it is a switch and looks wrong taller.
+   The 24px minimum is met with a transparent vertical border, which grows the
+   hit box without moving a pixel on screen. background-clip keeps the track
+   colour off the padding so the switch still reads as 21px tall. */
+/* The BUTTON is 38x24 so it satisfies WCAG 2.2 SC 2.5.8 as measured. The
+   painted track is a 21px ::before inside it, because a 24px-tall track stops
+   reading as a switch.
+   Two earlier attempts were worse and are worth recording. Padding on the
+   button grew the border box, so the visible rounded rect went 38x21 -> 40x27:
+   it measured as passing while looking different. A transparent ::after
+   overlay kept the appearance and did extend the clickable area, but
+   getBoundingClientRect still reported 21px, so every audit tool - including
+   qa/e2e - would go on flagging it forever. A fix only the author can see is
+   not a fix. */
 .st-toggle {
-  width: 38px; height: 21px; border-radius: 11px; padding: 0; flex-shrink: 0;
-  background: rgba(255,255,255,0.08); border: 0.5px solid var(--bdr2);
-  position: relative; cursor: pointer; transition: background 0.15s, border-color 0.15s;
+  width: 38px; height: 24px; flex-shrink: 0;
+  background: none; border: none; padding: 0;
+  position: relative; cursor: pointer;
 }
-.st-toggle.on { background: var(--purple); border-color: var(--purple); }
+.st-toggle::before {
+  content: '';
+  position: absolute; left: 0; top: 50%; transform: translateY(-50%);
+  width: 38px; height: 21px; border-radius: 11px; box-sizing: border-box;
+  background: rgba(255,255,255,0.08); border: 0.5px solid var(--bdr2);
+  transition: background 0.15s, border-color 0.15s;
+}
+.st-toggle.on::before { background: var(--purple); border-color: var(--purple); }
 .st-toggle-thumb {
-  position: absolute; top: 3px; left: 3px;
+  position: absolute; top: 50%; transform: translateY(-50%); left: 3px;
   width: 13px; height: 13px; border-radius: 50%; display: block; pointer-events: none;
   background: rgba(255,255,255,0.35); transition: left 0.15s, background 0.15s;
 }
@@ -4378,9 +4407,15 @@ body.landing {
   font-size: var(--fs-caption); font-weight: 700; color: var(--txt);
   line-height: 1.6; margin: 0 0 24px; max-width: 780px;
 }
+/* Was 154x18. Height came straight from the line-box with zero vertical
+   padding, so it failed WCAG 2.2 SC 2.5.8 on every route that renders the
+   footer - 26 of them, which made this the second-largest tap-target failure
+   after .pb-star. Vertical padding rather than min-height so the text sits
+   optically centred instead of top-aligned in a taller box. */
 .pf-footer-expand {
   display: inline-flex; align-items: center; gap: 5px;
-  background: none; border: none; cursor: pointer; padding: 0;
+  background: none; border: none; cursor: pointer; padding: 3px 0;
+  min-height: 24px;
   font-size: var(--fs-caption); font-weight: 600; color: var(--accent);
   margin-bottom: 24px;
 }

--- a/app/hours/page.tsx
+++ b/app/hours/page.tsx
@@ -167,7 +167,7 @@ export default function BestHours() {
                 <div style={{
                   position: 'absolute', top: -6, height: 56,
                   left: `${pct}%`, width: 2,
-                  background: 'var(--accent)',
+                  background: 'var(--accent-solid)',
                   borderRadius: 2,
                   transform: 'translateX(-1px)',
                   boxShadow: '0 0 6px var(--accent)',

--- a/app/liq/page.tsx
+++ b/app/liq/page.tsx
@@ -254,7 +254,7 @@ function RealClusters({ clusters, currentPrice }: { clusters: Bucket[]; currentP
         })}
       </div>
 
-      <div style={{ padding: '6px 14px 8px', borderTop: '0.5px solid rgba(255,255,255,0.05)', fontSize: 'var(--fs-caption)', color: '#444' }}>
+      <div style={{ padding: '6px 14px 8px', borderTop: '0.5px solid rgba(255,255,255,0.05)', fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)' }}>
         {t('LIQ_CLUSTERS_FOOTER_LEGEND')}
       </div>
     </div>
@@ -341,7 +341,7 @@ export default function LiqPage() {
       ? { txt: t('LIQ_BIAS_LONG_HEAVY'), sub: t('LIQ_BIAS_LONG_HEAVY_SUB'), col: '#f87171' }
       : bands.totalShortM > bands.totalLongM * 1.15
       ? { txt: t('LIQ_BIAS_SHORT_HEAVY'), sub: t('LIQ_BIAS_SHORT_HEAVY_SUB'), col: '#34d399' }
-      : { txt: t('LIQ_BIAS_BALANCED'), sub: t('LIQ_BIAS_BALANCED_SUB'), col: '#606060' }
+      : { txt: t('LIQ_BIAS_BALANCED'), sub: t('LIQ_BIAS_BALANCED_SUB'), col: 'var(--txt-dim)' }
     : null;
 
   return (
@@ -405,7 +405,7 @@ export default function LiqPage() {
       <div className="liq-range-hint">
         {t(rangeConf.hintKey)}
         {cd?.price && (
-          <span style={{ color: '#555', marginLeft: 8 }}>
+          <span style={{ color: 'var(--txt-dim)', marginLeft: 8 }}>
             · {fmtP(cd.price * (1 - rangeConf.maxDist))} – {fmtP(cd.price * (1 + rangeConf.maxDist))}
           </span>
         )}
@@ -418,7 +418,7 @@ export default function LiqPage() {
         </div>
       )}
       {cd?.price && !cd?.oi && (
-        <div className="card" style={{ textAlign: 'center', color: '#444', padding: '2rem' }}>
+        <div className="card" style={{ textAlign: 'center', color: 'var(--txt-dim)', padding: '2rem' }}>
           {t('LIQ_NO_OI_DATA', { coin: coin.toUpperCase() })}
         </div>
       )}

--- a/app/markets/page.tsx
+++ b/app/markets/page.tsx
@@ -15,7 +15,7 @@ import type { LabelKey } from '@/lib/labelKeys';
 type SortKey = 'volume' | 'change' | 'grade' | 'signal' | 'name';
 
 function topSignal(d: ReturnType<typeof useMarket>['store']['coins'][CoinId]): { key: LabelKey | null; col: string } {
-  if (!d) return { key: null, col: '#333' };
+  if (!d) return { key: null, col: 'var(--txt-dim)' };
   if (d.fundingRate != null) {
     const fr = d.fundingRate * 100;
     if (fr >= 0.04) return { key: 'MARKETS_SIGNAL_LONGS_OVERCROWDED', col: '#f87171' };
@@ -27,7 +27,7 @@ function topSignal(d: ReturnType<typeof useMarket>['store']['coins'][CoinId]): {
   if (d.oiTrend === 'strong_down') return { key: 'MARKETS_SIGNAL_NEW_SELLERS', col: '#f87171' };
   if (d.oiTrend === 'weak_up')     return { key: 'MARKETS_SIGNAL_SHORT_COVERING', col: '#fbbf24' };
   if (d.oiTrend === 'weak_down')   return { key: 'MARKETS_SIGNAL_LONGS_EXITING', col: '#94a3b8' };
-  return { key: 'MARKETS_SIGNAL_NONE', col: '#333' };
+  return { key: 'MARKETS_SIGNAL_NONE', col: 'var(--txt-dim)' };
 }
 
 const SORT_LABEL_KEYS: Record<SortKey, LabelKey> = {
@@ -298,7 +298,7 @@ export default function MarketsPage() {
               {/* Signal */}
               <div className="mkt-signal" style={{
                 paddingLeft: 12, fontSize: 'var(--fs-caption)',
-                color: sig.col === '#333' ? 'var(--txt3)' : sig.col,
+                color: sig.col === 'var(--txt-dim)' ? 'var(--txt3)' : sig.col,
                 whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
               }}>
                 {sig.key ? t(sig.key) : '-'}

--- a/app/ops/ops.module.css
+++ b/app/ops/ops.module.css
@@ -282,7 +282,9 @@
 .loginInput:focus { border-color: var(--accent-bdr); }
 .loginBtn {
   margin-top: 4px;
-  background: var(--accent);
+  /* White text on a filled blue - see the --accent-solid note in globals.css.
+     Border stays --accent: it is a graphic edge, not a text background. */
+  background: var(--accent-solid);
   border: 1px solid var(--accent);
   border-radius: var(--radius-data);
   color: #fff;

--- a/app/upgrade/page.tsx
+++ b/app/upgrade/page.tsx
@@ -90,7 +90,9 @@ export default function UpgradePage() {
 
       {/* Nav */}
       <nav style={{ position: 'sticky', top: 0, zIndex: 100, background: 'var(--bg)', borderBottom: '0.5px solid var(--bdr)', padding: '0 24px', height: 52, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-        <Link href="/arena" style={{ fontSize: 'var(--fs-label)', color: 'var(--txt3)', textDecoration: 'none', display: 'flex', alignItems: 'center', gap: 6 }}>
+        {/* minHeight for WCAG 2.2 SC 2.5.8 - a standalone back link, not one
+            inside a sentence, so the inline exception does not apply. Was 44x20. */}
+        <Link href="/arena" style={{ fontSize: 'var(--fs-label)', color: 'var(--txt3)', textDecoration: 'none', display: 'flex', alignItems: 'center', gap: 6, minHeight: 24 }}>
           {t('UPGRADE_BACK_LABEL')}
         </Link>
         <span style={{ fontSize: 'var(--fs-card-title)', fontWeight: 800, letterSpacing: '-.02em', color: 'var(--txt)' }}>
@@ -188,7 +190,17 @@ export default function UpgradePage() {
                   {t('UPGRADE_COMING_SOON_SIGNED_OUT_POST')}</>
                 )}
               </p>
-              <Link href="/arena" style={{ fontSize: 'var(--fs-label)', color: 'var(--txt3)', textDecoration: 'underline' }}>
+              {/* inline-flex + minHeight, not padding: this is a standalone
+                  link rather than one inside a sentence, so WCAG 2.2 SC 2.5.8's
+                  inline exception does not cover it and it needs the real 24px.
+                  Measured 81x15 before. */}
+              <Link
+                href="/arena"
+                style={{
+                  fontSize: 'var(--fs-label)', color: 'var(--txt3)', textDecoration: 'underline',
+                  display: 'inline-flex', alignItems: 'center', minHeight: 24,
+                }}
+              >
                 {t('UPGRADE_BACK_TO_ARENA_LINK')}
               </Link>
             </div>

--- a/app/upgrade/page.tsx
+++ b/app/upgrade/page.tsx
@@ -136,7 +136,7 @@ export default function UpgradePage() {
 
           {/* Pro card */}
           <div style={{ borderRadius: 16, padding: '24px 28px', border: '0.5px solid var(--accent-bdr)', background: 'linear-gradient(160deg, var(--accent-bg) 0%, var(--bg1) 60%)', position: 'relative' }}>
-            <div style={{ position: 'absolute', top: -11, left: '50%', transform: 'translateX(-50%)', fontSize: 'var(--fs-micro)', fontWeight: 700, letterSpacing: '.08em', textTransform: 'uppercase', background: 'var(--accent)', color: '#fff', padding: '3px 14px', borderRadius: 20, whiteSpace: 'nowrap' }}>
+            <div style={{ position: 'absolute', top: -11, left: '50%', transform: 'translateX(-50%)', fontSize: 'var(--fs-micro)', fontWeight: 700, letterSpacing: '.08em', textTransform: 'uppercase', background: 'var(--accent-solid)', color: '#fff', padding: '3px 14px', borderRadius: 20, whiteSpace: 'nowrap' }}>
               {t('UPGRADE_PRO_CARD_BADGE')}
             </div>
             <div style={{ fontSize: 'var(--fs-micro)', fontWeight: 700, letterSpacing: '.08em', textTransform: 'uppercase', color: 'var(--accent)', marginBottom: 6 }}>{t('UPGRADE_PRO_CARD_EYEBROW')}</div>
@@ -159,7 +159,7 @@ export default function UpgradePage() {
               <button
                 onClick={handleCheckout}
                 disabled={redirecting}
-                style={{ fontSize: 'var(--fs-data)', fontWeight: 700, color: '#fff', background: 'var(--accent)', padding: '14px 40px', borderRadius: 12, border: 'none', cursor: redirecting ? 'default' : 'pointer', opacity: redirecting ? 0.7 : 1, transition: 'opacity .15s, transform .15s', transform: 'translateY(0)' }}
+                style={{ fontSize: 'var(--fs-data)', fontWeight: 700, color: '#fff', background: 'var(--accent-solid)', padding: '14px 40px', borderRadius: 12, border: 'none', cursor: redirecting ? 'default' : 'pointer', opacity: redirecting ? 0.7 : 1, transition: 'opacity .15s, transform .15s', transform: 'translateY(0)' }}
                 onMouseEnter={e => { if (!redirecting) (e.currentTarget as HTMLButtonElement).style.transform = 'translateY(-1px)'; }}
                 onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.transform = 'translateY(0)'; }}
               >

--- a/components/CoinHeatmap.tsx
+++ b/components/CoinHeatmap.tsx
@@ -21,15 +21,26 @@ const CAT: Record<Cat, readonly CoinId[]> = {
 };
 
 function changeColor(chg: number | null): { bg: string; text: string } {
-  if (chg == null) return { bg: 'rgba(255,255,255,0.04)', text: '#444' };
+  if (chg == null) return { bg: 'rgba(255,255,255,0.04)', text: 'var(--txt-dim)' };
   if (chg >=  10) return { bg: 'rgba(52,211,153,0.30)',  text: '#34d399' };
   if (chg >=   5) return { bg: 'rgba(52,211,153,0.22)',  text: '#6ee7b7' };
   if (chg >=   2) return { bg: 'rgba(52,211,153,0.13)',  text: '#86efac' };
   if (chg >=   0) return { bg: 'rgba(52,211,153,0.07)',  text: '#4ade80' };
+  /* The red ramp used to darken the text (#fca5a5 -> #f87171 -> #ef4444 ->
+     #dc2626) at the same time as it made the tile background a more opaque red
+     (0.07 -> 0.38). Both moving together collapses the contrast exactly where
+     the number matters most: the -10% bucket measured 3.73:1 and the worst
+     bucket 2.43:1, so the biggest losers on the board were the hardest to read.
+     Text now LIGHTENS as the tile saturates - severity is carried by the tile,
+     which is the part that reads at a glance anyway - giving 8.6:1 to 9.6:1
+     across the whole ramp.
+     The green side has the same shape but does not fail (its worst bucket is
+     5.71:1) because green is inherently light; left as-is rather than churning
+     a passing palette, but the same rule applies if that ramp is ever extended. */
   if (chg >= -2)  return { bg: 'rgba(248,113,113,0.07)', text: '#fca5a5' };
-  if (chg >= -5)  return { bg: 'rgba(248,113,113,0.15)', text: '#f87171' };
-  if (chg >= -10) return { bg: 'rgba(248,113,113,0.25)', text: '#ef4444' };
-  return              { bg: 'rgba(248,113,113,0.38)',     text: '#dc2626' };
+  if (chg >= -5)  return { bg: 'rgba(248,113,113,0.15)', text: '#fcbcbc' };
+  if (chg >= -10) return { bg: 'rgba(248,113,113,0.25)', text: '#fecaca' };
+  return              { bg: 'rgba(248,113,113,0.38)',     text: '#fee2e2' };
 }
 
 function fmtPrice(p: number): string {
@@ -159,7 +170,7 @@ export default function CoinHeatmap() {
               fontSize: 'var(--fs-caption)', fontWeight: 600, padding: '3px 10px', borderRadius: 20, cursor: 'pointer',
               border: `0.5px solid ${cat === c ? 'rgba(255,255,255,0.2)' : 'rgba(255,255,255,0.07)'}`,
               background: cat === c ? 'rgba(255,255,255,0.1)' : 'transparent',
-              color: cat === c ? 'var(--txt)' : '#444',
+              color: cat === c ? 'var(--txt)' : 'var(--txt-dim)',
               transition: 'all .15s',
             }}
           >
@@ -180,9 +191,9 @@ export default function CoinHeatmap() {
             display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 3,
             border: '0.5px solid rgba(255,255,255,0.04)',
           }}>
-            <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 800, color: '#333' }}>-</span>
+            <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 800, color: 'var(--txt-dim)' }}>-</span>
             <span style={{ fontSize: 'var(--fs-caption)', color: '#2a2a2a' }}>-</span>
-            <span style={{ fontSize: 'var(--fs-label)', fontWeight: 700, color: '#333', lineHeight: 1 }}>-</span>
+            <span style={{ fontSize: 'var(--fs-label)', fontWeight: 700, color: 'var(--txt-dim)', lineHeight: 1 }}>-</span>
           </div>
         ))}
         {coins?.map(({ c, coin }) => {
@@ -211,7 +222,11 @@ export default function CoinHeatmap() {
                   in steps as coins reported in - and each step pushed the two
                   cards below the heatmap down the page. A dash holds the
                   slot; the tile is the same height from first paint. */}
-              <span style={{ fontSize: 'var(--fs-caption)', color: withAlpha(text, 'aa'), fontVariantNumeric: 'tabular-nums' }}>
+              {/* withAlpha(text, 'aa') = 67%, which knocked this price down to
+                  as little as 2.43:1 on the redder tiles. It is a live price,
+                  not decoration. The caption size already sets it apart from
+                  the percentage above it, so it takes the tile colour flat. */}
+              <span style={{ fontSize: 'var(--fs-caption)', color: text, fontVariantNumeric: 'tabular-nums' }}>
                 {coin?.price != null ? `$${fmtPrice(coin.price)}` : '-'}
               </span>
               <span style={{
@@ -230,12 +245,12 @@ export default function CoinHeatmap() {
         padding: '5px 14px 8px', borderTop: '0.5px solid rgba(255,255,255,0.05)',
         display: 'flex', alignItems: 'center', gap: 3,
       }}>
-        <span style={{ fontSize: 'var(--fs-caption)', color: '#333', marginRight: 4 }}>{t('COIN_HEATMAP_SCALE_LABEL')}</span>
+        <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)', marginRight: 4 }}>{t('COIN_HEATMAP_SCALE_LABEL')}</span>
         {[
           { label: '>+10%', c: '#34d399' }, { label: '+5%', c: '#6ee7b7' },
-          { label: '+2%', c: '#86efac' },   { label: '0', c: '#555' },
-          { label: '-2%', c: '#fca5a5' },   { label: '-5%', c: '#f87171' },
-          { label: '<-10%', c: '#dc2626' },
+          { label: '+2%', c: '#86efac' },   { label: '0', c: 'var(--txt-dim)' },
+          { label: '-2%', c: '#fca5a5' },   { label: '-5%', c: '#fcbcbc' },
+          { label: '<-10%', c: '#fee2e2' },
         ].map(({ label, c }) => (
           <span key={label} style={{ fontSize: 'var(--fs-caption)', color: c, fontWeight: 600 }}>{label}</span>
         ))}

--- a/components/ConfluenceScore.tsx
+++ b/components/ConfluenceScore.tsx
@@ -19,7 +19,7 @@ import type { PASignal } from '@/lib/priceAction';
 const VERDICT_CONFIG: Record<string, { labelKey: LabelKey; color: string }> = {
   STRONG_BULL:  { labelKey: 'CONFLUENCE_SCORE_VERDICT_STRONG_BULL',  color: '#34d399' },
   LEANING_BULL: { labelKey: 'CONFLUENCE_SCORE_VERDICT_LEANING_BULL', color: '#86efac' },
-  MIXED:        { labelKey: 'CONFLUENCE_SCORE_VERDICT_MIXED',        color: '#6b7280' },
+  MIXED:        { labelKey: 'CONFLUENCE_SCORE_VERDICT_MIXED',        color: 'var(--txt-dim)' },
   LEANING_BEAR: { labelKey: 'CONFLUENCE_SCORE_VERDICT_LEANING_BEAR', color: '#fca5a5' },
   STRONG_BEAR:  { labelKey: 'CONFLUENCE_SCORE_VERDICT_STRONG_BEAR',  color: '#f87171' },
 };

--- a/components/CycleChart.tsx
+++ b/components/CycleChart.tsx
@@ -91,7 +91,7 @@ export default function CycleChart() {
             {t('CYCLE_CHART_TITLE')}
           </span>
           {currentDay > 0 && (
-            <span style={{ fontSize: 'var(--fs-caption)', color: '#555', marginLeft: 8 }}>
+            <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)', marginLeft: 8 }}>
               {t('CYCLE_CHART_CURRENT_DAY', { day: currentDay })}
             </span>
           )}
@@ -197,8 +197,8 @@ export default function CycleChart() {
 
       {/* Footer */}
       <div style={{ padding: '4px 14px 8px', display: 'flex', gap: 12, flexWrap: 'wrap' }}>
-        <span style={{ fontSize: 'var(--fs-caption)', color: '#444' }}>{t('CYCLE_CHART_FOOTER_YAXIS')}</span>
-        <span style={{ fontSize: 'var(--fs-caption)', color: '#444' }}>{t('CYCLE_CHART_FOOTER_SOURCE')}</span>
+        <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)' }}>{t('CYCLE_CHART_FOOTER_YAXIS')}</span>
+        <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)' }}>{t('CYCLE_CHART_FOOTER_SOURCE')}</span>
       </div>
     </div>
   );

--- a/components/DcaCalc.tsx
+++ b/components/DcaCalc.tsx
@@ -108,7 +108,7 @@ export default function DcaCalc({ coin }: { coin: CoinId | '' }) {
                 disabled={entries.length <= 2}
                 style={{
                   width: 26, height: 34, borderRadius: 6, border: '0.5px solid var(--bdr)',
-                  background: 'transparent', color: entries.length <= 2 ? '#333' : 'var(--txt3)',
+                  background: 'transparent', color: entries.length <= 2 ? 'var(--txt-dim)' : 'var(--txt3)',
                   cursor: entries.length <= 2 ? 'not-allowed' : 'pointer', fontSize: '1rem', lineHeight: 1,
                   display: 'flex', alignItems: 'center', justifyContent: 'center',
                 }}

--- a/components/DrawdownChart.tsx
+++ b/components/DrawdownChart.tsx
@@ -84,7 +84,7 @@ export default function DrawdownChart() {
             {t('DRAWDOWN_CHART_NEAR_ATH_BADGE', { count: nearAth })}
           </span>
         )}
-        <span style={{ fontSize: 'var(--fs-caption)', color: '#333' }}>{t('DRAWDOWN_CHART_SOURCE')}</span>
+        <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)' }}>{t('DRAWDOWN_CHART_SOURCE')}</span>
       </div>
 
       {/* Loading / error states */}
@@ -112,7 +112,7 @@ export default function DrawdownChart() {
 
       {/* Bar chart rows */}
       {ath && rows.length === 0 && (
-        <div style={{ padding: '20px 14px', fontSize: 'var(--fs-caption)', color: '#444' }}>{t('DRAWDOWN_CHART_EMPTY')}</div>
+        <div style={{ padding: '20px 14px', fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)' }}>{t('DRAWDOWN_CHART_EMPTY')}</div>
       )}
 
       {ath && rows.length > 0 && (
@@ -133,17 +133,17 @@ export default function DrawdownChart() {
                     {drawdown!.toFixed(1)}%
                   </span>
                   {curPrice != null && (
-                    <span style={{ fontSize: 'var(--fs-caption)', color: '#555', fontVariantNumeric: 'tabular-nums' }}>
+                    <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)', fontVariantNumeric: 'tabular-nums' }}>
                       {fmtPrice(curPrice)}
                     </span>
                   )}
                   {athPrice != null && (
-                    <span style={{ fontSize: 'var(--fs-caption)', color: '#444', fontVariantNumeric: 'tabular-nums' }}>
+                    <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)', fontVariantNumeric: 'tabular-nums' }}>
                       {t('DRAWDOWN_CHART_ATH_PRICE', { price: fmtPrice(athPrice) })}
                     </span>
                   )}
                   {athDate && (
-                    <span style={{ fontSize: 'var(--fs-caption)', color: '#333', marginLeft: 'auto' }}>
+                    <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)', marginLeft: 'auto' }}>
                       {fmtDate(athDate)}
                     </span>
                   )}

--- a/components/EMASignal.tsx
+++ b/components/EMASignal.tsx
@@ -10,8 +10,11 @@ const VERDICT_CONFIG: Record<StrategyVerdict, { label: string; color: string; bg
   SHORT_SETUP:    { label: '▼ SHORT SETUP',    color: '#f87171', bg: 'rgba(248,113,113,0.08)', border: 'rgba(248,113,113,0.25)' },
   TRENDING_LONG:  { label: '↗ TRENDING LONG',  color: '#86efac', bg: 'rgba(134,239,172,0.06)', border: 'rgba(134,239,172,0.2)'  },
   TRENDING_SHORT: { label: '↘ TRENDING SHORT', color: '#fca5a5', bg: 'rgba(252,165,165,0.06)', border: 'rgba(252,165,165,0.2)'  },
-  FREEZE:         { label: '⏸ FREEZE',          color: '#6b7280', bg: 'rgba(107,114,128,0.06)', border: 'rgba(107,114,128,0.2)'  },
-  LOADING:        { label: '…',                 color: '#555',    bg: 'transparent',             border: 'transparent'            },
+  /* #6b7280 was 4.01:1 - the same grey-500 the econ calendar used for its
+     (never-reachable) LOW bucket. FREEZE is a live signal state, not a
+     placeholder, so it takes the AA-safe neutral. */
+  FREEZE:         { label: '⏸ FREEZE',          color: 'var(--txt-dim)', bg: 'rgba(107,114,128,0.06)', border: 'rgba(107,114,128,0.2)'  },
+  LOADING:        { label: '…',                 color: 'var(--txt-dim)',    bg: 'transparent',             border: 'transparent'            },
 };
 
 function fmt(n: number | null, decimals = 2): string {
@@ -102,7 +105,7 @@ export default function EMASignal({ signal, tf = '4h', coin }: Props) {
           <div style={{ fontSize: 'var(--fs-micro)', fontWeight: 700, letterSpacing: '.07em', textTransform: 'uppercase', color: 'var(--txt3)', marginBottom: 3 }}>
             EMA Ribbon Strategy
           </div>
-          <div style={{ fontSize: 'var(--fs-caption)', color: '#444' }}>
+          <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)' }}>
             3 moving averages (fast/mid/slow) · {tf.toUpperCase()} chart · daily trend filter
           </div>
         </div>
@@ -166,7 +169,7 @@ export default function EMASignal({ signal, tf = '4h', coin }: Props) {
         }}>
           {signal.conditions.map((c, i) => {
             const pass = c.pass;
-            const col  = pass === true ? '#34d399' : pass === false ? '#f87171' : '#555';
+            const col  = pass === true ? '#34d399' : pass === false ? '#f87171' : 'var(--txt-dim)';
             const bg   = pass === true ? 'rgba(52,211,153,0.07)' : pass === false ? 'rgba(248,113,113,0.07)' : 'rgba(255,255,255,0.02)';
             const icon = pass === true ? '✓' : pass === false ? '✗' : '-';
             return (
@@ -185,7 +188,7 @@ export default function EMASignal({ signal, tf = '4h', coin }: Props) {
                 onMouseLeave={e => { (e.currentTarget as HTMLDivElement).style.opacity = '1'; }}
               >
                 <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: col, flexShrink: 0 }}>{icon}</span>
-                <span style={{ fontSize: 'var(--fs-caption)', color: pass === null ? '#444' : 'var(--txt2)', lineHeight: 1.2 }}>
+                <span style={{ fontSize: 'var(--fs-caption)', color: pass === null ? 'var(--txt-dim)' : 'var(--txt2)', lineHeight: 1.2 }}>
                   {c.label}
                 </span>
               </div>
@@ -207,11 +210,11 @@ export default function EMASignal({ signal, tf = '4h', coin }: Props) {
           <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: '#f87171' }}>
             SL ${fmt(signal.sl)}
           </span>
-          <span style={{ fontSize: '0.6875rem', color: '#333' }}>·</span>
+          <span style={{ fontSize: '0.6875rem', color: 'var(--txt-dim)' }}>·</span>
           <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt2)' }}>
             Entry ~${fmt(signal.ema20_4h)} (20 EMA)
           </span>
-          <span style={{ fontSize: '0.6875rem', color: '#333' }}>·</span>
+          <span style={{ fontSize: '0.6875rem', color: 'var(--txt-dim)' }}>·</span>
           <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: '#34d399' }}>
             TP ${fmt(signal.tp)} (2:1)
           </span>

--- a/components/EconCalendarWidget.tsx
+++ b/components/EconCalendarWidget.tsx
@@ -5,6 +5,7 @@ import { SkeletonBar } from '@/components/Skeleton';
 import { useLabels } from '@/lib/labels';
 import type { LabelKey } from '@/lib/labelKeys';
 import { getAuthToken } from '@/lib/supabase';
+import { econImpactKey, type EconImpact } from '@/lib/classify';
 
 type CalEvent = {
   name: string; type: string; isoDate: string; impact: string;
@@ -13,8 +14,10 @@ type CalEvent = {
 
 type TFn = (key: LabelKey, vars?: Record<string, string | number>) => string;
 
-const IMPACT_COLOR: Record<string, string> = {
-  HIGH: '#f87171', MEDIUM: '#fbbf24', LOW: '#6b7280',
+/* LOW was #6b7280 = 3.77:1 on the rail card - and since econImpactKey did not
+   exist, EVERY row used it regardless of real impact. See lib/classify.ts. */
+const IMPACT_COLOR: Record<EconImpact, string> = {
+  HIGH: '#f87171', MEDIUM: '#fbbf24', LOW: 'var(--txt-dim)',
 };
 
 const MAX_ROWS = 5;
@@ -102,7 +105,7 @@ export default function EconCalendarWidget() {
       )}
 
       {rows.map(({ e, dateKey, showDateHeader }, i) => {
-        const col = IMPACT_COLOR[e.impact] ?? IMPACT_COLOR.LOW;
+        const col = IMPACT_COLOR[econImpactKey(e.impact)];
         return (
           <div key={i}>
             {showDateHeader && (

--- a/components/GrokChat.tsx
+++ b/components/GrokChat.tsx
@@ -611,7 +611,18 @@ export default function GrokChat() {
       </button>
 
       {/* ── Chat panel ── */}
-      <div className={`gchat-panel${open ? ' gchat-open' : ''}${expanded ? ' gchat-expanded' : ''}`}>
+      {/* inert while closed. The panel is hidden with opacity:0 and
+          pointer-events:none, neither of which removes anything from the tab
+          order - so 65 focusable controls inside it sat ahead of the page's own
+          navigation. The first nine Tab presses on /dashboard landed on quick-
+          reply buttons in an invisible chat panel. inert removes the subtree
+          from both the tab order and the accessibility tree in one attribute,
+          which is exactly the semantics opacity:0 was being asked to imply. */}
+      <div
+        className={`gchat-panel${open ? ' gchat-open' : ''}${expanded ? ' gchat-expanded' : ''}`}
+        inert={!open}
+        aria-hidden={!open}
+      >
 
         {/* ── Login modal overlay (shown when unauthenticated user tries to use Grok) ── */}
         {showLoginModal && (

--- a/components/GrokChat.tsx
+++ b/components/GrokChat.tsx
@@ -812,7 +812,7 @@ export default function GrokChat() {
                       <div style={{ fontSize: 'var(--fs-card-title)', fontWeight: 700, color: '#5aa3ff', margin: '2px 0 6px' }}>
                         {coin.toUpperCase()}/USDT
                       </div>
-                      <div style={{ fontSize: 'var(--fs-caption)', color: '#444' }}>
+                      <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)' }}>
                         {liveSearch ? 'Live search ON' : 'Fast mode · toggle Live for web search'}
                       </div>
                     </>

--- a/components/KLineProChart.tsx
+++ b/components/KLineProChart.tsx
@@ -1087,8 +1087,9 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
               // the US, and crypto-exchange API hosts are on common ad/privacy
               // blocklists, so a whole class of users would only ever see an
               // empty chart. Meanwhile the app already had the right answer
-              // elsewhere: MarketProvider's fetchKlines tries futures then spot.
-              // The chart just never got the same treatment.
+              // elsewhere: app/api/market/snapshot tries futures then spot (this
+              // used to live in MarketProvider.fetchKlines). The chart just never
+              // got the same treatment.
               //
               // Futures is also the better default on its own merits - this is a
               // perp-trading app, and fapi's candles are the ones the funding,

--- a/components/LabelsProvider.tsx
+++ b/components/LabelsProvider.tsx
@@ -60,7 +60,35 @@ export default function LabelsProvider({ children }: { children: React.ReactNode
       .then(r => r.json())
       .then(data => {
         if (reqId.current !== id) return; // a newer locale switch has since started
-        setMap(data);
+
+        /* Two guards, and neither is paranoia - both failure modes are live.
+         *
+         * 1. EMPTY PAYLOAD. app/api/labels deliberately answers `200 {}` on any
+         *    DB error, trusting the client to fall back. This used to call
+         *    setMap(data) unconditionally, which replaced all 2,570 seeded
+         *    English defaults with nothing - and since t() is `map[key] ?? key`,
+         *    every string on every page became its raw key: NAV_SIGN_IN,
+         *    NAV_DASHBOARD, and so on. The .catch below covers a network
+         *    failure but not a SUCCESSFUL response carrying an empty object.
+         *    Each half was defensible alone; together they defeated the seed.
+         *    Note saveCachedMap already refused to cache an empty map - the
+         *    same suspicion, one line further down, never applied here.
+         *
+         * 2. PARTIAL PAYLOAD. Merging over the defaults rather than replacing
+         *    them means a truncated response degrades to English instead of to
+         *    raw keys. app/api/labels warns about PostgREST's db-max-rows cap
+         *    for exactly this reason, and a locale that is only half-translated
+         *    hits it too - missing keys now show English, which is a normal
+         *    i18n fallback rather than a broken page.
+         *
+         * Found by QA, and found sideways: the e2e job running without Supabase
+         * env produced an /arena overflow and /markets CLS 0.255, which read as
+         * two layout bugs. The cause was raw keys being longer than their
+         * English strings and widening the layout. */
+        if (!data || typeof data !== 'object' || Array.isArray(data) || Object.keys(data).length === 0) {
+          return; // keep whatever is on screen - defaults, or the last good map
+        }
+        setMap({ ...DEFAULT_EN_LABELS, ...data });
         saveCachedMap(l, data);
       })
       .catch(() => { /* keep last-known map on transient failure */ })
@@ -76,7 +104,11 @@ export default function LabelsProvider({ children }: { children: React.ReactNode
     const real = loadLocalLocale();
     setLocaleState(real);
     const cached = loadCachedMap(real);
-    if (cached) { setMap(cached); setLoading(false); }
+    /* Merged over the defaults, not substituted for them - a cache written
+       by an older build, or for a locale that is only partly translated, would
+       otherwise render its missing keys raw. Same reasoning as the fetch path
+       above. */
+    if (cached) { setMap({ ...DEFAULT_EN_LABELS, ...cached }); setLoading(false); }
     fetchLabels(real);
   }, [fetchLabels]);
 
@@ -84,7 +116,7 @@ export default function LabelsProvider({ children }: { children: React.ReactNode
     setLocaleState(l);
     saveLocalLocale(l);
     const cached = loadCachedMap(l);
-    if (cached) setMap(cached);
+    if (cached) setMap({ ...DEFAULT_EN_LABELS, ...cached });
     fetchLabels(l);
   }, [fetchLabels]);
 

--- a/components/LandingContent.tsx
+++ b/components/LandingContent.tsx
@@ -318,7 +318,11 @@ export default function LandingContent({ dict, locale, dir }: Props) {
             {dict.footer.copyright}{' '}
             <Link href="/disclaimer" style={{ color: 'var(--txt3)', textDecoration: 'underline', textUnderlineOffset: 2 }}>{dict.footer.fullDisclaimer}</Link>
           </p>
-          <p style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', margin: 0, lineHeight: 1.6, opacity: 0.7 }}>
+          {/* opacity 0.7 on --txt3 computed to #58585d = 2.88:1, and the two
+              legal links inside inherited it. Fifth site of the same pattern -
+              see the --txt3 note in globals.css. Caption size carries the
+              de-emphasis; alpha on a token tuned to the AA line does not. */}
+          <p style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', margin: 0, lineHeight: 1.6 }}>
             By using LiquidityHQ, you acknowledge that you understand and agree to our{' '}
             <Link href="/disclaimer" style={{ color: 'var(--txt3)', textDecoration: 'underline', textUnderlineOffset: 2 }}>Disclaimer</Link>,{' '}
             <Link href="/terms" style={{ color: 'var(--txt3)', textDecoration: 'underline', textUnderlineOffset: 2 }}>Terms of Use</Link>,{' '}

--- a/components/LiqFeed.tsx
+++ b/components/LiqFeed.tsx
@@ -446,7 +446,7 @@ export default function LiqFeed({ onClusters, coinFilter }: { onClusters?: (clus
           <div className="liq-clusters">
             <div className="liq-clusters-title">
               {t('LIQ_FEED_CLUSTERS_TITLE')}
-              <span style={{ color: '#444', fontWeight: 400, marginLeft: 6 }}>{t('LIQ_FEED_CLUSTERS_SUBTITLE')}</span>
+              <span style={{ color: 'var(--txt-dim)', fontWeight: 400, marginLeft: 6 }}>{t('LIQ_FEED_CLUSTERS_SUBTITLE')}</span>
             </div>
             {filtered.map(c => (
               <div key={`${c.coin}::${c.price}`} className="liq-cluster-row">

--- a/components/MarketProvider.tsx
+++ b/components/MarketProvider.tsx
@@ -99,6 +99,13 @@ const SYM_MAP: Record<string, CoinId> = Object.fromEntries(
 
 export default function MarketProvider({ children }: { children: React.ReactNode }) {
   const [store, setStore] = useState<MarketStore>(defaultStore);
+  /* Mirror of `store` for callbacks that must read the CURRENT value without
+     depending on it. fetchSnapshot needs to know whether a coin already has a
+     price before deciding to seed one; depending on `store` would rebuild the
+     callback on every price tick and re-arm its interval. Written in the effect
+     below rather than during render - a ref write during render is its own
+     violation (react-hooks/refs). */
+  const storeRef = useRef<MarketStore>(defaultStore);
   const wsRef = useRef<WebSocket | null>(null);
   const retriesRef = useRef(0);
   const urlIdxRef = useRef(0);
@@ -118,6 +125,8 @@ export default function MarketProvider({ children }: { children: React.ReactNode
   /* Liquidation cascade: rolling event buffer + per-coin cooldown */
   const liqBufferRef    = useRef<Array<{ coin: string; side: 'LONG' | 'SHORT'; usd: number; ts: number }>>([]);
   const cascadeCooldown = useRef<Record<string, number>>({});
+
+  useEffect(() => { storeRef.current = store; }, [store]);
 
   const updateCoin = useCallback((id: CoinId, patch: Partial<MarketStore['coins'][CoinId]>) => {
     setStore(s => ({
@@ -333,150 +342,75 @@ export default function MarketProvider({ children }: { children: React.ReactNode
           });
         } catch { /* */ }
       }),
-      // Binance global account ratio (5m) + top trader position ratio - Binance-listed coins only
-      ...Object.entries(BINANCE_SYMS).map(async ([coin, sym]) => {
-        try {
-          const [globalRes, whaleRes] = await Promise.all([
-            fetch(`https://fapi.binance.com/futures/data/globalLongShortAccountRatio?symbol=${sym}&period=5m&limit=1`),
-            fetch(`https://fapi.binance.com/futures/data/topLongShortPositionRatio?symbol=${sym}&period=5m&limit=1`),
-          ]);
-          const [globalArr, whaleArr] = await Promise.all([globalRes.json(), whaleRes.json()]);
-          const g = Array.isArray(globalArr) ? globalArr[0] : null;
-          const w = Array.isArray(whaleArr)  ? whaleArr[0]  : null;
-          updateCoin(coin as CoinId, {
-            ...(g ? { bnLongRatio:       parseFloat(g.longAccount  || '0.5'),
-                       bnShortRatio:      parseFloat(g.shortAccount || '0.5') } : {}),
-            ...(w ? { bnWhaleLongRatio:  parseFloat(w.longAccount  || '0.5'),
-                       bnWhaleShortRatio: parseFloat(w.shortAccount || '0.5') } : {}),
-          });
-        } catch { /* */ }
-      }),
+      // The Binance half of this - two ratio requests per coin, 91 requests
+      // in total - moved to app/api/market/snapshot. Bybit stays here: it is
+      // one request per coin against a different provider with its own limit,
+      // and it is the only source for the Bybit-only coins.
     ]);
   }, [updateCoin]);
 
-  /* fetchKlines is declared before fetchVolume, which calls it. It used to sit
-     after, so fetchVolume closed over a const declared later - what
-     react-hooks/immutability means by "accessed before it is declared". Safe only
-     because fetchVolume is never invoked during render; moving it earlier removes
-     the dependency on that being true. */
-  const fetchKlines = useCallback(async (coin: CoinId, sym: string) => {
+  /* ── 24h ticker, 15m kline metrics and long/short ratios, in one call ──
+     Replaces fetchKlines (one kline request per coin), fetchVolume (a
+     45-symbol ticker/24hr batch plus a fetchKlines per coin) and the Binance
+     half of fetchLSR (two ratio requests per coin).
+
+     Measured on a real /dashboard load, those were 138 of the 193 Binance
+     requests the browser made, and 341 of the 554 request-weight. Every one
+     returned data identical for every visitor. Now one request.
+
+     app/api/market/snapshot fans out once per cache window on the server and
+     serves everyone from the result, so the upstream cost is fixed rather
+     than per-visitor. See that route for why that mattered: Binance limits by
+     IP, and a limited IP gets 418 on everything including the chart.
+
+     Polled at fetchVolume's old 3-minute cadence. The ratios are cached
+     server-side at their own 5-minute TTL, so this does not re-fetch them
+     more often than before.
+
+     Failure is silent and non-destructive: updateCoin runs only for coins the
+     response actually carried, so a partial or missing response leaves the
+     previous values on screen rather than blanking them. */
+  const fetchSnapshot = useCallback(async () => {
     try {
-      // Use futures klines (fapi) - more accurate taker buy/sell for perp traders
-      // Falls back to spot if futures endpoint fails (e.g. no perp for that symbol)
-      const futuresUrl = `https://fapi.binance.com/fapi/v1/klines?symbol=${sym}&interval=15m&limit=100`;
-      const spotUrl    = `https://api.binance.com/api/v3/klines?symbol=${sym}&interval=15m&limit=100`;
-      let raw = await fetch(futuresUrl);
-      if (!raw.ok) raw = await fetch(spotUrl);
-      const klines = await raw.json();
-      if (!Array.isArray(klines) || klines.length < 15) return;
+      const res = await fetch('/api/market/snapshot');
+      if (!res.ok) return;
+      const body = await res.json() as {
+        ticker?: Record<string, { price: number; change: number; high: number; low: number; vol24: number }>;
+        klines?: Record<string, Record<string, unknown>>;
+        lsr?: Record<string, Record<string, number>>;
+      };
+      /* vol24 always; price only as a FIRST paint.
 
-      const closes = klines.map((k: string[]) => parseFloat(k[4]));
-      const highs  = klines.map((k: string[]) => parseFloat(k[2]));
-      const lows   = klines.map((k: string[]) => parseFloat(k[3]));
-      const vols   = klines.map((k: string[]) => parseFloat(k[7])); // quote volume
+         The socket owns price, change, high and low - they arrive live and are
+         correct to the second. Applying the cached ticker on every poll would
+         overwrite a live price with one up to three minutes old, which on
+         screen is a visible tick backwards.
 
-      /* Volume ratio */
-      const current = vols[vols.length - 2];
-      const avg = vols.slice(0, -1).reduce((a: number, b: number) => a + b, 0) / (vols.length - 1);
-
-      /* MA20 */
-      const ma20Slice = closes.slice(-20);
-      const ma20 = ma20Slice.reduce((a: number, b: number) => a + b, 0) / ma20Slice.length;
-
-      /* RSI14 */
-      const rsi14 = computeRSI14(closes);
-
-      /* ── Volume Profile / POC ── */
-      const allPrices = [...highs, ...lows];
-      const minP = Math.min(...allPrices);
-      const maxP = Math.max(...allPrices);
-      const range = maxP - minP;
-      const BUCKETS = 60;
-      const bSize = range / BUCKETS;
-      const buckets = new Array<number>(BUCKETS).fill(0);
-
-      klines.forEach((k: string[], i: number) => {
-        const h = highs[i], l = lows[i], v = vols[i];
-        const lo = Math.max(0, Math.floor((l - minP) / bSize));
-        const hi = Math.min(BUCKETS - 1, Math.floor((h - minP) / bSize));
-        const span = Math.max(1, hi - lo + 1);
-        for (let b = lo; b <= hi; b++) buckets[b] += v / span;
-      });
-
-      // POC = bucket with max volume
-      let maxVol = 0, pocBucket = 0;
-      buckets.forEach((v, i) => { if (v > maxVol) { maxVol = v; pocBucket = i; } });
-      const poc = minP + (pocBucket + 0.5) * bSize;
-
-      // Value Area: expand from POC to capture 70% of total volume
-      const totalVol = buckets.reduce((a, b) => a + b, 0);
-      let lo = pocBucket, hi = pocBucket, captured = buckets[pocBucket];
-      while (captured < totalVol * 0.70 && (lo > 0 || hi < BUCKETS - 1)) {
-        const addLo = lo > 0 ? buckets[lo - 1] : 0;
-        const addHi = hi < BUCKETS - 1 ? buckets[hi + 1] : 0;
-        if (addLo >= addHi && lo > 0) { lo--; captured += buckets[lo]; }
-        else if (hi < BUCKETS - 1)    { hi++; captured += buckets[hi]; }
-        else                           { lo--; captured += buckets[lo]; }
+         But before the socket connects there is no price at all, which is what
+         restPoll() was doing on mount: one ticker/24hr call for 45 symbols,
+         request weight 80, purely to fill the gap for a second or two. Seeding
+         from data already in this response removes that call entirely. The
+         null check is what keeps it a seed rather than a stomp - once a coin
+         has any price, the socket owns it and this never touches it again.
+         restPoll still exists for the socket-down fallback path. */
+      for (const [coin, v] of Object.entries(body.ticker ?? {})) {
+        if (!v) continue;
+        const id = coin as CoinId;
+        const patch: Partial<CoinData> = {};
+        if (v.vol24 != null) patch.vol24 = v.vol24;
+        if (storeRef.current.coins[id]?.price == null && v.price) {
+          patch.price = v.price; patch.change = v.change; patch.high = v.high; patch.low = v.low;
+        }
+        if (Object.keys(patch).length) updateCoin(id, patch);
       }
-      const val = minP + lo * bSize;
-      const vah = minP + (hi + 1) * bSize;
-
-      /* ── Taker Buy/Sell ratio (last 8 candles ≈ 2h) ──
-         k[9] = taker buy base volume, k[5] = total base volume
-         Smaller window = reacts faster to recent momentum shifts
-         takerBuyRatio > 0.55 = buyers hitting asks (aggression = bullish)
-         takerBuyRatio < 0.45 = sellers hitting bids (aggression = bearish) */
-      let totalBuyVol = 0, totalBaseVol = 0;
-      klines.slice(-8).forEach((k: string[]) => {
-        totalBuyVol  += parseFloat(k[9]);   // taker buy base vol
-        totalBaseVol += parseFloat(k[5]);   // total base vol
-      });
-      const takerBuyRatio = totalBaseVol > 0 ? totalBuyVol / totalBaseVol : null;
-
-      /* ── VWAP - use BASE volume (k[5]) for standard formula ── */
-      // quoteVol (k[7]) biases the average; base vol gives true VWAP
-      let sumTPV = 0, sumVol = 0;
-      klines.forEach((k: string[], i: number) => {
-        const tp       = (highs[i] + lows[i] + closes[i]) / 3;
-        const baseVol  = parseFloat(k[5]);                      // BTC (base) volume
-        sumTPV += tp * baseVol;
-        sumVol += baseVol;
-      });
-      const vwap = sumVol > 0 ? sumTPV / sumVol : null;
-
-      // Chart pattern detection from last 25 candles OHLC
-      const patternCandles = klines.slice(-25).map((k: string[]) => ({
-        o: parseFloat(k[1]), h: parseFloat(k[2]), l: parseFloat(k[3]), c: parseFloat(k[4]),
-      }));
-      const patterns = detectPatterns(patternCandles);
-      const chartPattern = patterns.length > 0 ? patterns.join('; ') : null;
-
-      updateCoin(coin, { volRatio: avg > 0 ? current / avg : 1, ma20, rsi14, poc, vah, val, vwap, takerBuyRatio, chartPattern });
+      for (const [coin, m] of Object.entries(body.klines ?? {})) {
+        if (m && Object.keys(m).length) updateCoin(coin as CoinId, m as Partial<CoinData>);
+      }
+      for (const [coin, r] of Object.entries(body.lsr ?? {})) {
+        if (r && Object.keys(r).length) updateCoin(coin as CoinId, r as Partial<CoinData>);
+      }
     } catch { /* */ }
   }, [updateCoin]);
-
-  /* ── Binance volume + klines ── */
-  const fetchVolume = useCallback(async () => {
-    const binanceCoins = Object.entries(BINANCE_SYMS).filter(([c]) => c !== 'hype');
-    const syms = binanceCoins.map(([, s]) => s);
-    try {
-      const batch = encodeURIComponent(JSON.stringify(syms));
-      const res = await fetch(`https://api.binance.com/api/v3/ticker/24hr?symbols=${batch}`);
-      const arr = await res.json();
-      if (!Array.isArray(arr)) return;
-      arr.forEach((d: Record<string, string>) => {
-        const id = SYM_MAP[d.symbol];
-        if (!id) return;
-        updateCoin(id, { vol24: parseFloat(d.quoteVolume || '0') });
-        fetchKlines(id, d.symbol);
-      });
-    } catch {
-      binanceCoins.forEach(([coin, sym], i) => {
-        setTimeout(() => fetchKlines(coin as CoinId, sym), i * 300);
-      });
-    }
-  }, [updateCoin]); // eslint-disable-line react-hooks/exhaustive-deps
-
 
   /* ── Bybit klines for Bybit-only coins (HYPE, PEPE, BONK, XAU, SPX, …) ── */
   // Bybit kline format (newest-first): [startTime, open, high, low, close, volume, turnover]
@@ -1313,11 +1247,10 @@ export default function MarketProvider({ children }: { children: React.ReactNode
 
   /* ── Initialise on mount ── */
   useEffect(() => {
-    restPoll(); // immediate prices before WS connects
     startWS();
     fetchBybit();
     fetchLSR();
-    fetchVolume();
+    fetchSnapshot();
     fetchBybitKlines();       // RSI/MA20/VWAP/POC for HYPE
     fetchFNG();
     fetchCMCGlobal();
@@ -1341,7 +1274,7 @@ export default function MarketProvider({ children }: { children: React.ReactNode
     const intervals = [
       setInterval(fetchBybit,             8  * 60 * 1000),
       setInterval(fetchLSR,               5  * 60 * 1000),
-      setInterval(fetchVolume,            3  * 60 * 1000),
+      setInterval(fetchSnapshot,          3  * 60 * 1000),
       setInterval(fetchBybitKlines,       3  * 60 * 1000),  // same cadence as Binance klines
       setInterval(fetchFNG,             24  * 60 * 60 * 1000),
       setInterval(fetchCMCGlobal,         5  * 60 * 1000),   // BTC/ETH dom - CMC, every 5m

--- a/components/MultiTFSqueezeView.tsx
+++ b/components/MultiTFSqueezeView.tsx
@@ -71,7 +71,7 @@ function computeTFSignal(
 }
 
 function cellColors(sig: TFSignal): { bg: string; text: string; border: string } {
-  if (sig.dir === 'NEUTRAL') return { bg: 'transparent', text: '#444', border: 'transparent' };
+  if (sig.dir === 'NEUTRAL') return { bg: 'transparent', text: 'var(--txt-dim)', border: 'transparent' };
   const isFlush = sig.dir === 'FLUSH';
   const base    = isFlush ? '#f87171' : '#34d399';
   const alpha   = sig.strength >= 70 ? '28' : sig.strength >= 40 ? '16' : '0c';
@@ -216,7 +216,7 @@ export default function MultiTFSqueezeView() {
               fontSize: 'var(--fs-caption)', fontWeight: 700,
               color: rowActive
                 ? (dominantDir === 'SQUEEZE' ? '#34d399' : '#f87171')
-                : '#555',
+                : 'var(--txt-dim)',
               letterSpacing: '.03em',
             }}>
               {c.toUpperCase()}
@@ -239,7 +239,7 @@ export default function MultiTFSqueezeView() {
                       {icon}
                     </span>
                     <span style={{
-                      fontSize: 'var(--fs-caption)', fontWeight: 600, color: sig.rsi != null ? cols.text : '#333',
+                      fontSize: 'var(--fs-caption)', fontWeight: 600, color: sig.rsi != null ? cols.text : 'var(--txt-dim)',
                       fontVariantNumeric: 'tabular-nums',
                     }}>
                       {sig.rsi != null ? Math.round(sig.rsi) : '-'}
@@ -252,14 +252,14 @@ export default function MultiTFSqueezeView() {
             {/* Global squeeze score */}
             <span style={{
               fontSize: 'var(--fs-caption)', fontWeight: 700, textAlign: 'right',
-              color: sq.dir !== 'NEUTRAL' ? sq.color : '#333',
+              color: sq.dir !== 'NEUTRAL' ? sq.color : 'var(--txt-dim)',
               fontVariantNumeric: 'tabular-nums',
             }}>
               {sq.score > 0 ? sq.score : '-'}
             </span>
           </div>
         );
-        }) : <div style={{ padding: '10px 12px', fontSize: 'var(--fs-caption)', color: '#444' }}>{t('MULTI_TF_SQUEEZE_VIEW_NO_MATCH', { search })}</div>;
+        }) : <div style={{ padding: '10px 12px', fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)' }}>{t('MULTI_TF_SQUEEZE_VIEW_NO_MATCH', { search })}</div>;
       })()}
       </div>
 
@@ -276,11 +276,11 @@ export default function MultiTFSqueezeView() {
         style={{
           width: '100%', padding: '9px 0', background: 'none', border: 'none',
           borderTop: '0.5px solid rgba(255,255,255,0.05)', cursor: 'pointer',
-          fontSize: 'var(--fs-caption)', color: '#444', fontWeight: 600, letterSpacing: '.03em',
+          fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)', fontWeight: 600, letterSpacing: '.03em',
           transition: 'color 0.15s',
         }}
         onMouseEnter={e => (e.currentTarget.style.color = '#888')}
-        onMouseLeave={e => (e.currentTarget.style.color = '#444')}
+        onMouseLeave={e => (e.currentTarget.style.color = 'var(--txt-dim)')}
       >
         {expanded ? t('MULTI_TF_SQUEEZE_VIEW_SHOW_LESS') : t('MULTI_TF_SQUEEZE_VIEW_SHOW_ALL', { count: rows.length })}
       </button>
@@ -289,7 +289,7 @@ export default function MultiTFSqueezeView() {
       <div style={{ padding: '6px 14px', borderTop: '0.5px solid rgba(255,255,255,0.05)', display: 'flex', gap: 12, flexWrap: 'wrap' }}>
         <span style={{ fontSize: 'var(--fs-caption)', color: '#34d399' }}>{t('MULTI_TF_SQUEEZE_VIEW_LEGEND_SQUEEZE')}</span>
         <span style={{ fontSize: 'var(--fs-caption)', color: '#f87171' }}>{t('MULTI_TF_SQUEEZE_VIEW_LEGEND_FLUSH')}</span>
-        <span style={{ fontSize: 'var(--fs-caption)', color: '#444' }}>{t('MULTI_TF_SQUEEZE_VIEW_LEGEND_FORMULA')}</span>
+        <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)' }}>{t('MULTI_TF_SQUEEZE_VIEW_LEGEND_FORMULA')}</span>
       </div>
     </div>
   );
@@ -297,5 +297,5 @@ export default function MultiTFSqueezeView() {
 
 const hdrStyle: React.CSSProperties = {
   fontSize: 'var(--fs-caption)', fontWeight: 600, letterSpacing: '.07em',
-  textTransform: 'uppercase', color: '#333',
+  textTransform: 'uppercase', color: 'var(--txt-dim)',
 };

--- a/components/NavDrawer.tsx
+++ b/components/NavDrawer.tsx
@@ -462,7 +462,15 @@ export default function NavDrawer() {
         </button>
       </nav>
 
-      <div id="nav-drawer" className={`nav-drawer${drawerOpen ? ' open' : ''}`}>
+      {/* inert while closed - see the same fix in GrokChat. The drawer is
+          hidden with a transform and pointer-events:none, so its 23 focusable
+          controls stayed in the tab order behind an invisible panel. */}
+      <div
+        id="nav-drawer"
+        className={`nav-drawer${drawerOpen ? ' open' : ''}`}
+        inert={!drawerOpen}
+        aria-hidden={!drawerOpen}
+      >
         <div className="nav-overlay" onClick={() => setDrawerOpen(false)} />
         <div className="nav-menu">
           <div className="nav-search-bar">

--- a/components/PWAInstallPrompt.tsx
+++ b/components/PWAInstallPrompt.tsx
@@ -91,7 +91,7 @@ export default function PWAInstallPrompt() {
         <button
           onClick={install}
           style={{
-            background: 'var(--accent)',
+            background: 'var(--accent-solid)',
             border: 'none',
             borderRadius: 6,
             padding: '5px 11px',

--- a/components/PageHint.tsx
+++ b/components/PageHint.tsx
@@ -74,6 +74,15 @@ export default function PageHint({ pageKey, title, body }: Props) {
           padding: '0 2px',
           flexShrink: 0,
           opacity: 0.6,
+          /* WCAG 2.2 SC 2.5.8: 24x24 minimum. The glyph alone measured 14x16,
+             and this button renders on every page carrying a hint - it was 5 of
+             the app's remaining tap-target failures by itself. Centred rather
+             than enlarged so the x looks identical; only the hit area grows. */
+          minWidth: 24,
+          minHeight: 24,
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
         }}
         aria-label={t('PAGE_HINT_DISMISS_LABEL')}
       >×</button>

--- a/components/SetupScanner.tsx
+++ b/components/SetupScanner.tsx
@@ -86,7 +86,7 @@ function CoinCard({ row, rank }: { row: ScanRow; rank: number }) {
   const { t } = useLabels();
   const cd = row.coin;
   const fr = classifyFunding(cd.fundingRate ?? 0);
-  const frColor = fr.rpm === 'pos' ? '#f87171' : fr.rpm === 'neg' ? '#34d399' : '#606060';
+  const frColor = fr.rpm === 'pos' ? '#f87171' : fr.rpm === 'neg' ? '#34d399' : 'var(--txt-dim)';
   const dirBg = row.dir === 'LONG_LIQ'
     ? 'rgba(248,113,113,0.06)' : row.dir === 'SHORT_SQ'
     ? 'rgba(52,211,153,0.06)' : 'transparent';

--- a/components/SignalAccuracy.tsx
+++ b/components/SignalAccuracy.tsx
@@ -81,9 +81,9 @@ export default function SignalAccuracy() {
           <Tip width={260} text={t('SIGNAL_ACCURACY_TOOLTIP')}>{t('SIGNAL_ACCURACY_TITLE')}</Tip>
         </span>
         {data?.candles && (
-          <span style={{ fontSize: 'var(--fs-caption)', color: '#444' }}>{t('SIGNAL_ACCURACY_CANDLES_INFO', { candles: data.candles })}</span>
+          <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)' }}>{t('SIGNAL_ACCURACY_CANDLES_INFO', { candles: data.candles })}</span>
         )}
-        <span style={{ fontSize: 'var(--fs-caption)', color: '#444' }}>{t('SIGNAL_ACCURACY_CACHE_NOTE')}</span>
+        <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)' }}>{t('SIGNAL_ACCURACY_CACHE_NOTE')}</span>
       </div>
 
       {/* Loading / error */}
@@ -117,7 +117,7 @@ export default function SignalAccuracy() {
               ({ labelKey, align, tipKey }) => (
                 <span key={labelKey} style={{
                   fontSize: 'var(--fs-micro)', fontWeight: 600, letterSpacing: '.07em',
-                  textTransform: 'uppercase', color: '#333', textAlign: align,
+                  textTransform: 'uppercase', color: 'var(--txt-dim)', textAlign: align,
                 }}>
                   {tipKey ? <Tip width={200} text={t(tipKey)}>{t(labelKey)}</Tip> : t(labelKey)}
                 </span>
@@ -148,13 +148,13 @@ export default function SignalAccuracy() {
                     <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: dirColor }}>{dirIcon}</span>
                     <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 600, color: 'var(--txt)' }}>{sig.label}</span>
                   </div>
-                  <span style={{ fontSize: 'var(--fs-caption)', color: '#444' }}>
+                  <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)' }}>
                     {t('SIGNAL_ACCURACY_AVG_RETURN', { sign: sig.direction === 'long' ? '+' : '', value: sig.avgReturn6.toFixed(2) })}
                   </span>
                 </div>
 
                 {/* Timeframe */}
-                <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 600, color: '#555', textAlign: 'right' }}>
+                <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 600, color: 'var(--txt-dim)', textAlign: 'right' }}>
                   {sig.timeframe}
                 </span>
 
@@ -171,7 +171,7 @@ export default function SignalAccuracy() {
                 </div>
 
                 {/* Signal count */}
-                <span style={{ fontSize: 'var(--fs-caption)', color: '#444', textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
+                <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)', textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
                   {sig.count}×
                 </span>
               </div>
@@ -180,7 +180,7 @@ export default function SignalAccuracy() {
 
           {/* Footer */}
           <div style={{ padding: '6px 14px 8px', borderTop: '0.5px solid rgba(255,255,255,0.05)' }}>
-            <span style={{ fontSize: 'var(--fs-caption)', color: '#333' }}>
+            <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)' }}>
               {t('SIGNAL_ACCURACY_FOOTER_NOTE')}
             </span>
           </div>

--- a/components/StopLossZone.tsx
+++ b/components/StopLossZone.tsx
@@ -145,7 +145,7 @@ export default function StopLossZone({ coin, grokSignal }: { coin: CoinId; grokS
   const tp   = stop ? computeTP(d, bias, stop) : null;
   const rr   = stop && tp ? (tp.distPct / stop.distPct) : null;
 
-  const biasCol = bias === 'long' ? '#34d399' : bias === 'short' ? '#f87171' : '#6b7280';
+  const biasCol = bias === 'long' ? '#34d399' : bias === 'short' ? '#f87171' : 'var(--txt-dim)';
 
   // Conflict: technical indicator bias vs Grok AI signal
   const grokUp = grokSignal?.toUpperCase() ?? '';

--- a/components/Tip.tsx
+++ b/components/Tip.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useRef, useCallback, useEffect } from 'react';
+import { useState, useRef, useCallback, useEffect, useId } from 'react';
 import { createPortal } from 'react-dom';
 
 interface TipProps {
@@ -15,6 +15,7 @@ export default function Tip({ text, children, width = 230, iconColor = 'var(--tx
   const [coords, setCoords] = useState({ top: 0, bottom: 0, left: 0 });
   const ref   = useRef<HTMLSpanElement>(null);
   const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const tipId = useId();
 
   const show = useCallback(() => {
     if (!ref.current) return;
@@ -46,15 +47,58 @@ export default function Tip({ text, children, width = 230, iconColor = 'var(--tx
         style={{ display: 'inline-flex', alignItems: 'center', gap: 3, cursor: 'default' }}
       >
         {children}
-        <span style={{
-          fontSize: 'var(--fs-caption)',
-          color: iconColor,
-          fontWeight: 400,
-          lineHeight: 1,
-          flexShrink: 0,
-          userSelect: 'none',
-          transition: 'color 0.15s',
-        }}
+        {/* The icon carries the interactive semantics, not the wrapper.
+         *
+         * This was a bare <span> with only mouse handlers: not focusable, not
+         * announced as anything, no way to open or dismiss it from a keyboard.
+         * QA measured 0 of 8 focusable across the page, and this one component
+         * has 55 call sites, so every one of them was a keyboard dead end.
+         *
+         * role="button" on a span rather than a real <button> on purpose - Tip
+         * wraps arbitrary children and is used inside headings, labels and
+         * clickable cards, so a nested <button> would be invalid HTML in an
+         * unknown number of those places. Same reasoning as the notification
+         * bell in app/arena, which documents it too.
+         *
+         * aria-describedby points at the portalled panel: screen readers then
+         * announce the tooltip text on focus without it needing to be in the
+         * tab order itself. */}
+        <span
+          role="button"
+          tabIndex={0}
+          aria-label={text}
+          aria-expanded={open}
+          aria-describedby={open ? tipId : undefined}
+          onFocus={() => { cancelHide(); show(); }}
+          onBlur={scheduleHide}
+          onKeyDown={e => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault(); e.stopPropagation();
+              open ? setOpen(false) : show();
+            } else if (e.key === 'Escape' && open) {
+              /* Escape has to work or a keyboard user who opens one has no way
+                 to close it without moving focus away. */
+              e.stopPropagation();
+              setOpen(false);
+            }
+          }}
+          style={{
+            fontSize: 'var(--fs-caption)',
+            color: iconColor,
+            fontWeight: 400,
+            lineHeight: 1,
+            flexShrink: 0,
+            userSelect: 'none',
+            transition: 'color 0.15s',
+            cursor: 'pointer',
+            /* 24px minimum so the icon is a real target for touch as well as
+               keyboard. Centred, so the glyph itself looks unchanged. */
+            minWidth: 24,
+            minHeight: 24,
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
           onMouseEnter={e => { (e.currentTarget as HTMLSpanElement).style.color = 'var(--accent)'; }}
           onMouseLeave={e => { (e.currentTarget as HTMLSpanElement).style.color = iconColor; }}
         >ⓘ</span>
@@ -70,6 +114,8 @@ export default function Tip({ text, children, width = 230, iconColor = 'var(--tx
         // off-screen. Portalling out to body-level sidesteps the whole class
         // of bug regardless of what card this Tip ends up inside.
         <span
+          id={tipId}
+          role="tooltip"
           onMouseEnter={cancelHide}
           onMouseLeave={scheduleHide}
           style={{

--- a/components/TradeJournal.tsx
+++ b/components/TradeJournal.tsx
@@ -797,7 +797,7 @@ function Inner() {
           {t('TRADE_JOURNAL_TAB_RULES')}{rules.filter(r => r.enabled).length > 0 && (
             <span style={{
               marginLeft: 5, fontSize: 'var(--fs-caption)', fontWeight: 700,
-              background: 'var(--accent)', color: '#fff',
+              background: 'var(--accent-solid)', color: '#fff',
               borderRadius: 10, padding: '1px 5px',
             }}>{rules.filter(r => r.enabled).length}</span>
           )}
@@ -806,7 +806,7 @@ function Inner() {
         <button className={`tj-tab${tab === 'bias' ? ' on' : ''}`} onClick={() => setTab('bias')}>{t('TRADE_JOURNAL_TAB_BIAS')}</button>
         <button className={`tj-tab${tab === 'thesis' ? ' on' : ''}`} onClick={() => setTab('thesis')} style={{ position: 'relative' }}>
           {t('TRADE_JOURNAL_TAB_THESIS')}{theses.length > 0 && (
-            <span style={{ marginLeft: 5, fontSize: 'var(--fs-caption)', fontWeight: 700, background: 'var(--accent)', color: '#fff', borderRadius: 10, padding: '1px 5px' }}>{theses.length}</span>
+            <span style={{ marginLeft: 5, fontSize: 'var(--fs-caption)', fontWeight: 700, background: 'var(--accent-solid)', color: '#fff', borderRadius: 10, padding: '1px 5px' }}>{theses.length}</span>
           )}
         </button>
       </div>
@@ -1021,7 +1021,7 @@ function Inner() {
               <div style={{ display: 'flex', justifyContent: 'center', gap: 16, marginBottom: 18, flexWrap: 'wrap' }}>
                 {(['TRADE_JOURNAL_HISTORY_EMPTY_BULLET_PNL', 'TRADE_JOURNAL_HISTORY_EMPTY_BULLET_WINRATE', 'TRADE_JOURNAL_HISTORY_EMPTY_BULLET_BIAS'] as const).map(bulletKey => (
                   <span key={bulletKey} style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', display: 'flex', alignItems: 'center', gap: 5 }}>
-                    <span style={{ width: 5, height: 5, borderRadius: '50%', background: 'var(--accent)', display: 'inline-block', flexShrink: 0 }} />
+                    <span style={{ width: 5, height: 5, borderRadius: '50%', background: 'var(--accent-solid)', display: 'inline-block', flexShrink: 0 }} />
                     {t(bulletKey)}
                   </span>
                 ))}

--- a/components/UpgradeGateModal.tsx
+++ b/components/UpgradeGateModal.tsx
@@ -113,7 +113,7 @@ export function FullPageUpgradeGate({ title, description }: { title: string; des
           {t('UPGRADE_GATE_CTA')}
         </a>
         <div style={{ textAlign: 'center', marginTop: 14 }}>
-          <Link href="/upgrade" style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', textDecoration: 'underline', textUnderlineOffset: 2 }}>
+          <Link href="/upgrade" style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', textDecoration: 'underline', textUnderlineOffset: 2, display: 'inline-flex', alignItems: 'center', minHeight: 24 }}>
             {t('UPGRADE_GATE_COMPARE_LINK')}
           </Link>
         </div>
@@ -217,7 +217,7 @@ export default function UpgradeGateModal({ open, onClose, feature }: Props) {
         </a>
 
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 14 }}>
-          <Link href="/upgrade" style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', textDecoration: 'underline', textUnderlineOffset: 2 }}>
+          <Link href="/upgrade" style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', textDecoration: 'underline', textUnderlineOffset: 2, display: 'inline-flex', alignItems: 'center', minHeight: 24 }}>
             {t('UPGRADE_GATE_COMPARE_LINK')}
           </Link>
           <button

--- a/components/UpgradeGateModal.tsx
+++ b/components/UpgradeGateModal.tsx
@@ -44,7 +44,7 @@ export function LockedFeatureCard({ title, description, onUnlock }: {
       <button
         onClick={onUnlock}
         style={{
-          background: 'var(--accent)', color: '#fff', border: 'none', cursor: 'pointer',
+          background: 'var(--accent-solid)', color: '#fff', border: 'none', cursor: 'pointer',
           fontSize: 'var(--fs-label)', fontWeight: 700, padding: '9px 16px', borderRadius: 8,
           flexShrink: 0,
         }}
@@ -104,7 +104,7 @@ export function FullPageUpgradeGate({ title, description }: { title: string; des
           href={ctaHref}
           style={{
             display: 'block', textAlign: 'center',
-            background: 'var(--accent)', color: '#fff',
+            background: 'var(--accent-solid)', color: '#fff',
             fontSize: 'var(--fs-body)', fontWeight: 700,
             padding: '12px 16px', borderRadius: 8,
             textDecoration: 'none',
@@ -207,7 +207,7 @@ export default function UpgradeGateModal({ open, onClose, feature }: Props) {
           href={ctaHref}
           style={{
             display: 'block', textAlign: 'center',
-            background: 'var(--accent)', color: '#fff',
+            background: 'var(--accent-solid)', color: '#fff',
             fontSize: 'var(--fs-body)', fontWeight: 700,
             padding: '12px 16px', borderRadius: 8,
             textDecoration: 'none',

--- a/components/WhaleTradesFeed.tsx
+++ b/components/WhaleTradesFeed.tsx
@@ -142,7 +142,7 @@ export default function WhaleTradesFeed() {
           <span className="wf-stat-lbl">{t('WHALE_TRADES_FEED_STAT_NET_FLOW')}</span>
           <span className="wf-stat-val" style={{ color: netFlow >= 0 ? '#22d3ee' : '#f97316' }}>
             {netFlow >= 0 ? '+' : ''}{fmtUSD(Math.abs(netFlow))}
-            <span style={{ fontSize: 'var(--fs-caption)', color: '#444', marginLeft: 3 }}>
+            <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)', marginLeft: 3 }}>
               {netFlow >= 0 ? '↑' : '↓'}
             </span>
           </span>

--- a/lib/classify.ts
+++ b/lib/classify.ts
@@ -196,6 +196,25 @@ export function getCoinsInHeadline(headline: string): string[] {
 
 interface EconEntry { name: string; type: string; impact: string; }
 
+/* Producers here emit lowercase 'high' / 'med'; app/api/econ-calendar emits
+   lowercase 'high' too, and filters everything else out upstream. Both UI
+   consumers (components/EconCalendarWidget, app/econ-calendar) keyed their
+   colour maps on 'HIGH' / 'MEDIUM' / 'LOW', so every lookup missed and every
+   row fell through to the LOW grey - FOMC, CPI and NFP rendered identically to
+   a filler event, which is the entire point of the impact column. Found while
+   measuring contrast: the grey it fell back to was also failing AA at 3.77:1.
+   Normalising lives next to the values it normalises so the two can't drift
+   apart again. 'med' is deliberate - that is the literal the classifier emits,
+   not 'medium'. */
+export type EconImpact = 'HIGH' | 'MEDIUM' | 'LOW';
+
+export function econImpactKey(raw: string | null | undefined): EconImpact {
+  const s = String(raw ?? '').trim().toUpperCase();
+  if (s === 'HIGH') return 'HIGH';
+  if (s === 'MED' || s === 'MEDIUM') return 'MEDIUM';
+  return 'LOW';
+}
+
 export function classifyEcon(name: string): EconEntry | null {
   const n = name.toLowerCase();
   if (/fomc|federal open|rate decision|fed decision|federal funds rate/.test(n)) return { name, type: 'FOMC', impact: 'high' };

--- a/lib/klineMetrics.ts
+++ b/lib/klineMetrics.ts
@@ -1,0 +1,125 @@
+import { computeRSI14 } from './rsi';
+import { detectPatterns } from './patterns';
+
+/* Everything MarketProvider used to derive from a coin's 15-minute candles,
+ * lifted out verbatim so app/api/market/snapshot can compute it once on the
+ * server instead of every visitor computing it in their own browser.
+ *
+ * Pure: klines in, numbers out. No fetching, no React, no store. That is the
+ * whole reason it can live in both places without drifting - the previous
+ * version of this problem (computeRSI14) was two copies of the same maths, and
+ * a one-line difference there would have moved coins across the 30/70 badge
+ * thresholds silently.
+ *
+ * Binance kline array indices, since they are otherwise unreadable:
+ *   [1] open  [2] high  [3] low  [4] close
+ *   [5] base volume     [7] quote volume     [9] taker buy base volume
+ */
+
+export interface KlineMetrics {
+  volRatio: number;
+  ma20: number;
+  rsi14: number | null;
+  poc: number;
+  vah: number;
+  val: number;
+  vwap: number | null;
+  takerBuyRatio: number | null;
+  chartPattern: string | null;
+}
+
+/** Volume-profile resolution. 60 buckets over the high-low range. */
+const BUCKETS = 60;
+/** Value area = the price band holding this share of traded volume. */
+const VALUE_AREA_SHARE = 0.70;
+/** Taker buy/sell window: 8 candles at 15m is about two hours. */
+const TAKER_WINDOW = 8;
+/** Pattern detection reads the most recent candles only. */
+const PATTERN_WINDOW = 25;
+
+/** Needs at least 15 closes for RSI14; fewer and the whole set is unreliable. */
+export const MIN_KLINES = 15;
+
+export function computeKlineMetrics(klines: string[][]): KlineMetrics | null {
+  if (!Array.isArray(klines) || klines.length < MIN_KLINES) return null;
+
+  const closes = klines.map(k => parseFloat(k[4]));
+  const highs  = klines.map(k => parseFloat(k[2]));
+  const lows   = klines.map(k => parseFloat(k[3]));
+  const vols   = klines.map(k => parseFloat(k[7]));   // quote volume
+
+  /* Volume ratio: the last CLOSED candle against the average of everything
+     before it. Index -2, not -1, because the final candle is still forming and
+     would always look low. */
+  const current = vols[vols.length - 2];
+  const avg = vols.slice(0, -1).reduce((a, b) => a + b, 0) / (vols.length - 1);
+
+  const ma20Slice = closes.slice(-20);
+  const ma20 = ma20Slice.reduce((a, b) => a + b, 0) / ma20Slice.length;
+
+  const rsi14 = computeRSI14(closes);
+
+  /* ── Volume profile: POC and value area ── */
+  const allPrices = [...highs, ...lows];
+  const minP = Math.min(...allPrices);
+  const maxP = Math.max(...allPrices);
+  const bSize = (maxP - minP) / BUCKETS;
+  const buckets = new Array<number>(BUCKETS).fill(0);
+
+  klines.forEach((_k, i) => {
+    const h = highs[i], l = lows[i], v = vols[i];
+    const lo = Math.max(0, Math.floor((l - minP) / bSize));
+    const hi = Math.min(BUCKETS - 1, Math.floor((h - minP) / bSize));
+    const span = Math.max(1, hi - lo + 1);
+    for (let b = lo; b <= hi; b++) buckets[b] += v / span;
+  });
+
+  let maxVol = 0, pocBucket = 0;
+  buckets.forEach((v, i) => { if (v > maxVol) { maxVol = v; pocBucket = i; } });
+  const poc = minP + (pocBucket + 0.5) * bSize;
+
+  /* Expand outward from the POC, always taking the heavier neighbour, until
+     VALUE_AREA_SHARE of volume is inside. */
+  const totalVol = buckets.reduce((a, b) => a + b, 0);
+  let lo = pocBucket, hi = pocBucket, captured = buckets[pocBucket];
+  while (captured < totalVol * VALUE_AREA_SHARE && (lo > 0 || hi < BUCKETS - 1)) {
+    const addLo = lo > 0 ? buckets[lo - 1] : 0;
+    const addHi = hi < BUCKETS - 1 ? buckets[hi + 1] : 0;
+    if (addLo >= addHi && lo > 0) { lo--; captured += buckets[lo]; }
+    else if (hi < BUCKETS - 1)    { hi++; captured += buckets[hi]; }
+    else                           { lo--; captured += buckets[lo]; }
+  }
+  const val = minP + lo * bSize;
+  const vah = minP + (hi + 1) * bSize;
+
+  /* Taker buy/sell aggression over the recent window.
+     >0.55 = buyers lifting offers, <0.45 = sellers hitting bids. */
+  let totalBuyVol = 0, totalBaseVol = 0;
+  klines.slice(-TAKER_WINDOW).forEach(k => {
+    totalBuyVol  += parseFloat(k[9]);
+    totalBaseVol += parseFloat(k[5]);
+  });
+  const takerBuyRatio = totalBaseVol > 0 ? totalBuyVol / totalBaseVol : null;
+
+  /* VWAP on BASE volume, not quote. Quote volume biases the average toward
+     high-price candles and does not give a true VWAP. */
+  let sumTPV = 0, sumVol = 0;
+  klines.forEach((k, i) => {
+    const tp = (highs[i] + lows[i] + closes[i]) / 3;
+    const baseVol = parseFloat(k[5]);
+    sumTPV += tp * baseVol;
+    sumVol += baseVol;
+  });
+  const vwap = sumVol > 0 ? sumTPV / sumVol : null;
+
+  const patternCandles = klines.slice(-PATTERN_WINDOW).map(k => ({
+    o: parseFloat(k[1]), h: parseFloat(k[2]), l: parseFloat(k[3]), c: parseFloat(k[4]),
+  }));
+  const patterns = detectPatterns(patternCandles);
+
+  return {
+    volRatio: avg > 0 ? current / avg : 1,
+    ma20, rsi14, poc, vah, val, vwap, takerBuyRatio,
+    chartPattern: patterns.length > 0 ? patterns.join('; ') : null,
+  };
+}

--- a/lib/marketStore.ts
+++ b/lib/marketStore.ts
@@ -222,7 +222,7 @@ export function computeSqueezeScore(coin: CoinData | undefined): {
   label: string;
   color: string;
 } {
-  if (!coin) return { score: 0, dir: 'NEUTRAL', label: 'No data', color: '#444' };
+  if (!coin) return { score: 0, dir: 'NEUTRAL', label: 'No data', color: 'var(--txt-dim)' };
 
   let longRisk = 0;    // longs overleveraged → price dump incoming
   let shortRisk = 0;   // shorts overleveraged → price pump incoming
@@ -273,7 +273,7 @@ export function computeSqueezeScore(coin: CoinData | undefined): {
     return { score, dir: 'LONG_LIQ', label: 'Long liquidation risk ↓', color: '#ff9a92' };
   if (shortRisk > longRisk && shortSignals >= 2)
     return { score, dir: 'SHORT_SQ', label: 'Short squeeze ↑', color: '#7de0a4' };
-  return { score, dir: 'NEUTRAL', label: 'Balanced', color: '#606060' };
+  return { score, dir: 'NEUTRAL', label: 'Balanced', color: 'var(--txt-dim)' };
 }
 
 /* ── Coin Health Score ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

**Aggregate release PR for everything on `qa`** — 12 commits, two promotions. Merging this PR is the release: merge → deploy prod manually → re-check → tag.

Staging: **https://liquidity-hq-qa.onrender.com** — `qa` = `352816a`, deployed 2026-08-05 11:07 UTC.

> **Re-promoted 11:07 UTC.** This PR originally covered the Binance fan-out and tap targets only. It now also carries the four open QA defects. If you already tested parts A and B, they are unchanged — **but the build under you was replaced**, so re-run at least step 11 (the settings switch) before signing off. New work is parts C–G.

| | Before | After |
|---|---|---|
| Binance requests / page load | 193 | **56** |
| Binance request-weight / page load | 554 | **214** |
| Tap-target failures (WCAG 2.5.8) | 93 | **0** |
| Colour-contrast violations (axe, 8 routes) | 270 | **0** |
| E2E (Playwright, 177 checks) | 4 failed / 173 passed | **177 passed** |
| Unit tests | 65 | 75 |
| Lint | 0 errors / 94 warnings | 0 errors / 94 warnings |

## What changed

| Change | Measured |
|---|---|
| **Binance fan-out moved server-side** | 193 → **56** requests, 554 → **214** request-weight per page load |
| **Tap targets brought to the WCAG 24px minimum** | 93 real failures → **0** |
| **§1.4** `/api/labels` `200 {}` wiped all 2,570 seeded labels → every page rendered raw keys (`NAV_SIGN_IN`) | guarded; also closed 2 red E2E tests |
| **§1.2** `Tip` info icon was a keyboard dead end at 55 call sites | focus / Enter / Space / Esc, `role="tooltip"`, 24×24 |
| **§1.1** Closed chat panel (65 controls) + nav drawer (23) still in the tab order | `inert` + `aria-hidden` |
| **§4.3** Colour contrast | 270 → **0** |
| **Econ calendar impact colours never worked** | lowercase `high`/`med` vs `HIGH`/`MEDIUM` keys — every lookup missed |

Also carries the `main` → `dev` doc merge, so `qa` now has the workflow docs that only lived on `main`.

## Why

**The fan-out** is the last big piece of the blank-chart problem. v2026.08.05 removed the RSI portion; this removes ticker, kline metrics and long/short ratios. Every one returned data identical for every visitor. Binance limits by IP — shared on mobile CGNAT and office NAT — and a limited IP gets 418 on everything including the chart's own calls.

**The tap targets** are a WCAG 2.2 AA conformance gap, and the count everyone had was wrong in both directions: the audit said 159, QA measured 213. Both counted links inside sentences, which SC 2.5.8 explicitly exempts. Real split across 30 routes at iPhone 13 viewport: **117 exempt, 93 genuine failures**, now 0.

**§1.4** is production-latent: it needs no bad deploy, only a transient Supabase error, and the whole UI turns into raw keys. **§1.1 and §1.2** make the app unusable by keyboard. **§4.3** was making live numbers unreadable, not just failing an audit.

### Two E2E failures already red on `qa` are now closed

`qa` was at **4 failed / 173 passed** before this promotion, filed as two unrelated bugs. Both were §1.4:

| Failing test | Real cause |
|---|---|
| `responsive › /arena has no horizontal overflow` — *"overflows by 28px at desktop"* | `HOURS_WIN_LONDON_BADGE` (22 chars) rendering instead of `LONDON OPEN` (11) — the raw key is twice as wide |
| `smoke › /login renders its form` — *"element(s) not found"* | `LOGIN_SUBTITLE_SIGNIN` rendering instead of `Sign in to your account` |

Neither was a responsive bug or a login bug.

### On §4.3 — both the estimate and my first proposed fix were wrong

The audit put contrast at **32** failures, mostly brand blue. Measuring axe-core across eight routes on a production build found **270**, of which brand blue was **20**. Three systemic causes:

1. **~57 hardcoded `#333`/`#444`/`#555`/`#606060`** — 1.54:1 to 3.20:1. Real data, not decoration: scanner column headers, price cells, scores, funding rates. Now one `--txt-dim` token.
2. **Five `opacity` multipliers stacked on `--txt3`**, which is tuned to sit just above 4.5:1, so any alpha drops it under. One dimmed the legal notice and its Disclaimer/Terms links on all six app routes.
3. **`.lp-root` re-declared `--txt3: #48484a`**, reverting the earlier AA fix on the landing page — the first page every visitor sees. 17 failures from one line.

Darkening `--accent` in one token would have traded one failure for another:

| Pair | `#1a7aff` | `#1668E3` |
|---|---|---|
| white text **on** accent (CTAs, nav pill) | 3.98 ✗ | **5.09 ✓** |
| accent **as** text on `--bg0` (links, badges) | **5.06 ✓** | 3.95 ✗ |

Hence two tokens: `--accent` unchanged for text/borders/glows, `--accent-solid` (`#1668e3`) only where blue is a background under white text.

## How to test (QA)

All steps on **https://liquidity-hq-qa.onrender.com**. Free plan — it sleeps when idle, so the first request may take ~50s. Reload once before judging anything.

**A. Market data still correct — the risky half**
1. Open the dashboard. Every coin shows a price within a second or two, **and keeps ticking**. Frozen prices after first paint is the failure this could plausibly cause — watch 30 seconds.
2. 24h volume, RSI, MA20 and VWAP all present on the coin cards.
3. Long/short ratio bars populated.
4. DevTools → Network, filter `binance`, hard-refresh: roughly **56 requests, not ~193**. No per-coin kline or ratio calls.
5. Filter `market/snapshot` — one request, ~21KB. Leave four minutes, expect exactly one more.
6. `/scanner` and `/arena` still render their data (same store).

**B. Tap targets — 390px viewport or a real phone**
7. `/playbook` — ★ icons comfortable to tap and **visually unchanged**.
8. Footer "Show full risk disclosures" — easier to hit, still expands.
9. Dismiss a blue page hint with the `×`; it stays dismissed on reload.
10. `/arena` notification bell still toggles and shows green when on.
11. **`/settings` — the one to check properly.** The analytics switch must still *look* like a switch: 38×21 track, round thumb, purple when on, thumb slides. It was restructured, not resized. **Re-run this one — the build changed under you.**
12. `/briefing` — "See all in Arena" and "Full scanner" links navigate.

**C. §1.1 — keyboard focus order**
13. On `/dashboard`, from page load press <kbd>Tab</kbd> repeatedly **without touching the mouse**. Pass: first stops are the cookie consent bar, then main navigation. Fail: focus vanishes into chat quick-reply buttons you cannot see.
14. Open the chat and Tab again — its controls must now be reachable.
15. At a narrow viewport, same check with the nav drawer closed, then open.

**D. §1.2 — tooltips by keyboard**
16. Keep tabbing until focus lands on a small circled-i icon. The tooltip must appear **on focus alone**, no mouse.
17. <kbd>Esc</kbd> closes it. <kbd>Enter</kbd> reopens it. Hover behaves exactly as before.
18. Find a tooltip inside a clickable card — opening it must **not** trigger the card.

**E. §1.4 — labels**
19. Browse `/dashboard`, `/arena`, `/scanner`, `/login`. Nothing should ever show an ALL_CAPS_UNDERSCORE string like `NAV_SIGN_IN` or `LOGIN_SUBTITLE_SIGNIN`. Switch language in Settings and back.

**F. §4.3 — contrast. Compare against production (https://liquidity-hq.com).**
**Colour only — nothing should move, resize or reflow.**
20. `/scanner`: column headers (Coin / 15 Min / 1 Hour), price cells, the Majors / Alts / DeFi-AI filter buttons, "Balanced" and the score numbers — all were near-invisible, now readable.
21. `/settings` signed out: the locked feature list (Account, My Watchlist, Trading Profile).
22. Any page footer: the legal notice and its **Disclaimer** / **Terms** links.
23. Landing page footer, and the plan price/sub text.
24. Coin heatmap: the deepest-red tiles must have readable text.
25. `/arena` signed out: **Quick Research** / **Deep Research** legible amber, and still navigate to `/login` when clicked.
26. Brand blue: primary buttons and the active nav pill are a slightly deeper blue with crisper white text — landing hero CTA, "Get Started Free", cookie **Accept**, "Most popular" plan badge, `/upgrade` Recommended badge and Pro button.
27. **Blue *text* and blue *borders* must be UNCHANGED.** Compare a funding-page carry-arb badge and any underlined reasoning link against production. If those shifted, the wrong token was applied — report it.

**G. Econ calendar**
28. `/econ-calendar` and the Econ Calendar widget on `/dashboard` must show **red** high-impact dots, badges and left borders — not grey. The "next event" banner at the top of `/econ-calendar` should be red-accented.

**H. Release**
29. Merge this PR into `main`.
30. Deploy prod manually — Render → `liquidity-hq-prod` → Manual Deploy → Deploy latest commit (`autoDeploy: no`, so the merge alone ships nothing).
31. Re-check A–G against liquidity-hq.com.
32. Tag `v2026.08.05.2`.

## Risk level

**Medium** — touches the market data path every page reads, plus a shared stylesheet and 36 files of colour tokens. No auth, payments, migrations or env var changes.

**No migrations. No new environment variables.** Nothing needs setting on prod before the deploy.

Rollback is clean: Render → Deploys → *Rollback to this deploy*.

**Known limitations and things not verified:**
- **`aggTrades` stays in the browser** — 45 requests, 180 of the remaining 214 weight. It carries whale detection with per-client dedup and DOM events; moving it needs a push channel, not a relocation. Known remainder, not an oversight.
- The snapshot cache is **in-memory per-instance** — a restart empties it and the first visitor pays the fill.
- `BASELINE.tapTargetsUnder24` in `qa/e2e/_shared.ts` is **217** and is now wrong: raw count is 117, real failures 0. Worth deciding whether that baseline should count exempt targets at all — your file, your call.
- **Light theme was never measured.** All contrast work was on the dark theme, which is the default and what every route serves by default. The `[data-theme="light"]` overrides were not swept. Not a regression from this release — it was never measured before either — but it is unverified.
- **Routes not measured for contrast.** axe ran on `/`, `/dashboard`, `/arena`, `/scanner`, `/markets`, `/settings`, `/upgrade`, `/login`. Not on `/alerts`, `/journal`, `/news`, `/backtest`, `/liq`, `/funding`, `/econ-calendar`, `/hours`, `/ops`. Those got token substitutions but no measured proof.
- **`--txt2` on the `#191b1e` card is 4.31:1.** Nothing renders it there today, so not a live defect, but it would become one if secondary text moved onto that card. Recorded in `__tests__/contrastTokens.test.mts` rather than fixed — clearing it means relightening secondary type app-wide, a visible typography change that should be a deliberate decision, not a side effect.
- **`ci.yml` has no `timeout-minutes` on the E2E job.** A genuinely hung run burns to GitHub's 6-hour default instead of failing fast. Not introduced here; flagging it because a 31-minute run was indistinguishable from a stuck one. QA owns CI test workflows.

## Screenshots (if UI change)

None attached. Parts A and B intend **no** visual change — steps 7 and 11 are the check, and if anything *looks* different there, that is the bug.

Part F is the opposite: it intends a visible change, but only in colour. Best verified by putting staging and production side by side on `/scanner`, where 179 of the 270 contrast failures were.
