### PR TITLE
test(e2e): ratchet the tap-target baseline to 122 after PR #23

### DIFF
--- a/qa/e2e/_shared.ts
+++ b/qa/e2e/_shared.ts
@@ -24,10 +24,33 @@ export const ROUTES = [
  */
 export const BASELINE = {
   /**
-   * §4.1 - tap targets under the WCAG 2.2 AA 24px floor, mobile, all routes.
+   * Interactive elements whose rendered box is under 24x24 CSS px, mobile, all
+   * routes.
    *
-   * 217, CORRECTED UP from 159 on 2026-08-05. This is NOT a ratchet violation
-   * and is NOT precedent for raising a baseline - read this before citing it.
+   * READ THIS BEFORE CALLING IT A WCAG NUMBER. It is not one. Earlier versions
+   * of this comment, and audit §4.1, described it as "tap targets below the
+   * WCAG 2.2 AA 24px floor". That framing is wrong and was corrected
+   * 2026-08-05. WCAG 2.2 SC 2.5.8 has exceptions a getBoundingClientRect()
+   * sweep cannot model:
+   *
+   *   - Spacing: an undersized target conforms if a 24px-diameter circle
+   *     centred on it does not intersect another target's circle.
+   *   - Inline: targets inside a sentence or block of text are exempt outright.
+   *     That covers a.pf-footer-bottom-link, the largest single contributor.
+   *
+   * axe-core's `target-size` rule, run at this exact viewport, reports
+   * violations=0 / incomplete=0 / passes=156 on /playbook alone. So this metric
+   * tracks something real and worth reducing - small touch targets on a PWA,
+   * against the 44px Apple HIG comfort target - but it is NOT a conformance
+   * failure count, and it must not be cited as one.
+   *
+   * 122, RATCHETED DOWN from 217 on 2026-08-05 after PR #23
+   * (fix/tap-target-sizes) cleared button.pb-star (55) and
+   * button.pf-footer-expand (28). Remaining: 84 a.pf-footer-bottom-link,
+   * 31 a.consent-link, 7 bare <a>.
+   *
+   * 217 itself was CORRECTED UP from the audit's 159 - which was not a ratchet
+   * violation and is not precedent for raising a baseline.
    *
    * The number must match the viewport THIS SUITE runs at: the mobile project
    * is devices['iPhone 13'], which is 390x844. At the audit's 375x812 the count
@@ -53,7 +76,7 @@ export const BASELINE = {
    * The only legitimate reason to change this number again is DOWNWARD, when a
    * fix lands.
    */
-  tapTargetsUnder24: 217,
+  tapTargetsUnder24: 122,
   /** §4.2 - controls whose only label is a placeholder. */
   controlsWithoutName: 4,
   /** §6.4 - pages with no <h1>, desktop. */


### PR DESCRIPTION
## Summary

Ratchets `BASELINE.tapTargetsUnder24` from **217 → 122** after PR #23, and stops the comment describing that number as a count of WCAG failures, because it isn't one.

## What changed

- `qa/e2e/_shared.ts` — baseline 217 → 122, plus a rewritten comment explaining what the metric actually measures.

Test tooling only. No application code.

## Why

PR #23 (`fix/tap-target-sizes`, merged as `249bdce`) enlarged several controls but did not touch `qa/e2e`, so the baseline was left stale-high. A baseline above the real number still passes — it just stops catching regressions at the right level, which defeats the whole point of the ratchet.

Re-measured at **390×844**, the viewport the mobile project actually uses (`devices['iPhone 13']`), not the audit's 375×812:

| | count |
|---|---|
| `button.pb-star` | **cleared** (was 55) |
| `button.pf-footer-expand` | **cleared** (was 28) |
| `a.pf-footer-bottom-link` | 84 remaining |
| `a.consent-link` | 31 remaining |
| bare `<a>` | 7 remaining |
| **total** | **122** |

Nice detail: PR #23 fixed the genuinely small *controls* and left the footer text links — which are the ones exempt under SC 2.5.8's inline exception anyway. Right call.

## The comment change matters more than the number

Audit §4.1 and the previous version of this comment both call this *"tap targets below the WCAG 2.2 AA 24px floor."* **It is not that.**

SC 2.5.8 exempts targets with sufficient spacing, and exempts inline targets inside a block of text outright — the latter covers `a.pf-footer-bottom-link`, the largest remaining contributor. axe-core's `target-size` rule at this same viewport:

```
/playbook   violations=0  incomplete=0  passes=156
```

The metric is still worth tracking — small touch targets are a real ergonomic problem for an installable PWA against the 44px Apple HIG target — but it is **not** a conformance-failure count and must not be cited as one.

## How to test (QA)

1. `git fetch && git checkout test/lower-tap-target-baseline`
2. `npm ci`, ensure `.env.local` has the dev Supabase URL + anon key
3. `npx playwright test qa/e2e/a11y.spec.ts --project=mobile` → **5 passed**
4. `npx tsc --noEmit` → clean

If you re-measure: do it at **390×844**, and read axe's `incomplete` results as well as `violations` — axe defers uncertain `target-size` cases to `incomplete` rather than failing them, so reading only `violations` makes "deferred" look like "clean".

## Risk level

**Low** — test tooling only. Worst case is a test threshold, not a user-facing defect.

## Note on overlap

Touches the same file as #22 (`qa/e2e/_shared.ts`), different region. Whichever merges second may need a trivial rebase — happy to do it.
