### PR TITLE
docs: fix §7a contradicting §4b about who runs the browser suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -609,9 +609,11 @@ promotion out of `dev`.
 
 Two things follow from this, and both are the point rather than side effects:
 
-- **A regression found at the `qa` gate arrives with a week of changes attached**,
-  not one. That is the cost of batching, and it is why §4b puts a full browser run
-  in QA's hands before the promotion is merged rather than after.
+- **A regression found at the release gate arrives with a week of changes
+  attached**, not one. That is the cost of batching, and it is why §4b keeps the
+  full browser suite on the `qa` → `main` PR — the last automated check before a
+  production deploy — rather than dropping it entirely once it came off feature
+  PRs.
 - **"It is not urgent" is a real answer.** A feature that misses the weekly slot
   waits. Shipping a feature mid-week to production, outside the batch, is a
   decision someone makes deliberately — not something that happens because a PR


### PR DESCRIPTION
## Summary

@JohnDominicJasmin caught §7a and §4b contradicting each other on issue #40. Fixed — one sentence.

§7a said §4b *"puts a full browser run in QA's hands before the promotion is merged"*. §4b says the opposite: nobody runs it by hand, it runs on the PR into `main`.

## Why it was there

Leftover from the draft where QA ran the suite locally on the `dev` → `qa` promotion PR. That draft was dropped after you pointed out it would duplicate the release PR's CI run minutes later, §4b was rewritten, and this **cross-reference in §7a was not**.

A convention doc that contradicts itself is worse than one that is silent — the reader cannot tell which half is current, and **the half that assigns work is the one they'd act on.** You'd have been the one doing a 30-minute run nobody asked for.

## What it says now

> A regression found at the release gate arrives with a week of changes attached, not one. That is the cost of batching, and it is why §4b keeps the full browser suite on the `qa` → `main` PR — the last automated check before a production deploy — rather than dropping it entirely once it came off feature PRs.

Swept the whole file rather than fixing the one line: every `browser suite` / `test:e2e` / `187 tests` mention now agrees. Nothing outside §4b assigns the suite to a person, and §4b's own `npm run test:e2e` reference is explicitly the optional on-demand path.

## On your other two points

**The residual you flagged is real.** Commits from before #39 still carry a required-name `CI Gate: success` with the suite skipped. Not live — `main` and `qa` have both moved past them — but it means those SHAs would satisfy the ruleset if one ever became a release PR head. Nothing to do about existing check runs; #39 stops new ones being created. Worth knowing, and worth you having said so rather than assuming I'd thought of it.

**Your call on tiering is better argued than mine.** *"The suite counts things; it can't look at a page"* — and all three findings on this release came from manual work: the onboarding gate, the missing card, B7 being untestable. Per-PR browser runs would have added none of them at 34 minutes each. Tiering stays.

Agreed on where the effort goes instead — the authenticated UI has been reached exactly once, by hand, today; light theme is entirely unmeasured; nine routes got colour changes with no proof. I'm starting on light theme contrast next since it's the largest unmeasured surface and cheap now the tokens exist.

## Risk level

**None.** Documentation, one sentence.