### PR TITLE
fix(dashboard, landing): signal chip contrast + homepage hero reduced-motion

### DIFF
--- a/__tests__/contrastTokens.test.mts
+++ b/__tests__/contrastTokens.test.mts
@@ -56,16 +56,18 @@ const SURFACES: Record<string, string> = {
 };
 
 /* Surfaces that are NOT tokens - one-off card backgrounds found by running axe
-   against the built app. Only asserted for the tokens actually observed on
-   them, because that is all the measurement established.
-   Known gap, recorded rather than papered over: --txt2 is 4.31:1 on #191b1e.
-   Nothing renders --txt2 there today, so it is not a live defect, but moving
-   any secondary text onto that card would create one. Fixing it means
-   relightening --txt2 app-wide, which is a visible typography change and the
-   owner's call - not something to slip into a contrast pass. If that surface
-   ever gains secondary text, raise --txt2 to >= #7e8298 and add it below. */
+   against the built app.
+   #14161a is the .csb2-sig chip: 2% white over --bg3. It used to be 4% white,
+   which computed to #191b1e and left --txt2 at 4.31:1 and --txt3 at 4.32:1 -
+   the only surface in the app where the muted tokens fell short.
+   That was recorded here as a known gap rather than fixed, on the reasoning
+   that clearing it meant relightening --txt2 across all 215 of its call sites.
+   Wrong framing: halving one overlay fixes the same pair and moves nothing
+   else. Owner picked that when it was put as a choice rather than a mechanism.
+   ALL FOUR text tokens are now asserted against it, --txt2 included, so the
+   overlay cannot drift back up without failing here. */
 const MEASURED_PAIRS: { surface: string; tokens: string[] }[] = [
-  { surface: '#191b1e', tokens: ['txt', 'txt3', 'txt-dim'] },
+  { surface: '#14161a', tokens: ['txt', 'txt2', 'txt3', 'txt-dim'] },
 ];
 
 test('design token contrast', async (t) => {

--- a/app/globals.css
+++ b/app/globals.css
@@ -405,7 +405,18 @@ body::after {
 .csb2-price     { font-size: var(--fs-data); font-weight: 700; color: var(--txt); font-family: var(--font-mono), monospace; font-variant-numeric: tabular-nums; }
 .csb2-bottom    { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
 .csb2-chg       { font-size: var(--fs-data); font-weight: 700; font-variant-numeric: tabular-nums; }
-.csb2-sig       { font-size: var(--fs-caption); font-weight: 700; padding: 1px 5px; border-radius: 4px; max-width: 130px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; background: rgba(255,255,255,0.04); }
+/* 0.04 -> 0.02. This chip is the one surface in the app where the muted text
+   tokens land short: 4% white over --bg3 computes to #191b1e, and on that
+   --txt2 measured 4.31:1 against the 4.5:1 floor. --txt3 was 4.32:1 here too
+   until it was nudged to #7b8297.
+   Darkening the chip rather than lightening --txt2 is the deliberate choice:
+   --txt2 is used in 215 places, so raising it would relighten every caption,
+   label and timestamp in the app to fix one element. Halving one overlay moves
+   nothing else. At 2% both tokens clear - --txt2 4.52:1, --txt3 4.73:1 - and
+   the chip is still visibly a chip.
+   If this ever goes back up, re-measure both tokens against the result; the
+   assertion in __tests__/contrastTokens.test.mts pins the pair. */
+.csb2-sig       { font-size: var(--fs-caption); font-weight: 700; padding: 1px 5px; border-radius: 4px; max-width: 130px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; background: rgba(255,255,255,0.02); }
 .csb2-bar-track { height: 3px; background: rgba(255,255,255,0.06); border-radius: 0 0 var(--radius-data) var(--radius-data); margin: 0 -10px; }
 .csb2-bar-fill  { height: 100%; border-radius: 0 0 var(--radius-data) var(--radius-data); transition: width 0.8s ease, background 0.3s; }
 

--- a/components/BeamsBackground.tsx
+++ b/components/BeamsBackground.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useSyncExternalStore } from 'react';
 import { motion } from 'motion/react';
 
 interface Beam {
@@ -34,10 +34,46 @@ function createBeam(width: number, height: number): Beam {
 
 const OPACITY_MAP = { subtle: 0.6, medium: 0.8, strong: 1 };
 
+/* WCAG 2.2.2 Pause, Stop, Hide is Level A, and this component paints the FIRST
+   thing a visitor sees on the public marketing homepage.
+   Two things here ran forever with no way to stop them: the requestAnimationFrame
+   loop below, and the Motion opacity pulse at the bottom of this file. Neither
+   checked prefers-reduced-motion, so someone who had asked their operating system
+   to reduce motion got both anyway.
+   Not a deliberate exception - the app honours the setting in four other places
+   (globals.css, SpotlightTour.tsx). This file was missed.
+
+   Read through useSyncExternalStore rather than useState + useEffect because a
+   media query IS an external store, and the setState-in-an-effect version trips
+   the React Compiler's cascading-render rule. It also gives a defined value on
+   the very first render instead of a frame of "unknown". */
+const REDUCE_MOTION = '(prefers-reduced-motion: reduce)';
+
+function subscribeReduceMotion(onChange: () => void) {
+  // Subscribed, not read once: the setting can change mid-session, and a user
+  // toggling it is the clearest statement of intent there is.
+  const mq = window.matchMedia(REDUCE_MOTION);
+  mq.addEventListener('change', onChange);
+  return () => mq.removeEventListener('change', onChange);
+}
+
+const readReduceMotion = () => window.matchMedia(REDUCE_MOTION).matches;
+
+/* Server-side there is no media query to read, so assume reduced. Erring toward
+   "still" means the worst case is one static frame before hydration corrects it,
+   rather than motion reaching someone who asked for none. */
+const readReduceMotionOnServer = () => true;
+
 export function BeamsBackground({ intensity = 'strong' }: { intensity?: 'subtle' | 'medium' | 'strong' }) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const beamsRef = useRef<Beam[]>([]);
   const rafRef = useRef<number>(0);
+
+  const reduceMotion = useSyncExternalStore(
+    subscribeReduceMotion,
+    readReduceMotion,
+    readReduceMotionOnServer,
+  );
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -92,29 +128,39 @@ export function BeamsBackground({ intensity = 'strong' }: { intensity?: 'subtle'
       ctx.restore();
     };
 
+    /* Draws exactly one frame. Advancing the beams and scheduling the next frame
+       are both skipped under reduced motion, so the artwork still paints - it
+       just never moves.
+       Deliberately not "render nothing": 2.2.2 objects to movement, not to the
+       image, and a blank hero would punish someone for setting the preference.
+       The still frame is the same composition, frozen. */
     const animate = () => {
       const { w, h } = getSize();
       ctx.clearRect(0, 0, w, h);
       ctx.filter = 'blur(35px)';
       const total = beamsRef.current.length;
       beamsRef.current.forEach((beam, i) => {
-        beam.y -= beam.speed;
-        beam.pulse += beam.pulseSpeed;
-        if (beam.y + beam.length < -100) resetBeam(beam, i, total);
+        if (!reduceMotion) {
+          beam.y -= beam.speed;
+          beam.pulse += beam.pulseSpeed;
+          if (beam.y + beam.length < -100) resetBeam(beam, i, total);
+        }
         drawBeam(beam);
       });
-      rafRef.current = requestAnimationFrame(animate);
+      if (!reduceMotion) rafRef.current = requestAnimationFrame(animate);
     };
 
     setup();
-    window.addEventListener('resize', setup);
+    // Still repaints on resize when frozen, or the frame stretches.
+    const onResize = () => { setup(); if (reduceMotion) animate(); };
+    window.addEventListener('resize', onResize);
     animate();
 
     return () => {
-      window.removeEventListener('resize', setup);
+      window.removeEventListener('resize', onResize);
       cancelAnimationFrame(rafRef.current);
     };
-  }, [intensity]);
+  }, [intensity, reduceMotion]);
 
   return (
     <>
@@ -140,8 +186,14 @@ export function BeamsBackground({ intensity = 'strong' }: { intensity?: 'subtle'
           pointerEvents: 'none',
           zIndex: 1,
         }}
-        animate={{ opacity: [0.05, 0.2, 0.05] }}
-        transition={{ duration: 10, ease: 'easeInOut', repeat: Infinity }}
+        /* The second half of the 2.2.2 fix. This pulsed forever via
+           repeat: Infinity regardless of the user's preference. Under reduced
+           motion it holds a fixed opacity at the midpoint of the range it used
+           to travel, so the depth effect survives without the movement. */
+        animate={reduceMotion ? { opacity: 0.125 } : { opacity: [0.05, 0.2, 0.05] }}
+        transition={reduceMotion
+          ? { duration: 0 }
+          : { duration: 10, ease: 'easeInOut', repeat: Infinity }}
       />
     </>
   );


### PR DESCRIPTION
## Summary

Two accessibility fixes. They are unrelated in code but were batched here on the
owner's instruction after the second one was found while the first was still open.

1. **`.csb2-sig` chip contrast** — the chip's background overlay goes from 4% white to 2%, closing the last recorded contrast gap.
2. **Homepage hero ignored `prefers-reduced-motion`** — two animations on the public marketing page ran forever regardless of the setting. Now they hold still.

---

# 1. Signal chip contrast

## What it was

4% white over `--bg3` computes to `#191b1e`, and on that surface `--txt2` measured **4.31:1** against the 4.5:1 floor. `--txt3` was 4.32:1 here too, until it was nudged to `#7b8297` in an earlier release. It was the only surface in the app where the muted tokens fell short.

## Why it wasn't fixed before, and why that was wrong

It was recorded in `__tests__/contrastTokens.test.mts` as a known gap on the reasoning that clearing it meant relightening `--txt2` — **used in 215 places**, so every caption, label and timestamp in the app would get brighter to fix one element. Owner's call, correctly deferred.

That framing was wrong. **Halving one overlay fixes the same pair and moves nothing else.** I only offered it as an option once the owner pushed back on the jargon and I had to state the choice in plain terms — which is its own lesson about how the option was presented.

```
overlay 4%  bg=#191b1e   --txt2 4.31   --txt3 4.51
overlay 3%  bg=#16181c   --txt2 4.43   --txt3 4.64
overlay 2%  bg=#14161a   --txt2 4.52   --txt3 4.73   <- both clear
```

## Latent, not live

Nothing renders `--txt2` on that chip today, so no user was reading anything too faint. But *"nothing uses it yet"* is a poor reason to leave a surface below the floor — the next person to put a caption on that card has no way to know it needs checking.

The test now asserts **all four** text tokens against the new surface, `--txt2` included, so the overlay cannot drift back up without failing.

---

# 2. Homepage hero ignored `prefers-reduced-motion`

## What it was

`components/BeamsBackground.tsx` paints the animated blue beams behind the headline on `/`, the public marketing homepage. Two separate animations ran there:

- an uncapped `requestAnimationFrame` loop redrawing 30 gradient beams every frame, forever
- a Motion `opacity` pulse with `repeat: Infinity`, cycling the whole page light and dark on a 10-second loop

**Neither checked `prefers-reduced-motion`.** The file contained no `matchMedia` call at all.

WCAG 2.2 SC 2.2.2 (Pause, Stop, Hide) is **Level A** — the lowest conformance bar there is — and it requires any animation that starts automatically and runs longer than five seconds to be pausable, stoppable or hideable. Both of these ran indefinitely with no control.

This is the highest-traffic surface in the product and the one page a first-time visitor cannot opt out of.

## Not a deliberate exception

The app already honours the setting in four places in `app/globals.css` and in `components/SpotlightTour.tsx`. Checked before writing anything, because "we decided not to" and "we forgot" call for different responses. This was the second.

## What it does now

Under reduced motion the beams paint **one still frame** and the overlay holds a fixed `opacity: 0.125` — the midpoint of the `0.05 → 0.2` range it used to travel. Everyone else sees exactly what they saw before, unchanged.

Deliberately **not** "render nothing". SC 2.2.2 objects to movement, not to the image, and blanking the hero would punish someone for setting the preference. The still frame is the same composition, frozen.

The preference is **subscribed to, not read once** — toggling it mid-visit takes effect immediately, without a reload. A user changing that setting is the clearest statement of intent there is, and a one-shot read on mount would ignore it.

## Implementation note — why `useSyncExternalStore`

The obvious shape is `useState` + a `useEffect` that calls `setReduceMotion(mq.matches)`. That version was written first and **added a 95th lint warning**: the React Compiler flags `setState` called synchronously inside an effect as a cascading render.

A media query *is* an external store, so `useSyncExternalStore` is the right primitive rather than a workaround for the lint rule. It also returns a defined value on the very first render instead of a frame of "unknown". Warning count stays at **94** — no new debt.

Server-side there is no media query to read, so the server snapshot reports `reduce`. Erring toward "still" means the worst case before hydration is one static frame, rather than motion reaching someone who asked for none.

## Verification — measured, not reasoned about

A Playwright harness samples the canvas pixel data twice, 1.2 s apart, under both `reducedMotion: 'reduce'` and `'no-preference'`. Three assertions, because "frozen" alone would also pass if the canvas never painted:

| | reduced: painted | reduced: frozen | default: still moves |
|---|---|---|---|
| **Before** (rebuilt at the pre-fix commit) | yes | **no** — `1332792` vs `1347889` | yes |
| **After** | yes | **yes** — `1499207` vs `1499207` | yes |

The overlay was checked separately via computed style: a moving value before, exactly `0.125` after.

The "before" row is a real rebuild of the previous source, not an assumption — the pre-fix behaviour was reproduced before the fix was trusted.

---

## Gates

`npm run lint` 0 errors / 94 warnings (unchanged) · `npx tsc --noEmit` clean · `npm test` **75 passing** · `npm run build` clean.

Both fixes verified against **one** production build, on this branch, after the second commit — not measured separately and assumed to compose. The chip rule was confirmed present in the built CSS as `background:#ffffff05` (the minifier's form of 2%) before the numbers above were trusted.

## How to test (QA)

**Chip contrast** — `/dashboard`, the coin sidebar. Each card has a small pill holding the signal text ("Tight consolidation", "Balanced", that sort of thing).

1. The pill should look **fractionally darker** than before and otherwise identical.
2. The text on it must still read clearly.
3. Nothing else on any page should change — no other selector uses this rule.

**Reduced motion** — the public homepage `/`, logged out.

4. Turn on the operating system setting: **Windows** Settings → Accessibility → Visual effects → *Animation effects* off. **macOS** System Settings → Accessibility → Display → *Reduce motion*.
5. Load `/`. The blue beams behind the headline should be **visible but completely still**, and the page should not pulse light and dark.
6. Turn the setting back off and reload. The beams should drift upward again and the pulse should return.
7. With the page still open, toggle the setting. It should switch over **without a reload**.
8. Everything else on the page — text, buttons, the header — should be unaffected either way.

## Risk level

**Low.**

- Chip: one CSS value on one element. No layout, no logic, no other selector.
- Beams: one component, and every change is behind a branch that only executes when the visitor has explicitly asked for reduced motion. The default path is byte-identical in behaviour to before, which is what the "default: still moves" column above is there to prove.

**Unverified:** the reduced-motion behaviour was measured with Playwright's emulation, which sets the CSS media feature exactly as a real operating system does — but it was not checked against a physical machine with the OS toggle on. Step 5 above is the check that closes that gap.
