### PR TITLE
Release 2026-08-06: BOLA/IDOR coverage, API status codes, /arena accessibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,11 @@ jobs:
   e2e:
     name: E2E (Playwright)
     runs-on: ubuntu-latest
+    # A full run is ~31 minutes. Without a cap, a genuinely hung run burns to
+    # GitHub's 6-hour default, and a stuck run looks identical to a slow one -
+    # which happened while this suite was being brought up. 45 leaves headroom
+    # for a cold runner without hiding a hang.
+    timeout-minutes: 45
     # Only after lint/typecheck/unit/build are green. A broken build would
     # produce 216 browser failures that all say "the build is broken", which
     # buries the one line that actually explains it.
@@ -108,6 +113,32 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
           NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ secrets.E2E_TURNSTILE_SITE_KEY }}
+
+          # Authenticated fixtures for qa/e2e/bola.spec.ts - BOLA/IDOR, the one
+          # spec that signs in. Two seeded accounts on the DEV Supabase project
+          # only. A holds one row per table under test; B is deliberately empty,
+          # because the test is "B asks for A's rows by id and must be refused".
+          #
+          # Passwords rather than tokens on purpose: a Supabase access token
+          # expires in about an hour, so a pasted token passes once and then
+          # fails CI the next day. The spec mints a fresh token per run.
+          #
+          # These are ordinary user-level accounts. The service-role key is NOT
+          # here and must never be - it bypasses RLS entirely, which is exactly
+          # what this spec exists to verify.
+          #
+          # Absent, bola.spec.ts SKIPS with a stated reason rather than passing.
+          # A BOLA test that runs without fixtures proves nothing, and a vacuous
+          # pass is indistinguishable from a real one.
+          E2E_USER_A_EMAIL: ${{ secrets.E2E_USER_A_EMAIL }}
+          E2E_USER_A_PASSWORD: ${{ secrets.E2E_USER_A_PASSWORD }}
+          E2E_USER_A_ID: ${{ secrets.E2E_USER_A_ID }}
+          E2E_USER_B_EMAIL: ${{ secrets.E2E_USER_B_EMAIL }}
+          E2E_USER_B_PASSWORD: ${{ secrets.E2E_USER_B_PASSWORD }}
+          E2E_USER_B_ID: ${{ secrets.E2E_USER_B_ID }}
+          E2E_A_TRADE_ID: ${{ secrets.E2E_A_TRADE_ID }}
+          E2E_A_HYPOTHESIS_ID: ${{ secrets.E2E_A_HYPOTHESIS_ID }}
+          E2E_A_PRICE_ALERT_ID: ${{ secrets.E2E_A_PRICE_ALERT_ID }}
 
       # Uploaded on failure too - that is the run you actually need to read.
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,26 @@ jobs:
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
           NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ secrets.E2E_TURNSTILE_SITE_KEY }}
 
+          # Selects the lhq_dev_ table prefix. NOT optional, and not a nicety:
+          # lib/tables.ts reads
+          #     NEXT_PUBLIC_APP_ENV === 'dev' ? 'lhq_dev_' : 'lhq_'
+          # so anything that is not exactly 'dev' - INCLUDING undefined, which is
+          # what CI had - selects the PRODUCTION table names. CI then queried
+          # lhq_hypotheses / lhq_price_alerts against the dev project, which has
+          # neither (only lhq_dev_* exist there, plus lhq_signup_ip_log). Every
+          # such query errored and apiError mapped it to a 500.
+          #
+          # That is why bola.spec.ts saw GET /api/hypotheses return 500 to
+          # account A for A's OWN rows - nothing to do with authorization. It
+          # also means every authenticated CI run before this line existed was
+          # querying tables that were not there, so those runs asserted less
+          # than they appeared to.
+          #
+          # Belongs in THIS step, not the build step: NEXT_PUBLIC_* is inlined at
+          # build time, and playwright.config.ts's webServer runs
+          # `npm run build && npm start` as a child of this step, inheriting env.
+          NEXT_PUBLIC_APP_ENV: dev
+
           # Authenticated fixtures for qa/e2e/bola.spec.ts - BOLA/IDOR, the one
           # spec that signs in. Two seeded accounts on the DEV Supabase project
           # only. A holds one row per table under test; B is deliberately empty,

--- a/app/api/hypotheses/[id]/route.ts
+++ b/app/api/hypotheses/[id]/route.ts
@@ -30,15 +30,29 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     if (k in body) update[k] = body[k];
   }
 
+  /* maybeSingle, not single. The .eq('user_id') above is the ownership filter,
+     so an update aimed at somebody else's row - or at an id that does not exist
+     - legitimately matches ZERO rows. single() treats that as the error
+     PGRST116 and apiError turned it into a 500, so every authorization denial
+     on this route looked identical to a genuine server fault. Found by QA's
+     BOLA suite: a PATCH against a UUID that exists nowhere returned 500 too,
+     which is what isolated it from anything to do with entitlements.
+     The data was never at risk - it failed closed - but you cannot alert on
+     500s when refusals are also 500s. */
   const { data, error } = await sb(token)
     .from(T.hypotheses)
     .update(update)
     .eq('id', id)
     .eq('user_id', authData.user.id)
     .select()
-    .single();
+    .maybeSingle();
 
   if (error) return apiError('hypotheses/[id]', error);
+  /* 404, not 403. 403 would confirm the row exists and belongs to someone else,
+     which hands an attacker a working existence oracle for enumerating ids.
+     404 is the same answer for "no such row" and "not yours", so it leaks
+     nothing while still being an honest, alertable status code. */
+  if (!data) return NextResponse.json({ error: 'Not found' }, { status: 404 });
   return NextResponse.json({ hypothesis: data });
 }
 

--- a/app/api/price-alerts/route.ts
+++ b/app/api/price-alerts/route.ts
@@ -20,10 +20,18 @@ async function getUser(token: string) {
 }
 
 export async function GET(req: NextRequest) {
+  /* 401, not an empty 200. This used to answer `{ alerts: [] }` to anyone,
+     which exposed nothing - the list really was empty - but it was the only
+     one of the three user-data routes to do so: /api/hypotheses and
+     /api/settings both 401. An unauthenticated caller receiving 200 from a
+     user-data endpoint stops being harmless the moment someone adds a default
+     or a shared row, and the inconsistency is exactly what makes that easy to
+     miss. Found by QA's BOLA suite. Callers already handle 401 from the two
+     sibling routes, and the client only requests this when signed in. */
   const token = req.headers.get('Authorization')?.replace('Bearer ', '');
-  if (!token) return NextResponse.json({ alerts: [] });
+  if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   const user = await getUser(token);
-  if (!user) return NextResponse.json({ alerts: [] });
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   const { data, error } = await sb(token)
     .from(T.price_alerts)
@@ -92,15 +100,22 @@ export async function PATCH(req: NextRequest) {
   if (body.direction !== undefined)    patch.direction    = body.direction;
   if (Object.keys(patch).length === 0) return NextResponse.json({ error: 'nothing to update' }, { status: 400 });
 
+  /* maybeSingle, not single - see the same fix in app/api/hypotheses/[id].
+     .eq('user_id') is the ownership filter, so patching someone else's alert
+     matches zero rows, and single() reported that as PGRST116 which apiError
+     turned into a 500. Authorization denials were indistinguishable from server
+     faults in the logs. */
   const { data, error } = await sb(token)
     .from(T.price_alerts)
     .update(patch)
     .eq('id', id)
     .eq('user_id', user.id)
     .select()
-    .single();
+    .maybeSingle();
 
   if (error) return apiError('price-alerts', error);
+  // 404 rather than 403 so the response is not an existence oracle for ids.
+  if (!data) return NextResponse.json({ error: 'Not found' }, { status: 404 });
   return NextResponse.json({ alert: data });
 }
 
@@ -114,12 +129,21 @@ export async function DELETE(req: NextRequest) {
   const id = searchParams.get('id');
   if (!id) return NextResponse.json({ error: 'id required' }, { status: 400 });
 
-  const { error } = await sb(token)
+  /* .select() so we can tell "deactivated a row" from "matched nothing".
+     Without it this answered `{ ok: true }` to a delete aimed at someone else's
+     alert, having changed nothing - Supabase reports success for an UPDATE that
+     matches zero rows. Never a security hole, and QA's suite proved the row
+     survives, but "ok" for a no-op is the same ambiguity as the 500 above, just
+     pointing the other way. Not flagged as a defect; fixed for consistency with
+     PATCH so both say what actually happened. */
+  const { data, error } = await sb(token)
     .from(T.price_alerts)
     .update({ active: false })
     .eq('id', id)
-    .eq('user_id', user.id); // ownership check - prevents deleting other users' alerts
+    .eq('user_id', user.id) // ownership check - prevents deleting other users' alerts
+    .select('id');
 
   if (error) return apiError('price-alerts', error);
+  if (!data?.length) return NextResponse.json({ error: 'Not found' }, { status: 404 });
   return NextResponse.json({ ok: true });
 }

--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -208,6 +208,10 @@ function ArenaContent() {
   const [jpyUsd, setJpyUsd]                 = useState<number | null>(null);
   const scannerRef      = useRef<HTMLDivElement>(null);
   const hoverOpenTimer  = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /* Whether the scanner was opened by hover rather than by a click. Only a
+     hover-opened panel closes again on mouse-out - closing a click-opened one
+     the moment the pointer drifts off would make it unusable. */
+  const openedByHover   = useRef(false);
 
   /* ── Price alert mini-form ── */
   const [alertFormOpen, setAlertFormOpen] = useState(false);
@@ -303,14 +307,54 @@ function ArenaContent() {
     }).catch(() => {});
   }
 
-  // Hover over trigger → auto-open; moving away cancels the timer
+  /* Hover over the trigger auto-opens the scanner after 800ms.
+   *
+   * That behaviour is deliberate and is kept. What was missing is everything
+   * WCAG 2.1 SC 1.4.13 (Content on Hover or Focus, AA) requires of content
+   * triggered by pointer hover. Measured before this change: Escape did nothing
+   * and moving the pointer away left the panel open indefinitely, so a user who
+   * merely passed over the bar on the way somewhere else was left with a panel
+   * covering the page and no way to dismiss it without clicking. QA filed it as
+   * issue #31 after we established it predates PR #29.
+   *
+   * The three requirements, and where each is now met:
+   *   Dismissable - Escape closes it, without moving the pointer. See the
+   *                 keydown effect below.
+   *   Hoverable   - the mouseleave lives on the wrapper that contains BOTH the
+   *                 bar and the flyout, so moving the pointer from one into the
+   *                 other never fires it. The panel survives being hovered.
+   *   Persistent  - it stays until the pointer leaves the whole widget, Escape,
+   *                 or a click outside. Nothing times it out from under you.
+   *
+   * A click-opened panel is deliberately NOT closed by mouse-out; only a
+   * hover-opened one is, which is what openedByHover tracks. */
   const handleScannerHoverEnter = () => {
     if (scannerOpen) return;
-    hoverOpenTimer.current = setTimeout(() => setScannerOpen(true), 800);
+    hoverOpenTimer.current = setTimeout(() => {
+      openedByHover.current = true;
+      setScannerOpen(true);
+    }, 800);
   };
   const handleScannerHoverLeave = () => {
     if (hoverOpenTimer.current) { clearTimeout(hoverOpenTimer.current); hoverOpenTimer.current = null; }
+    if (openedByHover.current) {
+      openedByHover.current = false;
+      setScannerOpen(false);
+    }
   };
+
+  // SC 1.4.13 "Dismissable": Escape must close it without moving the pointer.
+  useEffect(() => {
+    if (!scannerOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        openedByHover.current = false;
+        setScannerOpen(false);
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [scannerOpen]);
 
   // Close scanner when clicking anywhere outside the scanner widget
   useEffect(() => {
@@ -1172,7 +1216,16 @@ function ArenaContent() {
             whose Enter/Space fires a click that bubbles up to this handler -
             which is why that button needs no onClick of its own. */}
         <div
-          onClick={() => { setScannerOpen(v => { if (v) setScannerSearch(''); return !v; }); if (!scannerOpen) setTimeout(() => scannerSearchRef.current?.focus(), 60); }}
+          onClick={() => {
+            /* A deliberate click takes ownership of the panel: clear the
+               hover flag so drifting the pointer away no longer closes it,
+               and cancel any pending hover-open so it cannot reopen behind
+               a click that just closed it. */
+            openedByHover.current = false;
+            if (hoverOpenTimer.current) { clearTimeout(hoverOpenTimer.current); hoverOpenTimer.current = null; }
+            setScannerOpen(v => { if (v) setScannerSearch(''); return !v; });
+            if (!scannerOpen) setTimeout(() => scannerSearchRef.current?.focus(), 60);
+          }}
           style={{
             width: '100%', display: 'flex', alignItems: 'center', gap: 8,
             padding: '7px 12px', borderRadius: 8,

--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -1156,8 +1156,22 @@ function ArenaContent() {
         onMouseEnter={handleScannerHoverEnter}
         onMouseLeave={handleScannerHoverLeave}
       >
-        {/* ── Compact trigger bar ── */}
-        <button
+        {/* ── Compact trigger bar ──
+            The bar itself is a plain <div>, not a <button>. It used to be a
+            button, which made the notification bell further down a control
+            nested inside a control - axe's nested-interactive rule, and the
+            reason the bell was already a div[role=button] rather than a
+            <button>. That earlier change only dodged the invalid-HTML half of
+            the problem; the accessibility tree still saw a control inside a
+            control, so screen readers announce one thing and expose two.
+
+            This div carries the onClick so clicking anywhere on the bar still
+            toggles, but deliberately has NO role and NO tabIndex: axe only
+            treats focusable or role-bearing ancestors as interactive, so a bare
+            div is not one. Keyboard access comes from the real <button> inside,
+            whose Enter/Space fires a click that bubbles up to this handler -
+            which is why that button needs no onClick of its own. */}
+        <div
           onClick={() => { setScannerOpen(v => { if (v) setScannerSearch(''); return !v; }); if (!scannerOpen) setTimeout(() => scannerSearchRef.current?.focus(), 60); }}
           style={{
             width: '100%', display: 'flex', alignItems: 'center', gap: 8,
@@ -1167,6 +1181,16 @@ function ArenaContent() {
             cursor: 'pointer', textAlign: 'left', transition: 'background 0.15s, border-color 0.15s',
           }}
         >
+          {/* The actual control: carries the accessible name and aria-expanded,
+              and fills the bar so the click target is unchanged. */}
+          <button
+            aria-expanded={scannerOpen}
+            style={{
+              flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', gap: 8,
+              background: 'none', border: 'none', padding: 0, margin: 0,
+              color: 'inherit', font: 'inherit', textAlign: 'left', cursor: 'pointer',
+            }}
+          >
           {/* Dot indicator */}
           <span style={{
             width: 6, height: 6, borderRadius: '50%', flexShrink: 0,
@@ -1214,7 +1238,15 @@ function ArenaContent() {
               </span>
             );
           })()}
-          {/* Notification bell - div to avoid button-in-button invalid HTML */}
+          </button>
+
+          {/* Notification bell - now a SIBLING of the trigger button, not a
+              child of it. Kept as div[role=button] rather than reverted to a
+              real <button> only because the surrounding markup has not changed
+              otherwise; either is valid here now that it is not nested.
+              stopPropagation matters more than before: this sits inside the
+              bar's onClick, so without it enabling notifications would also
+              toggle the scanner panel. */}
           <div
             role="button"
             tabIndex={0}
@@ -1241,8 +1273,10 @@ function ArenaContent() {
               {!notifEnabled && <line x1="2" y1="2" x2="22" y2="22" />}
             </svg>
           </div>
-          <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)', flexShrink: 0 }}>{scannerOpen ? '▲' : '▼'}</span>
-        </button>
+          {/* Decorative: aria-expanded on the trigger button already conveys
+              this state, so announcing an arrow glyph on top of it is noise. */}
+          <span aria-hidden="true" style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)', flexShrink: 0 }}>{scannerOpen ? '▲' : '▼'}</span>
+        </div>
 
         {/* ── Flyout panel (appears on hover / click) ── */}
         {scannerOpen && (
@@ -1912,14 +1946,20 @@ function ArenaContent() {
               transition: 'left 0.25s cubic-bezier(0.34, 1.56, 0.64, 1)',
             }} />
           </span>
-          <Tip
-            width={260}
-            iconColor="rgba(255,255,255,0.6)"
-            text={t('ARENA_ANTICHOP_TIP')}
-          >
-            <span style={{ opacity: 0.8, letterSpacing: '0.01em' }}>{t('ARENA_ANTICHOP_LABEL')}</span>
-          </Tip>
+          <span style={{ opacity: 0.8, letterSpacing: '0.01em' }}>{t('ARENA_ANTICHOP_LABEL')}</span>
         </button>
+        {/* Tip sits OUTSIDE the button, not wrapped around its label.
+            Tip's trigger became a real focusable control when it was made
+            keyboard operable, so nesting it inside this button produced a
+            control inside a control - axe nested-interactive. It is the only
+            constraint that component carries: Tip must never be rendered inside
+            a <button>, <a>, or anything with an interactive role.
+            The label stays inside the button so clicking it still toggles. */}
+        <Tip
+          width={260}
+          iconColor="rgba(255,255,255,0.6)"
+          text={t('ARENA_ANTICHOP_TIP')}
+        />
         {/* opacity 0.35 computed to #55565b = 2.75:1. This hint explains what
             the anti-chop toggle beside it actually does, so it has to be
             readable; --txt-dim carries the same de-emphasis at 5.80:1. */}

--- a/components/Tip.tsx
+++ b/components/Tip.tsx
@@ -4,7 +4,13 @@ import { createPortal } from 'react-dom';
 
 interface TipProps {
   text: string;
-  children: React.ReactNode;
+  /* Optional. Tip usually wraps the label it explains, but where that label
+     lives inside a <button> the Tip has to sit outside it - its trigger is a
+     real focusable control, and a control inside a control is an
+     axe nested-interactive violation. Rendering <Tip text={...} /> with no
+     children gives a standalone ⓘ for exactly that case. See the anti-chop
+     toggle in app/arena. */
+  children?: React.ReactNode;
   width?: number;
   iconColor?: string;
 }

--- a/pendings/QA_A11Y_FINDINGS_2026-08-05.md
+++ b/pendings/QA_A11Y_FINDINGS_2026-08-05.md
@@ -196,6 +196,37 @@ rather than to keys.
 **Not introduced by the 2026-08-05 release** — `LabelsProvider.tsx` is not in
 that diff. Pre-existing and unrelated to it.
 
+#### This is also what is keeping CI red — fixing it fixes both
+
+Established after the owner added the three `E2E_*` repo secrets. They worked:
+
+```
+"supabaseUrl is required"     →   0 occurrences
+"Missing Supabase admin env"  → 464 occurrences
+```
+
+The `NEXT_PUBLIC_*` values are now present. What is still missing is
+`SUPABASE_SERVICE_ROLE_KEY`, which `/api/labels` needs because it reads through
+`getSupabaseAdmin()`. **That key should not be added to CI** — it bypasses RLS
+entirely, and putting it in a CI environment is a materially worse trade than
+leaving four tests red.
+
+All four remaining `e2e` failures are downstream of this one defect:
+
+| Failing test | Why |
+|---|---|
+| `/login renders its form` (desktop + mobile) | the spec matches the text "Sign in to your account", which is **itself a label** — it renders as a raw key |
+| `/arena has no horizontal overflow` | raw keys are longer than their English strings, widening the layout by 28px |
+| `/markets CLS 0.255` | the same raw-key text reflowing during load |
+
+If `LabelsProvider` kept its English seed when the response is empty, CI would
+render English and all four would pass **without any service-role key**.
+
+So this one small fix does three things: removes a latent production failure
+mode, turns four red CI tests green, and avoids putting the most dangerous key
+in the project into a CI environment. It is the highest value-per-line change
+currently on the list.
+
 ---
 
 ## 2. ⚠️ Correction to our own finding — the tap-target number is mislabelled

--- a/pendings/QA_A11Y_FINDINGS_2026-08-05.md
+++ b/pendings/QA_A11Y_FINDINGS_2026-08-05.md
@@ -332,6 +332,35 @@ independently: `components/BeamsBackground.tsx` runs an uncapped
 `prefers-reduced-motion` check anywhere in the file. That is WCAG 2.2.2 Pause,
 Stop, Hide at **Level A**, on the public marketing homepage.
 
+### How much to trust that source-level audit
+
+Enough to investigate every item. Not enough to action any of them unchecked.
+Its own severity ratings did not survive contact with a browser:
+
+| Its claim | What running it showed |
+|---|---|
+| A11Y-10 (tab order), Critical | **Confirmed — and understated.** It estimated ~40 phantom tab stops; the real figure is 86 of 106 focusable controls, more than double |
+| A11Y-7 (`Tip.tsx`), Critical | **Confirmed exactly.** 8 triggers on `/dashboard`, 0 focusable |
+| A11Y-14 (Settings labels), Critical | **Could not be tested at all.** `/settings` renders zero form controls signed out |
+
+That third row is the one to keep in mind. Its scorecard rates A11Y-14 as
+**Critical** — a runtime severity — for a surface it never executed, because a
+static reader cannot tell the difference between "this input has no label" and
+"this input does not render for you". The finding may well be correct. The
+*confidence* attached to it is not earned, and the scorecard presents both
+kinds of claim identically.
+
+So: treat the source-level items as **leads with file:line attached**, which is
+genuinely valuable, and let the runtime check set the severity. Two of three
+Critical claims held up, which is a decent hit rate — but the one that did not
+is indistinguishable from the others by looking at the report alone.
+
+This is the same failure mode QA hit twice today from the other direction: a
+harness reporting 217 "WCAG failures" that axe passes, and a 3-run `/scanner`
+sample that reversed at 10 runs. Static analysis over-asserts about runtime;
+undersampled measurement over-asserts about stability. Both need the other to
+check them.
+
 ---
 
 ## 5. Blocking asks

--- a/pendings/QA_A11Y_FINDINGS_2026-08-05.md
+++ b/pendings/QA_A11Y_FINDINGS_2026-08-05.md
@@ -16,6 +16,61 @@ installed **outside** the project so `package.json` is untouched.
 
 ---
 
+## 0a. RESOLUTION — added by dev, 2026-08-05
+
+**All four confirmed defects in section 1 are fixed**, merged to `dev` via PR #27
+(`31de814`..`e516406`) and promoted to `qa`. QA's findings below are left exactly
+as written; this section records what closed them, so the record shows the
+finding and the fix separately rather than a doc that quietly agrees with itself.
+
+| # | Finding | Status | Fix |
+|---|---|---|---|
+| 1.1 | 86 focusable controls inside closed panels | ✅ Fixed | `inert` + `aria-hidden` on `.gchat-panel` (65 controls) and `.nav-drawer` (23) |
+| 1.2 | `Tip.tsx` "ⓘ" unreachable by keyboard, 55 call sites | ✅ Fixed | focusable `role="button"`, opens on focus, Enter/Space toggles, Escape dismisses, `role="tooltip"` + `aria-describedby`, 24×24 hit area |
+| 1.3 | `#1A7AFF` + white = 3.98:1 | ✅ Fixed | new `--accent-solid` `#1668e3` = 5.09:1, applied to 27 filled-accent surfaces |
+| 1.4 | Failed labels fetch wipes the English fallback | ✅ Fixed | empty/malformed payload guarded; real payloads merged **over** the defaults so a partial response degrades to English, not to raw keys. 6 tests in `__tests__/labelsFallback.test.mts` |
+| 2 | Tap-target number is mislabelled | ✅ Accepted | baseline 217 → 122 and the metric renamed (PR #26). Independently reproduced: 122, all of them `<a>`, i.e. 100% SC 2.5.8 inline-exempt. **Real WCAG failures: 0** |
+| 3 | `/scanner` CLS | ✅ Closed | retired from `CLS_UNSTABLE` to a real `CLS_BUDGET` of 0.25 (PR #22). 24 runs on the shipped build: warm min 0.007, median 0.011, max 0.028 |
+
+### Two things QA got right that dev did not
+
+**§1.4 was found sideways, and that is the point.** It surfaced as two failures
+that looked like unrelated product bugs — `/arena` overflowing 28px and a
+`/login` smoke failure. Both were raw i18n keys being longer than their English
+strings: `HOURS_WIN_LONDON_BADGE` (22 chars) rendering instead of `LONDON OPEN`
+(11) *is* the 28px, and `LOGIN_SUBTITLE_SIGNIN` instead of "Sign in to your
+account" is why `getByText` matched nothing. Fixing labels took CI from
+**4 failed / 173 passed** to **177 passed**. Neither was ever a responsive
+defect or an auth defect.
+
+**QA's escalation was the diagnostic.** The observation that all three open PRs
+failed identically — *including a documentation-only PR with zero code* — is
+what proved it was environmental rather than any branch's content. That reframed
+a latent bug into a blocker on every future PR in the repo.
+
+### One correction dev owes this document
+
+§1.3 was the only correct contrast figure anyone had. Audit §4.3 put the total
+at **32** failures and blamed the brand blue. Measured with axe across 8 routes
+on a production build it was **270**, of which the brand blue was 20. Three
+systemic causes did the rest: ~57 hardcoded greys bypassing the token system,
+five `opacity` multipliers stacked on a `--txt3` already tuned to the AA line,
+and `.lp-root` re-declaring `--txt3` and silently reverting an earlier AA fix on
+the landing page. Now **0**, verified against staging itself.
+
+Dev also posted a wrong tap-target count on PR #25 (93 "genuine failures") from
+a sweep that modelled neither SC 2.5.8 exception — the same class of error as
+the audit's 159. QA's correction in section 2 stands.
+
+### Still open from this document
+
+- **§4 — the authenticated surface has never been tested.** Unchanged. None of
+  the above touches it.
+- **§5.1 — two seeded test accounts.** Still the blocking ask, still owner/dev.
+  This is the single highest-value unblock on the board.
+
+---
+
 ## 0. Status summary
 
 | | |

--- a/pendings/QA_A11Y_FINDINGS_2026-08-05.md
+++ b/pendings/QA_A11Y_FINDINGS_2026-08-05.md
@@ -1,0 +1,398 @@
+# QA — accessibility findings + the authenticated-surface gap, 2026-08-05
+
+**Run by:** the QA session. **No application code was modified.** Everything here
+is a finding handed to the development session.
+
+Follow-up to `pendings/QA_E2E_FINDINGS_2026-08-05.md` (first execution of the
+E2E suite) and `pendings/QA_AUDIT_2026-08-04.md` (the original sweep). Where
+this document disagrees with either, the disagreement was measured, and the
+measurement is shown.
+
+**Method.** axe-core 4.x driven by Playwright against a production build of the
+2026-08-05 release, WCAG 2.0/2.1/2.2 A + AA rule sets, at desktop 1440×900 and
+at iPhone 13 mobile metrics. Plus a source-level static review, whose claims
+were then re-tested at runtime — two of three confirmed, one untestable. axe was
+installed **outside** the project so `package.json` is untouched.
+
+---
+
+## 0. Status summary
+
+| | |
+|---|---|
+| Confirmed defects handed to dev | 4 |
+| Corrections to our own prior findings | 1 |
+| Findings that could not be tested (need auth) | 6 |
+| Blocking asks remaining | 1 (test accounts — the CI secrets are now set) |
+
+**The single most important line in this document:** every QA result this project
+has ever produced covers the **signed-out** surface only. The authenticated half
+of the app — Settings, TradeJournal, Alerts, the chat panel — has never been
+examined by anyone, by any method. See §4.
+
+---
+
+## 1. 🔴 Confirmed defects
+
+### 1.1 81% of every page's tab stops are inside closed, invisible panels
+
+**Severity: Critical. Every route. Predates all of 2026-08-05's work.**
+
+`components/NavDrawer.tsx` (`.nav-menu`) and `components/GrokChat.tsx`
+(`.gchat-panel`) stay mounted when closed, hidden only via `opacity`,
+`transform` and `pointer-events`. None of those remove an element from the tab
+order or the accessibility tree.
+
+Measured on `/dashboard`, production build:
+
+```
+nav-menu     opacity=1  pointerEvents=none  inert=false  FOCUSABLE_INSIDE=22
+gchat-panel  opacity=0  pointerEvents=none  inert=false  FOCUSABLE_INSIDE=64
+page focusables=106   before <main>=36
+```
+
+86 of 106 focusable controls sit in panels the user cannot see. Empirically the
+**10th Tab press** lands inside the hidden drawer:
+
+```
+ 9. button.lang-nav-btn "EN"
+10. input.nav-search        <<IN CLOSED NAV-MENU>>
+11. a.nav-tile "Dashboard"  <<IN CLOSED NAV-MENU>>
+12. a.nav-tile "Briefing"   <<IN CLOSED NAV-MENU>>
+```
+
+A keyboard user tabs through ~22 invisible drawer controls before reaching page
+content, and ~64 invisible chat-panel controls before the footer. A screen
+reader's link-by-link navigation surfaces the same phantom stops.
+
+**WCAG:** 2.4.3 Focus Order (A), 1.3.2 Meaningful Sequence (A).
+
+**Fix direction:** conditionally render when closed — which `SettingsModal`,
+`UsageModal` and `UpgradeGateModal` already do correctly in this codebase — or
+add the `inert` attribute (`<div className="nav-menu" inert={!drawerOpen}>`;
+React 19 passes boolean `inert` straight through).
+
+**Repro:** load any page, press Tab from the address bar, count focus stops
+before `<main>` is reached. Expect the visible nav only.
+
+### 1.2 The shared "ⓘ" tooltip trigger is unreachable by keyboard
+
+**Severity: Critical. One component, 55 call sites across 31 files.**
+
+`components/Tip.tsx:41-46` renders a `<span>` carrying `onClick` and
+`onMouseEnter`, with no `tabIndex`, no `role` and no `onKeyDown`.
+
+Measured on `/dashboard`:
+
+```
+inline-flex spans containing "ⓘ": 8
+  keyboard-focusable: 0    role: 0    tabindex: 0
+```
+
+A keyboard-only user cannot focus any of them, so the click handler is
+unreachable for that user regardless of what it does.
+
+**WCAG:** 2.1.1 Keyboard (A).
+
+**Fix direction:** make the trigger a real `<button type="button">`, add
+`onFocus`/`onBlur` alongside the existing mouse handlers so focus opens the tip,
+give the portalled tooltip `role="tooltip"` and an `id`, and reference it from
+the trigger via `aria-describedby`. One component fixes all 55 sites.
+
+### 1.3 Colour contrast — audit §4.3 CONFIRMED by an independent tool
+
+Audit §4.3 ends with an explicit instruction that had never been carried out:
+
+> **Before acting on this section, run a real tool** (axe-core, Lighthouse, or
+> Chrome DevTools' own contrast picker) to confirm.
+
+Done. axe-core, WCAG A+AA, desktop:
+
+```
+[serious] color-contrast — 37 nodes across 9 routes
+  .nav-more-btn.on.desktop-nav-item
+    contrast 3.98  (foreground #ffffff, background #1a7aff, 16px normal)
+```
+
+axe independently reproduces **3.98:1** — matching to two decimals the figure
+produced by a checker its own author had flagged as unreliable. Also confirmed:
+
+| Ratio | Where | Colours |
+|---|---|---|
+| **3.98** | every active nav pill + the primary CTA | `#ffffff` on `#1a7aff` |
+| **2.06** | `/scanner`, 21 nodes | `#444444` on `#06070a` |
+| **3.79** | `/scanner` `.mr-scale-good` | `#656b7e` on `#06070a` |
+
+Plus `select-name` (**critical**): the `/liq` `<select>` has no implicit or
+explicit label — the fourth unnamed control from audit §4.2, and the worst of
+them.
+
+**The design-token change is justified.** Proceed with it.
+
+### 1.4 A failed labels fetch wipes the English fallback and renders raw keys sitewide
+
+**Severity: High. Latent on production today. Found via CI, not by looking.**
+
+Surfaced when the `e2e` job ran on a GitHub runner without Supabase env vars.
+Two failures that looked like layout bugs turned out to share one cause:
+
+```
+/arena overflows by 28px at desktop
+  div.app-bar-right  "LONDON OPEN · 1h 54m EN NAV_SIGN_IN"
+  a.auth-signin-btn  "NAV_SIGN_IN"
+  div.nav-menu       "NAV_SECTION_MAIN NAV_DASHBOARD NAV_BRIEFIN…"
+  scrollWidth 1468 vs innerWidth 1440
+
+/markets CLS 0.255, and 0.256 on retry   (budget 0.1)
+```
+
+Those are **raw i18n label keys**, not text. Unresolved keys are longer than
+their English strings, so the layout widens and reflows.
+
+`PENDING.md` records a fix for exactly this — seeding `lib/labelDefaults.en.json`
+so that "worst case is now a brief English flash before the real locale loads,
+**never a raw key**." The seed is intact and correct: 2,570 keys, and
+`NAV_SIGN_IN → "Sign In"` is present. It is being **overwritten**.
+
+Two fail-open designs that do not compose:
+
+`app/api/labels/route.ts`
+```
+ 12:  // empty object on any error rather than 500ing the page; the client's t()
+ 93:  } catch { /* fail open to {} */ }
+106:  if (Object.keys(data).length === 0) {
+107:    return NextResponse.json(data, …)      // HTTP 200 carrying {}
+```
+
+`components/LabelsProvider.tsx:59-66`
+```js
+fetch(`/api/labels?locale=${l}`)
+  .then(r => r.json())
+  .then(data => {
+    setMap(data);            // ← unconditional; {} replaces 2,570 defaults
+    saveCachedMap(l, data);
+  })
+  .catch(() => { /* keep last-known map on transient failure */ })
+```
+
+The route deliberately returns `200 {}` on any DB error, trusting the client to
+fall back. The client's `.catch` covers a *network* failure but not a
+**successful response carrying an empty object**, so `setMap({})` destroys the
+seed. Each half is defensible alone; together they render every label in the app
+as its raw key.
+
+**Why it matters beyond CI.** Production is fine today — Supabase is up and the
+labels table is populated. But any Supabase incident, an RLS change, or the
+PostgREST `db-max-rows` cap that this same route warns about at line 62 would
+turn the entire UI into `NAV_SIGN_IN` / `NAV_DASHBOARD` / `NAV_SECTION_MAIN`,
+silently, with no error anywhere.
+
+**Fix direction:** do not install an empty or non-object payload over the
+defaults, e.g.
+`setMap(data && Object.keys(data).length ? data : DEFAULT_EN_LABELS)`, or merge
+the response over `DEFAULT_EN_LABELS` so a partial response degrades to English
+rather than to keys.
+
+**Not introduced by the 2026-08-05 release** — `LabelsProvider.tsx` is not in
+that diff. Pre-existing and unrelated to it.
+
+---
+
+## 2. ⚠️ Correction to our own finding — the tap-target number is mislabelled
+
+Audit §4.1 reports "159 tap targets below the 24px WCAG 2.2 AA floor";
+`QA_E2E_FINDINGS_2026-08-05.md` §1.2 corrected the count to 217 and kept the
+same framing. **The count is right. The conformance claim is not.**
+
+axe's `target-size` rule, run at iPhone 13 metrics (390×844):
+
+```
+/playbook   violations=0  incomplete=0  passes=156
+/scanner    violations=0  incomplete=0  passes=106
+/refund     violations=0  incomplete=0  passes= 94
+```
+
+The rule ran — it is not disabled or inapplicable — and passed every target,
+including `/playbook`'s 55 `button.pb-star` controls measured at 16×13.
+
+WCAG 2.2 SC 2.5.8 carries exceptions that a `getBoundingClientRect()` sweep does
+not model:
+
+- **Spacing** — an undersized target conforms if a 24px-diameter circle centred
+  on it does not intersect the circle of any other target.
+- **Inline** — targets within a sentence or block of text are exempt entirely.
+  That covers the footer links, which are 112 of the 217.
+
+**Consequence for the work queue.** Audit §8 ranks "fix `.pf-footer-*` tap-target
+heights" at #3 and the 14×16 close buttons at #4, both justified as AA
+conformance. On this evidence they are **ergonomics, not conformance failures**,
+and belong below the contrast work. Still worth doing — the app is an installable
+PWA and the 44px Apple HIG target stands, as audit §4.1 already noted — but not
+as AA blockers.
+
+`BASELINE.tapTargetsUnder24` in `qa/e2e/_shared.ts` stays at 217, because the
+count is accurate and the ratchet still catches regressions. Its comment needs
+correcting to say what it actually measures: elements under 24px, not SC 2.5.8
+violations.
+
+⚠️ Worth one human spot-check with a ruler before formally downgrading this.
+axe's `target-size` implementation has its own limits, and "0 violations, 0
+incomplete" everywhere is a strong claim. But the burden of proof has shifted.
+
+---
+
+## 3. `/scanner` CLS — full before/after data
+
+Three builds, 10 consecutive identical loads each, desktop 1440×900, production
+build, 2.5s hydration wait then buffered `layout-shift` entries.
+
+| Build | values | min | mean | max |
+|---|---|---|---|---|
+| `main`, no fixes | 1.289 1.138 1.185 1.341 1.659 1.836 1.452 1.724 0.775 2.312 | 0.775 | **1.471** | **2.312** |
+| `dev`, + `fix/scanner-layout-shift` | 1.693 1.278 1.196 1.535 0.861 1.221 1.330 1.440 1.276 0.622 | 0.622 | **1.245** | **1.693** |
+| release, + `fix/scanner-card-layout-shift` | 0.028 0.149 0.246 0.176 0.232 0.178 0.041 0.229 0.037 0.220 | 0.028 | **0.154** | **0.246** |
+
+Same release against staging (`liquidity-hq-qa.onrender.com`), 6 runs:
+min 0.022, mean 0.117, max 0.199.
+
+Local and staging agree on magnitude. The absolute numbers differ because these
+shifts are **data-arrival dependent** — anything that moves when data lands
+(network latency, cache warmth, cold start) moves the measurement.
+
+**That property is also why the fix worked.** This was never an unsized element
+with a stable wrong value; it was a race whose magnitude depended on timing.
+Reserving space removes the dependency on *when* data arrives, which is why two
+independently-measured baselines both collapsed by ~10× from different starting
+points.
+
+Other routes, release build, same method:
+
+| Route | before | after |
+|---|---|---|
+| `/arena` | 0.364 — one 0.297 shift at ~1s from `FOOTER.pf-footer` | **0.026** |
+| `/briefing` | 0.167 | 0.107 — still above 0.1, no fix attempted |
+| `/dashboard` | 0.006 | 0.006 |
+| `/` | 0 | 0 |
+
+**Two follow-ups:**
+
+1. `/scanner` is now bounded enough for a real budget. At 0.028–0.246 it no
+   longer needs the `CLS_UNSTABLE` treatment proposed in PR #22 — a
+   `CLS_BUDGET` of ~0.30 would hold. QA will revise that branch.
+2. **`/briefing` at 0.107 is now the last route above the "good" threshold**,
+   driven by five `DIV.card` (`.mb-brief-card`) elements resizing once data
+   arrives. Same shape as `/scanner`, presumably the same fix.
+
+**Correction to an earlier QA report:** the scanner fix was initially measured at
+0.691 over **3** runs and reported as insufficient. Ten runs show 0.246. The
+3-run sample was an undersampled fluke; the fix is substantially better than
+first stated.
+
+---
+
+## 4. 🔴 The authenticated surface has never been tested
+
+Measured signed-out against the release build:
+
+```
+/settings   inputs=2   .st-input / .st-field-label = 0
+/journal    inputs=2   .tj-inp   / .tj-lbl         = 0
+```
+
+Neither form renders. An axe pass on `/settings` therefore returns "no
+violations" while proving **nothing** — the controls do not exist to be checked.
+
+This is the same failure mode that makes an unseeded BOLA test dangerous: a
+vacuous pass is indistinguishable from a genuine one.
+
+### Findings that cannot be confirmed or refuted until this is fixed
+
+A source-level review produced 28 findings. Three were runtime-testable: §1.1
+and §1.2 above were confirmed (§1.1 was *understated* by 2×), one was
+untestable. The rest touch surfaces behind auth. Recorded here so they are not
+lost, and explicitly marked **UNVERIFIED — do not action yet**:
+
+| # | Claim | File |
+|---|---|---|
+| U1 | ~24 Settings inputs: visible `<label>` with no `htmlFor` and no `aria-label` fallback | `components/SettingsModal.tsx`, `app/settings/page.tsx` |
+| U2 | TradeJournal `aria-label` strings drifted from visible labels — "Entry \*" vs "Entry" | `components/TradeJournal.tsx:854-874` |
+| U3 | TradeJournal inline-edit: 4 controls with no accessible name at all | `components/TradeJournal.tsx:1148-1186` |
+| U4 | Rule-builder selects: no label, visible or hidden | `components/TradeJournal.tsx:1361-1443` |
+| U5 | Auth error messages lack `role="alert"` — failures are silent to AT | `app/login/page.tsx:298,401` and the reset/forgot pages |
+| U6 | GrokChat replies arrive with no `aria-live` announcement | `components/GrokChat.tsx:789` |
+
+U2 is worth flagging early even unverified: it is the `HANDOVER.md` §14
+anti-pattern forming. If someone "fixes" it by adding `htmlFor`/`id` **without**
+deleting the `aria-label`, they recreate the documented voice-control defect
+exactly, because `aria-label` overrides an explicit association too.
+
+One further unverified finding is **not** behind auth and is worth checking
+independently: `components/BeamsBackground.tsx` runs an uncapped
+`requestAnimationFrame` loop plus a `repeat: Infinity` Motion animation with no
+`prefers-reduced-motion` check anywhere in the file. That is WCAG 2.2.2 Pause,
+Stop, Hide at **Level A**, on the public marketing homepage.
+
+---
+
+## 5. Blocking asks
+
+### 5.1 Two seeded test accounts — owner / dev
+
+Unblocks BOLA/IDOR (OWASP API #1, still the largest untested area) **and** the
+six findings in §4.
+
+**They must be seeded.** Account A needs ≥1 row in the trade journal, price
+alerts, settings, hypotheses and a subscription row, plus the row IDs, since the
+test must request them explicitly. Account B only needs to log in.
+
+Credentials, not tokens — access tokens expire in ~1h, so a pasted token works
+once and breaks CI the next day. With email + password a fresh token is minted
+per run.
+
+`.env.e2e.local` in the QA checkout (`.gitignore` already covers `.env*`):
+
+```
+E2E_USER_A_EMAIL=...
+E2E_USER_A_PASSWORD=...
+E2E_USER_B_EMAIL=...
+E2E_USER_B_PASSWORD=...
+```
+
+Dev Supabase only (`wdtjhrilakoitfcezxpx`). Never prod. Never the service-role
+key. Both accounts must be email-confirmed or the login call returns 400.
+
+### 5.2 ✅ DONE — three GitHub repo secrets
+
+`E2E_SUPABASE_URL`, `E2E_SUPABASE_ANON_KEY`, `E2E_TURNSTILE_SITE_KEY` were added
+by the owner on 2026-08-05 and confirmed present. The `e2e` job's four failures
+on `main` were all traceable to their absence — two `/login` specs directly, and
+`/arena` overflow plus `/markets` CLS via §1.4's raw-key cascade.
+
+Worth keeping in mind for the future: that run is the reason §1.4 was found at
+all. Running the suite in a **degraded** environment surfaced a latent
+production defect that a fully-configured run would have hidden. That is an
+argument for occasionally testing without env on purpose, not only with it.
+
+---
+
+## 6. Reproducing
+
+axe-core is deliberately **not** a project dependency. Install it anywhere
+outside the repo and inject it:
+
+```js
+const axeSource = fs.readFileSync('<path>/axe-core/axe.min.js', 'utf8');
+await page.addScriptTag({ content: axeSource });
+const res = await page.evaluate(() => window.axe.run(document, {
+  runOnly: { type: 'tag', values: ['wcag2a','wcag2aa','wcag21a','wcag21aa','wcag22aa'] },
+}));
+```
+
+Two traps worth knowing:
+
+- **Read `incomplete`, not just `violations`.** axe reports cases it cannot
+  decide as `incomplete`. A rule returning nothing in `violations` may simply
+  have deferred to manual review — reporting that as "clean" would be wrong.
+  §2's conclusion depended on checking that `target-size` had 0 in *both*.
+- **Check the page actually rendered what you are auditing.** §4 exists because
+  a clean axe result on `/settings` meant only that the form was not on screen.

--- a/qa/e2e/_auth.ts
+++ b/qa/e2e/_auth.ts
@@ -1,0 +1,78 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Credentials + token minting for the authenticated specs.
+ *
+ * Two accounts, both on the DEV Supabase project only. A is seeded with one row
+ * in each table under test; B is deliberately empty, because the BOLA test is
+ * "B asks for A's rows by id and must be refused" - giving B its own data would
+ * only obscure that.
+ *
+ * Passwords rather than tokens on purpose: a Supabase access token expires in
+ * about an hour, so a pasted token passes once and then fails CI the next day.
+ * Minting per run is the only version that keeps working unattended.
+ */
+
+/** Reads KEY=value files without adding a dotenv dependency. CI has no files, only env. */
+function loadEnvFile(file: string): void {
+  const p = path.resolve(process.cwd(), file);
+  if (!fs.existsSync(p)) return;
+  for (const line of fs.readFileSync(p, 'utf8').split(/\r?\n/)) {
+    const m = /^\s*([A-Z0-9_]+)\s*=\s*(.*)$/.exec(line);
+    if (!m) continue;
+    const [, k, raw] = m;
+    if (process.env[k]) continue;           // real env always wins over a file
+    process.env[k] = raw.trim().replace(/^["']|["']$/g, '');
+  }
+}
+loadEnvFile('.env.e2e.local');
+loadEnvFile('.env.local');
+
+export const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+export const SUPABASE_ANON = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '';
+
+export const FIXTURES = {
+  aEmail: process.env.E2E_USER_A_EMAIL ?? '',
+  aPassword: process.env.E2E_USER_A_PASSWORD ?? '',
+  aId: process.env.E2E_USER_A_ID ?? '',
+  bEmail: process.env.E2E_USER_B_EMAIL ?? '',
+  bPassword: process.env.E2E_USER_B_PASSWORD ?? '',
+  bId: process.env.E2E_USER_B_ID ?? '',
+  /** A's row ids. The test must request these explicitly - guessing ids is how
+   *  this test ends up asserting nothing. */
+  tradeId: process.env.E2E_A_TRADE_ID ?? '',
+  hypothesisId: process.env.E2E_A_HYPOTHESIS_ID ?? '',
+  priceAlertId: process.env.E2E_A_PRICE_ALERT_ID ?? '',
+} as const;
+
+/** Everything the authenticated specs need, or they must skip rather than pass. */
+export const AUTH_READY =
+  !!(SUPABASE_URL && SUPABASE_ANON &&
+     FIXTURES.aEmail && FIXTURES.aPassword && FIXTURES.bEmail && FIXTURES.bPassword &&
+     FIXTURES.tradeId && FIXTURES.hypothesisId && FIXTURES.priceAlertId);
+
+export const AUTH_SKIP_REASON =
+  'authenticated fixtures absent - set E2E_USER_A_* / E2E_USER_B_* / E2E_A_*_ID ' +
+  '(see the issue "QA unblocked: two seeded test accounts"). Skipping rather than ' +
+  'passing: a BOLA test that runs without fixtures proves nothing.';
+
+/** Password grant against the dev project. Throws loudly - a silent auth failure
+ *  would make every cross-account assertion trivially "pass". */
+export async function signIn(email: string, password: string): Promise<string> {
+  const res = await fetch(`${SUPABASE_URL}/auth/v1/token?grant_type=password`, {
+    method: 'POST',
+    headers: { apikey: SUPABASE_ANON, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok || !body.access_token) {
+    throw new Error(
+      `sign-in failed for ${email}: HTTP ${res.status} ${JSON.stringify(body).slice(0, 200)}. ` +
+      `If this is 500 "Database error querying schema", the auth.users row has NULL ` +
+      `token columns - GoTrue scans them into non-nullable Go strings. See the ` +
+      `seeded-accounts issue for the coalesce fix.`,
+    );
+  }
+  return body.access_token as string;
+}

--- a/qa/e2e/_shared.ts
+++ b/qa/e2e/_shared.ts
@@ -24,10 +24,33 @@ export const ROUTES = [
  */
 export const BASELINE = {
   /**
-   * §4.1 - tap targets under the WCAG 2.2 AA 24px floor, mobile, all routes.
+   * Interactive elements whose rendered box is under 24x24 CSS px, mobile, all
+   * routes.
    *
-   * 217, CORRECTED UP from 159 on 2026-08-05. This is NOT a ratchet violation
-   * and is NOT precedent for raising a baseline - read this before citing it.
+   * READ THIS BEFORE CALLING IT A WCAG NUMBER. It is not one. Earlier versions
+   * of this comment, and audit §4.1, described it as "tap targets below the
+   * WCAG 2.2 AA 24px floor". That framing is wrong and was corrected
+   * 2026-08-05. WCAG 2.2 SC 2.5.8 has exceptions a getBoundingClientRect()
+   * sweep cannot model:
+   *
+   *   - Spacing: an undersized target conforms if a 24px-diameter circle
+   *     centred on it does not intersect another target's circle.
+   *   - Inline: targets inside a sentence or block of text are exempt outright.
+   *     That covers a.pf-footer-bottom-link, the largest single contributor.
+   *
+   * axe-core's `target-size` rule, run at this exact viewport, reports
+   * violations=0 / incomplete=0 / passes=156 on /playbook alone. So this metric
+   * tracks something real and worth reducing - small touch targets on a PWA,
+   * against the 44px Apple HIG comfort target - but it is NOT a conformance
+   * failure count, and it must not be cited as one.
+   *
+   * 122, RATCHETED DOWN from 217 on 2026-08-05 after PR #23
+   * (fix/tap-target-sizes) cleared button.pb-star (55) and
+   * button.pf-footer-expand (28). Remaining: 84 a.pf-footer-bottom-link,
+   * 31 a.consent-link, 7 bare <a>.
+   *
+   * 217 itself was CORRECTED UP from the audit's 159 - which was not a ratchet
+   * violation and is not precedent for raising a baseline.
    *
    * The number must match the viewport THIS SUITE runs at: the mobile project
    * is devices['iPhone 13'], which is 390x844. At the audit's 375x812 the count
@@ -53,7 +76,7 @@ export const BASELINE = {
    * The only legitimate reason to change this number again is DOWNWARD, when a
    * fix lands.
    */
-  tapTargetsUnder24: 217,
+  tapTargetsUnder24: 122,
   /** §4.2 - controls whose only label is a placeholder. */
   controlsWithoutName: 4,
   /** §6.4 - pages with no <h1>, desktop. */

--- a/qa/e2e/_shared.ts
+++ b/qa/e2e/_shared.ts
@@ -122,6 +122,32 @@ export const CLS_BUDGET: Record<string, number> = {
      0.365 to 0.068 over three runs. Note it was the footer, not gchat-fab:
      per-source attribution put the FAB at 0.1% of the shift. */
   '/briefing': 0.20,  // observed 0.148, 0.153, 0.176
+
+  /* /scanner moved here from CLS_UNSTABLE on 2026-08-05, meeting the retirement
+     condition that entry set for itself ("fix the race, re-measure over >=10
+     runs, then give /scanner a real CLS_BUDGET").
+
+     The instability was real when measured, and it was measured on `dev`, which
+     had fix/scanner-layout-shift (the heatmap tile-height fix) but NOT
+     fix/scanner-card-layout-shift, which rewrote the heatmap ranking, three card
+     skeletons and PageHint. Both are now on main.
+
+     24 runs on the shipped build, production server, two batches:
+       cold  0.176 0.010 0.013 0.016 0.010 0.011 0.010 0.016 0.009 0.028 0.007 0.014
+       warm  0.008 0.007 0.007 0.008 0.012 0.010 0.028 0.007 0.011 0.012 0.016 0.011
+     Warm: min 0.007, median 0.011, mean 0.011, max 0.028.
+     The single 0.176 was run #1 against a just-started server; the second batch
+     was run to test exactly that, and reproduced nothing above 0.028. That is a
+     cold-start cost, not the ~3x race the old distribution showed.
+
+     Budget is 0.25 rather than deleting the route outright, even though the
+     median is well under CLS_GOOD, because CI always measures a cold server -
+     the webServer builds and starts immediately before the run - so 0.1 would
+     gate on the one number that legitimately varies. 0.25 clears the observed
+     cold worst case with headroom and is still ~9x tighter than the ~2.0 a
+     ceiling would have needed before the fix.
+     Lower it to CLS_GOOD (delete this line) if cold-start ever measures <0.1. */
+  '/scanner': 0.25,
 };
 
 /** The "good" CLS threshold every route not in CLS_BUDGET must meet. */
@@ -134,32 +160,19 @@ export const CLS_GOOD = 0.1;
  * visible, it just is not a pass/fail gate. Nothing here is "allowed"; it is
  * unmeasurable-by-threshold, which is a WORSE state than a bad fixed number.
  *
- * /scanner, 10 consecutive identical loads on this branch (dev, i.e. WITH
- * fix/scanner-layout-shift):
+ * EMPTY as of 2026-08-05. /scanner was the only entry and has been retired to
+ * CLS_BUDGET at 0.25 - see the note there for the 24-run distribution that
+ * justified it. The mechanism stays because the distinction it draws is a real
+ * one, and re-deriving it under pressure would be worse than keeping it.
  *
- *   0.622  0.861  1.196  1.221  1.276  1.278  1.330  1.440  1.535  1.693
- *   min 0.622   mean 1.245   max 1.693
- *
- * The same 10-run measurement on main, without the fix, was min 0.775,
- * mean 1.471, max 2.312. So the fix helps - roughly 15% off the mean and 27%
- * off the worst case - but /scanner is still 6x-17x the 0.1 "good" threshold
- * and just as non-deterministic. An earlier 3-run sample of this branch read
- * 0.432/0.691/0.454 and was reported as "fixed"; 10 runs show that was an
- * undersampled fluke. Three samples are not enough for this route.
- *
- * No budget, because a budget was tried and failed immediately: 3 samples on
- * main gave a max of 1.002, a budget of 1.10 was set from it, and the very next
- * run measured 1.195. An unsized element yields a repeatable number; a ~3x
- * spread on identical input means something races. A ceiling that survived the
- * tail would need to be ~2.0, loose enough to catch no regression worth
- * catching - and playwright.config.ts is explicit that a flaky pass is worse
- * than a fail, because it teaches everyone to re-run until green.
- *
- * To retire this entry: fix the race, re-measure over >=10 runs, then give
- * /scanner a real CLS_BUDGET, or delete it from here entirely if it gets under
- * CLS_GOOD.
+ * The bar for adding a route here, unchanged: an entry must carry a measured
+ * distribution (>=10 runs, not 3 - an earlier 3-run sample of /scanner read
+ * 0.432/0.691/0.454 and was reported as "fixed", which 10 runs disproved) AND
+ * a retirement condition saying what has to be true to remove it. Without both
+ * this becomes the place flaky tests go to be forgotten, which is the failure
+ * mode it exists to prevent.
  */
-export const CLS_UNSTABLE = new Set<string>(['/scanner']);
+export const CLS_UNSTABLE = new Set<string>([]);
 
 /**
  * Settle a page: wait for hydration, then assert the stylesheet actually

--- a/qa/e2e/_shared.ts
+++ b/qa/e2e/_shared.ts
@@ -105,6 +105,40 @@ export const CLS_BUDGET: Record<string, number> = {
 export const CLS_GOOD = 0.1;
 
 /**
+ * Routes whose CLS is too UNSTABLE to assert any number against.
+ *
+ * Still measured and attached to the report on every run - the value stays
+ * visible, it just is not a pass/fail gate. Nothing here is "allowed"; it is
+ * unmeasurable-by-threshold, which is a WORSE state than a bad fixed number.
+ *
+ * /scanner, 10 consecutive identical loads on this branch (dev, i.e. WITH
+ * fix/scanner-layout-shift):
+ *
+ *   0.622  0.861  1.196  1.221  1.276  1.278  1.330  1.440  1.535  1.693
+ *   min 0.622   mean 1.245   max 1.693
+ *
+ * The same 10-run measurement on main, without the fix, was min 0.775,
+ * mean 1.471, max 2.312. So the fix helps - roughly 15% off the mean and 27%
+ * off the worst case - but /scanner is still 6x-17x the 0.1 "good" threshold
+ * and just as non-deterministic. An earlier 3-run sample of this branch read
+ * 0.432/0.691/0.454 and was reported as "fixed"; 10 runs show that was an
+ * undersampled fluke. Three samples are not enough for this route.
+ *
+ * No budget, because a budget was tried and failed immediately: 3 samples on
+ * main gave a max of 1.002, a budget of 1.10 was set from it, and the very next
+ * run measured 1.195. An unsized element yields a repeatable number; a ~3x
+ * spread on identical input means something races. A ceiling that survived the
+ * tail would need to be ~2.0, loose enough to catch no regression worth
+ * catching - and playwright.config.ts is explicit that a flaky pass is worse
+ * than a fail, because it teaches everyone to re-run until green.
+ *
+ * To retire this entry: fix the race, re-measure over >=10 runs, then give
+ * /scanner a real CLS_BUDGET, or delete it from here entirely if it gets under
+ * CLS_GOOD.
+ */
+export const CLS_UNSTABLE = new Set<string>(['/scanner']);
+
+/**
  * Settle a page: wait for hydration, then assert the stylesheet actually
  * applied.
  *

--- a/qa/e2e/bola.spec.ts
+++ b/qa/e2e/bola.spec.ts
@@ -1,0 +1,279 @@
+import { test, expect, request as pwRequest } from '@playwright/test';
+import { AUTH_READY, AUTH_SKIP_REASON, FIXTURES, SUPABASE_URL, SUPABASE_ANON, signIn } from './_auth';
+
+/**
+ * BOLA / IDOR - OWASP API Security #1.
+ *
+ * The question every other spec in this suite leaves unanswered: can a
+ * legitimately signed-in user reach another user's rows by asking for them by
+ * id? Everything else here tests the signed-out surface, where the answer is
+ * always 401 and nothing is learned about this.
+ *
+ * Why it needs its own file: it is the only spec that authenticates, and the
+ * only one that can fail in a way that means "user data is exposed".
+ *
+ * WHY THE ASSERTIONS LOOK PARANOID
+ *
+ * A status code is not evidence here. `PATCH .../someone-elses-id` returning
+ * 200 is ambiguous - Supabase reports success for an UPDATE that matched zero
+ * rows, which is exactly what a correct ownership filter produces. So every
+ * write attempt is followed by a read AS THE OWNER to prove the row did not
+ * change. Without that second read this file would pass against a genuinely
+ * broken app.
+ *
+ * Equally, an empty result is only meaningful if the row exists. Test 1 proves
+ * A can read its own fixtures first; if that fails everything after it would
+ * "pass" vacuously, so it fails the run loudly instead.
+ */
+
+test.describe('BOLA / IDOR - cross-account access', () => {
+  test.skip(!AUTH_READY, AUTH_SKIP_REASON);
+
+  // HTTP-level. Running both viewport projects would just double the requests.
+  test.beforeEach(({}, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop', 'HTTP-level, viewport irrelevant');
+  });
+
+  let tokenA = '';
+  let tokenB = '';
+
+  test.beforeAll(async () => {
+    tokenA = await signIn(FIXTURES.aEmail, FIXTURES.aPassword);
+    tokenB = await signIn(FIXTURES.bEmail, FIXTURES.bPassword);
+    expect(tokenA, 'A and B must be different sessions').not.toBe(tokenB);
+  });
+
+  const auth = (t: string) => ({ Authorization: `Bearer ${t}` });
+
+  /**
+   * Statuses treated as "access was refused".
+   *
+   * 500 is in here deliberately, and it is a defect rather than an accident:
+   * measured 2026-08-06, B's write attempts return
+   * `500 {"error":"Something went wrong. Please try again."}` - including for a
+   * UUID that does not exist at all, which proves the 500 is about B (no
+   * entitlement row) and not about reaching A's data. A's own writes return
+   * 200, so the endpoints work.
+   *
+   * It fails CLOSED, so it is not a security hole and this suite must not fail
+   * the build over it. But a denial surfacing as 500 makes real server errors
+   * indistinguishable from refused access in the logs and in GlitchTip, so
+   * every test below annotates when it sees one. Security is asserted by
+   * re-reading the row as its owner, never by the status code.
+   */
+  const REFUSED = [200, 400, 401, 403, 404, 500];
+
+  const noteIf500 = (status: number, what: string) => {
+    if (status !== 500) return;
+    test.info().annotations.push({
+      type: 'known-issue',
+      description:
+        `${what} refused with HTTP 500 rather than 403. Fails closed - data is ` +
+        `safe - but denial is indistinguishable from a server fault in logs.`,
+    });
+  };
+
+  /** Direct PostgREST, bypassing the app - measures RLS itself. */
+  const rest = async (t: string, table: string, query: string) => {
+    const ctx = await pwRequest.newContext();
+    const r = await ctx.get(`${SUPABASE_URL}/rest/v1/${table}?${query}`, {
+      headers: { apikey: SUPABASE_ANON, Authorization: `Bearer ${t}` },
+      failOnStatusCode: false,
+    });
+    const body = await r.json().catch(() => null);
+    await ctx.dispose();
+    return { status: r.status(), body };
+  };
+
+  // ── 1. Fixtures are real ────────────────────────────────────────────────
+  // Everything below is meaningless if A's rows do not exist. This runs first
+  // and fails the file rather than letting later tests pass vacuously.
+  test('A can read its own seeded rows (guards against a vacuous pass)', async ({ request }) => {
+    const hyp = await request.get('/api/hypotheses', { headers: auth(tokenA), failOnStatusCode: false });
+    expect(hyp.status(), 'A should be able to list its hypotheses').toBe(200);
+    const hypBody = await hyp.json();
+    const hypRows = Array.isArray(hypBody) ? hypBody : (hypBody.hypotheses ?? hypBody.data ?? []);
+    expect(
+      JSON.stringify(hypRows),
+      `A's seeded hypothesis ${FIXTURES.hypothesisId} must be visible to A, or this file proves nothing`,
+    ).toContain(FIXTURES.hypothesisId);
+
+    const alerts = await request.get('/api/price-alerts', { headers: auth(tokenA), failOnStatusCode: false });
+    expect(alerts.status()).toBe(200);
+    expect(JSON.stringify(await alerts.json())).toContain(FIXTURES.priceAlertId);
+  });
+
+  // ── 2. B cannot LIST A's data ───────────────────────────────────────────
+  test('B listing its own collections never returns A rows', async ({ request }) => {
+    // Only UUID-shaped fixtures are safe as substring needles. A's price-alert
+    // id is the integer "1", so `not.toContain("1")` would match almost any
+    // JSON body - including B's own legitimate response. That produced a false
+    // failure the first time this ran. Integer-keyed rows are covered by the
+    // per-row ownership tests and the RLS test instead.
+    const needles: Array<[string, string]> = [
+      ["A's user id", FIXTURES.aId],
+      ["A's hypothesis", FIXTURES.hypothesisId],
+      ["A's trade", FIXTURES.tradeId],
+    ].filter(([, v]) => v.length >= 8) as Array<[string, string]>;
+
+    for (const path of ['/api/hypotheses', '/api/price-alerts', '/api/settings']) {
+      const r = await request.get(path, { headers: auth(tokenB), failOnStatusCode: false });
+      expect([200, 404], `${path} should answer B`).toContain(r.status());
+      const text = await r.text();
+      for (const [what, needle] of needles) {
+        expect(text, `${path} leaked ${what} to B`).not.toContain(needle);
+      }
+    }
+  });
+
+  // ── 3. B cannot MUTATE A's rows by id ───────────────────────────────────
+  // The important half. Each attempt is verified by re-reading as A.
+  test("B cannot modify A's hypothesis by id", async ({ request }) => {
+    const before = await rest(tokenA, 'lhq_dev_hypotheses', `id=eq.${FIXTURES.hypothesisId}&select=*`);
+    expect(before.status, "A must be able to read its own hypothesis").toBe(200);
+    expect(before.body?.length, 'fixture missing - cannot test').toBe(1);
+
+    const r = await request.patch(`/api/hypotheses/${FIXTURES.hypothesisId}`, {
+      headers: { ...auth(tokenB), 'Content-Type': 'application/json' },
+      data: { title: 'OWNED BY B', status: 'invalidated' },
+      failOnStatusCode: false,
+    });
+    // 200 here is NOT a failure by itself: an UPDATE matching zero rows succeeds.
+    expect(REFUSED).toContain(r.status());
+    noteIf500(r.status(), "PATCH /api/hypotheses/{id} as a non-owner");
+
+    const after = await rest(tokenA, 'lhq_dev_hypotheses', `id=eq.${FIXTURES.hypothesisId}&select=*`);
+    expect(
+      JSON.stringify(after.body),
+      `B MUTATED A's hypothesis. HTTP was ${r.status()} - which is why this test re-reads as the owner.`,
+    ).not.toContain('OWNED BY B');
+    expect(after.body?.length, "A's hypothesis must still exist").toBe(1);
+  });
+
+  test("B cannot delete A's hypothesis by id", async ({ request }) => {
+    const r = await request.delete(`/api/hypotheses/${FIXTURES.hypothesisId}`, {
+      headers: auth(tokenB), failOnStatusCode: false,
+    });
+    expect(REFUSED).toContain(r.status());
+    noteIf500(r.status(), "DELETE /api/hypotheses/{id} as a non-owner");
+
+    const after = await rest(tokenA, 'lhq_dev_hypotheses', `id=eq.${FIXTURES.hypothesisId}&select=id`);
+    expect(
+      after.body?.length,
+      `B DELETED A's hypothesis. HTTP was ${r.status()}.`,
+    ).toBe(1);
+  });
+
+  test("B cannot modify or deactivate A's price alert by id", async ({ request }) => {
+    const patch = await request.patch(`/api/price-alerts?id=${FIXTURES.priceAlertId}`, {
+      headers: { ...auth(tokenB), 'Content-Type': 'application/json' },
+      data: { label: 'OWNED BY B', target_price: 1 },
+      failOnStatusCode: false,
+    });
+    expect(REFUSED).toContain(patch.status());
+    noteIf500(patch.status(), "PATCH /api/price-alerts as a non-owner");
+
+    const del = await request.delete(`/api/price-alerts?id=${FIXTURES.priceAlertId}`, {
+      headers: auth(tokenB), failOnStatusCode: false,
+    });
+    expect(REFUSED).toContain(del.status());
+    noteIf500(del.status(), "DELETE /api/price-alerts as a non-owner");
+
+    const after = await rest(tokenA, 'lhq_dev_price_alerts', `id=eq.${FIXTURES.priceAlertId}&select=*`);
+    expect(after.body?.length, "A's price alert must still exist").toBe(1);
+    const row = after.body?.[0] ?? {};
+    expect(JSON.stringify(row), "B renamed A's price alert").not.toContain('OWNED BY B');
+    // DELETE here is a soft delete (active:false). If B could reach it, the
+    // alert would silently stop firing for A - a data-loss bug that returns 200.
+    expect(row.active, "B deactivated A's price alert - it would silently stop firing").not.toBe(false);
+  });
+
+  test("B cannot overwrite A's settings", async ({ request }) => {
+    const r = await request.patch('/api/settings', {
+      headers: { ...auth(tokenB), 'Content-Type': 'application/json' },
+      data: { user_id: FIXTURES.aId, account_size: 999999, risk_per_trade: 99 },
+      failOnStatusCode: false,
+    });
+    expect(REFUSED).toContain(r.status());
+    noteIf500(r.status(), "PATCH /api/settings with a foreign user_id in the body");
+
+    // Mass-assignment check: passing user_id in the body must not let B write
+    // to A's row. If the handler trusted that field this would silently succeed.
+    const after = await rest(tokenA, 'lhq_dev_user_settings', `user_id=eq.${FIXTURES.aId}&select=*`);
+    const s = after.body?.[0] ?? {};
+    expect(
+      s.account_size,
+      "B overwrote A's settings via a user_id in the request body (mass assignment)",
+    ).not.toBe(999999);
+  });
+
+  // ── 4. RLS floor, measured directly ─────────────────────────────────────
+  // The API routes query with the user's token, so RLS is the second layer.
+  // Checking it separately means a future route that switches to the
+  // service-role client does not silently lose all protection.
+  test('RLS refuses B direct PostgREST access to A rows', async () => {
+    const tables: Array<[string, string]> = [
+      ['lhq_dev_hypotheses', FIXTURES.hypothesisId],
+      ['lhq_dev_price_alerts', FIXTURES.priceAlertId],
+      ['lhq_dev_trades', FIXTURES.tradeId],
+    ];
+    for (const [table, id] of tables) {
+      const asA = await rest(tokenA, table, `id=eq.${id}&select=id`);
+      expect(asA.body?.length, `fixture ${table}/${id} missing - test would be vacuous`).toBe(1);
+
+      const asB = await rest(tokenB, table, `id=eq.${id}&select=*`);
+      expect([200, 401, 403]).toContain(asB.status);
+      expect(
+        Array.isArray(asB.body) ? asB.body.length : 0,
+        `RLS let B read A's row in ${table}`,
+      ).toBe(0);
+    }
+
+    const settingsAsB = await rest(tokenB, 'lhq_dev_user_settings', `user_id=eq.${FIXTURES.aId}&select=*`);
+    expect(
+      Array.isArray(settingsAsB.body) ? settingsAsB.body.length : 0,
+      "RLS let B read A's settings",
+    ).toBe(0);
+  });
+
+  // ── 5. Controls ─────────────────────────────────────────────────────────
+  // Proves the endpoints are actually reachable and gated, so a network
+  // failure cannot masquerade as "access correctly denied" above.
+  test('the same requests without a token are rejected', async ({ request }) => {
+    for (const path of ['/api/hypotheses', '/api/price-alerts', '/api/settings']) {
+      const r = await request.get(path, { failOnStatusCode: false });
+      const body = await r.text();
+
+      // /api/hypotheses and /api/settings answer 401. /api/price-alerts answers
+      // 200 {"alerts":[]} - measured 2026-08-06. That is not a leak, and the
+      // empty-collection assertion below is what actually matters, but it is
+      // inconsistent with its two siblings and worth recording.
+      if (r.status() === 200) {
+        test.info().annotations.push({
+          type: 'known-issue',
+          description:
+            `${path} answers an anonymous caller with HTTP 200 instead of 401, ` +
+            `unlike /api/hypotheses and /api/settings. No data is exposed - the ` +
+            `collection is empty - but the inconsistency is real.`,
+        });
+        expect(body, `${path} returned data to an anonymous caller`).not.toContain(FIXTURES.aId);
+        expect(body, `${path} returned A's hypothesis anonymously`).not.toContain(FIXTURES.hypothesisId);
+        expect(
+          /\[\s*\]/.test(body) || body.length < 60,
+          `${path} answered 200 anonymously AND returned rows: ${body.slice(0, 160)}`,
+        ).toBeTruthy();
+      } else {
+        expect([401, 403], `${path} must reject an anonymous caller`).toContain(r.status());
+      }
+    }
+  });
+
+  test("a forged token for A's user id is rejected", async ({ request }) => {
+    const b64 = (o: unknown) => Buffer.from(JSON.stringify(o)).toString('base64url');
+    const forged = `${b64({ alg: 'none', typ: 'JWT' })}.${b64({ sub: FIXTURES.aId, role: 'authenticated', email: FIXTURES.aEmail })}.`;
+    const r = await request.get('/api/hypotheses', {
+      headers: { Authorization: `Bearer ${forged}` }, failOnStatusCode: false,
+    });
+    expect([401, 403], 'an unsigned token claiming to be A was accepted').toContain(r.status());
+  });
+});

--- a/qa/e2e/perf.spec.ts
+++ b/qa/e2e/perf.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { settle, CLS_BUDGET, CLS_GOOD } from './_shared';
+import { settle, CLS_BUDGET, CLS_GOOD, CLS_UNSTABLE } from './_shared';
 
 // Core Web Vitals + third-party request volume.
 //
@@ -7,7 +7,13 @@ import { settle, CLS_BUDGET, CLS_GOOD } from './_shared';
 // measurement - no network latency, no Render cold start. Budgets are set
 // loose enough that only a real regression trips them.
 
-const KEY_ROUTES = ['/', '/login', '/arena', '/dashboard', '/markets', '/briefing'];
+// /scanner was missing from this list until 2026-08-05, and it is by far the
+// worst route in the app for layout shift - CLS 0.622-1.693 over 10 identical
+// loads even WITH fix/scanner-layout-shift, up to 17x the "good" threshold. A
+// Core Web Vitals spec that skips the worst offender is not doing its job, and
+// this one did for its whole existence. If you add a route to the app, add it
+// here too; the cost is a few seconds per run.
+const KEY_ROUTES = ['/', '/login', '/arena', '/dashboard', '/markets', '/briefing', '/scanner'];
 
 test.describe('performance', () => {
   test.beforeEach(({ }, testInfo) => {
@@ -15,7 +21,7 @@ test.describe('performance', () => {
   });
 
   for (const route of KEY_ROUTES) {
-    test(`${route} stays within CLS and LCP budget`, async ({ page }) => {
+    test(`${route} stays within CLS and LCP budget`, async ({ page }, testInfo) => {
       await settle(page, route);
 
       const vitals = await page.evaluate(() => new Promise<{ lcp: number; cls: number }>(resolve => {
@@ -34,22 +40,42 @@ test.describe('performance', () => {
         setTimeout(() => resolve({ lcp: Math.round(lcp), cls: +cls.toFixed(3) }), 1200);
       }));
 
-      // Audit §3.2 claimed 0.000 everywhere. That was wrong - /arena and
-      // /briefing both shift visibly during load (see CLS_BUDGET in _shared.ts
-      // for the measurements and which element moves). Those two are held to a
-      // documented known-bad budget; every other route is held to the real
-      // 0.1 "good" threshold.
-      const budget = CLS_BUDGET[route] ?? CLS_GOOD;
-      const known = route in CLS_BUDGET;
-      expect(
-        vitals.cls,
-        known
-          ? `${route} CLS ${vitals.cls} exceeded its known-bad budget of ${budget}. ` +
-            `This route already fails the 0.1 "good" threshold; it just got worse. ` +
-            `Do NOT raise the budget - see CLS_BUDGET in qa/e2e/_shared.ts.`
-          : `${route} CLS regressed to ${vitals.cls} (budget ${budget}). Content is ` +
-            `jumping during load.`,
-      ).toBeLessThan(budget);
+      // Record every measurement, asserted or not, so the number reaches the
+      // report even for routes too unstable to gate on.
+      testInfo.attach(`cls-${route.replace(/\W+/g, '_') || 'root'}.txt`, {
+        body: `${route}  CLS=${vitals.cls}  LCP=${vitals.lcp}ms`,
+        contentType: 'text/plain',
+      });
+
+      // Audit §3.2 claimed 0.000 everywhere. That was wrong - see CLS_BUDGET
+      // and CLS_UNSTABLE in _shared.ts for what actually shifts and by how
+      // much. Known-bad routes get a documented budget; the rest are held to
+      // the real 0.1 "good" threshold.
+      if (CLS_UNSTABLE.has(route)) {
+        // Measured and reported, deliberately NOT asserted. /scanner's CLS
+        // varies ~3x across identical loads, so any threshold either flakes or
+        // is too loose to catch anything. This is a worse state than a bad
+        // fixed number, not a pass - see CLS_UNSTABLE for the distribution and
+        // what has to happen before it becomes a real assertion again.
+        testInfo.annotations.push({
+          type: 'known-issue',
+          description:
+            `${route} CLS ${vitals.cls} - non-deterministic (0.622-1.693 over 10 runs), ` +
+            `not gated. See CLS_UNSTABLE in qa/e2e/_shared.ts.`,
+        });
+      } else {
+        const budget = CLS_BUDGET[route] ?? CLS_GOOD;
+        const known = route in CLS_BUDGET;
+        expect(
+          vitals.cls,
+          known
+            ? `${route} CLS ${vitals.cls} exceeded its known-bad budget of ${budget}. ` +
+              `This route already fails the 0.1 "good" threshold; it just got worse. ` +
+              `Do NOT raise the budget - see CLS_BUDGET in qa/e2e/_shared.ts.`
+            : `${route} CLS regressed to ${vitals.cls} (budget ${budget}). Content is ` +
+              `jumping during load.`,
+        ).toBeLessThan(budget);
+      }
 
       // Measured 84-720ms locally. 2500ms is Google's "good" bar - generous
       // headroom so this only fires on a genuine regression.

--- a/qa/e2e/perf.spec.ts
+++ b/qa/e2e/perf.spec.ts
@@ -7,12 +7,19 @@ import { settle, CLS_BUDGET, CLS_GOOD, CLS_UNSTABLE } from './_shared';
 // measurement - no network latency, no Render cold start. Budgets are set
 // loose enough that only a real regression trips them.
 
-// /scanner was missing from this list until 2026-08-05, and it is by far the
-// worst route in the app for layout shift - CLS 0.622-1.693 over 10 identical
-// loads even WITH fix/scanner-layout-shift, up to 17x the "good" threshold. A
+// /scanner was missing from this list until 2026-08-05, and at the time it was
+// added it was by far the worst route in the app for layout shift - CLS
+// 0.622-1.693 over 10 identical loads even WITH fix/scanner-layout-shift. A
 // Core Web Vitals spec that skips the worst offender is not doing its job, and
-// this one did for its whole existence. If you add a route to the app, add it
-// here too; the cost is a few seconds per run.
+// this one did for its whole existence.
+// It now measures 0.007-0.028 warm over 24 runs and carries a real 0.25 budget
+// (see CLS_BUDGET). Worth noting WHY it looked non-deterministic: the route was
+// only ever measured on a build missing fix/scanner-card-layout-shift, so the
+// spread was a genuine race that has since been fixed - not observer noise. The
+// lesson that survives is the sampling one: 3 runs called it fixed, 10 runs
+// disproved that.
+// If you add a route to the app, add it here too; the cost is a few seconds per
+// run.
 const KEY_ROUTES = ['/', '/login', '/arena', '/dashboard', '/markets', '/briefing', '/scanner'];
 
 test.describe('performance', () => {
@@ -52,16 +59,19 @@ test.describe('performance', () => {
       // much. Known-bad routes get a documented budget; the rest are held to
       // the real 0.1 "good" threshold.
       if (CLS_UNSTABLE.has(route)) {
-        // Measured and reported, deliberately NOT asserted. /scanner's CLS
-        // varies ~3x across identical loads, so any threshold either flakes or
-        // is too loose to catch anything. This is a worse state than a bad
-        // fixed number, not a pass - see CLS_UNSTABLE for the distribution and
-        // what has to happen before it becomes a real assertion again.
+        // Measured and reported, deliberately NOT asserted, for a route whose
+        // CLS varies so much that any threshold either flakes or is too loose to
+        // catch anything. That is a WORSE state than a bad fixed number, not a
+        // pass - the annotation exists so it cannot be mistaken for one.
+        // CLS_UNSTABLE is currently EMPTY (/scanner was retired to a real budget
+        // on 2026-08-05), so this branch does not run today. Kept because the
+        // distinction is real and re-deriving it mid-incident would be worse.
         testInfo.annotations.push({
           type: 'known-issue',
           description:
-            `${route} CLS ${vitals.cls} - non-deterministic (0.622-1.693 over 10 runs), ` +
-            `not gated. See CLS_UNSTABLE in qa/e2e/_shared.ts.`,
+            `${route} CLS ${vitals.cls} - non-deterministic, not gated. ` +
+            `See CLS_UNSTABLE in qa/e2e/_shared.ts for the distribution and the ` +
+            `retirement condition.`,
         });
       } else {
         const budget = CLS_BUDGET[route] ?? CLS_GOOD;

--- a/qa/e2e/security.spec.ts
+++ b/qa/e2e/security.spec.ts
@@ -117,17 +117,17 @@ test.describe('api security', () => {
   });
 
   // ─────────────────────────────────────────────────────────────────────
-  // NOT COVERED - the single biggest gap in this suite.
+  // BOLA / IDOR (OWASP API #1) used to be a test.fixme here - the single
+  // biggest gap in this suite, and the one thing every other spec left
+  // unanswered, because everything else tests the signed-out surface where
+  // the answer is always 401.
   //
-  // BOLA / IDOR (OWASP API #1) needs two real signed-in accounts to prove
-  // user B cannot read user A's journal entries, alerts, settings or
-  // subscription row. HANDOVER.md §1 says two test accounts exist.
+  // It now lives in qa/e2e/bola.spec.ts, which authenticates as two seeded
+  // accounts and proves B cannot read or mutate A's rows. It is a separate
+  // file because it is the only spec that signs in, and the only one whose
+  // failure means "user data is exposed".
   //
-  // To enable: set E2E_TOKEN_A and E2E_TOKEN_B (Supabase access tokens) as
-  // repo secrets, then write the cross-account reads here. Until then this is
-  // UNVERIFIED, not passing.
+  // It skips - loudly, never passes - when the fixtures are absent. See
+  // qa/e2e/_auth.ts for what it needs.
   // ─────────────────────────────────────────────────────────────────────
-  test.fixme('BOLA: user B cannot read user A resources', async () => {
-    // Blocked on E2E_TOKEN_A / E2E_TOKEN_B. See audit intro.
-  });
 });


### PR DESCRIPTION
## Summary

Release candidate on `qa` — **19 commits**, everything since `v2026.08.05.2`. Merging this PR is the release: merge → deploy prod manually → re-check → tag.

Staging: **https://liquidity-hq-qa.onrender.com** — `qa` = `6258c43`, deployed 2026-08-05 19:11 UTC.

Almost all of it is accessibility, API correctness and test coverage. **No migrations. No new environment variables. No schema changes.** Both highest-risk categories are absent.

| | Before | After |
|---|---|---|
| BOLA/IDOR automated coverage | **none, ever** | **9 tests in CI** |
| `nested-interactive` on `/arena` | 2 | **0** |
| WCAG 1.4.13 on the scanner panel | fails Dismissable | **passes** |
| Authorization denials | HTTP **500** | HTTP **404** |
| Anonymous `GET /api/price-alerts` | **200** | **401** |
| E2E suite | 178 | **187 passing** |
| Unit tests | 75 | 75 |
| Lint | 0 errors / 94 warnings | unchanged |

## What changed

### Security — the largest untested area in the product now has tests

Nobody had ever verified that one customer cannot read another's data. QA wrote 9 tests against two seeded accounts and **found no hole**: every route scopes with `.eq('user_id', user.id)` *and* queries with the user's token, so RLS is a second layer rather than the only one.

Covered: cross-account read, modify, delete, mass-assignment via `user_id` in the body, direct PostgREST access, anonymous requests, and a forged `alg:none` token claiming another user's `sub`.

Not covered, stated plainly: the **trade journal** has no API route — `TradeJournal.tsx` queries Supabase directly from the browser, so its protection is RLS alone. That is covered by the direct-PostgREST test, but there is no API surface to probe. If a journal route is ever added, the spec needs a case for it.

### Two API defects that fell out of writing those tests

**Authorization denials returned 500.** `.eq('user_id')` *is* the ownership filter, so a write aimed at another user's row matches zero rows — and `.single()` reports zero rows as an error, which `apiError` turned into a 500. Nothing was ever at risk; it failed closed. But a denial that surfaces as 500 is indistinguishable from a genuine fault in the logs, so you cannot alert on 500s. Now 404.

**404 rather than 403 deliberately.** A 403 confirms the row exists and belongs to somebody else, which is a working existence oracle for enumerating ids. 404 is the same answer for "no such row" and "not yours".

**`GET /api/price-alerts` answered anonymous callers 200** where `/api/hypotheses` and `/api/settings` both 401. No data was exposed — the list really was empty — but it stops being harmless the day someone adds a default. Now 401.

Also fixed without being reported: `DELETE /api/price-alerts` answered `{ok: true}` to a delete that changed nothing, because Supabase reports success for an UPDATE matching zero rows.

### A CI configuration gap that made previous green runs mean less than they looked

`lib/tables.ts` picks the table prefix with `NEXT_PUBLIC_APP_ENV === 'dev' ? 'lhq_dev_' : 'lhq_'`. CI never set that variable, so **CI built with production table names and queried the dev database**, which has none of them.

Measured both directions on a production build, account A reading its **own** rows:

| | without the var | with `=dev` |
|---|---|---|
| `/api/hypotheses` | 500 | 200 |
| `/api/price-alerts` | 500 | 200 |
| `/api/settings` | 500 | 200 |

Every authenticated CI run before this was querying tables that were not there. Those runs were green because nothing authenticated was being exercised — not because the app was proven correct. The BOLA suite is the first thing that hit those routes in CI, which is how a gap older than all of this finally surfaced.

### Accessibility on `/arena`

**Controls nested inside other controls (`nested-interactive`), 2 → 0.** One was introduced by making the `Tip` tooltip keyboard operable in the last release — its trigger became a real focusable control, so every `Tip` inside a `<button>` became a control inside a control. The other predated it: the notification bell was written as `div[role=button]` with a comment saying it avoided "button-in-button invalid HTML", which fixed the HTML-validity half but not the accessibility half — the tree still exposed two controls where the user sees one.

**The hover-opened scanner panel now meets WCAG 2.1 SC 1.4.13 (AA).** Hovering the coin bar opens the panel after 800ms — deliberate, and kept. What was missing is everything the spec requires of hover-triggered content: Escape did nothing, and moving the pointer away left the panel open indefinitely. Passing over the bar on the way somewhere else left a panel covering the page with no way to dismiss it except clicking.

Now: Escape closes it; mouse-out closes it *if hover opened it*; a click-opened panel deliberately survives mouse-out, because closing that the instant the pointer drifts off would make it unusable.

### Test tooling

`/scanner` retired from `CLS_UNSTABLE` to a real `CLS_BUDGET` of 0.25, after 24 runs on the shipped build measured warm min 0.007 / median 0.011 / max 0.028 — down from the 0.622–1.693 that justified ungating it. The tap-target baseline ratcheted 217 → 122, and the metric renamed, because it was never a WCAG conformance count: all 122 remaining are `<a>` elements inside blocks of text, which SC 2.5.8 exempts outright. **Real WCAG tap-target failures: 0.** `timeout-minutes: 45` added to the E2E job so a hung run fails fast instead of burning to GitHub's 6-hour default.

## How to test (QA)

All steps on **https://liquidity-hq-qa.onrender.com**. Free plan — it sleeps when idle, so the first request may take ~50s. Reload once before judging anything.

**A. `/arena` scanner panel — the biggest behaviour change**
1. Hover the coin bar **without clicking**. The scanner panel opens after ~1s. (Unchanged.)
2. Press <kbd>Esc</kbd> → it closes. **New.**
3. Hover again, then move the mouse away without clicking → it closes on its own. **New.**
4. **Click** the bar to open it, then move the mouse away → it must **stay open**. This is the regression risk of the change.
5. <kbd>Esc</kbd> closes that one too.
6. With the panel open, move the pointer from the bar **down into the panel** → must not close.
7. Click outside → still closes, as before.

**B. `/arena` controls**
8. Click the notification bell → toggles notifications. The scanner panel opening at the same time is the hover behaviour from A, not the click — check the bell's own state changed.
9. <kbd>Tab</kbd> to the coin bar and press <kbd>Enter</kbd> → opens. <kbd>Enter</kbd> again → closes.
10. The anti-chop toggle beside the chart still switches on click; its ⓘ still opens on focus and closes on <kbd>Esc</kbd>.
11. Signed out, **Quick Research** / **Deep Research** still navigate to `/login`.

**C. Price alerts and hypotheses — the API changes**
12. Signed in, `/alerts`: price alerts list, create, edit and delete normally.
13. **Signed out, reload `/alerts`** → the page must still render with an empty alerts list, not an error or a stuck skeleton. This is the regression risk of the 401 change.
14. `/arena`: drag a chart alert to a new price → still saves.
15. `/journal` hypotheses: create, edit, delete still work.

**D. Nothing else should have moved**
16. `/dashboard`, `/scanner`, `/markets` — normal use. No visual change is intended anywhere in this release.

**E. Release**
17. Merge this PR into `main`.
18. Deploy prod manually — Render → `liquidity-hq-prod` → Manual Deploy → Deploy latest commit (`autoDeploy: no`, so merging alone ships nothing).
19. Re-check A–D against liquidity-hq.com.
20. Tag `v2026.08.06`.

## Risk level

**Low-Medium.** No migrations, no environment variable changes on any service, no auth or payment code, no schema changes. The app-code surface is one route's open/close logic, one component's DOM structure, and three API status codes.

Rollback is clean: Render → Deploys → *Rollback to this deploy*.

**Known limitations and things not verified:**

- **Light theme contrast has never been measured**, before this release or after. All contrast work was on the dark theme, which is the default and what every route serves by default. Unverified, not a regression.
- **Contrast was measured on 8 routes.** `/alerts`, `/journal`, `/news`, `/backtest`, `/liq`, `/funding`, `/econ-calendar`, `/hours` and `/ops` received token substitutions with no measured proof.
- **`--txt2` is 4.31:1 on the `#191b1e` card.** Nothing renders it there today, so not a live defect, but it would become one if secondary text moved onto that card. Recorded in `__tests__/contrastTokens.test.mts` rather than fixed, because clearing it means relightening secondary type app-wide — a visible typography change that should be a deliberate decision.
- **`aggTrades` stays in the browser** — 45 requests, 180 of the remaining 214 Binance request-weight. Moving it needs a push channel, not a relocation.
- **The trade journal has no API-route BOLA coverage** because it has no API route. See above.

## Separate finding — needs an owner decision, NOT in this release

`alert_fires` schema drift, found while verifying the signed-out `/alerts` page:

| | `lhq_alert_fires` | `lhq_dev_alert_fires` |
|---|---|---|
| **dev** | missing | missing |
| **prod** | present | **present — should not exist on prod** |

So `/alerts` "recent fires" 404s on dev for everyone, and prod carries a stray dev-prefixed table. The migration that created these was applied to prod only, and applied both variants there. Deliberately untouched: creating or dropping tables is a migration and always High risk, and prod Supabase is on the free plan with no backups.

Worth settling before anyone reads a clean dev `/alerts` as evidence of anything.
