### PR TITLE
docs: reconcile every status marker against what is actually true

### DIFF
--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -100,9 +100,9 @@ the claim was already stale when written up as audit §7.2.
 
 | Layer | What | Where |
 |---|---|---|
-| CI | GitHub Actions, on push to `dev` and `main`. Job `build`: lint → typecheck → test → build. Job `e2e`: Playwright, `needs: build` | `.github/workflows/ci.yml` |
-| Unit | `node --test`, 4 files, 44 assertions | `__tests__/*.test.mts` |
-| E2E | Playwright, 216 tests × desktop 1440×900 + iPhone 13, against a **production** build on port 3100 | `qa/e2e/*.spec.ts`, `playwright.config.ts` |
+| CI | GitHub Actions. Job `build` (lint → typecheck → test → build, ~2 min) on every push and PR. Job `e2e` (Playwright, ~34 min) **only on a PR into `main`** — see `CONTRIBUTING.md` §4b. Job `CI Gate` is the one required status check | `.github/workflows/ci.yml` |
+| Unit | `node --test`, 6 files, 75 assertions | `__tests__/*.test.mts` |
+| E2E | Playwright, 187 passing + 47 skipped × desktop 1440×900 + iPhone 13, against a **production** build on port 3100 | `qa/e2e/*.spec.ts`, `playwright.config.ts` |
 | Lint | ESLint via CLI — `next lint` no longer exists in Next 16, and `next build` stopped linting | `eslint.config.mjs` |
 
 Two things about the E2E suite that will bite otherwise:
@@ -345,9 +345,11 @@ auth email delivery that has not been exercised once. Treat as the top priority.
 
 ### Backlog (not urgent, nothing blocking)
 
-- **CI/CD pipeline** — logged in `PENDING.md` today. No CI exists; deploys are manual. A
-  build/typecheck gate at minimum, auto-deploy on merge to `main`, tests once any exist.
-  GitHub Actions is the obvious default. No scope decided.
+- ~~**CI/CD pipeline**~~ — **DONE.** Shipped 2026-08-01, restructured 2026-08-06. The text
+  here used to say *"No CI exists; deploys are manual"*, which stopped being true within a
+  day and sat stale for five. See the Testing & CI table above. Deploys are **still
+  manual and deliberately so** — `autoDeploy: "no"` on all three Render services, because
+  merging to `main` should not be able to ship on its own.
 - **Confluence Score validation** — `agree_count`/`agree_net` are recording correctly in
   prod, but **do not read the data yet.** Every row so far is `agree_count: 1` (a solo fire
   has no agreement to measure). Needs weeks of accumulation plus 24h resolution. A small

--- a/pendings/PENDING.md
+++ b/pendings/PENDING.md
@@ -1,5 +1,43 @@
 # Pending Work
 
+## STATUS INDEX — reconciled 2026-08-06
+
+**Read this table before anything below it.** This file is append-mostly and had
+grown four `⛔ OPEN` headings describing problems that were already solved, each
+superseded by a `✅` section further down that never went back to update the
+original. Grepping for `⛔` and reporting the hit — without reading the whole
+file — produced four wrong "still open" claims in a single session. Hence this
+index, and hence the rule below it.
+
+**Genuinely open:**
+
+| What | Owner | Where |
+|---|---|---|
+| Supabase Pro before real payments — still Free, still **zero backups** | owner | §"YOUR decision", top |
+| `qa` holds **dev's** Telegram token. Safe only while `CRON_SECRET` is unset there | owner, parked | §"QA needs its own Telegram bot" |
+| Coinglass v4 — deferred until revenue, **do not re-raise** | decided | §"OPEN — code (mine)" |
+| LemonSqueezy payments | deferred | `pendings/LEMONSQUEEZY.md` |
+
+**Resolved, kept for history — the heading was corrected in place:**
+
+| What | Resolved |
+|---|---|
+| dev and prod sharing one Telegram bot | 2026-08-04 — dev runs `@Liquidity_hq_dev_bot`, prod runs `LiquidityHQ_bot` |
+| dev RLS drift | 2026-08-04, re-swept 2026-08-06 — **0 tables with RLS off on dev or prod** |
+| `/scanner` CLS ~0.98 | 2026-08-05/06 — now 0.007–0.028 warm, carries a real `CLS_BUDGET` of 0.25 |
+| BOLA/IDOR unverified | 2026-08-06 — 9 tests in CI, no hole found |
+| Colour contrast (§4.3, §4.1) | 2026-08-06 — 270 → **0** violations across 8 routes |
+
+**The rule, so this does not recur:** when something is fixed, edit the heading
+that claims it is broken. Do not only append a `✅` section below it. A reader
+who greps will find the oldest marker, and that is what happened here four times.
+
+The intro below predates all of the above and describes the 2026-08-04 audit as
+a fresh handoff list. Most of it has since shipped — the index is authoritative
+where the two disagree.
+
+---
+
 Single source of truth. The original security audit (stop untraceable
 API-cost abuse, signup/trial abuse, any exploit that breaches system/keys/logs)
 is **fully resolved** - every finding fixed and live on prod, including the
@@ -273,7 +311,22 @@ dev `false` is correct, not a bug** — the bot belongs to prod and dev can no
 longer take it. Dev's `/alerts` will show its bot-unhealthy warning banner
 permanently until dev gets its own bot.
 
-### ⛔ Root cause still open — dev and prod share one bot (YOUR action)
+### ✅ RESOLVED 2026-08-04 — dev got its own bot (was: "dev and prod share one bot")
+
+**Fixed. See "Environments finally isolated" further down for what actually
+happened.** dev runs `@Liquidity_hq_dev_bot`, prod runs `LiquidityHQ_bot`, and
+both report `webhook_ok: true` at the same time — which was structurally
+impossible while they shared one.
+
+The heading here said `⛔ Root cause still open` until 2026-08-06 and was the
+single most misleading line in this file: it is near the top, it is emphatic, and
+the section that resolves it sits ~340 lines below with no back-reference. It
+produced a wrong "dev and prod share a bot" claim as recently as today.
+
+**The pairing that IS still real is dev ↔ qa, not dev ↔ prod** — `liquidity-hq-qa`
+holds *dev's* token. See "QA needs its own Telegram bot" near the end.
+
+The original text follows, for the history of why it mattered:
 
 Dev can no longer *steal* the webhook by accident, but whichever environment
 registered last still owns it, and two consequences remain:
@@ -328,7 +381,15 @@ rows are left in both projects — never looked up, so harmless. Consequence for
 the i18n bookkeeping below: the seeded row count now **exceeds** the registry
 count by 9 per locale. Do not treat that gap as missing work.
 
-## ⛔ OPEN — code (mine)
+## 🔭 MIXED — mostly shipped, one deferred decision (heading corrected 2026-08-06)
+
+This heading said `⛔ OPEN — code (mine)` and covered ~200 lines in which almost
+everything is now marked `✅ FIXED` or `✅ SHIPPED` in its own sub-heading. The
+only thing still outstanding is the Coinglass deferral immediately below, and
+that is a decision, not work.
+
+Read the sub-headings, not this one. Kept rather than deleted because the
+sub-sections explain *why* several fixes look the way they do.
 
 ### Coinglass v4 migration — DEFERRED until there is revenue (decided 2026-07-30)
 
@@ -640,7 +701,28 @@ Two things worth remembering from that:
 - `?force=1` matters: a plain call short-circuits when the URL already matches
   and would skip re-applying `TELEGRAM_WEBHOOK_SECRET`.
 
-## ⛔ OPEN — dev RLS drift, one table fixed, worth a periodic re-check
+## ✅ RESOLVED — dev RLS drift (re-swept 2026-08-06, still clean)
+
+**Not open.** Fixed 2026-08-04 and re-verified 2026-08-06 against both projects:
+
+```
+dev   0 tables with RLS off   29 lhq_dev_* tables   10 RLS-on-zero-policies
+prod  0 tables with RLS off   30 lhq_*     tables   11 RLS-on-zero-policies
+```
+
+The zero-policy counts track each other, which is the intended shape — those are
+server-only tables where deny-all is correct and service-role bypasses RLS.
+
+One genuinely new gap was found and fixed on 2026-08-06, a *different* table:
+`public.lhq_signup_ip_log` had RLS **disabled** on dev while prod had it enabled,
+so anyone with the dev anon key — which is in CI, in `.env.local`, and inlined
+into the QA staging build — could read or modify every signup IP record. Enabled
+with zero policies, matching prod exactly; the `hook_restrict_signup_velocity`
+SECURITY DEFINER hook still fires, verified with a real signup.
+
+The standing advice below is still worth following. The original text follows:
+
+### Original finding, 2026-08-04
 
 `lhq_dev_user_settings` had RLS **enabled with zero policies** - deny-all, not
 allow-all. Service-role clients (webhooks, cron, `/api/*`) bypass RLS, so writes
@@ -668,15 +750,36 @@ re-running after any schema work on dev, since this drift was silent.
 Still Free, still zero backups. Parked until revenue by your call; listed here
 only so it is not mistaken for handled.
 
-### 2. Nothing else is blocking
+### 2. `qa` holds dev's Telegram token — parked by your call
 
-The dev-bot item that used to sit here is done (above). No QA item is waiting on
-you.
+See "QA needs its own Telegram bot" near the end of this file. Safe today only
+because `CRON_SECRET` is unset on `qa`, which makes `setup-webhook` fail closed —
+re-verified 2026-08-06, it returns 401. **Do not set `CRON_SECRET` on `qa`** until
+it has its own bot; doing so would let `qa` point dev's bot at itself and silently
+take every alert.
 
-### Branch/deploy state (2026-08-04)
+### 3. Nothing else is blocking
 
-`dev` = `32b2e86`, `main` = `40a5096` (a merge of the same content), nothing
-unmerged. Prod live on `40a5096`, dev on `32b2e86`, CI green on both.
+The dev-bot item that used to sit here is done. No QA item is waiting on you.
+
+### Branch/deploy state
+
+**Do not trust a snapshot in this file.** It said `dev` = `32b2e86`,
+`main` = `40a5096` from 2026-08-04, which was four releases stale by 2026-08-06
+and is exactly the kind of line that gets read as current.
+
+Check it instead — it takes two seconds and cannot go stale:
+
+```
+git fetch --prune origin
+git log --oneline -1 origin/main
+git rev-list --count origin/main..origin/qa   # unreleased on qa
+git rev-list --count origin/qa..origin/dev    # unpromoted on dev
+git tag --sort=-v:refname | head -1           # what production claims to be
+```
+
+Production is whatever the newest tag points at, and the tag is only pushed after
+a deploy reaches `live` (§Tagging in `CONTRIBUTING.md`).
 
 ## 🔭 DEFERRED — tied to unfinished payment feature
 
@@ -958,7 +1061,33 @@ only cleared on unmount. A user who leaves a tab open in fallback mode will ban
 their own IP within about six minutes. Worth fixing independently of the
 fan-out work; the fix is probably a slower fallback interval plus a cap.
 
-## ⛔ OPEN — /scanner has ~0.98 CLS, and the audit's 0.000 figure is wrong
+## ✅ RESOLVED 2026-08-06 — /scanner CLS (was: "~0.98, and the audit's 0.000 is wrong")
+
+**Both halves of that heading are now history.** The audit's 0.000 claim was
+indeed wrong — that part stands as a finding about the audit. But `/scanner` is
+no longer ~0.98.
+
+Measured over 24 runs on the shipped build, production server, two batches:
+
+```
+warm   min 0.007   median 0.011   mean 0.011   max 0.028
+```
+
+A single 0.176 appeared on the first run against a just-started server; a second
+batch was run specifically to test whether that was cold-start or the tail of the
+old race, and reproduced nothing above 0.028.
+
+It has been retired from `CLS_UNSTABLE` (measured but ungated) to a real
+`CLS_BUDGET` of **0.25** in `qa/e2e/_shared.ts`, so it is now asserted like every
+other route. `CLS_UNSTABLE` is empty as a result; the mechanism stays, with its
+entry bar documented — a distribution over ≥10 runs *and* a retirement condition.
+
+What actually fixed it was `fix/scanner-card-layout-shift` (heatmap ranking,
+three card skeletons, `PageHint`), not the earlier tile-height fix. The
+distribution below was measured on a build that had only the latter, which is why
+it read as non-deterministic.
+
+The original finding follows:
 
 **Found 2026-08-05** while fixing `/arena`'s layout shift (PR #5).
 

--- a/pendings/QA_AUDIT_2026-08-04.md
+++ b/pendings/QA_AUDIT_2026-08-04.md
@@ -3,8 +3,33 @@
 Full end-to-end sweep: build gates, code, API security, DB, responsiveness
 (desktop + mobile), accessibility, SEO, performance, tech debt.
 
-**Run by:** a QA-only session. **Nothing here was fixed** — this file is the
-handoff to the development session. No source file was modified by the audit.
+**Run by:** a QA-only session. No source file was modified by the audit itself —
+this file was the handoff to the development session.
+
+> ## ⚠️ STATUS AS OF 2026-08-06 — most of this is fixed
+>
+> The line below used to read *"Nothing here was fixed"*, which was true on
+> 2026-08-04 and badly misleading by 2026-08-06. Two releases have shipped
+> against these findings. **Do not read a finding here as current without
+> checking this table first.**
+>
+> | Finding | Status |
+> |---|---|
+> | §1.1 ~450 browser-side Binance calls on every route | ✅ Fixed — moved server-side, 193 → 56 requests, 554 → 214 weight |
+> | §4.3 brand blue `#1A7AFF` + white = 3.98:1 | ✅ Fixed — `--accent-solid` `#1668e3` = 5.09:1 |
+> | §4.3 `/scanner` column headers 1.55:1 | ✅ Fixed — part of 270 → **0** contrast violations across 8 routes |
+> | §4.1 "159 sub-24px tap targets" | ⚠️ **The number was wrong.** SC 2.5.8 exempts inline targets in text; real failures were 0. Baseline renamed and ratcheted 217 → 122, and 122 is not a conformance count |
+> | §3.2 "CLS 0.000 on every page" | ⚠️ **Wrong.** `/arena` was 0.365, `/scanner` ~0.98. Both fixed since — `/arena` 0.068, `/scanner` 0.007–0.028 |
+> | §5.1 `/briefing` hydration mismatch | ⛔ Still open |
+> | §6 zero canonical tags, one shared meta description | ⛔ Still open — `pagesWithCanonical: 0`, `pagesWithoutH1: 13` |
+> | BOLA/IDOR "unverified, needs two test tokens" | ✅ Closed 2026-08-06 — two seeded accounts, 9 tests in CI, **no hole found** |
+>
+> Contrast was measured on 8 routes. Nine others received token substitutions
+> with **no measured proof**, and the light theme has never been measured at
+> all — before this audit or after it.
+>
+> Live status is in `pendings/PENDING.md`, which carries a reconciled index at
+> the top. This file is kept as the record of what was measured on 2026-08-04.
 
 **Method.** Everything below was *measured*, not inferred, unless a row says
 otherwise. Target was a fresh `npm run build` served by `npm start` on

--- a/pendings/QA_E2E_FINDINGS_2026-08-05.md
+++ b/pendings/QA_E2E_FINDINGS_2026-08-05.md
@@ -187,6 +187,26 @@ regressions and are not. This was observed directly during run 1.
 
 ## 5. Still open
 
+> **⚠️ Reconciled 2026-08-06 — most of this table is now closed.** Statuses below
+> are as of 2026-08-05 and were not updated as things shipped. Current position:
+>
+> | Item | Now |
+> |---|---|
+> | **BOLA / IDOR** | ✅ **Closed.** Two seeded accounts, 9 tests in `qa/e2e/bola.spec.ts`, running in CI. No hole found — every route scopes by `user_id` *and* queries with the user's token, so RLS is a second layer. The `test.fixme` in `security.spec.ts` is replaced with a pointer |
+> | 3 CI secrets | ✅ Set. Plus 9 more for the BOLA fixtures |
+> | Leaked-password protection | ⛔ Still open — owner, 2 Supabase toggles |
+> | Stray `C:\Users\Dominic\package-lock.json` | ⛔ **Still there**, still hijacking Next's workspace root. Outside the repo, so it needs deleting by hand |
+> | `/arena` CLS | ✅ 0.365 → 0.068 |
+> | `/briefing` CLS | ⛔ Still open — carries a `CLS_BUDGET` of 0.20 |
+> | `/playbook` `button.pb-star` | ✅ Cleared — 55 targets fixed |
+> | Audit §3.2 and §4.1 text | ✅ Corrected in place, see the banner on `QA_AUDIT_2026-08-04.md` |
+> | `HANDOVER.md` §3 | ✅ Corrected — and corrected **again** 2026-08-06, because the CI restructure made the first correction stale |
+>
+> That last row is the pattern worth noticing: a doc corrected once still goes
+> stale. `PENDING.md` now carries a reconciled index at the top for this reason.
+
+### Original table, 2026-08-05
+
 | Item | Owner | Note |
 |---|---|---|
 | **BOLA / IDOR** | **owner + QA** | Unchanged since the audit. `security.spec.ts` still carries a `test.fixme`. Needs `E2E_TOKEN_A` / `E2E_TOKEN_B` for the two test accounts. **The largest untested area in the product.** |


### PR DESCRIPTION
## Summary

These files misled me **four times in one session** — including telling the owner that dev and prod share a Telegram bot, when that was fixed on 2026-08-04 and the section proving it sat 340 lines further down the same file.

Reconciled `PENDING.md`, `QA_AUDIT_2026-08-04.md`, `QA_E2E_FINDINGS_2026-08-05.md` and `HANDOVER.md` against reality.

## The failure mode

`PENDING.md` is append-mostly. A problem gets a `⛔ OPEN` heading. Weeks later it's fixed, and picks up a `✅` section — **hundreds of lines below, with the original heading untouched.**

Grep for `⛔`, report the hit, be wrong. Four times.

## Corrected in place

| Heading | Reality |
|---|---|
| "dev and prod share one bot" | ✅ Fixed 2026-08-04. **The real pairing is dev ↔ qa** — `liquidity-hq-qa` holds *dev's* token, safe only while `CRON_SECRET` is unset there. Re-verified: `setup-webhook` returns 401 on qa |
| "dev RLS drift" | ✅ Resolved, re-swept today — **0 tables with RLS off** on either project. Records the separate `lhq_signup_ip_log` gap found and fixed today |
| "/scanner has ~0.98 CLS" | ✅ Resolved — 24 runs measure warm min 0.007, median 0.011, max 0.028. Now carries a real `CLS_BUDGET` of 0.25 |
| "OPEN — code (mine)" | 🔭 Covered ~200 lines in which nearly every sub-item is already `FIXED`/`SHIPPED`. Only the Coinglass deferral remains, and that's a decision |

Also removed a hardcoded branch/deploy snapshot that was **four releases stale**, replaced with the commands to check — those can't rot.

## The other three files

**`QA_AUDIT_2026-08-04.md`** said *"Nothing here was fixed."* True when written, badly wrong now. Banner added mapping each finding to its current state — including the two the audit itself got wrong: *"CLS 0.000 on every page"* (it wasn't) and *"159 sub-24px tap targets"* (real conformance count: **0**).

**`QA_E2E_FINDINGS_2026-08-05.md`** — its "Still open" table is mostly closed. BOLA/IDOR especially: that's now 9 tests in CI, no hole found.

**`HANDOVER.md`** — the Testing & CI table was corrected on 2026-08-05 and **went stale again within the same week**, describing pre-restructure triggers and 216 tests. Its backlog still said *"No CI exists; deploys are manual"*, which stopped being true within a day of being written.

That last one is the pattern worth naming: **a doc corrected once still goes stale.** Hence the index.

## The rule, now stated at the top of `PENDING.md`

> When something is fixed, **edit the heading that claims it is broken.** Appending a `✅` section below it is not enough, because a reader who greps finds the oldest marker first.

## Still genuinely open — unchanged by this PR

Supabase Pro before payments · `qa`'s shared Telegram token · Coinglass (deferred) · leaked-password protection · `/briefing` CLS · SEO canonicals and `<h1>`s · the stray `C:\Users\Dominic\package-lock.json` still hijacking Next's workspace root

## How to test

```
grep -n "⛔" pendings/PENDING.md
```

Exactly **one heading** should match — QA's own Telegram bot, which is real. The other hits are quoted references inside the corrections explaining what was wrong.

`npm run lint` 0 errors · `tsc` clean · `npm test` 75 passing.

## Risk level

**None.** Documentation only. No code, no config, no workflow.