### PR TITLE
ci: run the browser suite once per release, on the PR into main

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -50,13 +50,12 @@
 - [ ] **New environment variable?** If yes, list it here and say which services still need it set. A var that exists only on dev is a broken deploy waiting to happen
 - [ ] Anything I could not verify is stated in the PR, not left for QA to discover
 
-### If this is a `dev` → `qa` promotion — QA fills this in
-
-CI does **not** run the browser suite on this PR. It runs on the `qa` → `main`
-release PR only, so this box is the browser check for everything going to staging.
-See CONTRIBUTING.md section 4b.
-
-- [ ] `npm run test:e2e` run locally — result posted as a comment (pass/fail, and the count)
+> **Note on the browser suite.** CI runs Playwright on a PR into `main` only — the
+> release. Feature PRs and `dev` → `qa` promotions get the four fast gates above and
+> nothing more, so **the first automated browser check any change gets is at the
+> release gate**. If this PR is risky enough that you want it sooner, run
+> `npm run test:e2e` locally or use Actions → CI → Run workflow, and say so here.
+> See CONTRIBUTING.md §4b.
 
 ## Screenshots (if UI change)
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -50,6 +50,14 @@
 - [ ] **New environment variable?** If yes, list it here and say which services still need it set. A var that exists only on dev is a broken deploy waiting to happen
 - [ ] Anything I could not verify is stated in the PR, not left for QA to discover
 
+### If this is a `dev` → `qa` promotion — QA fills this in
+
+CI does **not** run the browser suite on this PR. It runs on the `qa` → `main`
+release PR only, so this box is the browser check for everything going to staging.
+See CONTRIBUTING.md section 4b.
+
+- [ ] `npm run test:e2e` run locally — result posted as a comment (pass/fail, and the count)
+
 ## Screenshots (if UI change)
 
 *Before and after. "N/A - no visual change" is a valid answer; leaving it blank is not.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,25 +1,75 @@
 name: CI
 
+# ─────────────────────────────────────────────────────────────────────────────
+# WHERE THE BROWSER SUITE RUNS. Read this before adding a trigger.
+#
+# Aug 3-5 2026 burned 1,755 Actions minutes in three days on a private repo with
+# a 2,000 min/month allowance - roughly $124/month annualised, and it hard-
+# stopped CI mid-release when the spending limit was hit.
+#
+# The rule now: the ~2 minute job runs on everything. The ~34 minute Playwright
+# suite runs on exactly ONE automatic trigger - a PR into `main`, which is the
+# release, immediately before a production deploy.
+#
+# What replaces it everywhere else is QA running the suite LOCALLY when a
+# dev -> qa PR arrives (CONTRIBUTING section 4b). That is a real gate with a
+# named owner, not a hope.
+#
+# Why one CI run survives at all: QA's local run is one machine with .env.local
+# present. CI is the only place the app builds WITHOUT developer env, and that
+# difference has produced two real defects - the labels bug (only reproduces
+# when /api/labels returns {}, which never happens locally) and the
+# NEXT_PUBLIC_APP_ENV table-prefix gap. ~136 min/month for the last check
+# between a green laptop and production.
+# ─────────────────────────────────────────────────────────────────────────────
+
 on:
-  # qa is the branch QA tests against, so a broken merge into it costs QA a
-  # wasted test run and a false bug report before anyone looks at CI. Checking
-  # it here is cheaper than that. Note the qa Render service does NOT
-  # auto-deploy - a merge into qa is not live until someone triggers it - so
-  # this is a gate on the branch, not a last line of defence before users.
-  push:
-    branches: [dev, qa, main]
-  # Also on PRs, or CI only ever runs AFTER a merge - which is the one moment
-  # it cannot help. The convention makes the PR the review point (CONTRIBUTING
-  # section 4), so the checks have to be green before the merge button, not
-  # after. Covers PRs from any branch, including QA-authored ones, which a
-  # push trigger limited to [dev, main] never sees.
+  # The PR is the review point (CONTRIBUTING section 4), so the gate has to be
+  # here - CI that only runs after a merge runs at the one moment it cannot
+  # help. `types` is explicit so a label or a title edit can never spend 34
+  # minutes; `synchronize` is the one that fires on each push to an open PR.
   pull_request:
     branches: [dev, qa, main]
+    types: [opened, reopened, synchronize, ready_for_review]
+
+  push:
+    # `qa` is deliberately ABSENT. CONTRIBUTING section 6 makes dev -> qa
+    # fast-forward only, so the commit landing on qa is bit-identical to one
+    # already tested on dev. Worse, the qa->main release PR stays open for the
+    # whole cycle, so each ff-push to qa ALSO fired `synchronize` on it - one
+    # promotion used to bill three full runs.
+    branches: [dev, main]
+
+  # For running the browser suite on demand: re-checking after a flake, or
+  # proving a fix without opening a release PR first.
+  workflow_dispatch:
+    inputs:
+      e2e:
+        description: Run the full browser suite
+        type: boolean
+        default: true
+
+# Without this, every push to a PR stacked another run and the superseded one
+# carried on to completion. Nothing was ever cancelled. Costs no coverage.
+#
+# event_name is in the group so a dispatch and a push never share a lane.
+concurrency:
+  group: ci-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref_name }}
+  # PRs and dev cancel freely - only the tip matters. main NEVER cancels
+  # mid-flight; a second push queues behind the first. On a pull_request event
+  # ref_name is "33/merge", not a branch, so the dev comparison cannot
+  # false-positive there.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref_name == 'dev' }}
+
+permissions:
+  contents: read
 
 jobs:
   build:
     name: Lint + typecheck + test + build
     runs-on: ubuntu-latest
+    # Had no cap at all, so a hung npm ci billed toward GitHub's 6-hour default.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -36,7 +86,7 @@ jobs:
       # Runs first because it is the fastest of the four steps.
       #
       # Fails on errors only. Warnings are printed but do not block - there are
-      # 93 of them, a pre-existing React Compiler backlog documented in
+      # 94 of them, a pre-existing React Compiler backlog documented in
       # eslint.config.mjs. Deliberately no --max-warnings=0: it would either
       # force a 67-file refactor of live code today, or be set to a number
       # nobody maintains.
@@ -64,15 +114,28 @@ jobs:
   e2e:
     name: E2E (Playwright)
     runs-on: ubuntu-latest
+    # Only after lint/typecheck/unit/build are green. A broken build would
+    # produce 216 browser failures that all say "the build is broken", which
+    # buries the one line that actually explains it.
+    needs: build
+    # THE COST DECISION, in one expression. A PR into `main` is the release, and
+    # the production deploy is the next manual step after it merges. Nothing
+    # else triggers this automatically.
+    #
+    # base_ref, not ref_name - on a pull_request event ref_name is "33/merge".
+    # base_ref is empty on push and on dispatch, so both fall through.
+    #
+    # PRs into `dev` and into `qa` deliberately get the 2-minute job only. What
+    # covers them is QA running this same suite locally when the dev -> qa PR
+    # arrives. See CONTRIBUTING 4b.
+    if: >-
+      github.base_ref == 'main' ||
+      (github.event_name == 'workflow_dispatch' && inputs.e2e)
     # A full run is ~31 minutes. Without a cap, a genuinely hung run burns to
     # GitHub's 6-hour default, and a stuck run looks identical to a slow one -
     # which happened while this suite was being brought up. 45 leaves headroom
     # for a cold runner without hiding a hang.
     timeout-minutes: 45
-    # Only after lint/typecheck/unit/build are green. A broken build would
-    # produce 216 browser failures that all say "the build is broken", which
-    # buries the one line that actually explains it.
-    needs: build
     steps:
       - uses: actions/checkout@v4
 
@@ -91,8 +154,30 @@ jobs:
       # project. devices['iPhone 13'] defaults to WebKit, and without that pin
       # every mobile test fails here with "Executable doesn't exist at
       # .../webkit-2336" - which is what happened the first time this suite ran.
+      #
+      # Cached on the Playwright VERSION, not the lockfile hash: a dependency
+      # bump elsewhere should not evict a 120MB browser download that was
+      # otherwise re-fetched on every single run.
+      - name: Resolve Playwright version
+        id: pw
+        run: echo "v=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Chromium
+        id: pwcache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-${{ steps.pw.outputs.v }}
+
       - name: Install Chromium
+        if: steps.pwcache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+
+      # The browser binary is cached but its apt system libraries are not -
+      # those live outside ~/.cache. ~5s.
+      - name: Install Chromium system deps
+        if: steps.pwcache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       # playwright.config.ts's webServer runs `npm run build && npm start` on
       # port 3100, so CI and local exercise the same production build.
@@ -160,10 +245,63 @@ jobs:
           E2E_A_HYPOTHESIS_ID: ${{ secrets.E2E_A_HYPOTHESIS_ID }}
           E2E_A_PRICE_ALERT_ID: ${{ secrets.E2E_A_PRICE_ALERT_ID }}
 
-      # Uploaded on failure too - that is the run you actually need to read.
+      # failure() only. This used to upload on every green run too - ~15s and
+      # storage for a report nobody opens. failure() still excludes
+      # cancellations, so a concurrency-cancelled run uploads nothing.
       - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
+        if: ${{ failure() }}
         with:
-          name: playwright-report
+          name: playwright-report-${{ github.run_attempt }}
           path: qa/e2e-report/
           retention-days: 14
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # THE ONLY REQUIRED STATUS CHECK. Do not require `build` or `e2e` directly.
+  #
+  # GitHub's behaviour here is unintuitive and both halves are traps:
+  #
+  #   * A job skipped by its own `if:` reports SUCCESS to branch protection. So
+  #     requiring `E2E (Playwright)` would be satisfied by it NOT running - which
+  #     is now the normal case on every PR that is not a release.
+  #   * A job skipped because `needs:` FAILED also reports SUCCESS. So requiring
+  #     `e2e` while `build` is not required would let a broken build merge on a
+  #     green tick.
+  #
+  # This job therefore asserts the REASON for a skip, not merely the absence of
+  # a failure. always() rather than !cancelled() so a cancelled run still ends
+  # red - harmless, because cancellation only happens when a newer SHA arrives
+  # and checks are evaluated per-SHA.
+  # ───────────────────────────────────────────────────────────────────────────
+  gate:
+    name: CI Gate
+    if: ${{ always() }}
+    needs: [build, e2e]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Every job that should have run, ran and passed
+        env:
+          BUILD: ${{ needs.build.result }}
+          E2E: ${{ needs.e2e.result }}
+          BASE: ${{ github.base_ref }}
+        run: |
+          set -uo pipefail
+          echo "build=$BUILD  e2e=$E2E  base=$BASE"
+          fail=0
+          # build carries no `if:`, so anything other than success is real.
+          [ "$BUILD" = success ] || { echo "::error::build job: $BUILD"; fail=1; }
+          if [ "$BASE" = main ]; then
+            # A release PR. E2E was supposed to run. `skipped` here means build
+            # died - and GitHub would otherwise report that skip as a green
+            # check. This branch is what closes that hole.
+            [ "$E2E" = success ] \
+              || { echo "::error::e2e job: $E2E - required for a PR into main"; fail=1; }
+          else
+            # Not a release. E2E is expected to skip, but if it somehow ran and
+            # failed, that is still a failure.
+            case "$E2E" in
+              success|skipped) ;;
+              *) echo "::error::e2e job: $E2E"; fail=1 ;;
+            esac
+          fi
+          exit $fail

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,7 +248,17 @@ on `dev` for a day with nobody wondering why it never reached staging.
 4. If the QA folder has no `CLAUDE.md` / `CONTRIBUTING.md`, it has not pulled
    since this convention landed. **Pull `main` first**, then check out the
    feature branch, so both folders are working to the same standard.
-5. **When every step passes, QA merges `qa` into `main`** and then deploys —
+5. **On a `dev` → `qa` promotion PR, run the browser suite locally before the
+   promotion is merged.** This is QA's, and it is the only automated browser
+   check that change gets before staging — CI does not run the suite on that PR.
+   Full detail in §4b; the short version:
+
+   ```
+   npm run test:e2e
+   ```
+
+   ~30 minutes, 187 tests. Report pass/fail on the PR like any other step.
+6. **When every step passes, QA merges `qa` into `main`** and then deploys —
    both steps, in that order. See below.
 
    `qa` → `main`, not the feature branch → `main`. By the time QA is testing,
@@ -349,6 +359,79 @@ independent check on it.
 This section exists because it was missing and the gap produced a real wrong
 answer: with no rule for QA-authored code, the dev session simply asserted that
 it would review such a branch — a role the document never gave it.
+
+---
+
+## 4b. What CI runs, and what QA runs
+
+**CI does not run the browser suite on most pushes.** Actions minutes are metered
+on a private repo, and three days of unrestricted running burned 1,755 minutes —
+about $124/month annualised — and hard-stopped CI mid-release when the spending
+limit hit. Nothing was deleted to fix that. The expensive half moved to a person
+with a name.
+
+### What GitHub runs
+
+| Event | Lint · typecheck · unit · build | Playwright |
+|---|---|---|
+| Push to a feature branch | ✅ ~2 min | — |
+| PR into `dev` | ✅ | — |
+| PR into `qa` | ✅ | — |
+| Push to `dev` or `main` | ✅ | — |
+| **PR into `main`** (the release) | ✅ | ✅ **full, 187 tests, ~34 min** |
+| Manual run (Actions → CI → Run workflow) | ✅ | ✅ if you tick the box |
+
+One automated browser run per release, immediately before a production deploy.
+
+### What QA runs
+
+**On a `dev` → `qa` promotion PR, before merging it:**
+
+```bash
+npm run test:e2e                    # full suite, ~30 min, builds and serves on :3100
+E2E_PORT=3000 npx playwright test   # or reuse a server you already have running
+```
+
+`.env.e2e.local` supplies the BOLA fixtures. It is gitignored and already in both
+checkouts; if it is missing, `bola.spec.ts` **skips with a stated reason** rather
+than passing, so a green run without it is not a green run.
+
+Report pass/fail on the PR. **This is the gate.** Nothing else exercises a browser
+against that change before it reaches staging.
+
+### What dev runs
+
+Unchanged — the four fast gates before opening any PR: `npm run lint`,
+`npx tsc --noEmit`, `npm test`, `npm run build`. E2E was never on dev's list and is
+not being added to it.
+
+### Be honest about what a local run cannot catch
+
+A green local run is **not** equivalent to CI, and the gap has already produced two
+real defects:
+
+- **The labels defect (2026-08-05).** `/api/labels` answers `200 {}` on a DB error
+  and the client applied it, wiping all 2,570 seeded English labels so every page
+  rendered raw keys. It only reproduces **without** Supabase env — CI's situation,
+  never yours locally with `.env.local` present. It surfaced as `/arena` overflowing
+  28px and a `/login` smoke failure, and it was red on *every* branch, including a
+  documentation-only PR.
+- **The table-prefix gap (2026-08-05).** CI had no `NEXT_PUBLIC_APP_ENV`, so it
+  built with production table names and queried the dev project, which has none of
+  them. Every authenticated CI run before it was fixed asserted less than it looked
+  like it did. Locally the variable is set, so the bug is invisible.
+
+Both are *environment-difference* bugs, invisible on a developer machine by
+construction. That is the entire reason one CI run survives at the `main` gate
+rather than the suite moving completely onto laptops.
+
+### The trade being made
+
+A browser regression now surfaces on QA's machine, not on the PR that introduced
+it — and dev ships to QA with no browser verification at all. When QA's run fails
+it is a round trip: report, dev cuts a `fix/` branch, re-promotes, QA re-runs 30
+minutes. That cost is accepted in exchange for roughly $120/month and a clear
+division of labour, and it is bounded by the weekly release cadence in §7a.
 
 ---
 
@@ -511,6 +594,30 @@ The two merges that actually reach users — `dev` → `qa` and `qa` → `main` 
 a PR like everything else. They are the merges with the highest blast radius,
 so they are the wrong place to skip the paper trail. A promotion PR needs no
 essay: a title, a list of what is going out, and the checklist below.
+
+### 7a. How often a release goes out
+
+**Features batch to a weekly release. Bug fixes and hotfixes ship when they are
+ready.**
+
+| What | Cadence |
+|---|---|
+| New features, additions, refactors, docs | Batched into **one release a week** |
+| Bug fixes | As soon as they are verified — do not wait for the weekly slot |
+| Hotfixes (production is broken) | Immediately, and they skip `qa` — see §6 |
+
+Merging to `dev` is not affected — that stays continuous. What batches is the
+promotion out of `dev`.
+
+Two things follow from this, and both are the point rather than side effects:
+
+- **A regression found at the `qa` gate arrives with a week of changes attached**,
+  not one. That is the cost of batching, and it is why §4b puts a full browser run
+  in QA's hands before the promotion is merged rather than after.
+- **"It is not urgent" is a real answer.** A feature that misses the weekly slot
+  waits. Shipping a feature mid-week to production, outside the batch, is a
+  decision someone makes deliberately — not something that happens because a PR
+  merged.
 
 ### Before `dev` → `qa`
 
@@ -687,6 +794,23 @@ Rules:
   destructive, that is where to do it.
 - Applied through the Supabase MCP (`apply_migration`), per
   `docs/HANDOVER.md` §5.
+- **Check the project you actually hit.** After applying anything, run this
+  against **prod**:
+
+  ```sql
+  select relname from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+   where n.nspname = 'public' and relname like 'lhq_dev_%';
+  -- must return zero rows on prod
+  ```
+
+  A dev-prefixed table on production means a migration meant for dev was applied
+  to prod. That happened **twice** and went unnoticed for weeks — `lhq_dev_alert_fires`
+  and `lhq_dev_user_settings` were both sitting on prod, empty, until a network
+  tab on `/alerts` surfaced the first one on 2026-08-05. Nothing broke, because
+  the app resolves table names through `lib/tables.ts` and never reads those, but
+  prod Supabase is on the free plan with **no backups** — the next one might not
+  be harmless. Two seconds of checking beats finding out later.
 
 ### Environment variables
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,18 +248,13 @@ on `dev` for a day with nobody wondering why it never reached staging.
 4. If the QA folder has no `CLAUDE.md` / `CONTRIBUTING.md`, it has not pulled
    since this convention landed. **Pull `main` first**, then check out the
    feature branch, so both folders are working to the same standard.
-5. **On a `dev` → `qa` promotion PR, run the browser suite locally before the
-   promotion is merged.** This is QA's, and it is the only automated browser
-   check that change gets before staging — CI does not run the suite on that PR.
-   Full detail in §4b; the short version:
-
-   ```
-   npm run test:e2e
-   ```
-
-   ~30 minutes, 187 tests. Report pass/fail on the PR like any other step.
-6. **When every step passes, QA merges `qa` into `main`** and then deploys —
+5. **When every step passes, QA merges `qa` into `main`** and then deploys —
    both steps, in that order. See below.
+
+   Merging opens the release PR's final CI run: **the full browser suite, 187
+   tests, ~34 minutes** (§4b). It is the only place that suite runs
+   automatically. Wait for it. A red run there means something QA's manual pass
+   did not reach, and it blocks the production deploy.
 
    `qa` → `main`, not the feature branch → `main`. By the time QA is testing,
    the change is already on `dev` and `qa`; merging the original feature branch
@@ -362,13 +357,13 @@ it would review such a branch — a role the document never gave it.
 
 ---
 
-## 4b. What CI runs, and what QA runs
+## 4b. Where the browser suite runs
 
-**CI does not run the browser suite on most pushes.** Actions minutes are metered
-on a private repo, and three days of unrestricted running burned 1,755 minutes —
-about $124/month annualised — and hard-stopped CI mid-release when the spending
-limit hit. Nothing was deleted to fix that. The expensive half moved to a person
-with a name.
+**CI does not run the Playwright suite on most pushes.** Actions minutes are
+metered on a private repo, and three days of unrestricted running burned 1,755
+minutes — about $124/month annualised — and hard-stopped CI mid-release when the
+spending limit was hit. Nothing was deleted to fix that. It was moved to the one
+place it is worth 34 minutes.
 
 ### What GitHub runs
 
@@ -378,62 +373,65 @@ with a name.
 | PR into `dev` | ✅ | — |
 | PR into `qa` | ✅ | — |
 | Push to `dev` or `main` | ✅ | — |
-| **PR into `main`** (the release) | ✅ | ✅ **full, 187 tests, ~34 min** |
+| **PR into `main`** (the release) | ✅ | ✅ **187 tests, ~34 min** |
 | Manual run (Actions → CI → Run workflow) | ✅ | ✅ if you tick the box |
 
-One automated browser run per release, immediately before a production deploy.
+**One automated browser run per release, immediately before production.**
 
-### What QA runs
+### Nobody runs it by hand
 
-**On a `dev` → `qa` promotion PR, before merging it:**
+Not dev, not QA. Dev's pre-PR gates are the four fast ones — `npm run lint`,
+`npx tsc --noEmit`, `npm test`, `npm run build`. QA's job is manual testing on
+staging, following the PR's "How to test" steps.
+
+This was deliberated and changed twice. An earlier draft had QA running
+`npm run test:e2e` locally on the promotion PR. It was dropped because it landed
+minutes before the release PR's CI run — **the same 187 tests, on the same
+commit, twice**, differing only in environment. Between the two, CI is the
+stricter one and costs nobody's afternoon, so the human run went.
+
+If you *want* it before then — a risky release, a big refactor — run it:
 
 ```bash
 npm run test:e2e                    # full suite, ~30 min, builds and serves on :3100
-E2E_PORT=3000 npx playwright test   # or reuse a server you already have running
+E2E_PORT=3000 npx playwright test   # or reuse a server already running
 ```
 
-`.env.e2e.local` supplies the BOLA fixtures. It is gitignored and already in both
-checkouts; if it is missing, `bola.spec.ts` **skips with a stated reason** rather
-than passing, so a green run without it is not a green run.
+`.env.e2e.local` supplies the BOLA fixtures. Without it `bola.spec.ts` **skips
+with a stated reason** rather than passing, so a green run missing that file is
+not a green run. There is also a manual trigger in Actions → CI → Run workflow.
 
-Report pass/fail on the PR. **This is the gate.** Nothing else exercises a browser
-against that change before it reaches staging.
+### What that means for the gap
 
-### What dev runs
+Between a feature merging into `dev` and the release PR opening, **nothing
+exercises a browser automatically**. Staging catches it instead: QA tests by hand
+on a real deployed build, which is a different and in some ways better check —
+a machine cannot tell you a layout looks wrong.
 
-Unchanged — the four fast gates before opening any PR: `npm run lint`,
-`npx tsc --noEmit`, `npm test`, `npm run build`. E2E was never on dev's list and is
-not being added to it.
+The cost is honest and worth stating: a browser-level regression surfaces at the
+release gate with a week of changes attached, not on the PR that caused it. That
+is bounded by the weekly cadence in §7a, and it is the trade made in exchange for
+roughly $120/month.
 
-### Be honest about what a local run cannot catch
+### Why the release run cannot be dropped too
 
-A green local run is **not** equivalent to CI, and the gap has already produced two
-real defects:
+CI is the only place the app builds **without** developer environment variables,
+and that difference has produced two real defects:
 
-- **The labels defect (2026-08-05).** `/api/labels` answers `200 {}` on a DB error
-  and the client applied it, wiping all 2,570 seeded English labels so every page
-  rendered raw keys. It only reproduces **without** Supabase env — CI's situation,
-  never yours locally with `.env.local` present. It surfaced as `/arena` overflowing
-  28px and a `/login` smoke failure, and it was red on *every* branch, including a
-  documentation-only PR.
+- **The labels defect (2026-08-05).** `/api/labels` answers `200 {}` on a DB
+  error and the client applied it, wiping all 2,570 seeded English labels so
+  every page rendered raw keys. It only reproduces **without** Supabase env — CI's
+  situation, never a developer machine with `.env.local` present. It surfaced as
+  `/arena` overflowing 28px and a `/login` smoke failure, and it was red on
+  *every* branch, including a documentation-only PR.
 - **The table-prefix gap (2026-08-05).** CI had no `NEXT_PUBLIC_APP_ENV`, so it
-  built with production table names and queried the dev project, which has none of
-  them. Every authenticated CI run before it was fixed asserted less than it looked
-  like it did. Locally the variable is set, so the bug is invisible.
+  built with production table names and queried the dev project, which has none
+  of them. Every authenticated CI run before it was fixed asserted less than it
+  looked like it did. Locally the variable is set, so the bug is invisible.
 
 Both are *environment-difference* bugs, invisible on a developer machine by
-construction. That is the entire reason one CI run survives at the `main` gate
-rather than the suite moving completely onto laptops.
-
-### The trade being made
-
-A browser regression now surfaces on QA's machine, not on the PR that introduced
-it — and dev ships to QA with no browser verification at all. When QA's run fails
-it is a round trip: report, dev cuts a `fix/` branch, re-promotes, QA re-runs 30
-minutes. That cost is accepted in exchange for roughly $120/month and a clear
-division of labour, and it is bounded by the weekly release cadence in §7a.
-
----
+construction. A local run is not a substitute for this one; it is a different,
+weaker check.
 
 ## 5. Solo / low-ceremony work
 


### PR DESCRIPTION
## Summary

CI was costing **~$124/month** and hard-stopped mid-release yesterday when the spending limit hit — PRs #33 and #34 both failed at 11 seconds with *"the job was not started because recent account payments have failed."*

**Nothing is deleted.** The 32-minute Playwright suite moves to QA, run locally on the `dev` → `qa` promotion PR. One CI run survives, on the `qa` → `main` release PR, immediately before a production deploy.

@JohnDominicJasmin — **`ci.yml` is your file** and this assigns you a new recurring task, so this needs your review rather than my merge. Say the word and I'll change anything here.

## The numbers

**1,755 Actions minutes over Aug 3–5** — three days — against a 2,000/month allowance. Three causes, all structural:

| Cause | Detail |
|---|---|
| Nothing ever cancelled | No `concurrency:` key, so a superseded run finished anyway, beside its replacement |
| One `dev`→`qa` promotion billed **3×** | `push:[qa]` + the promotion PR + `synchronize` on the standing `qa`→`main` release PR |
| The suite ran on everything | 32 min, `workers: 1`, serial. Your docs-only PR #24 paid full price |

## What runs where now

| Event | Lint · typecheck · unit · build | Playwright |
|---|---|---|
| Push to a feature branch | ✅ ~2 min | — |
| PR into `dev` | ✅ | — |
| **PR into `qa`** | ✅ | — |
| Push to `dev` / `main` | ✅ | — |
| **PR into `main`** (release) | ✅ | ✅ **187 tests, ~34 min** |
| Manual run | ✅ | ✅ if you tick the box |

**Your new step:** on a `dev` → `qa` promotion PR, run `npm run test:e2e` locally and post pass/fail before merging it. ~30 min. `.env.e2e.local` has the BOLA fixtures; `E2E_PORT=3000` reuses a running server.

That is now the only browser check anything gets before staging.

## Why one CI run survives

Your local run is one machine with `.env.local` present. **CI is the only place the app builds without developer env** — and that difference produced both of yesterday's environment bugs:

- **The labels defect.** Only reproduces when `/api/labels` returns `{}`, which never happens locally. You found it precisely because CI ran on a docs-only PR.
- **The `NEXT_PUBLIC_APP_ENV` gap.** CI built with production table names against the dev project. Locally the variable is set, so it is invisible.

Neither is catchable on a laptop. ~136 min/month to keep that check in front of production.

## `CI Gate` — the part worth a close look

A new ~10-line job that becomes **the only required status check**. It exists because GitHub does two things that are actively dangerous here:

- A job skipped by its own `if:` reports **success** to branch protection. Requiring `E2E (Playwright)` would be satisfied by it *not running* — now the normal case.
- A job skipped because `needs:` **failed** also reports success. Requiring `e2e` without also requiring `build` would let a broken build merge on a green tick.

So the gate asserts the *reason* for a skip, not the absence of failure: on a PR into `main` it demands `e2e = success`; elsewhere it accepts `skipped` but never a failure; and it always demands `build = success`.

## Also in here

- `qa` out of the `push:` triggers — `dev` → `qa` is fast-forward, so the commit is bit-identical to one already tested
- Chromium cached on the Playwright version — 120 MB was re-downloaded every run
- HTML report uploads on `failure()` only, not every green run
- `timeout-minutes: 10` on the build job, which had none (a hang billed toward GitHub's 6-hour default)

## Docs

- **`CONTRIBUTING.md` §4b** — new. The table above, your step, and an honest section on what a local run cannot catch, using both of yesterday's bugs as the worked examples.
- **§7a** — new. Weekly release cadence for features; bug fixes ship when ready.
- **§4 test checklist** — your `npm run test:e2e` step on promotion PRs.
- **§7 migrations** — a post-migration check for dev-prefixed tables on prod. Two of them (`lhq_dev_alert_fires`, `lhq_dev_user_settings`) were sitting on production empty until yesterday.
- **PR template** — a QA box for the local E2E result.

## Expected saving

**~17,500 → ~2,000 min/month.** Back inside the free allowance most months.

Caveat: Aug 3–5 was the CI bring-up window, so 585 min/day is an upper bound. The ratio is the durable number, not the absolute figures.

## The trade, stated plainly

A browser regression now surfaces on **your** machine, not on the PR that caused it — and dev ships to you with no browser verification at all. When your run fails it is a round trip: you report, dev cuts a `fix/`, re-promotes, you re-run 30 minutes.

That is a real cost and it lands mostly on you. If you think it lands too heavily, say so — putting the suite back on the `dev` → `qa` PR is a two-line change and I would rather have that conversation now than after a painful release.

## How to test

1. This PR itself: `E2E (Playwright)` should show **Skipped**, `CI Gate` green, total ~2 min.
2. Push a second commit to this branch — the first run should be **cancelled**, not completed.
3. When it merges and the next release PR opens into `main`, the full suite should run there.

⚠️ **Branch protection, in this order, or every open PR becomes unmergeable:**

1. Let this run once so `CI Gate` registers in the check picker
2. **Add** `CI Gate` as a required check on `dev`, `qa`, `main`
3. **Then** remove `Lint + typecheck + test + build` and `E2E (Playwright)`

Leaving `E2E (Playwright)` required blocks every PR that is not a release, because it now legitimately skips.

## Risk level

**Medium.** No application code — CI config and docs only. The risk is procedural: if the branch-protection steps are done out of order, PRs get stuck; and if the local-run step is skipped in practice, changes reach staging with no browser check at all.