### PR TITLE
fix(arena): make the hover-opened scanner dismissable and self-closing

### DIFF
--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -208,6 +208,10 @@ function ArenaContent() {
   const [jpyUsd, setJpyUsd]                 = useState<number | null>(null);
   const scannerRef      = useRef<HTMLDivElement>(null);
   const hoverOpenTimer  = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /* Whether the scanner was opened by hover rather than by a click. Only a
+     hover-opened panel closes again on mouse-out - closing a click-opened one
+     the moment the pointer drifts off would make it unusable. */
+  const openedByHover   = useRef(false);
 
   /* ── Price alert mini-form ── */
   const [alertFormOpen, setAlertFormOpen] = useState(false);
@@ -303,14 +307,54 @@ function ArenaContent() {
     }).catch(() => {});
   }
 
-  // Hover over trigger → auto-open; moving away cancels the timer
+  /* Hover over the trigger auto-opens the scanner after 800ms.
+   *
+   * That behaviour is deliberate and is kept. What was missing is everything
+   * WCAG 2.1 SC 1.4.13 (Content on Hover or Focus, AA) requires of content
+   * triggered by pointer hover. Measured before this change: Escape did nothing
+   * and moving the pointer away left the panel open indefinitely, so a user who
+   * merely passed over the bar on the way somewhere else was left with a panel
+   * covering the page and no way to dismiss it without clicking. QA filed it as
+   * issue #31 after we established it predates PR #29.
+   *
+   * The three requirements, and where each is now met:
+   *   Dismissable - Escape closes it, without moving the pointer. See the
+   *                 keydown effect below.
+   *   Hoverable   - the mouseleave lives on the wrapper that contains BOTH the
+   *                 bar and the flyout, so moving the pointer from one into the
+   *                 other never fires it. The panel survives being hovered.
+   *   Persistent  - it stays until the pointer leaves the whole widget, Escape,
+   *                 or a click outside. Nothing times it out from under you.
+   *
+   * A click-opened panel is deliberately NOT closed by mouse-out; only a
+   * hover-opened one is, which is what openedByHover tracks. */
   const handleScannerHoverEnter = () => {
     if (scannerOpen) return;
-    hoverOpenTimer.current = setTimeout(() => setScannerOpen(true), 800);
+    hoverOpenTimer.current = setTimeout(() => {
+      openedByHover.current = true;
+      setScannerOpen(true);
+    }, 800);
   };
   const handleScannerHoverLeave = () => {
     if (hoverOpenTimer.current) { clearTimeout(hoverOpenTimer.current); hoverOpenTimer.current = null; }
+    if (openedByHover.current) {
+      openedByHover.current = false;
+      setScannerOpen(false);
+    }
   };
+
+  // SC 1.4.13 "Dismissable": Escape must close it without moving the pointer.
+  useEffect(() => {
+    if (!scannerOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        openedByHover.current = false;
+        setScannerOpen(false);
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [scannerOpen]);
 
   // Close scanner when clicking anywhere outside the scanner widget
   useEffect(() => {
@@ -1172,7 +1216,16 @@ function ArenaContent() {
             whose Enter/Space fires a click that bubbles up to this handler -
             which is why that button needs no onClick of its own. */}
         <div
-          onClick={() => { setScannerOpen(v => { if (v) setScannerSearch(''); return !v; }); if (!scannerOpen) setTimeout(() => scannerSearchRef.current?.focus(), 60); }}
+          onClick={() => {
+            /* A deliberate click takes ownership of the panel: clear the
+               hover flag so drifting the pointer away no longer closes it,
+               and cancel any pending hover-open so it cannot reopen behind
+               a click that just closed it. */
+            openedByHover.current = false;
+            if (hoverOpenTimer.current) { clearTimeout(hoverOpenTimer.current); hoverOpenTimer.current = null; }
+            setScannerOpen(v => { if (v) setScannerSearch(''); return !v; });
+            if (!scannerOpen) setTimeout(() => scannerSearchRef.current?.focus(), 60);
+          }}
           style={{
             width: '100%', display: 'flex', alignItems: 'center', gap: 8,
             padding: '7px 12px', borderRadius: 8,


### PR DESCRIPTION
Closes #31.

## Summary

The scanner panel keeps opening on 800ms hover — the behaviour is deliberate and I kept it. What was missing is everything **WCAG 2.1 SC 1.4.13 Content on Hover or Focus (AA)** requires of hover-triggered content. It met none of the three.

## Why this is a defect, not a preference

The question in #31 was "is hover-to-open intended?" I think the honest answer is: the *opening* clearly was — someone wrote an 800ms timer on purpose. The rest was not considered. Measured on `dev` before this change:

| SC 1.4.13 requirement | Before |
|---|---|
| **Dismissable** without moving the pointer | ❌ Escape did nothing |
| **Hoverable** — pointer can enter the content | ✅ (already fine) |
| **Persistent** — stays until dismissed | ⚠️ stayed *forever*, even on mouse-out |

So a user who merely passed over the coin bar on the way somewhere else was left with a panel covering the page and no way to dismiss it except clicking. That is a conformance failure, which takes it out of "product preference" territory.

## What changed

- **Escape closes it**, without moving the pointer.
- **Mouse-out closes it — but only if hover opened it.** `openedByHover` tracks the gesture. Closing a *click*-opened panel the instant the pointer drifts off would make it unusable.
- **A click clears any pending hover timer**, so the panel cannot reopen behind a click that just closed it.
- `mouseleave` stays on the wrapper containing **both** the bar and the flyout, so moving from one into the other never fires it — that is what keeps "Hoverable" satisfied.

## Verification

Production build, 8 checks:

```
1. starts closed                                OK
2. hover still opens it (feature kept)          OK
3. Escape dismisses (1.4.13 Dismissable)        OK
4. hover reopens after Escape                   OK
5. closes on mouse-out when hover-opened        OK
6. click opens it                               OK
7. click-opened SURVIVES mouse-out              OK
8. Escape closes click-opened too               OK
```

Gates: `tsc` clean · `npm test` 75 passing · lint 0 errors / 94 warnings.

## Credit where it is due

@JohnDominicJasmin (QA) found this while reviewing PR #29, originally reported it as a click regression, then re-measured on both builds and filed #31 with a clean before/after showing it predates #29. The evidence in that issue — polling every 250ms and showing the open lands in the 750–1000ms bucket on *both* builds — is what made this diagnosable rather than arguable.

I was wrong first in that exchange too: my own probe reported the bell click as safe because it compared a before/after count that my own earlier hover had already contaminated.

## How to test (QA)

On `/arena`:

1. **Hover the coin bar, do not click.** Panel opens after ~1s. (Unchanged.)
2. Press <kbd>Esc</kbd> → closes. **This is the new bit.**
3. Hover again, then move the mouse away without clicking → closes on its own.
4. **Click** the bar to open it, then move the mouse away → it must **stay open**. This is the regression risk of the change.
5. <kbd>Esc</kbd> closes that one too.
6. With the panel open, move the pointer from the bar **down into the panel** → must not close.
7. Click outside → still closes, as before.

## Risk level

**Low.** Contained to one widget's open/close logic on one route. No data path, no API, no styling. Step 4 is the case most likely to break.