### PR TITLE
fix(api): DELETE no longer reports success for a delete that removed nothing

### DIFF
--- a/app/api/hypotheses/[id]/evidence/route.ts
+++ b/app/api/hypotheses/[id]/evidence/route.ts
@@ -94,11 +94,17 @@ export async function DELETE(req: NextRequest) {
   const evidenceId = req.nextUrl.searchParams.get('evidenceId');
   if (!evidenceId) return NextResponse.json({ error: 'evidenceId required' }, { status: 400 });
 
-  const { error } = await sb(token)
+  /* Same fix as the parent route's DELETE, found by the same sweep. .eq('user_id')
+     is the ownership filter, so deleting somebody else's evidence row matches
+     zero rows - and PostgREST calls that success. Not reported by QA; found by
+     grepping every .delete() in app/api after they caught the hypotheses one. */
+  const { data, error } = await sb(token)
     .from(T.hypothesis_evidence)
     .delete()
     .eq('id', evidenceId)
-    .eq('user_id', authData.user.id);
+    .eq('user_id', authData.user.id)
+    .select('id');
   if (error) return apiError('hypotheses/[id]/evidence', error);
+  if (!data?.length) return NextResponse.json({ error: 'Not found' }, { status: 404 });
   return NextResponse.json({ ok: true });
 }

--- a/app/api/hypotheses/[id]/route.ts
+++ b/app/api/hypotheses/[id]/route.ts
@@ -63,11 +63,24 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ i
   if (!authData.user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   const { id } = await params;
-  const { error } = await sb(token)
+  /* .select() so we can tell "deleted a row" from "matched nothing".
+     Without it this answered `{ ok: true }` to a delete aimed at someone else's
+     hypothesis, and to an id that exists nowhere - PostgREST reports success for
+     a DELETE matching zero rows. The ownership filter held and nothing was ever
+     removed, so no data was at risk, but a UI that optimistically drops a row on
+     2xx would have shown it vanish and then reappear on reload.
+     Found by QA on the 2026-08-06 release. It is the same defect fixed on
+     /api/price-alerts in that release, one file over - the sweep that produced
+     that fix stopped at the file it started in. */
+  const { data, error } = await sb(token)
     .from(T.hypotheses)
     .delete()
     .eq('id', id)
-    .eq('user_id', authData.user.id);
+    .eq('user_id', authData.user.id)
+    .select('id');
   if (error) return apiError('hypotheses/[id]', error);
+  // 404, not 403 - a 403 would confirm the row exists and belongs to somebody
+  // else, which is an existence oracle for enumerating ids. Matches PATCH above.
+  if (!data?.length) return NextResponse.json({ error: 'Not found' }, { status: 404 });
   return NextResponse.json({ ok: true });
 }


### PR DESCRIPTION
## Summary

Closes the defect QA filed against the 2026-08-06 release. `DELETE /api/hypotheses/[id]` answered `200 {"ok":true}` to a non-owner and to an id that exists nowhere.

Also fixes the same bug in `DELETE /api/hypotheses/[id]/evidence`, which nobody reported — see below.

## Why it happened

`.eq('user_id', ...)` **is** the ownership filter, so a delete aimed at someone else's row matches **zero** rows — and PostgREST reports zero-row deletes as success. The row survived; only the status code lied.

@JohnDominicJasmin was right to ship without it. No data was ever at risk. But a 200 for *"you may not do that"* is indistinguishable in the logs from a 200 for *"done"*, and a UI that optimistically removes a row on 2xx would show it vanish and then reappear on reload.

## Verified both directions

Reproduced against the seeded accounts **before** touching anything:

```
want  got
404   200 <<  B DELETE A's hypothesis          body={"ok":true}
404   200 <<  B DELETE nonexistent hypothesis  body={"ok":true}
404   200 <<  A DELETE nonexistent hypothesis  body={"ok":true}
404   200 <<  B DELETE A's evidence            body={"ok":true}
```

After:

```
404   404     B DELETE A's hypothesis
404   404     B DELETE nonexistent hypothesis
404   404     A DELETE nonexistent hypothesis
404   404     B DELETE A's evidence
```

**A's hypothesis was still present after all four attempts, before and after** — confirming the ownership filter always held and this was purely the response. And **A deleting its own row still returns 200**: the probe creates a throwaway hypothesis and deletes it, so the happy path is proven rather than assumed.

404 rather than 403, matching the PATCH handlers: a 403 confirms the row exists and belongs to someone else, which is a working existence oracle for enumerating ids.

## The part worth calling out

**The evidence route was not in your report. I found it by grepping every `.delete()` in `app/api` — which is the sweep that should have happened when I fixed this identical bug on `/api/price-alerts`, one file over, in the release you just shipped.**

I fixed the instance in front of me and not the pattern. That is exactly how the second one survived into production, and you catching the first is the only reason there was a second look.

Deliberately **not** changed after reviewing them: `/api/alert-prefs` (deleting a mute that is not set is a legitimate no-op), and the `ops/`, `push/` and `news/ingest` routes, which are admin- or cleanup-scoped with a different auth model.

## How to test (QA)

Sign in, open `/journal`:

1. Create a hypothesis → add evidence to it → delete the evidence → delete the hypothesis. Each should disappear and **stay gone after a reload**.
2. Delete something twice (or hit the endpoint for an id that no longer exists) → **404**, not a silent success.
3. Nothing else on the page should behave differently.

Your `bola.spec.ts` should also now be able to assert `404` on the delete cases if you want to promote them from observation to assertion — your file, your call.

## Risk level

**Low.** Two response paths in two route handlers. No schema, no auth logic, no UI. The regression risk is a caller that treated `200` as "gone" and now sees `404` — checked: `TradeJournal.tsx` and the journal page both check `res.ok` and surface the error, and neither can produce a delete for a row it does not own.