### PR TITLE
Release 2026-08-06.2: DELETE returns 404 not false success, alert_fires table prefix, CI restructure

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -50,13 +50,12 @@
 - [ ] **New environment variable?** If yes, list it here and say which services still need it set. A var that exists only on dev is a broken deploy waiting to happen
 - [ ] Anything I could not verify is stated in the PR, not left for QA to discover
 
-### If this is a `dev` → `qa` promotion — QA fills this in
-
-CI does **not** run the browser suite on this PR. It runs on the `qa` → `main`
-release PR only, so this box is the browser check for everything going to staging.
-See CONTRIBUTING.md section 4b.
-
-- [ ] `npm run test:e2e` run locally — result posted as a comment (pass/fail, and the count)
+> **Note on the browser suite.** CI runs Playwright on a PR into `main` only — the
+> release. Feature PRs and `dev` → `qa` promotions get the four fast gates above and
+> nothing more, so **the first automated browser check any change gets is at the
+> release gate**. If this PR is risky enough that you want it sooner, run
+> `npm run test:e2e` locally or use Actions → CI → Run workflow, and say so here.
+> See CONTRIBUTING.md §4b.
 
 ## Screenshots (if UI change)
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -50,6 +50,14 @@
 - [ ] **New environment variable?** If yes, list it here and say which services still need it set. A var that exists only on dev is a broken deploy waiting to happen
 - [ ] Anything I could not verify is stated in the PR, not left for QA to discover
 
+### If this is a `dev` → `qa` promotion — QA fills this in
+
+CI does **not** run the browser suite on this PR. It runs on the `qa` → `main`
+release PR only, so this box is the browser check for everything going to staging.
+See CONTRIBUTING.md section 4b.
+
+- [ ] `npm run test:e2e` run locally — result posted as a comment (pass/fail, and the count)
+
 ## Screenshots (if UI change)
 
 *Before and after. "N/A - no visual change" is a valid answer; leaving it blank is not.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,25 +1,75 @@
 name: CI
 
+# ─────────────────────────────────────────────────────────────────────────────
+# WHERE THE BROWSER SUITE RUNS. Read this before adding a trigger.
+#
+# Aug 3-5 2026 burned 1,755 Actions minutes in three days on a private repo with
+# a 2,000 min/month allowance - roughly $124/month annualised, and it hard-
+# stopped CI mid-release when the spending limit was hit.
+#
+# The rule now: the ~2 minute job runs on everything. The ~34 minute Playwright
+# suite runs on exactly ONE automatic trigger - a PR into `main`, which is the
+# release, immediately before a production deploy.
+#
+# What replaces it everywhere else is QA running the suite LOCALLY when a
+# dev -> qa PR arrives (CONTRIBUTING section 4b). That is a real gate with a
+# named owner, not a hope.
+#
+# Why one CI run survives at all: QA's local run is one machine with .env.local
+# present. CI is the only place the app builds WITHOUT developer env, and that
+# difference has produced two real defects - the labels bug (only reproduces
+# when /api/labels returns {}, which never happens locally) and the
+# NEXT_PUBLIC_APP_ENV table-prefix gap. ~136 min/month for the last check
+# between a green laptop and production.
+# ─────────────────────────────────────────────────────────────────────────────
+
 on:
-  # qa is the branch QA tests against, so a broken merge into it costs QA a
-  # wasted test run and a false bug report before anyone looks at CI. Checking
-  # it here is cheaper than that. Note the qa Render service does NOT
-  # auto-deploy - a merge into qa is not live until someone triggers it - so
-  # this is a gate on the branch, not a last line of defence before users.
-  push:
-    branches: [dev, qa, main]
-  # Also on PRs, or CI only ever runs AFTER a merge - which is the one moment
-  # it cannot help. The convention makes the PR the review point (CONTRIBUTING
-  # section 4), so the checks have to be green before the merge button, not
-  # after. Covers PRs from any branch, including QA-authored ones, which a
-  # push trigger limited to [dev, main] never sees.
+  # The PR is the review point (CONTRIBUTING section 4), so the gate has to be
+  # here - CI that only runs after a merge runs at the one moment it cannot
+  # help. `types` is explicit so a label or a title edit can never spend 34
+  # minutes; `synchronize` is the one that fires on each push to an open PR.
   pull_request:
     branches: [dev, qa, main]
+    types: [opened, reopened, synchronize, ready_for_review]
+
+  push:
+    # `qa` is deliberately ABSENT. CONTRIBUTING section 6 makes dev -> qa
+    # fast-forward only, so the commit landing on qa is bit-identical to one
+    # already tested on dev. Worse, the qa->main release PR stays open for the
+    # whole cycle, so each ff-push to qa ALSO fired `synchronize` on it - one
+    # promotion used to bill three full runs.
+    branches: [dev, main]
+
+  # For running the browser suite on demand: re-checking after a flake, or
+  # proving a fix without opening a release PR first.
+  workflow_dispatch:
+    inputs:
+      e2e:
+        description: Run the full browser suite
+        type: boolean
+        default: true
+
+# Without this, every push to a PR stacked another run and the superseded one
+# carried on to completion. Nothing was ever cancelled. Costs no coverage.
+#
+# event_name is in the group so a dispatch and a push never share a lane.
+concurrency:
+  group: ci-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref_name }}
+  # PRs and dev cancel freely - only the tip matters. main NEVER cancels
+  # mid-flight; a second push queues behind the first. On a pull_request event
+  # ref_name is "33/merge", not a branch, so the dev comparison cannot
+  # false-positive there.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref_name == 'dev' }}
+
+permissions:
+  contents: read
 
 jobs:
   build:
     name: Lint + typecheck + test + build
     runs-on: ubuntu-latest
+    # Had no cap at all, so a hung npm ci billed toward GitHub's 6-hour default.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -36,7 +86,7 @@ jobs:
       # Runs first because it is the fastest of the four steps.
       #
       # Fails on errors only. Warnings are printed but do not block - there are
-      # 93 of them, a pre-existing React Compiler backlog documented in
+      # 94 of them, a pre-existing React Compiler backlog documented in
       # eslint.config.mjs. Deliberately no --max-warnings=0: it would either
       # force a 67-file refactor of live code today, or be set to a number
       # nobody maintains.
@@ -64,15 +114,28 @@ jobs:
   e2e:
     name: E2E (Playwright)
     runs-on: ubuntu-latest
+    # Only after lint/typecheck/unit/build are green. A broken build would
+    # produce 216 browser failures that all say "the build is broken", which
+    # buries the one line that actually explains it.
+    needs: build
+    # THE COST DECISION, in one expression. A PR into `main` is the release, and
+    # the production deploy is the next manual step after it merges. Nothing
+    # else triggers this automatically.
+    #
+    # base_ref, not ref_name - on a pull_request event ref_name is "33/merge".
+    # base_ref is empty on push and on dispatch, so both fall through.
+    #
+    # PRs into `dev` and into `qa` deliberately get the 2-minute job only. What
+    # covers them is QA running this same suite locally when the dev -> qa PR
+    # arrives. See CONTRIBUTING 4b.
+    if: >-
+      github.base_ref == 'main' ||
+      (github.event_name == 'workflow_dispatch' && inputs.e2e)
     # A full run is ~31 minutes. Without a cap, a genuinely hung run burns to
     # GitHub's 6-hour default, and a stuck run looks identical to a slow one -
     # which happened while this suite was being brought up. 45 leaves headroom
     # for a cold runner without hiding a hang.
     timeout-minutes: 45
-    # Only after lint/typecheck/unit/build are green. A broken build would
-    # produce 216 browser failures that all say "the build is broken", which
-    # buries the one line that actually explains it.
-    needs: build
     steps:
       - uses: actions/checkout@v4
 
@@ -91,8 +154,30 @@ jobs:
       # project. devices['iPhone 13'] defaults to WebKit, and without that pin
       # every mobile test fails here with "Executable doesn't exist at
       # .../webkit-2336" - which is what happened the first time this suite ran.
+      #
+      # Cached on the Playwright VERSION, not the lockfile hash: a dependency
+      # bump elsewhere should not evict a 120MB browser download that was
+      # otherwise re-fetched on every single run.
+      - name: Resolve Playwright version
+        id: pw
+        run: echo "v=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Chromium
+        id: pwcache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-${{ steps.pw.outputs.v }}
+
       - name: Install Chromium
+        if: steps.pwcache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+
+      # The browser binary is cached but its apt system libraries are not -
+      # those live outside ~/.cache. ~5s.
+      - name: Install Chromium system deps
+        if: steps.pwcache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       # playwright.config.ts's webServer runs `npm run build && npm start` on
       # port 3100, so CI and local exercise the same production build.
@@ -160,10 +245,63 @@ jobs:
           E2E_A_HYPOTHESIS_ID: ${{ secrets.E2E_A_HYPOTHESIS_ID }}
           E2E_A_PRICE_ALERT_ID: ${{ secrets.E2E_A_PRICE_ALERT_ID }}
 
-      # Uploaded on failure too - that is the run you actually need to read.
+      # failure() only. This used to upload on every green run too - ~15s and
+      # storage for a report nobody opens. failure() still excludes
+      # cancellations, so a concurrency-cancelled run uploads nothing.
       - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
+        if: ${{ failure() }}
         with:
-          name: playwright-report
+          name: playwright-report-${{ github.run_attempt }}
           path: qa/e2e-report/
           retention-days: 14
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # THE ONLY REQUIRED STATUS CHECK. Do not require `build` or `e2e` directly.
+  #
+  # GitHub's behaviour here is unintuitive and both halves are traps:
+  #
+  #   * A job skipped by its own `if:` reports SUCCESS to branch protection. So
+  #     requiring `E2E (Playwright)` would be satisfied by it NOT running - which
+  #     is now the normal case on every PR that is not a release.
+  #   * A job skipped because `needs:` FAILED also reports SUCCESS. So requiring
+  #     `e2e` while `build` is not required would let a broken build merge on a
+  #     green tick.
+  #
+  # This job therefore asserts the REASON for a skip, not merely the absence of
+  # a failure. always() rather than !cancelled() so a cancelled run still ends
+  # red - harmless, because cancellation only happens when a newer SHA arrives
+  # and checks are evaluated per-SHA.
+  # ───────────────────────────────────────────────────────────────────────────
+  gate:
+    name: CI Gate
+    if: ${{ always() }}
+    needs: [build, e2e]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Every job that should have run, ran and passed
+        env:
+          BUILD: ${{ needs.build.result }}
+          E2E: ${{ needs.e2e.result }}
+          BASE: ${{ github.base_ref }}
+        run: |
+          set -uo pipefail
+          echo "build=$BUILD  e2e=$E2E  base=$BASE"
+          fail=0
+          # build carries no `if:`, so anything other than success is real.
+          [ "$BUILD" = success ] || { echo "::error::build job: $BUILD"; fail=1; }
+          if [ "$BASE" = main ]; then
+            # A release PR. E2E was supposed to run. `skipped` here means build
+            # died - and GitHub would otherwise report that skip as a green
+            # check. This branch is what closes that hole.
+            [ "$E2E" = success ] \
+              || { echo "::error::e2e job: $E2E - required for a PR into main"; fail=1; }
+          else
+            # Not a release. E2E is expected to skip, but if it somehow ran and
+            # failed, that is still a failure.
+            case "$E2E" in
+              success|skipped) ;;
+              *) echo "::error::e2e job: $E2E"; fail=1 ;;
+            esac
+          fi
+          exit $fail

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,7 +248,17 @@ on `dev` for a day with nobody wondering why it never reached staging.
 4. If the QA folder has no `CLAUDE.md` / `CONTRIBUTING.md`, it has not pulled
    since this convention landed. **Pull `main` first**, then check out the
    feature branch, so both folders are working to the same standard.
-5. **When every step passes, QA merges `qa` into `main`** and then deploys —
+5. **On a `dev` → `qa` promotion PR, run the browser suite locally before the
+   promotion is merged.** This is QA's, and it is the only automated browser
+   check that change gets before staging — CI does not run the suite on that PR.
+   Full detail in §4b; the short version:
+
+   ```
+   npm run test:e2e
+   ```
+
+   ~30 minutes, 187 tests. Report pass/fail on the PR like any other step.
+6. **When every step passes, QA merges `qa` into `main`** and then deploys —
    both steps, in that order. See below.
 
    `qa` → `main`, not the feature branch → `main`. By the time QA is testing,
@@ -349,6 +359,79 @@ independent check on it.
 This section exists because it was missing and the gap produced a real wrong
 answer: with no rule for QA-authored code, the dev session simply asserted that
 it would review such a branch — a role the document never gave it.
+
+---
+
+## 4b. What CI runs, and what QA runs
+
+**CI does not run the browser suite on most pushes.** Actions minutes are metered
+on a private repo, and three days of unrestricted running burned 1,755 minutes —
+about $124/month annualised — and hard-stopped CI mid-release when the spending
+limit hit. Nothing was deleted to fix that. The expensive half moved to a person
+with a name.
+
+### What GitHub runs
+
+| Event | Lint · typecheck · unit · build | Playwright |
+|---|---|---|
+| Push to a feature branch | ✅ ~2 min | — |
+| PR into `dev` | ✅ | — |
+| PR into `qa` | ✅ | — |
+| Push to `dev` or `main` | ✅ | — |
+| **PR into `main`** (the release) | ✅ | ✅ **full, 187 tests, ~34 min** |
+| Manual run (Actions → CI → Run workflow) | ✅ | ✅ if you tick the box |
+
+One automated browser run per release, immediately before a production deploy.
+
+### What QA runs
+
+**On a `dev` → `qa` promotion PR, before merging it:**
+
+```bash
+npm run test:e2e                    # full suite, ~30 min, builds and serves on :3100
+E2E_PORT=3000 npx playwright test   # or reuse a server you already have running
+```
+
+`.env.e2e.local` supplies the BOLA fixtures. It is gitignored and already in both
+checkouts; if it is missing, `bola.spec.ts` **skips with a stated reason** rather
+than passing, so a green run without it is not a green run.
+
+Report pass/fail on the PR. **This is the gate.** Nothing else exercises a browser
+against that change before it reaches staging.
+
+### What dev runs
+
+Unchanged — the four fast gates before opening any PR: `npm run lint`,
+`npx tsc --noEmit`, `npm test`, `npm run build`. E2E was never on dev's list and is
+not being added to it.
+
+### Be honest about what a local run cannot catch
+
+A green local run is **not** equivalent to CI, and the gap has already produced two
+real defects:
+
+- **The labels defect (2026-08-05).** `/api/labels` answers `200 {}` on a DB error
+  and the client applied it, wiping all 2,570 seeded English labels so every page
+  rendered raw keys. It only reproduces **without** Supabase env — CI's situation,
+  never yours locally with `.env.local` present. It surfaced as `/arena` overflowing
+  28px and a `/login` smoke failure, and it was red on *every* branch, including a
+  documentation-only PR.
+- **The table-prefix gap (2026-08-05).** CI had no `NEXT_PUBLIC_APP_ENV`, so it
+  built with production table names and queried the dev project, which has none of
+  them. Every authenticated CI run before it was fixed asserted less than it looked
+  like it did. Locally the variable is set, so the bug is invisible.
+
+Both are *environment-difference* bugs, invisible on a developer machine by
+construction. That is the entire reason one CI run survives at the `main` gate
+rather than the suite moving completely onto laptops.
+
+### The trade being made
+
+A browser regression now surfaces on QA's machine, not on the PR that introduced
+it — and dev ships to QA with no browser verification at all. When QA's run fails
+it is a round trip: report, dev cuts a `fix/` branch, re-promotes, QA re-runs 30
+minutes. That cost is accepted in exchange for roughly $120/month and a clear
+division of labour, and it is bounded by the weekly release cadence in §7a.
 
 ---
 
@@ -511,6 +594,30 @@ The two merges that actually reach users — `dev` → `qa` and `qa` → `main` 
 a PR like everything else. They are the merges with the highest blast radius,
 so they are the wrong place to skip the paper trail. A promotion PR needs no
 essay: a title, a list of what is going out, and the checklist below.
+
+### 7a. How often a release goes out
+
+**Features batch to a weekly release. Bug fixes and hotfixes ship when they are
+ready.**
+
+| What | Cadence |
+|---|---|
+| New features, additions, refactors, docs | Batched into **one release a week** |
+| Bug fixes | As soon as they are verified — do not wait for the weekly slot |
+| Hotfixes (production is broken) | Immediately, and they skip `qa` — see §6 |
+
+Merging to `dev` is not affected — that stays continuous. What batches is the
+promotion out of `dev`.
+
+Two things follow from this, and both are the point rather than side effects:
+
+- **A regression found at the `qa` gate arrives with a week of changes attached**,
+  not one. That is the cost of batching, and it is why §4b puts a full browser run
+  in QA's hands before the promotion is merged rather than after.
+- **"It is not urgent" is a real answer.** A feature that misses the weekly slot
+  waits. Shipping a feature mid-week to production, outside the batch, is a
+  decision someone makes deliberately — not something that happens because a PR
+  merged.
 
 ### Before `dev` → `qa`
 
@@ -687,6 +794,23 @@ Rules:
   destructive, that is where to do it.
 - Applied through the Supabase MCP (`apply_migration`), per
   `docs/HANDOVER.md` §5.
+- **Check the project you actually hit.** After applying anything, run this
+  against **prod**:
+
+  ```sql
+  select relname from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+   where n.nspname = 'public' and relname like 'lhq_dev_%';
+  -- must return zero rows on prod
+  ```
+
+  A dev-prefixed table on production means a migration meant for dev was applied
+  to prod. That happened **twice** and went unnoticed for weeks — `lhq_dev_alert_fires`
+  and `lhq_dev_user_settings` were both sitting on prod, empty, until a network
+  tab on `/alerts` surfaced the first one on 2026-08-05. Nothing broke, because
+  the app resolves table names through `lib/tables.ts` and never reads those, but
+  prod Supabase is on the free plan with **no backups** — the next one might not
+  be harmless. Two seconds of checking beats finding out later.
 
 ### Environment variables
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,18 +248,13 @@ on `dev` for a day with nobody wondering why it never reached staging.
 4. If the QA folder has no `CLAUDE.md` / `CONTRIBUTING.md`, it has not pulled
    since this convention landed. **Pull `main` first**, then check out the
    feature branch, so both folders are working to the same standard.
-5. **On a `dev` → `qa` promotion PR, run the browser suite locally before the
-   promotion is merged.** This is QA's, and it is the only automated browser
-   check that change gets before staging — CI does not run the suite on that PR.
-   Full detail in §4b; the short version:
-
-   ```
-   npm run test:e2e
-   ```
-
-   ~30 minutes, 187 tests. Report pass/fail on the PR like any other step.
-6. **When every step passes, QA merges `qa` into `main`** and then deploys —
+5. **When every step passes, QA merges `qa` into `main`** and then deploys —
    both steps, in that order. See below.
+
+   Merging opens the release PR's final CI run: **the full browser suite, 187
+   tests, ~34 minutes** (§4b). It is the only place that suite runs
+   automatically. Wait for it. A red run there means something QA's manual pass
+   did not reach, and it blocks the production deploy.
 
    `qa` → `main`, not the feature branch → `main`. By the time QA is testing,
    the change is already on `dev` and `qa`; merging the original feature branch
@@ -362,13 +357,13 @@ it would review such a branch — a role the document never gave it.
 
 ---
 
-## 4b. What CI runs, and what QA runs
+## 4b. Where the browser suite runs
 
-**CI does not run the browser suite on most pushes.** Actions minutes are metered
-on a private repo, and three days of unrestricted running burned 1,755 minutes —
-about $124/month annualised — and hard-stopped CI mid-release when the spending
-limit hit. Nothing was deleted to fix that. The expensive half moved to a person
-with a name.
+**CI does not run the Playwright suite on most pushes.** Actions minutes are
+metered on a private repo, and three days of unrestricted running burned 1,755
+minutes — about $124/month annualised — and hard-stopped CI mid-release when the
+spending limit was hit. Nothing was deleted to fix that. It was moved to the one
+place it is worth 34 minutes.
 
 ### What GitHub runs
 
@@ -378,62 +373,65 @@ with a name.
 | PR into `dev` | ✅ | — |
 | PR into `qa` | ✅ | — |
 | Push to `dev` or `main` | ✅ | — |
-| **PR into `main`** (the release) | ✅ | ✅ **full, 187 tests, ~34 min** |
+| **PR into `main`** (the release) | ✅ | ✅ **187 tests, ~34 min** |
 | Manual run (Actions → CI → Run workflow) | ✅ | ✅ if you tick the box |
 
-One automated browser run per release, immediately before a production deploy.
+**One automated browser run per release, immediately before production.**
 
-### What QA runs
+### Nobody runs it by hand
 
-**On a `dev` → `qa` promotion PR, before merging it:**
+Not dev, not QA. Dev's pre-PR gates are the four fast ones — `npm run lint`,
+`npx tsc --noEmit`, `npm test`, `npm run build`. QA's job is manual testing on
+staging, following the PR's "How to test" steps.
+
+This was deliberated and changed twice. An earlier draft had QA running
+`npm run test:e2e` locally on the promotion PR. It was dropped because it landed
+minutes before the release PR's CI run — **the same 187 tests, on the same
+commit, twice**, differing only in environment. Between the two, CI is the
+stricter one and costs nobody's afternoon, so the human run went.
+
+If you *want* it before then — a risky release, a big refactor — run it:
 
 ```bash
 npm run test:e2e                    # full suite, ~30 min, builds and serves on :3100
-E2E_PORT=3000 npx playwright test   # or reuse a server you already have running
+E2E_PORT=3000 npx playwright test   # or reuse a server already running
 ```
 
-`.env.e2e.local` supplies the BOLA fixtures. It is gitignored and already in both
-checkouts; if it is missing, `bola.spec.ts` **skips with a stated reason** rather
-than passing, so a green run without it is not a green run.
+`.env.e2e.local` supplies the BOLA fixtures. Without it `bola.spec.ts` **skips
+with a stated reason** rather than passing, so a green run missing that file is
+not a green run. There is also a manual trigger in Actions → CI → Run workflow.
 
-Report pass/fail on the PR. **This is the gate.** Nothing else exercises a browser
-against that change before it reaches staging.
+### What that means for the gap
 
-### What dev runs
+Between a feature merging into `dev` and the release PR opening, **nothing
+exercises a browser automatically**. Staging catches it instead: QA tests by hand
+on a real deployed build, which is a different and in some ways better check —
+a machine cannot tell you a layout looks wrong.
 
-Unchanged — the four fast gates before opening any PR: `npm run lint`,
-`npx tsc --noEmit`, `npm test`, `npm run build`. E2E was never on dev's list and is
-not being added to it.
+The cost is honest and worth stating: a browser-level regression surfaces at the
+release gate with a week of changes attached, not on the PR that caused it. That
+is bounded by the weekly cadence in §7a, and it is the trade made in exchange for
+roughly $120/month.
 
-### Be honest about what a local run cannot catch
+### Why the release run cannot be dropped too
 
-A green local run is **not** equivalent to CI, and the gap has already produced two
-real defects:
+CI is the only place the app builds **without** developer environment variables,
+and that difference has produced two real defects:
 
-- **The labels defect (2026-08-05).** `/api/labels` answers `200 {}` on a DB error
-  and the client applied it, wiping all 2,570 seeded English labels so every page
-  rendered raw keys. It only reproduces **without** Supabase env — CI's situation,
-  never yours locally with `.env.local` present. It surfaced as `/arena` overflowing
-  28px and a `/login` smoke failure, and it was red on *every* branch, including a
-  documentation-only PR.
+- **The labels defect (2026-08-05).** `/api/labels` answers `200 {}` on a DB
+  error and the client applied it, wiping all 2,570 seeded English labels so
+  every page rendered raw keys. It only reproduces **without** Supabase env — CI's
+  situation, never a developer machine with `.env.local` present. It surfaced as
+  `/arena` overflowing 28px and a `/login` smoke failure, and it was red on
+  *every* branch, including a documentation-only PR.
 - **The table-prefix gap (2026-08-05).** CI had no `NEXT_PUBLIC_APP_ENV`, so it
-  built with production table names and queried the dev project, which has none of
-  them. Every authenticated CI run before it was fixed asserted less than it looked
-  like it did. Locally the variable is set, so the bug is invisible.
+  built with production table names and queried the dev project, which has none
+  of them. Every authenticated CI run before it was fixed asserted less than it
+  looked like it did. Locally the variable is set, so the bug is invisible.
 
 Both are *environment-difference* bugs, invisible on a developer machine by
-construction. That is the entire reason one CI run survives at the `main` gate
-rather than the suite moving completely onto laptops.
-
-### The trade being made
-
-A browser regression now surfaces on QA's machine, not on the PR that introduced
-it — and dev ships to QA with no browser verification at all. When QA's run fails
-it is a round trip: report, dev cuts a `fix/` branch, re-promotes, QA re-runs 30
-minutes. That cost is accepted in exchange for roughly $120/month and a clear
-division of labour, and it is bounded by the weekly release cadence in §7a.
-
----
+construction. A local run is not a substitute for this one; it is a different,
+weaker check.
 
 ## 5. Solo / low-ceremony work
 

--- a/app/api/hypotheses/[id]/evidence/route.ts
+++ b/app/api/hypotheses/[id]/evidence/route.ts
@@ -94,11 +94,17 @@ export async function DELETE(req: NextRequest) {
   const evidenceId = req.nextUrl.searchParams.get('evidenceId');
   if (!evidenceId) return NextResponse.json({ error: 'evidenceId required' }, { status: 400 });
 
-  const { error } = await sb(token)
+  /* Same fix as the parent route's DELETE, found by the same sweep. .eq('user_id')
+     is the ownership filter, so deleting somebody else's evidence row matches
+     zero rows - and PostgREST calls that success. Not reported by QA; found by
+     grepping every .delete() in app/api after they caught the hypotheses one. */
+  const { data, error } = await sb(token)
     .from(T.hypothesis_evidence)
     .delete()
     .eq('id', evidenceId)
-    .eq('user_id', authData.user.id);
+    .eq('user_id', authData.user.id)
+    .select('id');
   if (error) return apiError('hypotheses/[id]/evidence', error);
+  if (!data?.length) return NextResponse.json({ error: 'Not found' }, { status: 404 });
   return NextResponse.json({ ok: true });
 }

--- a/app/api/hypotheses/[id]/route.ts
+++ b/app/api/hypotheses/[id]/route.ts
@@ -63,11 +63,24 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ i
   if (!authData.user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   const { id } = await params;
-  const { error } = await sb(token)
+  /* .select() so we can tell "deleted a row" from "matched nothing".
+     Without it this answered `{ ok: true }` to a delete aimed at someone else's
+     hypothesis, and to an id that exists nowhere - PostgREST reports success for
+     a DELETE matching zero rows. The ownership filter held and nothing was ever
+     removed, so no data was at risk, but a UI that optimistically drops a row on
+     2xx would have shown it vanish and then reappear on reload.
+     Found by QA on the 2026-08-06 release. It is the same defect fixed on
+     /api/price-alerts in that release, one file over - the sweep that produced
+     that fix stopped at the file it started in. */
+  const { data, error } = await sb(token)
     .from(T.hypotheses)
     .delete()
     .eq('id', id)
-    .eq('user_id', authData.user.id);
+    .eq('user_id', authData.user.id)
+    .select('id');
   if (error) return apiError('hypotheses/[id]', error);
+  // 404, not 403 - a 403 would confirm the row exists and belongs to somebody
+  // else, which is an existence oracle for enumerating ids. Matches PATCH above.
+  if (!data?.length) return NextResponse.json({ error: 'Not found' }, { status: 404 });
   return NextResponse.json({ ok: true });
 }

--- a/components/AlertOutcomes.tsx
+++ b/components/AlertOutcomes.tsx
@@ -1,10 +1,11 @@
 'use client';
 // Tier 2 #10 - honest track record for the directional alert types (squeeze,
-// EMA cross, distribution, RSI, whales). Reads lhq_alert_fires directly with
+// EMA cross, distribution, RSI, whales). Reads T.alert_fires directly with
 // the anon client (public SELECT policy, same pattern as live-tracking's read
 // of lhq_live_signals) - writes only ever happen server-side via the alert cron.
 import { useEffect, useState } from 'react';
 import { getSupabase } from '@/lib/supabase';
+import { T } from '@/lib/tables';
 import { StatRow } from '@/components/BacktestStatsUI';
 import Tip from '@/components/Tip';
 import EmptyState from '@/components/EmptyState';
@@ -48,8 +49,21 @@ export default function AlertOutcomes() {
     (async () => {
       const sb = getSupabase();
       if (!sb) { setError('Not configured'); return; }
+      /* T.alert_fires, not the literal 'lhq_alert_fires' this used to hardcode.
+         That literal is the PRODUCTION table name, so this component queried
+         prod's table name against whatever project it was pointed at - which
+         works on prod by coincidence and 404s everywhere else. It is the only
+         place in the codebase that bypassed lib/tables; the other six consumers
+         of this table all use T.alert_fires.
+         Consequence while it stood: the panel has never rendered on dev or
+         staging, so every QA pass over /alerts was passing over a feature that
+         could not load. Found while verifying the signed-out /alerts page for
+         an unrelated 401 change.
+         Note this does NOT make the panel work on dev by itself - see the
+         alert_fires table drift below. It stops the code lying about which
+         environment it is in, which is the part that is a code defect. */
       const { data, error: err } = await sb
-        .from('lhq_alert_fires')
+        .from(T.alert_fires)
         .select('rule_key, coin, dir, label, fired_at, outcome_pct_24h, resolved_24h, outcome_pct_48h, resolved_48h')
         .order('fired_at', { ascending: false })
         .limit(500);


### PR DESCRIPTION
## Summary

Release candidate on `qa` — 9 commits since `v2026.08.06`. Two API defect fixes, one of which QA reported, and a CI restructure that cuts the Actions bill by ~89%.

Staging: **https://liquidity-hq-qa.onrender.com** — `qa` = `001c33b`, deployed 2026-08-06 09:10 UTC.

**No migrations. No new environment variables. No schema changes.**

> **This PR is the first release under the new CI rules, and it is the proof.** The full Playwright suite runs *here* and nowhere else — feature PRs into `dev` no longer run it. `CI Gate` is now a required status check on `main`, so if that suite goes red **this PR cannot be merged**. Before today nothing stopped a merge to production.

## What changed

| Change | Impact |
|---|---|
| **`DELETE` reported success for a delete that removed nothing** | QA-reported. `200 {"ok":true}` → **404** |
| **`AlertOutcomes` hardcoded the prod table name** | `/alerts` "recent fires" panel never rendered outside production |
| **CI restructure** | ~17,500 → ~2,000 Actions min/month |

### 1. `DELETE` no longer lies about what it did — QA finding

`DELETE /api/hypotheses/[id]` answered `200 {"ok":true}` to a non-owner, and to an id that exists nowhere. `.eq('user_id', ...)` is the ownership filter, so the delete matched zero rows — and PostgREST reports zero-row deletes as success. The row survived; only the status code lied.

Reproduced before fixing, against the seeded accounts:

```
                                    before              after
B DELETE A's hypothesis             200 {"ok":true}  →  404
B DELETE nonexistent hypothesis     200 {"ok":true}  →  404
A DELETE nonexistent hypothesis     200 {"ok":true}  →  404
B DELETE A's evidence               200 {"ok":true}  →  404
```

A's hypothesis was present after all four attempts, **before and after** — confirming the ownership filter always held. A deleting its **own** row still returns 200; a throwaway was created and deleted to prove the happy path.

**The evidence route was not reported.** It came out of grepping every `.delete()` in `app/api` after QA caught the first one — which is the sweep that should have happened when the identical bug was fixed on `/api/price-alerts` in the last release, one file over. Fixing the reported instance and not the pattern is how a second one reached production.

404 rather than 403 throughout: a 403 confirms the row exists and belongs to someone else, which is an existence oracle for enumerating ids.

### 2. `AlertOutcomes` used the production table name everywhere

`components/AlertOutcomes.tsx` queried the literal `'lhq_alert_fires'` instead of `T.alert_fires`. That literal is the **production** name, so the component worked on prod by coincidence and 404'd everywhere else. It was the only place in the codebase bypassing `lib/tables.ts` — verified with a sweep, the last remaining `.from('lhq_...')` literal.

Consequence: **the "recent fires" panel on `/alerts` has never rendered on dev or staging.** Any QA pass over that page was passing over a feature that could not load.

Related, and already applied outside this PR: `lhq_dev_alert_fires` was created on dev (it was missing), and two stray dev-prefixed tables were dropped from **production** (`lhq_dev_alert_fires`, `lhq_dev_user_settings` — both empty, 0 rows, no FKs, nothing referencing them; verified immediately before dropping). Prod now has zero `lhq_dev_*` objects. A post-migration check for exactly this is now in `CONTRIBUTING.md` §7.

### 3. CI restructure

Three days burned **1,755 Actions minutes** against a 2,000/month allowance and hard-stopped CI mid-release when the spending limit hit. Causes, all structural: nothing ever cancelled; a `dev`→`qa` promotion billed **three** full runs; and the 32-minute suite ran on everything including docs-only PRs.

| Event | Fast job | Playwright |
|---|---|---|
| Push / PR into `dev` or `qa` | ✅ ~2 min | — |
| **PR into `main`** | ✅ | ✅ **187 tests, ~34 min** |
| Manual run | ✅ | ✅ optional |

Measured on real PRs today: **2m06s** and **1m40s**, down from ~34 min.

Also: superseded runs now cancel · `qa` removed from `push:` triggers · Chromium cached on the Playwright version · report uploads on failure only · `timeout-minutes` on the build job.

**`CI Gate`** is a new job and the only required status check. It exists because GitHub reports a *skipped* check as **success** — so requiring `E2E (Playwright)` directly would be satisfied by it not running, and a build failure would skip E2E and report green. The gate asserts the *reason* for a skip.

## Why

The `DELETE` bug: a 200 for "you may not do that" is indistinguishable in the logs from a 200 for "done", and a UI that optimistically removes a row on 2xx would show it vanish then reappear on reload.

The `AlertOutcomes` bug: a component that hardcodes one environment's table name is a lie about which environment it is in, and it silently disabled a whole panel outside prod.

The CI work: the bill stopped being theoretical when it blocked the last release.

## How to test (QA)

Staging is on Render's free plan — the first request after idle is slow and can time out. Reload once before judging anything.

**A. The `DELETE` fix — signed in, `/journal`**
1. Create a hypothesis. It appears.
2. Add evidence to it. It appears.
3. Delete the evidence → gone, and **still gone after a reload**.
4. Delete the hypothesis → gone, and still gone after a reload.
5. Delete something twice (or refresh and retry a delete for an item already removed) → the second attempt should fail cleanly, not silently claim success.

**B. `/alerts` — the panel that never worked outside prod**
6. Open `/alerts` signed in. Open DevTools → Network → filter `alert_fires`. The request must be for **`lhq_dev_alert_fires`** and return **200**, not 404.
7. The "recent fires" / win-rate card should render — on staging, for the first time. It may legitimately show an empty state, since dev has no fire history yet. An **empty card is a pass**; a missing card or an error is not.

**C. Price alerts still work — regression check on the last release's fix**
8. `/alerts` signed in: create, edit and delete a price alert. All three should behave normally.
9. Signed **out**, reload `/alerts` → the page must still render with an empty list, not an error or a stuck skeleton.

**D. Nothing else moved**
10. `/dashboard`, `/arena`, `/scanner`, `/markets` — normal use. No visual or behavioural change is intended anywhere in this release.

**E. Release**
11. Wait for **`CI Gate`** on this PR. It now includes the full Playwright suite and **blocks the merge if red** — this is the first release where that is true.
12. Merge this PR into `main`.
13. Deploy prod manually — Render → `liquidity-hq-prod` → Manual Deploy → Deploy latest commit.
14. Re-check A–D against liquidity-hq.com.
15. Run the prod migration check from `CONTRIBUTING.md` §7 — `select relname ... like 'lhq_dev_%'` must return zero rows.
16. Tag `v2026.08.06.2`.

## Risk level

**Low-Medium.** Two API response paths, one component identifier, and CI configuration. No migrations, no environment variables, no auth or payment code, no schema changes in this PR.

Rollback is clean: Render → Deploys → *Rollback to this deploy*.

**Known limitations, unchanged from the last release:**

- Light theme contrast has never been measured, before or after.
- Contrast was measured on 8 routes; `/alerts`, `/journal`, `/news`, `/backtest`, `/liq`, `/funding`, `/econ-calendar`, `/hours` and `/ops` received token substitutions with no measured proof.
- `--txt2` is 4.31:1 on the `#191b1e` card. Nothing renders it there today; recorded in `__tests__/contrastTokens.test.mts` rather than fixed, because clearing it means relightening secondary type app-wide.
- `aggTrades` stays in the browser — 45 requests, 180 of the remaining 214 Binance request-weight.
- The trade journal has no API route, so it has no API-level BOLA surface to probe. RLS is its only protection, covered by the direct-PostgREST test.

**New this release, worth stating:** feature PRs into `dev` no longer run the browser suite. A browser-level regression now surfaces here, at the release gate, with the whole batch attached — rather than on the PR that caused it. That is the deliberate trade documented in `CONTRIBUTING.md` §4b, and it is bounded by the weekly cadence in §7a.
