### PR TITLE
test(e2e): close the BOLA/IDOR gap with two authenticated accounts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,11 @@ jobs:
   e2e:
     name: E2E (Playwright)
     runs-on: ubuntu-latest
+    # A full run is ~31 minutes. Without a cap, a genuinely hung run burns to
+    # GitHub's 6-hour default, and a stuck run looks identical to a slow one -
+    # which happened while this suite was being brought up. 45 leaves headroom
+    # for a cold runner without hiding a hang.
+    timeout-minutes: 45
     # Only after lint/typecheck/unit/build are green. A broken build would
     # produce 216 browser failures that all say "the build is broken", which
     # buries the one line that actually explains it.
@@ -108,6 +113,32 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
           NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ secrets.E2E_TURNSTILE_SITE_KEY }}
+
+          # Authenticated fixtures for qa/e2e/bola.spec.ts - BOLA/IDOR, the one
+          # spec that signs in. Two seeded accounts on the DEV Supabase project
+          # only. A holds one row per table under test; B is deliberately empty,
+          # because the test is "B asks for A's rows by id and must be refused".
+          #
+          # Passwords rather than tokens on purpose: a Supabase access token
+          # expires in about an hour, so a pasted token passes once and then
+          # fails CI the next day. The spec mints a fresh token per run.
+          #
+          # These are ordinary user-level accounts. The service-role key is NOT
+          # here and must never be - it bypasses RLS entirely, which is exactly
+          # what this spec exists to verify.
+          #
+          # Absent, bola.spec.ts SKIPS with a stated reason rather than passing.
+          # A BOLA test that runs without fixtures proves nothing, and a vacuous
+          # pass is indistinguishable from a real one.
+          E2E_USER_A_EMAIL: ${{ secrets.E2E_USER_A_EMAIL }}
+          E2E_USER_A_PASSWORD: ${{ secrets.E2E_USER_A_PASSWORD }}
+          E2E_USER_A_ID: ${{ secrets.E2E_USER_A_ID }}
+          E2E_USER_B_EMAIL: ${{ secrets.E2E_USER_B_EMAIL }}
+          E2E_USER_B_PASSWORD: ${{ secrets.E2E_USER_B_PASSWORD }}
+          E2E_USER_B_ID: ${{ secrets.E2E_USER_B_ID }}
+          E2E_A_TRADE_ID: ${{ secrets.E2E_A_TRADE_ID }}
+          E2E_A_HYPOTHESIS_ID: ${{ secrets.E2E_A_HYPOTHESIS_ID }}
+          E2E_A_PRICE_ALERT_ID: ${{ secrets.E2E_A_PRICE_ALERT_ID }}
 
       # Uploaded on failure too - that is the run you actually need to read.
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,26 @@ jobs:
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
           NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ secrets.E2E_TURNSTILE_SITE_KEY }}
 
+          # Selects the lhq_dev_ table prefix. NOT optional, and not a nicety:
+          # lib/tables.ts reads
+          #     NEXT_PUBLIC_APP_ENV === 'dev' ? 'lhq_dev_' : 'lhq_'
+          # so anything that is not exactly 'dev' - INCLUDING undefined, which is
+          # what CI had - selects the PRODUCTION table names. CI then queried
+          # lhq_hypotheses / lhq_price_alerts against the dev project, which has
+          # neither (only lhq_dev_* exist there, plus lhq_signup_ip_log). Every
+          # such query errored and apiError mapped it to a 500.
+          #
+          # That is why bola.spec.ts saw GET /api/hypotheses return 500 to
+          # account A for A's OWN rows - nothing to do with authorization. It
+          # also means every authenticated CI run before this line existed was
+          # querying tables that were not there, so those runs asserted less
+          # than they appeared to.
+          #
+          # Belongs in THIS step, not the build step: NEXT_PUBLIC_* is inlined at
+          # build time, and playwright.config.ts's webServer runs
+          # `npm run build && npm start` as a child of this step, inheriting env.
+          NEXT_PUBLIC_APP_ENV: dev
+
           # Authenticated fixtures for qa/e2e/bola.spec.ts - BOLA/IDOR, the one
           # spec that signs in. Two seeded accounts on the DEV Supabase project
           # only. A holds one row per table under test; B is deliberately empty,

--- a/qa/e2e/_auth.ts
+++ b/qa/e2e/_auth.ts
@@ -1,0 +1,78 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Credentials + token minting for the authenticated specs.
+ *
+ * Two accounts, both on the DEV Supabase project only. A is seeded with one row
+ * in each table under test; B is deliberately empty, because the BOLA test is
+ * "B asks for A's rows by id and must be refused" - giving B its own data would
+ * only obscure that.
+ *
+ * Passwords rather than tokens on purpose: a Supabase access token expires in
+ * about an hour, so a pasted token passes once and then fails CI the next day.
+ * Minting per run is the only version that keeps working unattended.
+ */
+
+/** Reads KEY=value files without adding a dotenv dependency. CI has no files, only env. */
+function loadEnvFile(file: string): void {
+  const p = path.resolve(process.cwd(), file);
+  if (!fs.existsSync(p)) return;
+  for (const line of fs.readFileSync(p, 'utf8').split(/\r?\n/)) {
+    const m = /^\s*([A-Z0-9_]+)\s*=\s*(.*)$/.exec(line);
+    if (!m) continue;
+    const [, k, raw] = m;
+    if (process.env[k]) continue;           // real env always wins over a file
+    process.env[k] = raw.trim().replace(/^["']|["']$/g, '');
+  }
+}
+loadEnvFile('.env.e2e.local');
+loadEnvFile('.env.local');
+
+export const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+export const SUPABASE_ANON = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '';
+
+export const FIXTURES = {
+  aEmail: process.env.E2E_USER_A_EMAIL ?? '',
+  aPassword: process.env.E2E_USER_A_PASSWORD ?? '',
+  aId: process.env.E2E_USER_A_ID ?? '',
+  bEmail: process.env.E2E_USER_B_EMAIL ?? '',
+  bPassword: process.env.E2E_USER_B_PASSWORD ?? '',
+  bId: process.env.E2E_USER_B_ID ?? '',
+  /** A's row ids. The test must request these explicitly - guessing ids is how
+   *  this test ends up asserting nothing. */
+  tradeId: process.env.E2E_A_TRADE_ID ?? '',
+  hypothesisId: process.env.E2E_A_HYPOTHESIS_ID ?? '',
+  priceAlertId: process.env.E2E_A_PRICE_ALERT_ID ?? '',
+} as const;
+
+/** Everything the authenticated specs need, or they must skip rather than pass. */
+export const AUTH_READY =
+  !!(SUPABASE_URL && SUPABASE_ANON &&
+     FIXTURES.aEmail && FIXTURES.aPassword && FIXTURES.bEmail && FIXTURES.bPassword &&
+     FIXTURES.tradeId && FIXTURES.hypothesisId && FIXTURES.priceAlertId);
+
+export const AUTH_SKIP_REASON =
+  'authenticated fixtures absent - set E2E_USER_A_* / E2E_USER_B_* / E2E_A_*_ID ' +
+  '(see the issue "QA unblocked: two seeded test accounts"). Skipping rather than ' +
+  'passing: a BOLA test that runs without fixtures proves nothing.';
+
+/** Password grant against the dev project. Throws loudly - a silent auth failure
+ *  would make every cross-account assertion trivially "pass". */
+export async function signIn(email: string, password: string): Promise<string> {
+  const res = await fetch(`${SUPABASE_URL}/auth/v1/token?grant_type=password`, {
+    method: 'POST',
+    headers: { apikey: SUPABASE_ANON, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok || !body.access_token) {
+    throw new Error(
+      `sign-in failed for ${email}: HTTP ${res.status} ${JSON.stringify(body).slice(0, 200)}. ` +
+      `If this is 500 "Database error querying schema", the auth.users row has NULL ` +
+      `token columns - GoTrue scans them into non-nullable Go strings. See the ` +
+      `seeded-accounts issue for the coalesce fix.`,
+    );
+  }
+  return body.access_token as string;
+}

--- a/qa/e2e/bola.spec.ts
+++ b/qa/e2e/bola.spec.ts
@@ -1,0 +1,279 @@
+import { test, expect, request as pwRequest } from '@playwright/test';
+import { AUTH_READY, AUTH_SKIP_REASON, FIXTURES, SUPABASE_URL, SUPABASE_ANON, signIn } from './_auth';
+
+/**
+ * BOLA / IDOR - OWASP API Security #1.
+ *
+ * The question every other spec in this suite leaves unanswered: can a
+ * legitimately signed-in user reach another user's rows by asking for them by
+ * id? Everything else here tests the signed-out surface, where the answer is
+ * always 401 and nothing is learned about this.
+ *
+ * Why it needs its own file: it is the only spec that authenticates, and the
+ * only one that can fail in a way that means "user data is exposed".
+ *
+ * WHY THE ASSERTIONS LOOK PARANOID
+ *
+ * A status code is not evidence here. `PATCH .../someone-elses-id` returning
+ * 200 is ambiguous - Supabase reports success for an UPDATE that matched zero
+ * rows, which is exactly what a correct ownership filter produces. So every
+ * write attempt is followed by a read AS THE OWNER to prove the row did not
+ * change. Without that second read this file would pass against a genuinely
+ * broken app.
+ *
+ * Equally, an empty result is only meaningful if the row exists. Test 1 proves
+ * A can read its own fixtures first; if that fails everything after it would
+ * "pass" vacuously, so it fails the run loudly instead.
+ */
+
+test.describe('BOLA / IDOR - cross-account access', () => {
+  test.skip(!AUTH_READY, AUTH_SKIP_REASON);
+
+  // HTTP-level. Running both viewport projects would just double the requests.
+  test.beforeEach(({}, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop', 'HTTP-level, viewport irrelevant');
+  });
+
+  let tokenA = '';
+  let tokenB = '';
+
+  test.beforeAll(async () => {
+    tokenA = await signIn(FIXTURES.aEmail, FIXTURES.aPassword);
+    tokenB = await signIn(FIXTURES.bEmail, FIXTURES.bPassword);
+    expect(tokenA, 'A and B must be different sessions').not.toBe(tokenB);
+  });
+
+  const auth = (t: string) => ({ Authorization: `Bearer ${t}` });
+
+  /**
+   * Statuses treated as "access was refused".
+   *
+   * 500 is in here deliberately, and it is a defect rather than an accident:
+   * measured 2026-08-06, B's write attempts return
+   * `500 {"error":"Something went wrong. Please try again."}` - including for a
+   * UUID that does not exist at all, which proves the 500 is about B (no
+   * entitlement row) and not about reaching A's data. A's own writes return
+   * 200, so the endpoints work.
+   *
+   * It fails CLOSED, so it is not a security hole and this suite must not fail
+   * the build over it. But a denial surfacing as 500 makes real server errors
+   * indistinguishable from refused access in the logs and in GlitchTip, so
+   * every test below annotates when it sees one. Security is asserted by
+   * re-reading the row as its owner, never by the status code.
+   */
+  const REFUSED = [200, 400, 401, 403, 404, 500];
+
+  const noteIf500 = (status: number, what: string) => {
+    if (status !== 500) return;
+    test.info().annotations.push({
+      type: 'known-issue',
+      description:
+        `${what} refused with HTTP 500 rather than 403. Fails closed - data is ` +
+        `safe - but denial is indistinguishable from a server fault in logs.`,
+    });
+  };
+
+  /** Direct PostgREST, bypassing the app - measures RLS itself. */
+  const rest = async (t: string, table: string, query: string) => {
+    const ctx = await pwRequest.newContext();
+    const r = await ctx.get(`${SUPABASE_URL}/rest/v1/${table}?${query}`, {
+      headers: { apikey: SUPABASE_ANON, Authorization: `Bearer ${t}` },
+      failOnStatusCode: false,
+    });
+    const body = await r.json().catch(() => null);
+    await ctx.dispose();
+    return { status: r.status(), body };
+  };
+
+  // ── 1. Fixtures are real ────────────────────────────────────────────────
+  // Everything below is meaningless if A's rows do not exist. This runs first
+  // and fails the file rather than letting later tests pass vacuously.
+  test('A can read its own seeded rows (guards against a vacuous pass)', async ({ request }) => {
+    const hyp = await request.get('/api/hypotheses', { headers: auth(tokenA), failOnStatusCode: false });
+    expect(hyp.status(), 'A should be able to list its hypotheses').toBe(200);
+    const hypBody = await hyp.json();
+    const hypRows = Array.isArray(hypBody) ? hypBody : (hypBody.hypotheses ?? hypBody.data ?? []);
+    expect(
+      JSON.stringify(hypRows),
+      `A's seeded hypothesis ${FIXTURES.hypothesisId} must be visible to A, or this file proves nothing`,
+    ).toContain(FIXTURES.hypothesisId);
+
+    const alerts = await request.get('/api/price-alerts', { headers: auth(tokenA), failOnStatusCode: false });
+    expect(alerts.status()).toBe(200);
+    expect(JSON.stringify(await alerts.json())).toContain(FIXTURES.priceAlertId);
+  });
+
+  // ── 2. B cannot LIST A's data ───────────────────────────────────────────
+  test('B listing its own collections never returns A rows', async ({ request }) => {
+    // Only UUID-shaped fixtures are safe as substring needles. A's price-alert
+    // id is the integer "1", so `not.toContain("1")` would match almost any
+    // JSON body - including B's own legitimate response. That produced a false
+    // failure the first time this ran. Integer-keyed rows are covered by the
+    // per-row ownership tests and the RLS test instead.
+    const needles: Array<[string, string]> = [
+      ["A's user id", FIXTURES.aId],
+      ["A's hypothesis", FIXTURES.hypothesisId],
+      ["A's trade", FIXTURES.tradeId],
+    ].filter(([, v]) => v.length >= 8) as Array<[string, string]>;
+
+    for (const path of ['/api/hypotheses', '/api/price-alerts', '/api/settings']) {
+      const r = await request.get(path, { headers: auth(tokenB), failOnStatusCode: false });
+      expect([200, 404], `${path} should answer B`).toContain(r.status());
+      const text = await r.text();
+      for (const [what, needle] of needles) {
+        expect(text, `${path} leaked ${what} to B`).not.toContain(needle);
+      }
+    }
+  });
+
+  // ── 3. B cannot MUTATE A's rows by id ───────────────────────────────────
+  // The important half. Each attempt is verified by re-reading as A.
+  test("B cannot modify A's hypothesis by id", async ({ request }) => {
+    const before = await rest(tokenA, 'lhq_dev_hypotheses', `id=eq.${FIXTURES.hypothesisId}&select=*`);
+    expect(before.status, "A must be able to read its own hypothesis").toBe(200);
+    expect(before.body?.length, 'fixture missing - cannot test').toBe(1);
+
+    const r = await request.patch(`/api/hypotheses/${FIXTURES.hypothesisId}`, {
+      headers: { ...auth(tokenB), 'Content-Type': 'application/json' },
+      data: { title: 'OWNED BY B', status: 'invalidated' },
+      failOnStatusCode: false,
+    });
+    // 200 here is NOT a failure by itself: an UPDATE matching zero rows succeeds.
+    expect(REFUSED).toContain(r.status());
+    noteIf500(r.status(), "PATCH /api/hypotheses/{id} as a non-owner");
+
+    const after = await rest(tokenA, 'lhq_dev_hypotheses', `id=eq.${FIXTURES.hypothesisId}&select=*`);
+    expect(
+      JSON.stringify(after.body),
+      `B MUTATED A's hypothesis. HTTP was ${r.status()} - which is why this test re-reads as the owner.`,
+    ).not.toContain('OWNED BY B');
+    expect(after.body?.length, "A's hypothesis must still exist").toBe(1);
+  });
+
+  test("B cannot delete A's hypothesis by id", async ({ request }) => {
+    const r = await request.delete(`/api/hypotheses/${FIXTURES.hypothesisId}`, {
+      headers: auth(tokenB), failOnStatusCode: false,
+    });
+    expect(REFUSED).toContain(r.status());
+    noteIf500(r.status(), "DELETE /api/hypotheses/{id} as a non-owner");
+
+    const after = await rest(tokenA, 'lhq_dev_hypotheses', `id=eq.${FIXTURES.hypothesisId}&select=id`);
+    expect(
+      after.body?.length,
+      `B DELETED A's hypothesis. HTTP was ${r.status()}.`,
+    ).toBe(1);
+  });
+
+  test("B cannot modify or deactivate A's price alert by id", async ({ request }) => {
+    const patch = await request.patch(`/api/price-alerts?id=${FIXTURES.priceAlertId}`, {
+      headers: { ...auth(tokenB), 'Content-Type': 'application/json' },
+      data: { label: 'OWNED BY B', target_price: 1 },
+      failOnStatusCode: false,
+    });
+    expect(REFUSED).toContain(patch.status());
+    noteIf500(patch.status(), "PATCH /api/price-alerts as a non-owner");
+
+    const del = await request.delete(`/api/price-alerts?id=${FIXTURES.priceAlertId}`, {
+      headers: auth(tokenB), failOnStatusCode: false,
+    });
+    expect(REFUSED).toContain(del.status());
+    noteIf500(del.status(), "DELETE /api/price-alerts as a non-owner");
+
+    const after = await rest(tokenA, 'lhq_dev_price_alerts', `id=eq.${FIXTURES.priceAlertId}&select=*`);
+    expect(after.body?.length, "A's price alert must still exist").toBe(1);
+    const row = after.body?.[0] ?? {};
+    expect(JSON.stringify(row), "B renamed A's price alert").not.toContain('OWNED BY B');
+    // DELETE here is a soft delete (active:false). If B could reach it, the
+    // alert would silently stop firing for A - a data-loss bug that returns 200.
+    expect(row.active, "B deactivated A's price alert - it would silently stop firing").not.toBe(false);
+  });
+
+  test("B cannot overwrite A's settings", async ({ request }) => {
+    const r = await request.patch('/api/settings', {
+      headers: { ...auth(tokenB), 'Content-Type': 'application/json' },
+      data: { user_id: FIXTURES.aId, account_size: 999999, risk_per_trade: 99 },
+      failOnStatusCode: false,
+    });
+    expect(REFUSED).toContain(r.status());
+    noteIf500(r.status(), "PATCH /api/settings with a foreign user_id in the body");
+
+    // Mass-assignment check: passing user_id in the body must not let B write
+    // to A's row. If the handler trusted that field this would silently succeed.
+    const after = await rest(tokenA, 'lhq_dev_user_settings', `user_id=eq.${FIXTURES.aId}&select=*`);
+    const s = after.body?.[0] ?? {};
+    expect(
+      s.account_size,
+      "B overwrote A's settings via a user_id in the request body (mass assignment)",
+    ).not.toBe(999999);
+  });
+
+  // ── 4. RLS floor, measured directly ─────────────────────────────────────
+  // The API routes query with the user's token, so RLS is the second layer.
+  // Checking it separately means a future route that switches to the
+  // service-role client does not silently lose all protection.
+  test('RLS refuses B direct PostgREST access to A rows', async () => {
+    const tables: Array<[string, string]> = [
+      ['lhq_dev_hypotheses', FIXTURES.hypothesisId],
+      ['lhq_dev_price_alerts', FIXTURES.priceAlertId],
+      ['lhq_dev_trades', FIXTURES.tradeId],
+    ];
+    for (const [table, id] of tables) {
+      const asA = await rest(tokenA, table, `id=eq.${id}&select=id`);
+      expect(asA.body?.length, `fixture ${table}/${id} missing - test would be vacuous`).toBe(1);
+
+      const asB = await rest(tokenB, table, `id=eq.${id}&select=*`);
+      expect([200, 401, 403]).toContain(asB.status);
+      expect(
+        Array.isArray(asB.body) ? asB.body.length : 0,
+        `RLS let B read A's row in ${table}`,
+      ).toBe(0);
+    }
+
+    const settingsAsB = await rest(tokenB, 'lhq_dev_user_settings', `user_id=eq.${FIXTURES.aId}&select=*`);
+    expect(
+      Array.isArray(settingsAsB.body) ? settingsAsB.body.length : 0,
+      "RLS let B read A's settings",
+    ).toBe(0);
+  });
+
+  // ── 5. Controls ─────────────────────────────────────────────────────────
+  // Proves the endpoints are actually reachable and gated, so a network
+  // failure cannot masquerade as "access correctly denied" above.
+  test('the same requests without a token are rejected', async ({ request }) => {
+    for (const path of ['/api/hypotheses', '/api/price-alerts', '/api/settings']) {
+      const r = await request.get(path, { failOnStatusCode: false });
+      const body = await r.text();
+
+      // /api/hypotheses and /api/settings answer 401. /api/price-alerts answers
+      // 200 {"alerts":[]} - measured 2026-08-06. That is not a leak, and the
+      // empty-collection assertion below is what actually matters, but it is
+      // inconsistent with its two siblings and worth recording.
+      if (r.status() === 200) {
+        test.info().annotations.push({
+          type: 'known-issue',
+          description:
+            `${path} answers an anonymous caller with HTTP 200 instead of 401, ` +
+            `unlike /api/hypotheses and /api/settings. No data is exposed - the ` +
+            `collection is empty - but the inconsistency is real.`,
+        });
+        expect(body, `${path} returned data to an anonymous caller`).not.toContain(FIXTURES.aId);
+        expect(body, `${path} returned A's hypothesis anonymously`).not.toContain(FIXTURES.hypothesisId);
+        expect(
+          /\[\s*\]/.test(body) || body.length < 60,
+          `${path} answered 200 anonymously AND returned rows: ${body.slice(0, 160)}`,
+        ).toBeTruthy();
+      } else {
+        expect([401, 403], `${path} must reject an anonymous caller`).toContain(r.status());
+      }
+    }
+  });
+
+  test("a forged token for A's user id is rejected", async ({ request }) => {
+    const b64 = (o: unknown) => Buffer.from(JSON.stringify(o)).toString('base64url');
+    const forged = `${b64({ alg: 'none', typ: 'JWT' })}.${b64({ sub: FIXTURES.aId, role: 'authenticated', email: FIXTURES.aEmail })}.`;
+    const r = await request.get('/api/hypotheses', {
+      headers: { Authorization: `Bearer ${forged}` }, failOnStatusCode: false,
+    });
+    expect([401, 403], 'an unsigned token claiming to be A was accepted').toContain(r.status());
+  });
+});

--- a/qa/e2e/security.spec.ts
+++ b/qa/e2e/security.spec.ts
@@ -117,17 +117,17 @@ test.describe('api security', () => {
   });
 
   // ─────────────────────────────────────────────────────────────────────
-  // NOT COVERED - the single biggest gap in this suite.
+  // BOLA / IDOR (OWASP API #1) used to be a test.fixme here - the single
+  // biggest gap in this suite, and the one thing every other spec left
+  // unanswered, because everything else tests the signed-out surface where
+  // the answer is always 401.
   //
-  // BOLA / IDOR (OWASP API #1) needs two real signed-in accounts to prove
-  // user B cannot read user A's journal entries, alerts, settings or
-  // subscription row. HANDOVER.md §1 says two test accounts exist.
+  // It now lives in qa/e2e/bola.spec.ts, which authenticates as two seeded
+  // accounts and proves B cannot read or mutate A's rows. It is a separate
+  // file because it is the only spec that signs in, and the only one whose
+  // failure means "user data is exposed".
   //
-  // To enable: set E2E_TOKEN_A and E2E_TOKEN_B (Supabase access tokens) as
-  // repo secrets, then write the cross-account reads here. Until then this is
-  // UNVERIFIED, not passing.
+  // It skips - loudly, never passes - when the fixtures are absent. See
+  // qa/e2e/_auth.ts for what it needs.
   // ─────────────────────────────────────────────────────────────────────
-  test.fixme('BOLA: user B cannot read user A resources', async () => {
-    // Blocked on E2E_TOKEN_A / E2E_TOKEN_B. See audit intro.
-  });
 });


### PR DESCRIPTION
## Summary

Closes the BOLA/IDOR gap — the largest untested area in the product, and the `test.fixme` that has sat in `security.spec.ts` since the suite was written. **Nine tests, all passing. No hole found.**

Unblocked by the seeded accounts in #28 — thanks, the seeding is what makes this a real test rather than a green tick.

## What changed

| File | |
|---|---|
| `qa/e2e/bola.spec.ts` | new — 9 cross-account tests |
| `qa/e2e/_auth.ts` | new — fixture loading + password-grant token minting |
| `qa/e2e/security.spec.ts` | `test.fixme` replaced with a pointer |
| `.github/workflows/ci.yml` | forwards the 9 fixture vars; `timeout-minutes: 45` |

No application code.

## Result

| Test | |
|---|---|
| A can read its own seeded rows | ✅ guards against a vacuous pass |
| B listing collections never returns A rows | ✅ |
| B cannot modify A's hypothesis by id | ✅ |
| B cannot delete A's hypothesis by id | ✅ |
| B cannot modify or deactivate A's price alert | ✅ |
| B cannot overwrite A's settings via `user_id` in the body | ✅ mass assignment not exploitable |
| RLS refuses B direct PostgREST access | ✅ |
| Anonymous requests rejected | ✅ |
| Forged `alg:none` token claiming A's `sub` rejected | ✅ |

All four routes scope by `user_id` **and** query with the user's token, so RLS is a second layer rather than the only one. Now locked in by tests rather than assumed.

## Why the assertions look paranoid

**A status code is not evidence here.** `PATCH .../someone-elses-id` returning 200 is ambiguous — Supabase reports success for an UPDATE that matched zero rows, which is exactly what a correct ownership filter produces. So every write attempt is followed by a read **as the owner** to prove the row did not change. Without that second read this file would pass against a genuinely broken app.

**An empty result only means something if the row exists.** Test 1 asserts A can see its own fixtures before anything else runs. If the fixtures vanish, the file fails loudly instead of passing vacuously.

## Two defects found while writing it

Both reported on #28. Both recorded as `known-issue` annotations rather than build failures, because neither is a security hole.

**1. Authorization denials return 500, not 403.**

```
A PATCH own hypothesis                      -> 200   endpoint works
B PATCH A's hypothesis                      -> 500
B PATCH a UUID that does not exist at all   -> 500   <-- the tell
```

The nonexistent-UUID row isolates it: the 500 is about **B** having no entitlement row, not about reaching A's data. Fails closed, so data is safe — but a denial that surfaces as 500 cannot be alerted on separately from real server faults.

**2. `/api/price-alerts` answers anonymous callers `200 {"alerts":[]}`** where `/api/hypotheses` and `/api/settings` both answer 401. No data exposed, but inconsistent.

## Three corrections to my own spec

It failed 3 tests on first run and **all three were mine, not the app's**: A's price-alert id is the integer `"1"`, so using it as a substring needle matched almost any JSON body; and I assumed denials would be 401/403 without measuring first. Both are fixed and commented so the next reader does not repeat them.

## How to test (QA)

1. `git fetch && git checkout test/bola-idor-coverage`
2. `npm ci`; ensure `.env.local` has the dev Supabase URL + anon key, and `.env.e2e.local` has the nine `E2E_USER_*` / `E2E_A_*` values from #28
3. `npx playwright test qa/e2e/bola.spec.ts --project=desktop` → **9 passed**
4. **Delete or rename `.env.e2e.local` and re-run** → must **SKIP** with a stated reason, never pass. This is the important check: a BOLA test that runs without fixtures proves nothing, and a vacuous pass is indistinguishable from a real one
5. `npm run test:e2e` → **187 passed / 0 failed / 47 skipped**
6. `npx tsc --noEmit` clean; `npm run lint` 0 errors

## Risk level

**Low** — test tooling and CI config only, no application code. Worst case is a red check, not a user-facing defect.

## Note on the service-role key

It is deliberately **not** in CI and must never be. It bypasses RLS entirely, which is precisely the property this spec exists to verify — putting it in the test environment would make the suite unable to detect the thing it was written to detect.

## Not covered, stated plainly

The trade journal has no API route — `TradeJournal.tsx` queries Supabase directly from the browser, so its protection is RLS alone. That is covered by the direct-PostgREST test using `E2E_A_TRADE_ID`, but there is no API-route BOLA surface to probe. If a journal API route is ever added, this spec needs a case for it.
