### PR TITLE
fix(alerts): use the table registry instead of hardcoding the prod table name

### DIFF
--- a/components/AlertOutcomes.tsx
+++ b/components/AlertOutcomes.tsx
@@ -1,10 +1,11 @@
 'use client';
 // Tier 2 #10 - honest track record for the directional alert types (squeeze,
-// EMA cross, distribution, RSI, whales). Reads lhq_alert_fires directly with
+// EMA cross, distribution, RSI, whales). Reads T.alert_fires directly with
 // the anon client (public SELECT policy, same pattern as live-tracking's read
 // of lhq_live_signals) - writes only ever happen server-side via the alert cron.
 import { useEffect, useState } from 'react';
 import { getSupabase } from '@/lib/supabase';
+import { T } from '@/lib/tables';
 import { StatRow } from '@/components/BacktestStatsUI';
 import Tip from '@/components/Tip';
 import EmptyState from '@/components/EmptyState';
@@ -48,8 +49,21 @@ export default function AlertOutcomes() {
     (async () => {
       const sb = getSupabase();
       if (!sb) { setError('Not configured'); return; }
+      /* T.alert_fires, not the literal 'lhq_alert_fires' this used to hardcode.
+         That literal is the PRODUCTION table name, so this component queried
+         prod's table name against whatever project it was pointed at - which
+         works on prod by coincidence and 404s everywhere else. It is the only
+         place in the codebase that bypassed lib/tables; the other six consumers
+         of this table all use T.alert_fires.
+         Consequence while it stood: the panel has never rendered on dev or
+         staging, so every QA pass over /alerts was passing over a feature that
+         could not load. Found while verifying the signed-out /alerts page for
+         an unrelated 401 change.
+         Note this does NOT make the panel work on dev by itself - see the
+         alert_fires table drift below. It stops the code lying about which
+         environment it is in, which is the part that is a code defect. */
       const { data, error: err } = await sb
-        .from('lhq_alert_fires')
+        .from(T.alert_fires)
         .select('rule_key, coin, dir, label, fired_at, outcome_pct_24h, resolved_24h, outcome_pct_48h, resolved_48h')
         .order('fired_at', { ascending: false })
         .limit(500);


### PR DESCRIPTION
## Summary

`components/AlertOutcomes.tsx` queried the string literal `'lhq_alert_fires'` instead of `T.alert_fires`. That literal is the **production** table name, so the component queried prod's table name against whatever project the build was pointed at.

One line, plus the import. **Production behaviour is unchanged** — `T.alert_fires` resolves to exactly the literal that was there before.

## Why it matters

`lib/tables.ts` exists to resolve `lhq_` vs `lhq_dev_` per environment. This was the only place in the codebase that bypassed it — verified with a sweep, it was the single remaining `.from('lhq_...')` literal anywhere in `app/`, `components/` or `lib/`. The other six consumers of this table all use `T.alert_fires`.

| Environment | Before |
|---|---|
| **prod** | works — by coincidence, the hardcoded name matches |
| **dev / staging** | 404, table does not exist there |

So the "recent fires" track record on `/alerts` has **never rendered on dev or staging**. Any QA pass over that page was passing over a feature that could not load — which is the part worth flagging, because it means the page looked fine while a panel on it was silently dead.

Found while verifying the signed-out `/alerts` page for the unrelated 401 change in #29: the 404 in the network tab was for `lhq_alert_fires` while the build was pointed at the dev project.

## This does NOT make the panel work on dev

After the fix it correctly requests `lhq_dev_alert_fires` — which also does not exist there. Verified:

```
before fix:  404  lhq_alert_fires        <- prod's name, on dev
after fix:   404  lhq_dev_alert_fires    <- correct name, still absent
```

That remaining 404 is a separate table drift needing a migration, and it is **deliberately not in this PR**:

| | `lhq_alert_fires` | `lhq_dev_alert_fires` |
|---|---|---|
| **dev** | missing | missing |
| **prod** | present | **present — should not be on prod** |

Two things wrong there: dev never got the table, and prod got a dev-prefixed one it should not have. Creating or dropping tables is a migration, always High risk, and prod Supabase is free-tier with no backups — so that is the owner's call, not mine. Recorded in release PR #33.

What this commit fixes is the code defect: the component no longer claims to be in an environment it is not in.

## Verification

```
tsc --noEmit   clean
npm test       75 passing
npm run lint   0 errors, 94 warnings (unchanged)
npm run build  clean
```

Network tab on `/alerts`, dev build: request changed from `lhq_alert_fires` to `lhq_dev_alert_fires`.

## How to test (QA)

1. On staging `/alerts`, open DevTools → Network → filter `alert_fires`. The request must be for **`lhq_dev_alert_fires`**, not `lhq_alert_fires`. It will still **404** — expected, that is the migration above, not this change.
2. **On production after release**, the same filter must show **`lhq_alert_fires`** exactly as before, and the recent-fires panel must still render its rows. This is the only regression risk in the change: if that panel goes blank on prod, this is why.

## Risk level

**Low.** One identifier, resolved through a registry that already produces the identical string on production. No API, no schema, no styling. The prod check in step 2 is the whole test.