### PR TITLE
fix(ci): stop a stale CI Gate from satisfying the release PR's required check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,22 @@ name: CI
 # suite runs on exactly ONE automatic trigger - a PR into `main`, which is the
 # release, immediately before a production deploy.
 #
-# What replaces it everywhere else is QA running the suite LOCALLY when a
-# dev -> qa PR arrives (CONTRIBUTING section 4b). That is a real gate with a
-# named owner, not a hope.
+# NOBODY runs it by hand - not dev, not QA. An earlier draft had QA running it
+# locally on the dev -> qa PR; that was dropped because ordering it correctly
+# (manual testing first, suite last) put it minutes before this run, on the same
+# commit, differing only in environment. Between the two, keep the stricter one
+# that costs nobody an afternoon. See CONTRIBUTING section 4b.
 #
-# Why one CI run survives at all: QA's local run is one machine with .env.local
-# present. CI is the only place the app builds WITHOUT developer env, and that
-# difference has produced two real defects - the labels bug (only reproduces
-# when /api/labels returns {}, which never happens locally) and the
-# NEXT_PUBLIC_APP_ENV table-prefix gap. ~136 min/month for the last check
-# between a green laptop and production.
+# Why THIS run is the stricter one: it is the only place the app builds WITHOUT
+# developer env, and that difference has produced two real defects - the labels
+# bug (only reproduces when /api/labels returns {}, which never happens on a
+# machine with .env.local present) and the NEXT_PUBLIC_APP_ENV table-prefix gap.
+# ~136 min/month for the last automated check before production.
+#
+# What is given up, stated so nobody is surprised: between a feature merging
+# into dev and the release PR opening, nothing exercises a browser. A regression
+# surfaces here, with the whole batch attached, rather than on the PR that caused
+# it. Bounded by the weekly release cadence in CONTRIBUTING section 7a.
 # ─────────────────────────────────────────────────────────────────────────────
 
 on:
@@ -273,7 +279,33 @@ jobs:
   # and checks are evaluated per-SHA.
   # ───────────────────────────────────────────────────────────────────────────
   gate:
-    name: CI Gate
+    # The NAME is computed, and that is the whole point - it is what makes the
+    # required check un-forgeable. QA found the hole on release PR #38.
+    #
+    # The bug: `CI Gate` was a fixed name, so EVERY event that touched a commit
+    # published a check by that name. dev -> qa is fast-forward, so the merge
+    # commit on dev, the head of qa, and the head of the qa -> main release PR
+    # are all the SAME SHA. A push to dev published `CI Gate: success` on it -
+    # successful with E2E SKIPPED, because base_ref is empty on a push. GitHub
+    # evaluates required checks per commit, so the release PR showed
+    # `mergeable: true` while its own 34-minute suite was still running. A pass
+    # from a run that never opened a browser could green-light a production
+    # merge.
+    #
+    # Deleting the `push: [dev]` trigger would have fixed that one path and left
+    # the hole open: a dev -> qa promotion PR publishes checks against the same
+    # SHA too, also with E2E skipped. The fix has to be that the name itself
+    # cannot appear except on a release PR.
+    #
+    # A job `if:` cannot do this. A job skipped by `if:` still creates a check
+    # run, and branch protection counts a skipped check as SUCCESS - which is the
+    # same trap this job exists to close, one level up.
+    #
+    # So: PRs into main publish `CI Gate`, the required context. Everything else
+    # publishes `CI Gate (advisory)`, which no ruleset requires and which
+    # therefore cannot satisfy anything. Same logic runs either way, so the
+    # advisory result is still worth reading.
+    name: ${{ github.base_ref == 'main' && 'CI Gate' || 'CI Gate (advisory)' }}
     if: ${{ always() }}
     needs: [build, e2e]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

@JohnDominicJasmin caught this on release PR #38 — the PR showed **`mergeable: true` while its own 34-minute browser suite was still running.** They were right, and it is worse than a timing window.

## What was actually wrong

`CI Gate` was a **fixed job name**, so every event that touched a commit published a check by that name.

`dev` → `qa` is fast-forward only. So the merge commit on `dev`, the head of `qa`, and the head of the `qa` → `main` release PR are **all the same SHA**. The push to `dev` published `CI Gate: success` on it — successful **with E2E skipped**, because `base_ref` is empty on a push, so the e2e job's `if:` is false.

GitHub evaluates required status checks **per commit**. So the release PR was already satisfied by a run that had never opened a browser.

**That is not a race that closes on its own.** It is a pass being reused across events, and it would have let a production merge through on a check that proved nothing. Which is precisely what `CI Gate` was introduced to prevent — so the gate had the same class of bug it exists to close.

## Two fixes that don't work, and why

**Delete the `push: [dev]` trigger.** Obvious, and insufficient — a `dev` → `qa` promotion PR publishes checks against that same SHA too, also with E2E skipped. Any fix that enumerates triggers loses to the next trigger someone adds.

**Put an `if:` on the gate job.** Worse. A job skipped by `if:` **still creates a check run**, and branch protection counts a skipped check as **success**. That is the exact trap the gate exists to close, one level up.

## The fix

The name has to be unavailable outside a release PR:

```yaml
name: ${{ github.base_ref == 'main' && 'CI Gate' || 'CI Gate (advisory)' }}
```

| Event | Check published | Required? |
|---|---|---|
| PR into `main` | **`CI Gate`** | ✅ yes |
| PR into `dev` / `qa` | `CI Gate (advisory)` | no |
| Push to `dev` / `main` | `CI Gate (advisory)` | no |

Both run the same assertions, so the advisory result is still worth reading on a `dev` PR — it just cannot satisfy a ruleset.

## Also in here

The workflow header still described **QA running the suite locally** on the `dev` → `qa` PR. That was dropped before this workflow shipped — nobody runs it by hand now — and the file should not describe a process that is not the process.

## How to test

1. **This PR** (into `dev`) → the check should be named **`CI Gate (advisory)`**.
2. Next release PR (into `main`) → named **`CI Gate`**, required by the ruleset, and the PR must stay **not mergeable** until Playwright finishes.
3. Push to `dev` → advisory name, so the SHA it shares with a later release PR carries nothing that could satisfy `CI Gate`.

`npm run lint` 0 errors · `npx tsc --noEmit` clean · `npm test` 75 passing.

## Risk level

**Low.** One computed job name and a comment block. No application code. The thing to watch is that the required-check name in the ruleset stays exactly `CI Gate` — it does; nothing about the ruleset changes here.

## Note on #38

#38 is still open with its real E2E running. Once this merges, the *next* release PR gets the fixed behaviour. For #38 itself, the correct move is what you are already doing: **wait for its own E2E to report before merging**, rather than trusting `mergeable`.