### PR TITLE
test(a11y): cover the signed-in surface and assert SC 2.5.8 via axe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/web-push": "^3.6.4",
+        "axe-core": "^4.12.1",
         "eslint": "^9.39.5",
         "eslint-config-next": "^16.2.12",
         "tailwindcss": "^4",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/web-push": "^3.6.4",
+    "axe-core": "^4.12.1",
     "eslint": "^9.39.5",
     "eslint-config-next": "^16.2.12",
     "tailwindcss": "^4",

--- a/pendings/QA_A11Y_FINDINGS_2026-08-05.md
+++ b/pendings/QA_A11Y_FINDINGS_2026-08-05.md
@@ -376,7 +376,47 @@ first stated.
 
 ---
 
-## 4. 🔴 The authenticated surface has never been tested
+## 4. ✅ RESOLVED 2026-08-06 — the authenticated surface is now tested
+
+**All six U-findings below have been verified in a real browser, signed in.**
+Five confirmed, one refuted. `qa/e2e/a11y-auth.spec.ts` now runs them every
+suite, so they are re-checked rather than re-argued. The verdicts:
+
+| # | Claim | Verdict | Measured |
+|---|---|---|---|
+| U1 | ~24 Settings inputs unlabelled | ✅ **Confirmed, count wrong** | **9** unnamed controls, not ~24 — and in `SettingsModal.tsx` only. 12 `<label>` elements have no `for=` and wrap nothing, so they name nothing. `app/settings/page.tsx` is **fine** (13 of 14 named). |
+| U2 | `aria-label` drift, "Entry \*" vs "Entry" | ❌ **Refuted** | All 4 fields have accessible names. The `*` is a required marker, not label text. Only "Position Size ($)" differs from its `aria-label`, and the name a voice user speaks still matches. |
+| U3 | 4 inline-edit controls with no name | ✅ **Confirmed exactly** | 4 — `select.tj-edit-select`, 2× `input.tj-inp`, `textarea.tj-notes` |
+| U4 | Rule-builder selects unlabelled | ✅ **Confirmed** | 3 bare `<select>`: inline styles, no class, no id, no label of any kind |
+| U5 | Auth errors lack `role="alert"` | ✅ **Confirmed, wider than claimed** | **3** forms, not 1 — `/login` password, `/login` magic-link, **and `/forgot-password`**. `.login-error` has `role=null`, `aria-live=null`, and there are **zero** live regions anywhere on those pages. |
+| U6 | GrokChat replies not announced | ✅ **Confirmed** | `.gchat-msgs` has neither `aria-live` nor `role`; **0** live regions in the entire `.gchat-panel` |
+
+**Severity, now that they have been executed rather than read:** U1, U3 and U4
+are WCAG 2.2 **SC 4.1.2 Name, Role, Value, Level A** — a screen reader announces
+these as "edit text, blank". U5 and U6 are **SC 4.1.3 Status Messages, Level
+AA**. All five are real. None is as large as the source review implied, and one
+did not exist at all.
+
+**A defect found beyond the six, while verifying U1:** `app/settings/page.tsx`
+and `components/SettingsModal.tsx` are two implementations of the same settings
+UI, both reachable by users, with different accessibility. The page has
+`aria-label` on every `st-input`; the modal has none. Whoever fixes the modal
+should check they are not fixing the page a second time. Separately,
+`button.st-toggle` for Push Notifications on the page has no accessible name
+while the Analytics toggle directly below it does.
+
+**One harness note worth keeping.** The first pass of this verification scored
+U3 as *zero findings*. The journal had not rendered — but the page still had
+112 visible controls at that moment, all of them nav chrome and footer, so a
+"did the page load" guard based on counting controls passed cleanly. Every wait
+in the committed spec is scoped to an element the feature itself owns, and its
+absence now fails the test instead of quietly scoring zero. This is the same
+vacuous-pass failure mode described immediately below, reached from a third
+direction.
+
+The original section follows unchanged, for the record.
+
+---
 
 Measured signed-out against the release build:
 
@@ -396,7 +436,10 @@ vacuous pass is indistinguishable from a genuine one.
 A source-level review produced 28 findings. Three were runtime-testable: §1.1
 and §1.2 above were confirmed (§1.1 was *understated* by 2×), one was
 untestable. The rest touch surfaces behind auth. Recorded here so they are not
-lost, and explicitly marked **UNVERIFIED — do not action yet**:
+lost, and explicitly marked **UNVERIFIED — do not action yet**.
+*(Superseded 2026-08-06 — every row below has since been executed in a browser;
+see the verdict table at the top of this section. U2 in particular was refuted,
+so do not action it from this table.)*
 
 | # | Claim | File |
 |---|---|---|

--- a/qa/E2E_PLAN.md
+++ b/qa/E2E_PLAN.md
@@ -202,6 +202,11 @@ production key. Do not attempt to bypass the widget.
 
 ## 5. The gap this suite does not close
 
+> **SUPERSEDED 2026-08-06.** The BOLA gap below was closed by
+> `qa/e2e/bola.spec.ts` — 9 cross-account tests against both seeded accounts, no
+> hole found. The standing list of what the suite does *not* cover now lives in
+> [`TEST_GAPS.md`](TEST_GAPS.md); this section is kept for the record.
+
 **BOLA / IDOR — OWASP API #1 — remains UNVERIFIED.** There is no test proving
 user B cannot read user A's journal entries, alerts, settings, or subscription
 row. `security.spec.ts` has a `test.fixme` placeholder marking it.

--- a/qa/README.md
+++ b/qa/README.md
@@ -2,10 +2,16 @@
 
 Testing and quality-assurance workspace for LiquidityHQ.
 
+> **Before quoting a green CI run as evidence, read
+> [`TEST_GAPS.md`](TEST_GAPS.md).** It is the standing list of what the suite
+> does *not* cover. "187 tests passed" reads like "the product works", and it
+> does not.
+
 ## What lives where
 
 | File | What it is | Status |
 |---|---|---|
+| [`TEST_GAPS.md`](TEST_GAPS.md) | **What a green suite does not mean** — every known coverage gap, ranked by value per unit of effort, with what closing each would take. The answer to "what is still untested?" | Living list, updated as gaps close |
 | [`QA_TEST_PLAN.md`](QA_TEST_PLAN.md) | Manual test approach + rigor tiers, plus the RLS deny-all gotcha. Pre-existing — **moved here from `docs/` on 2026-08-04**, so `HANDOVER.md` §4's doc table still points at the old path. | Plan, largely unexecuted |
 | [`../pendings/QA_AUDIT_2026-08-04.md`](../pendings/QA_AUDIT_2026-08-04.md) | Full automated sweep, 2026-08-04 — build gates, 65-route API security, responsiveness at 1440/375, a11y, SEO, CWV, tech debt | Executed, findings unfixed |
 | [`E2E_PLAN.md`](E2E_PLAN.md) | Playwright suite + CI job — what's built, the 3 remaining shared-file changes, and 2 decisions needed | Scaffolded, not wired up |

--- a/qa/TEST_GAPS.md
+++ b/qa/TEST_GAPS.md
@@ -1,0 +1,260 @@
+# What a green suite does not mean
+
+**Owner: QA. Last measured 2026-08-06.**
+
+This file exists because "187 tests passed" reads like "the product works", and it
+does not. It is the standing list of what is **not** covered, why it matters, and
+what closing it would take.
+
+Read it before quoting a green CI run as evidence of anything.
+
+Two rules for keeping it honest:
+
+- **A gap leaves this list only when a test covers it**, not when someone is
+  confident it is fine. Confidence is what this file exists to replace.
+- **When a gap is closed, say what closed it** — the spec name, so the claim is
+  checkable.
+
+---
+
+## What the suite actually covers today
+
+| | |
+|---|---|
+| ✅ Signed-out surface | 32 routes, desktop + iPhone 13 |
+| ✅ Signed-in surface | Settings, TradeJournal, Grok chat — accessibility only, desktop only |
+| ✅ Cross-account access (BOLA/IDOR) | 9 tests, both seeded accounts, HTTP level |
+| ✅ Accessibility | axe WCAG 2.0/2.1/2.2 A+AA, tap targets, names, landmarks |
+| ✅ Performance | LCP + CLS budgets per route |
+| ✅ SEO / meta | canonical, titles, h1 |
+| ✅ Colour contrast | **dark theme only**, 8 routes measured |
+
+Everything below is outside that.
+
+---
+
+## 🔴 1. Market data and the clock cannot be controlled
+
+**The biggest gap by a wide margin, and the least visible.**
+
+Every test runs against whatever the live market is doing at that moment. There
+is no way to pin an input, so the product's own domain logic — the reason anyone
+uses it — has never been tested.
+
+Untestable today:
+
+- funding rate flipping **negative**, and the UI that is supposed to react to it
+- RSI crossing overbought / oversold thresholds
+- squeeze and flush scores at their alert boundaries
+- **24h and 48h alert outcome resolution** — a test would have to wait 24 hours
+- "Best Hours" and the economic calendar **across timezones**, including DST
+- what the app does when Binance/CMC returns an error, an empty array, a `null`
+  price, or a number where a string was expected
+- liquidation map behaviour at extremes
+
+Right now a passing run means "nothing crashed given today's prices". It does not
+mean the calculations are right, because nothing ever asserts a calculation
+against a **known** input.
+
+**To close:** intercept the market-data calls at the network layer
+(`page.route`) and serve recorded fixtures — one per scenario. Plus a fake clock
+for the time-dependent paths. This is the real work: recording representative
+payloads is most of it.
+
+**Cost:** days, not hours. **Value:** highest of anything on this list.
+
+---
+
+## 🟠 2. Nothing has ever looked at the pages
+
+Contrast ratios are computed from CSS values and the DOM is read
+programmatically. **No test has ever compared what the page looks like.**
+
+So all of these would pass every check currently in the suite:
+
+- text rendered in a colour that happens to match its background
+- two elements overlapping
+- a chart drawing at zero height
+- a modal opening off-screen
+- a layout collapsing at one specific width
+
+This is not theoretical. **Nine routes received colour-token substitutions with
+no measured proof** (recorded in every release note since 2026-08-05 as "not
+verified"), and the suite cannot tell whether they render correctly.
+
+**To close:** screenshot baselines per route per viewport per theme, with a
+pixel-diff threshold. Playwright has `toHaveScreenshot()` built in — no new
+dependency.
+
+**The catch:** live market data means the pixels change every run. This gap is
+**blocked on gap 1** for the data-heavy routes; the static/marketing routes could
+be baselined today.
+
+**Cost:** ~1 day for the static routes. **Value:** high, and it is the cheapest
+big win once fixtures exist.
+
+---
+
+## 🟠 3. Light theme has never been measured
+
+Contrast was measured on the **dark** theme only. The app ships a light theme
+(`Settings → Appearance → Light`), and no automated check has ever run against
+it.
+
+Every contrast number QA has ever reported — including the fixes in
+`__tests__/contrastTokens.test.mts` — describes dark mode.
+
+**To close:** parameterise the contrast sweep over `data-theme`, run both. The
+harness already exists; it just runs once.
+
+**Cost:** hours. **Value:** high for the cost — this is the cheapest item here.
+
+---
+
+## 🟠 4. Five languages ship; one is tested
+
+The app has English, 한국어, 中文, العربية, Русский. Every test asserts against
+**English** strings and English layout.
+
+**العربية is right-to-left.** An RTL layout is not a translation of an LTR one —
+it is a mirrored layout, and it breaks in ways nothing here would catch: icons
+pointing the wrong way, text overflowing the wrong edge, charts and number
+formatting reading backwards, `margin-left` where `margin-inline-start` was
+meant.
+
+Related and already burned: `LabelsProvider` overwrote 2,570 seeded English
+labels when `/api/labels` returned `200 {}` (found 2026-08-05, fixed). That
+defect was found by accident in a degraded CI environment. Nothing routinely
+checks that the label layer is intact in **any** language.
+
+**To close:** run the smoke + a11y sweep under each locale; add an RTL-specific
+layout check for Arabic.
+
+**Cost:** ~1 day. **Value:** high — one of these five is a different layout, not
+different words.
+
+---
+
+## 🟡 5. The payment and upgrade flow has never been exercised
+
+`/upgrade`, LemonSqueezy checkout, subscription state, Pro-gating. Reached only
+as an unauthenticated page render.
+
+Never tested: that a purchase grants Pro, that Pro-gated features unlock, that a
+lapsed subscription re-locks them, that a failed payment is handled. The
+timeframe chips in Settings carry `title="Fast timeframes are a Pro feature."` —
+whether that gate actually holds is unverified.
+
+**Why it is 🟡 and not 🔴:** it involves a third party's sandbox and real money
+paths, so it is genuinely awkward to automate — not because it matters less. It
+arguably matters most in money terms.
+
+**To close:** LemonSqueezy test mode + a seeded Pro account alongside the two
+existing fixtures.
+
+---
+
+## 🟡 6. Accessibility is asserted, never heard
+
+The suite checks that `aria-live`, `role`, and accessible names **exist**. It has
+never checked what a screen reader actually **announces**.
+
+An element can have every correct attribute and still be unusable — wrong reading
+order, a name that says "button" and nothing else, a live region that fires on
+every keystroke. Attribute presence is a floor, not a pass.
+
+**To close:** honestly, partly unclosable in CI. A real pass needs NVDA or
+VoiceOver and a person. Worth booking as a manual session rather than pretending
+automation covers it.
+
+---
+
+## 🟡 7. `qa` and `dev` share one database
+
+Documented in `CLAUDE.md` and accepted deliberately — Supabase's free plan caps
+the account at two projects, and dev + prod take both.
+
+Consequence, stated so nobody forgets: **QA test data and dev's data live in the
+same database.** A clean QA run is not proof the data path is clean; it may be
+proof that dev happened to leave good data lying around. Row counts, empty
+states, and "no results" assertions are all suspect.
+
+**To close:** a third Supabase project. Costs money. Owner's call.
+
+---
+
+## 🟡 8. Offline / PWA behaviour
+
+There is a service worker and an `/offline` route. Nothing tests the app going
+offline: whether cached routes serve, whether the offline page appears, whether
+queued actions replay on reconnect, or whether a stale service worker serves an
+old build after a deploy.
+
+That last one bites in production and is invisible in staging.
+
+**To close:** `context.setOffline(true)` plus service-worker lifecycle
+assertions. Playwright supports both.
+
+**Cost:** ~half a day.
+
+---
+
+## 🟢 9. Known harness weaknesses (QA's own bugs)
+
+Recorded here rather than hidden, because the suite is code and has defects too.
+
+- **`perf.spec` does not warm a route before measuring it.** Two LCP failures on
+  2026-08-06 were cold-start artefacts, not regressions — 3460ms cold vs 676ms
+  warm on the same build. Until this is fixed, an LCP failure needs a warm re-run
+  before it is believed.
+- **`playwright.config.ts` sets `reuseExistingServer: !process.env.CI`.** Locally
+  the suite will silently reuse whatever is already on port 3000, which may be a
+  different branch's build. Always check what is being served before trusting a
+  local run.
+- **`a11y-auth.spec.ts` is desktop-only** — deliberate (same DOM, double the
+  cost), but it does mean no signed-in mobile coverage exists at all.
+- **The trade journal has no API route**, so it has no API-level BOLA surface to
+  probe. Its data isolation is unverified at HTTP level; only the UI path is
+  covered.
+
+---
+
+## 🟢 10. No production error monitoring
+
+Not a test gap, but it belongs on the same list because it is the only item here
+that catches bugs **nobody thought to look for**.
+
+Today, if production breaks, the owner notices. There is no Sentry, no error
+aggregation, no alert. Every other line in this file describes something QA
+imagined; this one covers everything QA did not.
+
+**To close:** Sentry free tier, one afternoon. **Value per hour spent: the
+highest on this page.**
+
+---
+
+## Suggested order
+
+Ranked by value per unit of effort, not by severity:
+
+| | Item | Effort | Why this order |
+|---|---|---|---|
+| 1 | §10 error monitoring | hours | Free, and it catches unknown unknowns |
+| 2 | §3 light theme | hours | Harness exists, runs once, just needs a second pass |
+| 3 | §8 offline/PWA | ½ day | Self-contained, no fixtures needed |
+| 4 | §2 visual, static routes only | 1 day | Immediate value, not blocked on §1 |
+| 5 | §4 i18n + RTL | 1 day | Arabic is a different layout, not different words |
+| 6 | §1 data + clock fixtures | days | The big one — unblocks the rest of §2 |
+| 7 | §5 payments | days | Awkward, third party, matters most in money |
+| 8 | §6 screen reader | manual | Book a session; do not pretend CI covers it |
+
+---
+
+## Also see
+
+- `pendings/QA_AUDIT_2026-08-04.md` — the original audit
+- `pendings/QA_A11Y_FINDINGS_2026-08-05.md` — accessibility findings, §4 now
+  verified
+- `pendings/QA_E2E_FINDINGS_2026-08-05.md` — defects found running the suite
+- `qa/E2E_PLAN.md` — how the suite was built. Its §5 is superseded by this file;
+  the BOLA gap it describes was closed on 2026-08-06 by `qa/e2e/bola.spec.ts`.

--- a/qa/e2e/_auth.ts
+++ b/qa/e2e/_auth.ts
@@ -76,3 +76,102 @@ export async function signIn(email: string, password: string): Promise<string> {
   }
   return body.access_token as string;
 }
+
+/**
+ * Sign a Playwright context in as one of the seeded accounts.
+ *
+ * Everything automated in this suite before 2026-08-06 tested the SIGNED-OUT
+ * surface. Settings, TradeJournal, Alerts and the chat panel had been reached
+ * exactly once, by hand. This helper is what makes them reachable from a spec.
+ *
+ * Two things make it less obvious than "log in through the form":
+ *
+ * 1. It seeds the session into localStorage rather than driving /login. The
+ *    login form renders a Cloudflare Turnstile widget, and a spec that tries to
+ *    solve it either fails or teaches someone to bypass a bot check. Minting a
+ *    token and installing it is the same end state without touching Turnstile.
+ *
+ * 2. OnboardingGate blocks EVERY route - not just /dashboard - for a signed-in
+ *    user whose profile_complete is false, so a seeded session alone still lands
+ *    on the 5-step wizard and no app content renders. Both accounts now have
+ *    profile_complete and tour_seen set on the dev project, but this asserts the
+ *    app actually rendered rather than trusting that, because the failure looks
+ *    exactly like a broken page.
+ */
+export async function signedInContext(
+  browser: import('@playwright/test').Browser,
+  who: 'a' | 'b' = 'a',
+  opts: { viewport?: { width: number; height: number } } = {},
+) {
+  const email = who === 'a' ? FIXTURES.aEmail : FIXTURES.bEmail;
+  const password = who === 'a' ? FIXTURES.aPassword : FIXTURES.bPassword;
+
+  const res = await fetch(`${SUPABASE_URL}/auth/v1/token?grant_type=password`, {
+    method: 'POST',
+    headers: { apikey: SUPABASE_ANON, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  const session = await res.json().catch(() => ({}));
+  if (!session.access_token) {
+    throw new Error(`signedInContext: sign-in failed for ${email}: HTTP ${res.status}`);
+  }
+
+  // supabase-js v2 reads sb-<projectRef>-auth-token from localStorage.
+  const projectRef = new URL(SUPABASE_URL).hostname.split('.')[0];
+  const ctx = await browser.newContext({ viewport: opts.viewport ?? { width: 1440, height: 900 } });
+  await ctx.addInitScript(
+    ([ref, s]: [string, Record<string, unknown>]) => {
+      localStorage.setItem(`sb-${ref}-auth-token`, JSON.stringify({
+        access_token: s.access_token,
+        refresh_token: s.refresh_token,
+        expires_in: s.expires_in,
+        expires_at: Math.floor(Date.now() / 1000) + (s.expires_in as number),
+        token_type: 'bearer',
+        user: s.user,
+      }));
+    },
+    [projectRef, session] as [string, Record<string, unknown>],
+  );
+  return ctx;
+}
+
+/**
+ * Navigate a signed-in page and assert app content actually rendered.
+ *
+ * Throws rather than returning a bad page. A spec that measures the onboarding
+ * wizard, or Render's cold-start placeholder, reports confident numbers about
+ * the wrong document - the failure mode `settle()` exists to prevent for the
+ * signed-out suite, and the reason a whole audit run once reported 3,315
+ * sub-24px tap targets against an unstyled page.
+ */
+export async function gotoSignedIn(
+  page: import('@playwright/test').Page,
+  path: string,
+): Promise<void> {
+  await page.goto(path, { waitUntil: 'domcontentloaded' });
+  await page.waitForTimeout(4000);
+
+  const state = await page.evaluate(() => {
+    const text = document.body.innerText || '';
+    return {
+      onboarding: /step\s*0?1\s*\/\s*0?5|set up your\s*profile/i.test(text),
+      signedOut: /sign in to your account/i.test(text),
+      placeholder: /start building on render/i.test(text),
+      styled: document.styleSheets.length > 0,
+      controls: document.querySelectorAll('a[href],button,input,select,textarea').length,
+    };
+  });
+
+  if (state.onboarding) {
+    throw new Error(
+      `${path} rendered the ONBOARDING WIZARD, not the page. The account's ` +
+      `profile_complete is false, so OnboardingGate is blocking every route. ` +
+      `Set it on the dev project before measuring anything here.`,
+    );
+  }
+  if (state.signedOut) throw new Error(`${path} rendered signed-out - the seeded session did not take.`);
+  if (state.placeholder) throw new Error(`${path} returned Render's cold-start placeholder, not the app.`);
+  if (!state.styled || state.controls < 4) {
+    throw new Error(`${path} rendered without styles or controls (${state.controls}) - measurements would be meaningless.`);
+  }
+}

--- a/qa/e2e/_shared.ts
+++ b/qa/e2e/_shared.ts
@@ -75,10 +75,100 @@ export const BASELINE = {
    *
    * The only legitimate reason to change this number again is DOWNWARD, when a
    * fix lands.
+   *
+   * THIS NUMBER CANNOT DETECT THE REGRESSION IT LOOKS LIKE IT DETECTS.
+   * Re-measured 2026-08-06 (issue #46): all 122 are <a>, none is a control -
+   * 84 a.pf-footer-bottom-link, 31 a.consent-link, 7 bare a. Every one is a link
+   * inside a block of text, which SC 2.5.8 exempts outright, so the real count
+   * of WCAG failures here is ZERO. A genuine 16x16 button appearing anywhere
+   * moves this 122 -> 123, a 0.8% change in a number that already drifts when a
+   * footer link is added. Deleting footer links moves it DOWN, which reads as an
+   * improvement while conformance is unchanged.
+   *
+   * So this stays as the loose "small touch targets on a PWA" signal it actually
+   * is, and axeTargetSizeViolations below is what guards conformance.
    */
   tapTargetsUnder24: 122,
+  /**
+   * SC 2.5.8 failures per axe-core's own `target-size` rule, which models BOTH
+   * exceptions (spacing and inline) rather than re-deriving them by hand.
+   *
+   * Hand-rolling the exceptions is how tapTargetsUnder24 came to be quoted as a
+   * conformance count twice - 159, then 217, then 122, none of them a number of
+   * WCAG failures. axe reported 0 violations / 0 incomplete / 156 passes on
+   * /playbook alone, so this starts at the true value.
+   *
+   * Asserted with toBe(0), not a ratchet. Zero is the target and the only
+   * acceptable value; one real failure is 0 -> 1, which is unmissable. If this
+   * ever goes non-zero, that is a defect to file, not a baseline to raise.
+   */
+  axeTargetSizeViolations: 0,
   /** §4.2 - controls whose only label is a placeholder. */
   controlsWithoutName: 4,
+
+  /**
+   * SIGNED-IN controls with no accessible name by ANY route - not aria-label,
+   * aria-labelledby, label[for], a wrapping label, or title.
+   *
+   * Every number here was measured in the browser on 2026-08-06, signed in as
+   * the seeded account A, against the six claims in
+   * pendings/QA_A11Y_FINDINGS_2026-08-05.md §4. Those claims came from a source
+   * read and had sat unverifiable since 2026-08-05 because nothing automated
+   * could reach past the onboarding gate.
+   *
+   * These are WCAG 2.2 SC 4.1.2 Name, Role, Value failures at Level A. A screen
+   * reader announces "edit text, blank" and nothing else; voice control has no
+   * phrase to match. Ratchet DOWN as fixes land.
+   */
+  authUnnamedControls: {
+    /**
+     * components/SettingsModal.tsx, opened from the nav drawer's Settings tile.
+     * 9 controls unnamed, and 12 <label> elements that carry the visible text
+     * but have no for= and wrap nothing, so they name nothing.
+     *
+     * The claim that produced this said "~24 inputs". The real figure is 9.
+     *
+     * Note the split this exposes: app/settings/page.tsx renders the same
+     * settings UI with aria-label on every st-input (13 of 14 named), while the
+     * MODAL has none. Two implementations, one fixed and one not. Whoever fixes
+     * the modal should check they are not fixing the page a second time.
+     */
+    settingsModal: 9,
+    /** components/TradeJournal.tsx .tj-edit-form - the inline edit on a history
+     *  row. select.tj-edit-select, two input.tj-inp, textarea.tj-notes. The
+     *  original claim said 4 and 4 is exactly right. */
+    journalInlineEdit: 4,
+    /** TradeJournal rule builder, behind Rules -> "+ Custom Rule". Three bare
+     *  <select> with inline styles, no class, no id, no label of any kind. */
+    journalRuleBuilder: 3,
+  },
+
+  /**
+   * Status messages that render visibly but are never announced - WCAG 2.2
+   * SC 4.1.3 Status Messages, Level AA.
+   *
+   * These are BASELINES, not acceptance. They exist for the same reason every
+   * other number in this file does: CI has to be green on today's code or the
+   * gate stops meaning anything, and a red suite here would block unrelated
+   * releases. Both target ZERO and both are filed as defects.
+   */
+  unannouncedStatus: {
+    /**
+     * 3 - the .login-error container on the /login password form, the /login
+     * magic-link form, and /forgot-password. All three render
+     * `<div className="login-error">` with no role and no aria-live, and there
+     * is no live region anywhere else on those pages, so a screen reader user
+     * submits, hears nothing, and cannot tell whether anything happened.
+     * The original claim named /login only.
+     */
+    authForms: 3,
+    /**
+     * 1 - .gchat-msgs in components/GrokChat.tsx has neither aria-live nor
+     * role, and the whole .gchat-panel contains zero live regions. A reply
+     * streams in silently.
+     */
+    grokChat: 1,
+  },
   /** §6.4 - pages with no <h1>, desktop. */
   pagesWithoutH1: 13,
   /** §6.2 - pages emitting <link rel="canonical">. Target is ALL of them. */
@@ -213,3 +303,32 @@ export async function settle(page: Page, path: string): Promise<void> {
 export const INTERACTIVE_SELECTOR =
   'a[href],button,input:not([type=hidden]),select,textarea,' +
   '[role=button],[role=link],[role=tab],[role=switch],[tabindex]:not([tabindex="-1"])';
+
+/**
+ * Inject axe-core into the page and run it.
+ *
+ * axe-core is already installed (a transitive dependency of
+ * eslint-plugin-jsx-a11y) but is declared explicitly in devDependencies so a
+ * lint-config change cannot silently remove the test suite's dependency.
+ *
+ * Loaded from node_modules rather than a CDN: the suite must run offline and in
+ * CI without a network round-trip, and a CDN version bump would change results
+ * under us.
+ */
+export async function runAxe(
+  page: Page,
+  opts: { runOnly?: string[]; rules?: Record<string, { enabled: boolean }> } = {},
+): Promise<{ id: string; nodes: string[] }[]> {
+  await page.addScriptTag({ path: require.resolve('axe-core/axe.min.js') });
+  return page.evaluate(async (o) => {
+    const cfg: Record<string, unknown> = {};
+    if (o.runOnly) cfg.runOnly = { type: 'rule', values: o.runOnly };
+    if (o.rules) cfg.rules = o.rules;
+    // @ts-expect-error injected at runtime
+    const res = await window.axe.run(document, cfg);
+    return res.violations.map((v: { id: string; nodes: { target: string[] }[] }) => ({
+      id: v.id,
+      nodes: v.nodes.map((n) => n.target.join(' ')),
+    }));
+  }, opts);
+}

--- a/qa/e2e/a11y-auth.spec.ts
+++ b/qa/e2e/a11y-auth.spec.ts
@@ -1,0 +1,353 @@
+import { test, expect } from '@playwright/test';
+import { BASELINE } from './_shared';
+import { AUTH_READY, AUTH_SKIP_REASON, signedInContext } from './_auth';
+
+/**
+ * Accessibility of the SIGNED-IN surface.
+ *
+ * Everything else in qa/e2e/ tests the signed-out app. Settings, TradeJournal
+ * and the chat panel had been reached exactly once, by hand, on 2026-08-06 -
+ * which is why the six findings in pendings/QA_A11Y_FINDINGS_2026-08-05.md §4
+ * sat marked UNVERIFIED for a day. This spec is what makes them re-checkable
+ * every run instead of once by a person who remembered to look.
+ *
+ * Verdicts from that verification, all measured in the browser:
+ *
+ *   U1  SettingsModal unlabelled inputs            CONFIRMED (9, not the ~24 claimed)
+ *   U2  TradeJournal aria-label drift              REFUTED - see the test below
+ *   U3  inline-edit controls with no name          CONFIRMED (4, exactly as claimed)
+ *   U4  rule-builder selects with no label         CONFIRMED (3)
+ *   U5  auth errors not announced                  CONFIRMED, and wider than claimed
+ *   U6  GrokChat replies not announced             CONFIRMED
+ *
+ * WHY THE WAITS ARE SCOPED TO A FEATURE ELEMENT rather than a timeout or a
+ * page-wide control count: an earlier pass of this same verification scored
+ * "0 findings" on /journal because the journal had not rendered. The page still
+ * had 112 visible controls at that moment - all of them nav chrome and footer -
+ * so any "did the page load" guard based on counting would have passed. Every
+ * waitFor below names an element the feature itself owns, and its absence fails
+ * the test rather than quietly scoring zero.
+ */
+
+test.describe('accessibility (signed in)', () => {
+  test.skip(!AUTH_READY, AUTH_SKIP_REASON);
+  // Desktop only: these are the same DOM on mobile and running both doubles the
+  // cost of the slowest specs in the suite for no extra signal.
+  test.beforeEach(({ }, testInfo) => {
+    test.skip(testInfo.project.name === 'mobile', 'same DOM as desktop');
+  });
+
+  /**
+   * Accessible name by any of the routes that actually produce one.
+   *
+   * Deliberately generous - title= counts, a wrapping label counts. A control
+   * only fails here if it has no name at all, so a finding cannot be an artefact
+   * of a strict definition.
+   *
+   * One subtlety worth stating: own text names a <button>, but for an <input>,
+   * <select> or <textarea> the "text" is the value or the option list, which is
+   * not a name. Treating textContent as a name is what made an earlier pass
+   * report the edit-form notes field as labelled - it was reading back the
+   * fixture text stored in it.
+   */
+  const unnamedIn = (page: import('@playwright/test').Page, selector: string) =>
+    page.evaluate((sel: string) => {
+      const t = (s: string | null) => (s || '').replace(/\s+/g, ' ').trim();
+      return [...document.querySelectorAll(sel)]
+        .filter(el => { const r = el.getBoundingClientRect(); return r.width > 0 && r.height > 0; })
+        .filter(el => {
+          const tag = el.tagName.toLowerCase();
+          const labelledby = (el.getAttribute('aria-labelledby') || '').split(/\s+/)
+            .map(id => id && document.getElementById(id))
+            .filter((n): n is HTMLElement => !!n)
+            .map(n => t(n.innerText || n.textContent)).join(' ');
+          const explicit = el.id ? document.querySelector(`label[for="${CSS.escape(el.id)}"]`) : null;
+          const wrapping = el.closest('label');
+          const ownText = (tag === 'button' || el.getAttribute('role') === 'button')
+            ? t((el as HTMLElement).innerText || el.textContent) : '';
+          return !(t(el.getAttribute('aria-label')) || t(labelledby)
+            || (explicit ? t((explicit as HTMLElement).innerText || explicit.textContent) : '')
+            || (wrapping && wrapping !== explicit
+                ? t((wrapping as HTMLElement).innerText || wrapping.textContent) : '')
+            || t(el.getAttribute('title')) || ownText);
+        })
+        .map(el => el.tagName.toLowerCase()
+          + (typeof el.className === 'string' && el.className
+              ? '.' + el.className.trim().split(/\s+/)[0] : '')
+          + (el.getAttribute('placeholder')
+              ? ` placeholder="${el.getAttribute('placeholder')}"` : ''));
+    }, selector);
+
+  const CONTROLS = 'input:not([type=hidden]), select, textarea, button, [role=button]';
+
+  // ── U1 ──────────────────────────────────────────────────────────────────
+  test('U1: SettingsModal controls have accessible names', async ({ browser }, testInfo) => {
+    const ctx = await signedInContext(browser, 'a');
+    const page = await ctx.newPage();
+    try {
+      await page.goto('/dashboard', { waitUntil: 'domcontentloaded' });
+      await page.waitForSelector('button.nav-tile', { state: 'visible', timeout: 40_000 });
+      await page.evaluate(() => {
+        const b = [...document.querySelectorAll('button.nav-tile')]
+          .find(x => /settings/i.test((x as HTMLElement).innerText || ''));
+        (b as HTMLElement | undefined)?.click();
+      });
+      // Absence fails the test. The modal not opening is not "zero findings".
+      await page.waitForSelector('.smod-panel', { state: 'visible', timeout: 40_000 });
+
+      const unnamed = await unnamedIn(page, `.smod-panel ${CONTROLS}`);
+      // The other half of U1: the visible text IS there, it just names nothing.
+      const orphanLabels = await page.evaluate(() =>
+        [...document.querySelectorAll('.smod-panel label')]
+          .filter(l => !l.getAttribute('for') && !l.querySelector('input,select,textarea'))
+          .map(l => ((l as HTMLElement).innerText || '').trim().slice(0, 40)));
+
+      testInfo.attach('settings-modal-unnamed.txt', {
+        body: `unnamed controls:\n${unnamed.join('\n')}\n\nlabels naming nothing:\n${orphanLabels.join('\n')}`,
+        contentType: 'text/plain',
+      });
+
+      expect(
+        unnamed.length,
+        `SettingsModal controls with no accessible name: ` +
+        `${BASELINE.authUnnamedControls.settingsModal} -> ${unnamed.length}.\n` +
+        `${orphanLabels.length} <label> elements in this modal carry the visible text but have ` +
+        `no for= and wrap no control, so they name nothing: ${orphanLabels.join(', ')}.\n` +
+        `Fix by adding id/htmlFor pairs. Do NOT add aria-label alongside the visible <label> - ` +
+        `that overrides the visible text and breaks voice control (docs/HANDOVER.md §14).\n` +
+        unnamed.join('\n'),
+      ).toBeLessThanOrEqual(BASELINE.authUnnamedControls.settingsModal);
+    } finally { await ctx.close(); }
+  });
+
+  // ── U2 ──────────────────────────────────────────────────────────────────
+  /**
+   * U2 was REFUTED, and this test guards the thing that is actually true rather
+   * than the claim.
+   *
+   * The claim was that TradeJournal's aria-label strings had drifted from the
+   * visible labels, citing "Entry *" against aria-label "Entry". Measured, that
+   * is not drift: the asterisk is a required-field marker, and the accessible
+   * name a voice-control user speaks is "Entry", which matches. Of the four
+   * pairs only "Position Size ($)" differs from its aria-label "Position Size",
+   * and that also matches what a user would say.
+   *
+   * What IS true and worth holding: all four visible labels have no for=, so
+   * the aria-label is the ONLY name each field has. That is fine today, and it
+   * is one careless edit from not being fine - if anyone adds htmlFor without
+   * removing the aria-label, the aria-label silently wins and the visible text
+   * stops being the name. So this asserts every field keeps a name, and that
+   * no field ends up with both an aria-label and a real label association.
+   */
+  test('U2: TradeJournal log-trade fields keep exactly one source of name', async ({ browser }) => {
+    const ctx = await signedInContext(browser, 'a');
+    const page = await ctx.newPage();
+    try {
+      await page.goto('/journal', { waitUntil: 'domcontentloaded' });
+      await page.waitForSelector('input.tj-inp', { state: 'visible', timeout: 40_000 });
+
+      const pairs = await page.evaluate(() =>
+        [...document.querySelectorAll('.tj-field')].map(f => {
+          const lbl = f.querySelector('label');
+          const ctl = f.querySelector('input,select,textarea');
+          if (!lbl || !ctl) return null;
+          const t = (s: string | null) => (s || '').replace(/\s+/g, ' ').trim();
+          return {
+            visible: t((lbl as HTMLElement).innerText),
+            aria: t(ctl.getAttribute('aria-label')),
+            htmlFor: lbl.getAttribute('for') || '',
+            wraps: !!lbl.querySelector('input,select,textarea'),
+          };
+        }).filter(Boolean) as { visible: string; aria: string; htmlFor: string; wraps: boolean }[]);
+
+      expect(pairs.length, 'no .tj-field label/control pairs found - the form did not render').toBeGreaterThan(0);
+
+      const nameless = pairs.filter(p => !p.aria && !p.htmlFor && !p.wraps);
+      expect(nameless, `log-trade fields with no name at all: ${JSON.stringify(nameless)}`).toEqual([]);
+
+      // The override defect: an aria-label AND a real association. The
+      // aria-label wins, so the visible text stops being the accessible name.
+      const both = pairs.filter(p => p.aria && (p.htmlFor || p.wraps));
+      expect(
+        both,
+        `These fields have an aria-label AND an associated <label>. The aria-label wins, so ` +
+        `the visible text is no longer the accessible name and voice control breaks ` +
+        `(docs/HANDOVER.md §14). Remove the aria-label, keep the association: ${JSON.stringify(both)}`,
+      ).toEqual([]);
+    } finally { await ctx.close(); }
+  });
+
+  // ── U3 ──────────────────────────────────────────────────────────────────
+  test('U3: TradeJournal inline-edit controls have accessible names', async ({ browser }, testInfo) => {
+    const ctx = await signedInContext(browser, 'a');
+    const page = await ctx.newPage();
+    try {
+      await page.goto('/journal', { waitUntil: 'domcontentloaded' });
+      await page.waitForSelector('button.tj-tab', { state: 'visible', timeout: 40_000 });
+      await page.evaluate(() => {
+        const b = [...document.querySelectorAll('button.tj-tab')]
+          .find(x => /history/i.test((x as HTMLElement).innerText || ''));
+        (b as HTMLElement | undefined)?.click();
+      });
+      // Needs account A's fixture trade to exist. If it does not, this fails
+      // rather than passing on an empty history - which would be a false green.
+      await page.waitForSelector('button.tj-edit-btn', { state: 'visible', timeout: 40_000 });
+      await page.evaluate(() => (document.querySelector('button.tj-edit-btn') as HTMLElement).click());
+      await page.waitForSelector('.tj-edit-form', { state: 'visible', timeout: 20_000 });
+
+      const unnamed = await unnamedIn(page, `.tj-edit-form ${CONTROLS}`);
+      testInfo.attach('journal-inline-edit-unnamed.txt', { body: unnamed.join('\n'), contentType: 'text/plain' });
+      expect(
+        unnamed.length,
+        `Inline-edit controls with no accessible name: ` +
+        `${BASELINE.authUnnamedControls.journalInlineEdit} -> ${unnamed.length}.\n` +
+        `A screen reader announces these as "edit text, blank". ` +
+        `components/TradeJournal.tsx, the .tj-edit-form block.\n` + unnamed.join('\n'),
+      ).toBeLessThanOrEqual(BASELINE.authUnnamedControls.journalInlineEdit);
+    } finally { await ctx.close(); }
+  });
+
+  // ── U4 ──────────────────────────────────────────────────────────────────
+  test('U4: TradeJournal rule-builder selects have accessible names', async ({ browser }, testInfo) => {
+    const ctx = await signedInContext(browser, 'a');
+    const page = await ctx.newPage();
+    try {
+      await page.goto('/journal', { waitUntil: 'domcontentloaded' });
+      await page.waitForSelector('button.tj-tab', { state: 'visible', timeout: 40_000 });
+      await page.evaluate(() => {
+        const b = [...document.querySelectorAll('button.tj-tab')]
+          .find(x => ((x as HTMLElement).innerText || '').trim().toLowerCase().startsWith('rules'));
+        (b as HTMLElement | undefined)?.click();
+      });
+      const openedBuilder = await page.evaluate(() => {
+        const b = [...document.querySelectorAll('button')]
+          .filter(x => { const r = x.getBoundingClientRect(); return r.width > 0 && r.height > 0; })
+          .find(x => /custom rule/i.test((x as HTMLElement).innerText || ''));
+        if (!b) return false;
+        (b as HTMLElement).click();
+        return true;
+      });
+      expect(openedBuilder, 'the "+ Custom Rule" button was not found - the Rules tab did not render').toBe(true);
+      await page.waitForSelector('select', { state: 'visible', timeout: 20_000 });
+
+      const unnamed = await unnamedIn(page, 'select');
+      testInfo.attach('journal-rule-builder-unnamed.txt', { body: unnamed.join('\n'), contentType: 'text/plain' });
+      expect(
+        unnamed.length,
+        `Rule-builder selects with no accessible name: ` +
+        `${BASELINE.authUnnamedControls.journalRuleBuilder} -> ${unnamed.length}.\n` +
+        `These have inline styles, no class, no id and no label of any kind. ` +
+        `A select's option text is not its name.\n` + unnamed.join('\n'),
+      ).toBeLessThanOrEqual(BASELINE.authUnnamedControls.journalRuleBuilder);
+    } finally { await ctx.close(); }
+  });
+
+  // ── U5 ──────────────────────────────────────────────────────────────────
+  /**
+   * WCAG 2.2 SC 4.1.3 Status Messages, Level AA.
+   *
+   * Signed out, so no fixtures needed - it lives here because it is the same
+   * finding set. All three auth forms render the error into
+   * `<div className="login-error">` with no role and no aria-live, so a screen
+   * reader user submits, hears nothing, and has no way to know why nothing
+   * happened. The claim named /login only; /forgot-password does it too.
+   *
+   * Triggering it: /login has no <form> element at all. The submit button is
+   * disabled until Turnstile returns a token, but the password field carries
+   * onEnter={submitPassword}, so Enter reaches the handler regardless. The
+   * handler's own captcha branch then renders the SAME element the credential
+   * failure renders. The message differs; the element under test does not.
+   */
+  test('U5: auth error messages are announced', async ({ page }) => {
+    const forms: { path: string; act: () => Promise<void> }[] = [
+      { path: '/login', act: async () => {
+          await page.evaluate(() => {
+            const b = [...document.querySelectorAll('button')]
+              .find(x => /use password/i.test((x as HTMLElement).innerText || ''));
+            (b as HTMLElement | undefined)?.click();
+          });
+          await page.waitForSelector('input[type=password]', { state: 'visible', timeout: 20_000 });
+          await page.fill('input.login-email-input', 'qa-nonexistent@example.com');
+          await page.fill('input[type=password]', 'wrong-password-123');
+          await page.press('input[type=password]', 'Enter');
+        } },
+      { path: '/login', act: async () => {
+          await page.fill('input.login-email-input', 'qa-nonexistent@example.com');
+          await page.press('input.login-email-input', 'Enter');
+        } },
+      { path: '/forgot-password', act: async () => {
+          await page.fill('input.login-email-input', 'qa-nonexistent@example.com');
+          await page.press('input.login-email-input', 'Enter');
+        } },
+    ];
+
+    const notAnnounced: string[] = [];
+    for (const { path, act } of forms) {
+      await page.goto(path, { waitUntil: 'domcontentloaded' });
+      await page.waitForSelector('input.login-email-input', { state: 'visible', timeout: 40_000 });
+      await act();
+      await page.waitForSelector('.login-error', { state: 'visible', timeout: 20_000 });
+      const bad = await page.evaluate(() =>
+        [...document.querySelectorAll('.login-error')]
+          .filter(el => !el.getAttribute('role') && !el.getAttribute('aria-live'))
+          .map(el => `${location.pathname}: "${((el as HTMLElement).innerText || '').trim().slice(0, 60)}"`));
+      notAnnounced.push(...bad);
+    }
+
+    // Ratchet, not a hard assert - all 3 fail today. See BASELINE.unannouncedStatus
+    // for why this is a baseline rather than a red build.
+    expect(
+      notAnnounced.length,
+      `Auth errors that render visibly but are not announced: ` +
+      `${BASELINE.unannouncedStatus.authForms} -> ${notAnnounced.length}. ` +
+      `WCAG 2.2 SC 4.1.3 Status Messages, Level AA. Add role="alert" to the ` +
+      `.login-error container in app/login/page.tsx and app/forgot-password/page.tsx, ` +
+      `then lower this baseline in the same commit. Target is 0.\n` + notAnnounced.join('\n'),
+    ).toBeLessThanOrEqual(BASELINE.unannouncedStatus.authForms);
+  });
+
+  // ── U6 ──────────────────────────────────────────────────────────────────
+  /**
+   * Also SC 4.1.3. A Grok reply streams into .gchat-msgs with no live region
+   * anywhere in the panel, so a screen reader user asks a question and is never
+   * told an answer arrived.
+   *
+   * Asserts on the container, not on a real reply: sending one costs an API call
+   * per run and makes the test depend on a third party being up. The container
+   * carrying aria-live is what makes any reply announced, so it is the right
+   * thing to hold.
+   */
+  test('U6: GrokChat replies land in a live region', async ({ browser }) => {
+    const ctx = await signedInContext(browser, 'a');
+    const page = await ctx.newPage();
+    try {
+      await page.goto('/dashboard', { waitUntil: 'domcontentloaded' });
+      await page.waitForSelector('button.gchat-fab', { state: 'visible', timeout: 40_000 });
+      await page.evaluate(() => (document.querySelector('button.gchat-fab') as HTMLElement).click());
+      await page.waitForSelector('.gchat-msgs', { state: 'visible', timeout: 20_000 });
+
+      const live = await page.evaluate(() => {
+        const msgs = document.querySelector('.gchat-msgs')!;
+        const panel = document.querySelector('.gchat-panel');
+        return {
+          onMsgs: msgs.getAttribute('aria-live') || msgs.getAttribute('role'),
+          insidePanel: panel
+            ? panel.querySelectorAll('[aria-live], [role=log], [role=status], [role=alert]').length : 0,
+        };
+      });
+
+      const missing = (live.onMsgs === null && live.insidePanel === 0) ? 1 : 0;
+      // Ratchet, not a hard assert - this fails today. See BASELINE.unannouncedStatus.
+      expect(
+        missing,
+        `The Grok chat message list has no live region: ` +
+        `${BASELINE.unannouncedStatus.grokChat} -> ${missing}. .gchat-msgs carries neither ` +
+        `aria-live nor role, and there are ${live.insidePanel} live regions anywhere in the ` +
+        `panel. A reply arrives with no announcement, so a screen reader user has no way to ` +
+        `know the assistant answered. WCAG 2.2 SC 4.1.3, Level AA. ` +
+        `Add aria-live="polite" (or role="log") to .gchat-msgs in components/GrokChat.tsx, ` +
+        `then lower this baseline in the same commit. Target is 0.`,
+      ).toBeLessThanOrEqual(BASELINE.unannouncedStatus.grokChat);
+    } finally { await ctx.close(); }
+  });
+});

--- a/qa/e2e/a11y.spec.ts
+++ b/qa/e2e/a11y.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { ROUTES, BASELINE, settle, INTERACTIVE_SELECTOR } from './_shared';
+import { ROUTES, BASELINE, settle, runAxe, INTERACTIVE_SELECTOR } from './_shared';
 
 // Accessibility. Mixed strategy on purpose:
 //   - things that currently pass (alt text, duplicate ids, lang) -> hard assert
@@ -75,6 +75,31 @@ test.describe('accessibility', () => {
       `(${BASELINE.tapTargetsUnder24} -> ${found.length}). If DOWN, lower BASELINE.tapTargetsUnder24 ` +
       `in qa/e2e/_shared.ts in this same commit. If UP, you added a control that fails WCAG 2.2 AA.`,
     ).toBeLessThanOrEqual(BASELINE.tapTargetsUnder24);
+  });
+
+  // The conformance half of the test above. Issue #46: all 122 elements the
+  // ratchet tracks are <a> inside text blocks, which SC 2.5.8 exempts, so a real
+  // 16x16 button appearing would move that number 122 -> 123 and go unnoticed.
+  // axe-core's target-size rule models both the spacing and the inline exception
+  // properly, so a real failure here is 0 -> 1. Hard assert, not a ratchet.
+  test('no WCAG 2.2 SC 2.5.8 target-size violations', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== 'mobile', 'touch target sizing is a mobile concern');
+
+    const violations: string[] = [];
+    for (const route of ROUTES) {
+      await settle(page, route);
+      const found = await runAxe(page, { runOnly: ['target-size'] });
+      for (const v of found) violations.push(...v.nodes.map(n => `${route}  ${n}`));
+    }
+
+    testInfo.attach('axe-target-size.txt', { body: violations.join('\n') || '(none)', contentType: 'text/plain' });
+    expect(
+      violations.length,
+      `axe target-size violations: ${BASELINE.axeTargetSizeViolations} -> ${violations.length}.\n` +
+      `Unlike tapTargetsUnder24, these are REAL SC 2.5.8 AA failures - axe has already ` +
+      `applied the spacing and inline exceptions. Do not raise the baseline; file the defect.\n` +
+      violations.slice(0, 10).join('\n'),
+    ).toBe(BASELINE.axeTargetSizeViolations);
   });
 
   // Placeholder text is not an accessible name (WCAG 4.1.2).


### PR DESCRIPTION
## Summary

Closes #45 and #46. Both were addressed to QA and both are `qa/` changes.

**#45** — the authenticated surface now has automated coverage, and the six
findings that have sat marked `UNVERIFIED` since 2026-08-05 are settled: **five
confirmed, one refuted**, all measured in a browser rather than read from source.

**#46** — SC 2.5.8 is now asserted against axe-core's `target-size` rule, which
models the spacing and inline exceptions properly. A real regression is `0 -> 1`
instead of `122 -> 123`.

I took option **2** from #45 (the signed-in fixture) rather than option 3. Fixing
U1–U6 blind is app code, and changing code against claims nobody has confirmed is
the failure mode both of us have been bitten by this week — U2 below is exactly
why.

## What changed

| File | |
|---|---|
| `qa/e2e/_auth.ts` | `signedInContext()` and `gotoSignedIn()` — a signed-in browser context per spec |
| `qa/e2e/a11y-auth.spec.ts` | **new**, 6 tests, one per U-finding |
| `qa/e2e/a11y.spec.ts` | new axe `target-size` assertion alongside the existing ratchet |
| `qa/e2e/_shared.ts` | `axeTargetSizeViolations`, `authUnnamedControls`, `unannouncedStatus` |
| `package.json` / lock | `axe-core` declared explicitly (already in the tree as a transitive dep of `eslint-plugin-jsx-a11y`) |
| `pendings/QA_A11Y_FINDINGS_2026-08-05.md` | section 4 rewritten with the verdicts |

## The verdicts

| # | Claim | Verdict | Measured |
|---|---|---|---|
| U1 | ~24 Settings inputs unlabelled | ✅ **Confirmed, count wrong** | **9**, not ~24 — and in `SettingsModal.tsx` only |
| U2 | `aria-label` drift, "Entry \*" vs "Entry" | ❌ **Refuted** | all 4 fields have accessible names |
| U3 | 4 inline-edit controls with no name | ✅ **Confirmed exactly** | 4 |
| U4 | Rule-builder selects unlabelled | ✅ **Confirmed** | 3 |
| U5 | Auth errors lack `role="alert"` | ✅ **Confirmed, wider** | **3** forms, not 1 |
| U6 | GrokChat replies not announced | ✅ **Confirmed** | 0 live regions in the panel |

### U2 is refuted — please don't fix it

The claim was that `aria-label` had drifted from the visible label, citing
`"Entry *"` against `aria-label="Entry"`. Measured, that isn't drift: the `*` is
a required-field marker, and the accessible name a voice-control user speaks is
"Entry", which matches. Of the four pairs only `"Position Size ($)"` differs from
its `aria-label` `"Position Size"` — and that also matches what a user would say.

All four fields **have** accessible names. There is no SC 4.1.2 failure here.

Your warning on the issue still stands and I have encoded it: the four visible
labels have no `for=`, so the `aria-label` is the *only* name each field has. If
anyone adds `htmlFor` without removing the `aria-label`, the `aria-label`
silently wins and you get the HANDOVER section 14 defect. The U2 test asserts
exactly that — no field may end up with both.

### U1 is smaller than claimed, and in one of two places

`components/SettingsModal.tsx` — 9 unnamed controls, and 12 `<label>` elements
carrying the visible text with no `for=`, wrapping nothing, so they name nothing.

`app/settings/page.tsx` is **fine** — 13 of 14 controls named, every `st-input`
carries an `aria-label`.

**These are two implementations of the same settings UI, both reachable by
users, with different accessibility.** The page was fixed at some point and the
modal was not. Worth knowing before someone fixes the page a second time.

One extra while I was there: `button.st-toggle` for Push Notifications on the
page has no accessible name, while the Analytics toggle directly below it does.

### U5 is wider than claimed

Not just `/login`. `.login-error` renders with `role=null` and `aria-live=null`
on the `/login` password form, the `/login` magic-link form, **and
`/forgot-password`** — and those pages carry **zero** live regions anywhere, so
there is nothing else that could announce it.

Reaching it took a detour worth recording: `/login` has no `<form>` element at
all, and the submit button stays `disabled` until Turnstile returns a token. But
the password field carries `onEnter={submitPassword}`, so **Enter reaches the
handler regardless of the disabled button**. The handler's own captcha branch
then renders the same `.login-error` element the credential path renders.

Not a security hole — `submitPassword` does its own `!pwCaptchaToken` check, so
the captcha still gates the request. But the `disabled` attribute is decorative;
it is not what stops submission. Flagging it since it reads like the gate.

### U5 and U6 are baselines, not hard asserts

Both fail today. A hard assert would turn the suite red, and `CI Gate` is a
required check on PRs into `main` — that would block Friday's release of #43,
which has nothing to do with this. So they are recorded as baselines that target
zero, in the same shape as every other known-failing count in `_shared.ts`.

**They are defects to fix, not behaviour to accept.** Filing them separately.

## On #46

Re-measured and you are right. All 122 are `<a>`, every one inside a block of
text, so real SC 2.5.8 failures are **0** and the ratchet could not detect the
regression it exists to detect.

I took your **third** option rather than the second — assert against axe
directly, no second hand-rolled counter. Re-deriving the exceptions by hand is
how this metric came to be quoted as a conformance count at 159, then 217, then
122, none of which were failure counts. Delegating to the tool that models them
properly removes the class of error rather than one instance of it.

Measured 0 violations across all 32 routes at 390x844, so it is `toBe(0)`, not a
ratchet. `tapTargetsUnder24` stays as the loose signal it actually is, with a
comment that now says outright it cannot detect a real regression.

## Why the waits look paranoid

An earlier pass of this verification scored U3 as **zero findings**. The journal
had not rendered — but the page still had 112 visible controls at that moment,
all nav chrome and footer, so any "did the page load" guard based on counting
controls would have passed cleanly.

Every wait in the spec is scoped to an element the feature itself owns
(`button.tj-tab`, `.smod-panel`, `.tj-edit-form`, `.gchat-msgs`), and its absence
**fails** the test rather than quietly scoring zero. Same reason
`signedInContext` asserts the app rendered: `OnboardingGate` blocks every route
for a user whose `profile_complete` is false, and that failure looks identical to
a broken page.

The fixture also seeds the session into `localStorage` rather than driving
`/login` — the form renders Turnstile, and a spec that tries to solve it either
fails or teaches someone to bypass a bot check.

## How to test (QA)

Not on `qa` yet — this is QA's own tooling, so it goes to `dev` for your review
first. On this branch:

```
npx playwright test qa/e2e/a11y-auth.spec.ts --project=desktop   # 6 passed
npx playwright test qa/e2e/a11y.spec.ts      --project=mobile    # 6 passed
```

Needs the seeded accounts in `.env.e2e.local`; skips loudly without them rather
than passing.

To see the findings yourself, signed in as `qa.user.a@`:

1. `/dashboard` -> nav drawer -> **Settings** -> the number inputs have no labels
2. `/journal` -> **History** -> the pencil on a row -> 4 controls announce as blank
3. `/journal` -> **Rules** -> **+ Custom Rule** -> 3 selects with no name
4. `/login` -> "Use password instead" -> type anything -> Enter -> the error is
   visible but has no `role`/`aria-live`
5. `/dashboard` -> **Ask AI** -> the message list has no live region

## Risk level

**Low.** No app code. Test tooling, one devDependency declaration, one findings
doc. `npm ci` is unaffected — `axe-core` 4.12.1 was already in the tree; this
only stops a lint-config change from silently removing the suite's dependency.

Gates: lint 0 errors (94 warnings, identical to the `dev` tip — none mine), `tsc`
clean, 75/75 unit, production build succeeded.

**Not verified:** the new spec has not run in CI, only locally against a local
production build. It is desktop-only by design — same DOM on mobile, and running
both doubles the cost of the slowest specs for no extra signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
