### PR TITLE
fix(api): scrub PII from error reports, tag the release, separate qa from dev

### DIFF
--- a/__tests__/monitoringScrub.test.mts
+++ b/__tests__/monitoringScrub.test.mts
@@ -1,0 +1,185 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { scrubUrl, scrubText, scrubEvent, monitoringEnvironment } from '../lib/monitoring.ts';
+
+/* The PII scrubber runs on every event leaving the app for GlitchTip. It is the
+   last thing between a user's id or email and a third-party dashboard, and it
+   has no user-visible symptom when it breaks - a leak looks exactly like normal
+   operation from the inside.
+
+   So it is a pure function, tested here rather than "verified" by watching real
+   traffic. The failure this guards against is not "the scrubber throws"; it is
+   "the scrubber quietly stops matching a shape" - which is why the assertions
+   below check for the ABSENCE of specific values, not for a redaction marker
+   being present somewhere. */
+
+const UUID_A = '9489f7cf-3d9f-4f1e-8648-c5611562d466';
+const UUID_B = '00000000-1111-2222-3333-444444444444';
+
+test('monitoring PII scrubbing', async (t) => {
+  await t.test('URL paths lose row and user ids but keep the route shape', () => {
+    assert.equal(scrubUrl(`/api/hypotheses/${UUID_A}`), '/api/hypotheses/:id');
+    assert.equal(scrubUrl(`/api/trades/${UUID_A}/notes/${UUID_B}`), '/api/trades/:id/notes/:id');
+    // Collapsing to a shape is also what stops one broken route producing one
+    // issue per user - 400 identical bugs read as 400 bugs.
+    assert.equal(
+      scrubUrl(`/api/hypotheses/${UUID_A}`),
+      scrubUrl(`/api/hypotheses/${UUID_B}`),
+      'two users hitting the same broken route must group into one issue',
+    );
+  });
+
+  await t.test('query strings go entirely, path survives', () => {
+    assert.equal(scrubUrl('/scanner?coin=BTC&user=me@x.com'), '/scanner?<redacted>');
+    assert.equal(scrubUrl('/login?next=/dashboard'), '/login?<redacted>');
+    assert.ok(!scrubUrl('/x?email=a@b.com').includes('a@b.com'));
+  });
+
+  await t.test('emails in a path are redacted', () => {
+    assert.equal(scrubUrl('/api/ops/user/someone@example.com'), '/api/ops/user/:email');
+  });
+
+  await t.test('empty and plain URLs are left alone', () => {
+    assert.equal(scrubUrl(''), '');
+    assert.equal(scrubUrl('/dashboard'), '/dashboard');
+    // A coin symbol is not PII and the route is more useful with it.
+    assert.equal(scrubUrl('/markets/BTC'), '/markets/BTC');
+  });
+
+  await t.test('free text loses ids and emails', () => {
+    assert.equal(
+      scrubText(`row ${UUID_A} not found for user@example.com`),
+      'row :id not found for :email',
+    );
+  });
+
+  await t.test('an event is stripped of credentials, body and query', () => {
+    const event = scrubEvent({
+      request: {
+        url: `https://liquidity-hq.com/api/hypotheses/${UUID_A}?token=abc`,
+        query_string: 'token=abc',
+        cookies: { sb_session: 'xyz' },
+        data: { notes: 'my private trading journal entry' },
+        headers: {
+          Authorization: 'Bearer eyJhb',
+          apikey: 'anon-key-value',
+          Cookie: 'sb=1',
+          'X-Cron-Secret': 'shhh',
+          'User-Agent': 'Mozilla/5.0',
+          'content-type': 'application/json',
+        },
+      },
+      user: { id: UUID_A, email: 'someone@example.com', ip_address: '203.0.113.9', username: 'joe' },
+    });
+
+    const serialised = JSON.stringify(event);
+    for (const secret of ['Bearer eyJhb', 'anon-key-value', 'shhh', 'sb=1',
+                          'someone@example.com', '203.0.113.9', 'joe',
+                          'my private trading journal entry', 'token=abc']) {
+      assert.ok(!serialised.includes(secret), `event still contains ${secret}`);
+    }
+
+    // Kept on purpose - the user id is how you tell "one user" from "everyone",
+    // and it is the key you would use to reproduce.
+    assert.equal(event.user!.id, UUID_A);
+    // Harmless headers survive; this is a denylist, not a wipe.
+    assert.equal(event.request!.headers!['User-Agent'], 'Mozilla/5.0');
+    assert.equal(event.request!.headers!['content-type'], 'application/json');
+  });
+
+  await t.test('header matching ignores case', () => {
+    const event = scrubEvent({
+      request: { headers: { authorization: 'a', AUTHORIZATION: 'b', ApiKey: 'c' } },
+    });
+    assert.deepEqual(Object.keys(event.request!.headers!), []);
+  });
+
+  await t.test('exception messages and breadcrumbs are scrubbed too', () => {
+    const event = scrubEvent({
+      message: `failed for ${UUID_A}`,
+      exception: { values: [{ value: `no row ${UUID_A} for a@b.com` }] },
+      breadcrumbs: [
+        { message: `loaded ${UUID_A}`, data: { url: `/api/x/${UUID_A}?q=1` } },
+        { data: { from: `/journal/${UUID_A}`, to: `/journal/${UUID_B}?tab=history` } },
+      ],
+    });
+    assert.equal(event.message, 'failed for :id');
+    assert.equal(event.exception!.values![0].value, 'no row :id for :email');
+    assert.equal(event.breadcrumbs![0].message, 'loaded :id');
+    assert.equal(event.breadcrumbs![0].data!.url, '/api/x/:id?<redacted>');
+    assert.equal(event.breadcrumbs![1].data!.from, '/journal/:id');
+    assert.equal(event.breadcrumbs![1].data!.to, '/journal/:id?<redacted>');
+  });
+
+  await t.test('stack frame source context is scrubbed, not just the message', () => {
+    /* Regression test for the one thing the unit tests missed and the live
+       end-to-end run caught: the exception VALUE was correctly redacted while an
+       email survived in the source lines the SDK attaches around the throwing
+       frame. Anything that ships verbatim source is in scope. */
+    const event = scrubEvent({
+      exception: {
+        values: [{
+          value: 'boom',
+          stacktrace: {
+            frames: [{
+              context_line: `  const u = "${UUID_A}";`,
+              pre_context: ['// owner: someone@example.com', 'function f() {'],
+              post_context: [`  log("${UUID_B}")`],
+              vars: { email: 'someone@example.com', count: 3 },
+            }],
+          },
+        }],
+      },
+    });
+    const frame = event.exception!.values![0].stacktrace!.frames![0];
+    assert.equal(frame.context_line, '  const u = ":id";');
+    assert.deepEqual(frame.pre_context, ['// owner: :email', 'function f() {']);
+    assert.deepEqual(frame.post_context, ['  log(":id")']);
+    assert.equal(frame.vars!.email, ':email');
+    assert.equal(frame.vars!.count, 3, 'non-string locals must survive untouched');
+  });
+
+  await t.test('an event with none of those fields passes through unharmed', () => {
+    // Sentry sends plenty of events with no request and no user. Throwing here
+    // would drop the event entirely and take the error with it.
+    const event = scrubEvent({ level: 'error', tags: { route: 'cron/x' } });
+    assert.deepEqual(event, { level: 'error', tags: { route: 'cron/x' } });
+  });
+});
+
+test('monitoring environment resolution', async (t) => {
+  const saved = {
+    sentry: process.env.NEXT_PUBLIC_SENTRY_ENV,
+    app: process.env.NEXT_PUBLIC_APP_ENV,
+  };
+  const set = (sentry?: string, app?: string) => {
+    if (sentry === undefined) delete process.env.NEXT_PUBLIC_SENTRY_ENV;
+    else process.env.NEXT_PUBLIC_SENTRY_ENV = sentry;
+    if (app === undefined) delete process.env.NEXT_PUBLIC_APP_ENV;
+    else process.env.NEXT_PUBLIC_APP_ENV = app;
+  };
+
+  await t.test('the dedicated variable wins, which is the whole point', () => {
+    /* qa MUST run with NEXT_PUBLIC_APP_ENV=dev or lib/tables.ts switches it to
+       production table names - that has already happened once. So qa can only
+       get its own error-tracker label from a separate variable. */
+    set('qa', 'dev');
+    assert.equal(monitoringEnvironment(), 'qa');
+  });
+
+  await t.test('falls back to the app env, so prod and dev keep working unset', () => {
+    set(undefined, 'prod');
+    assert.equal(monitoringEnvironment(), 'prod');
+    set(undefined, 'dev');
+    assert.equal(monitoringEnvironment(), 'dev');
+  });
+
+  await t.test('never returns empty - an unlabelled event is unattributable', () => {
+    set(undefined, undefined);
+    assert.equal(monitoringEnvironment(), 'production');
+    set('', '');
+    assert.equal(monitoringEnvironment(), 'production');
+  });
+
+  set(saved.sentry, saved.app);
+});

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -154,6 +154,26 @@ without that is a silent switch to production.
 It is a `NEXT_PUBLIC_*` variable, so it is **inlined at build time**. Changing it
 requires a rebuild, not a restart.
 
+### Consequence: the error tracker needs its own variable
+
+Because `qa` must run with `NEXT_PUBLIC_APP_ENV=dev`, everything that reads that
+variable as a *label* reports qa as dev. GlitchTip did exactly this — qa's errors
+and dev's errors arrived under the same `dev` environment, and since the two
+services also share one Supabase project, nothing else distinguished them.
+
+The fix is **not** to change `NEXT_PUBLIC_APP_ENV`. It is
+`NEXT_PUBLIC_SENTRY_ENV`, read by `lib/monitoring.ts`, falling back to
+`NEXT_PUBLIC_APP_ENV` and then `production`:
+
+| Service | `NEXT_PUBLIC_APP_ENV` | `NEXT_PUBLIC_SENTRY_ENV` | Reports as |
+|---|---|---|---|
+| `liquidity-hq-prod` | `prod` | unset | `prod` |
+| `liquidity-hq-qa` | `dev` (required) | **`qa`** | `qa` |
+| `liquidity-hq-dev` | `dev` | unset | `dev` |
+
+The same rule applies to anything else that ever wants an environment *name*:
+add a variable, do not reuse the switch.
+
 ---
 
 ## 4c. QA service environment variables
@@ -164,6 +184,7 @@ deliberate exceptions. Set as of 2026-08-05:
 | Variable | Value | Why |
 |---|---|---|
 | `NEXT_PUBLIC_APP_ENV` | `dev` | **Not `qa`** — see §4b |
+| `NEXT_PUBLIC_SENTRY_ENV` | `qa` | The one place qa may call itself qa. Separates its errors from dev's in GlitchTip without touching table selection — see §4b. **Not yet set; needs adding on the qa service** |
 | `NEXT_PUBLIC_APP_URL` | `https://liquidity-hq-qa.onrender.com` | Its own URL, never dev's. Telegram webhook registration and email links build absolute URLs from this |
 | `NEXT_PUBLIC_SUPABASE_URL` / `_ANON_KEY` | dev project `wdtjhrilakoitfcezxpx` | Shares the dev database — see §1 |
 | `SUPABASE_SERVICE_ROLE_KEY` | dev project's | Server routes return empty results without it. `/api/labels` answered `{}` until it was set |

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,14 +1,14 @@
 import * as Sentry from '@sentry/nextjs';
+import { monitoringOptions } from '@/lib/monitoring';
 
 // No session replay / breadcrumb DOM capture here on purpose - PostHog already
 // does session replay for this app (see components/PostHogProvider.tsx); running
 // two replay recorders would double the privacy surface, not add value.
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  // Performance tracing off - see instrumentation.ts's comment. Was 99% of
-  // GlitchTip's free-tier event quota, crowding out real error alerting.
-  tracesSampleRate: 0,
-  environment: process.env.NEXT_PUBLIC_APP_ENV ?? 'production',
-});
+//
+// Shares lib/monitoring.ts with the server and edge runtimes. Before that, this
+// file carried its own copy of the options and was the one missing the release
+// tag and the PII scrubber - the client is where user ids end up in URLs, so it
+// was the copy that most needed them.
+Sentry.init(monitoringOptions());
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,34 +1,19 @@
 import * as Sentry from '@sentry/nextjs';
+import { monitoringOptions } from '@/lib/monitoring';
 
 // Server + edge init. NEXT_PUBLIC_SENTRY_DSN doubles as the server-side DSN
 // (Sentry DSNs are not secret - they're meant to be public) so one env var
 // covers both instrumentation.ts and instrumentation-client.ts. Unset DSN =
 // Sentry.init no-ops, same "off until configured" pattern as lib/email.ts.
+//
+// Everything that was spelled out per-runtime here now comes from
+// lib/monitoring.ts: environment, release tag, PII scrubbing, and the
+// tracesSampleRate: 0 quota decision with the reasoning behind it. The node and
+// edge blocks were byte-identical duplicates of each other and a near-duplicate
+// of the client's, which is how the client ended up without the same guarantees.
 export async function register() {
-  const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
-
-  if (process.env.NEXT_RUNTIME === 'nodejs') {
-    Sentry.init({
-      dsn,
-      // Performance tracing off - GlitchTip's free-tier event quota (1,000/mo)
-      // was 99% consumed by trace events (2,138 in one month) vs 14 real
-      // error issues, throttling the exact error-alerting apiError() relies
-      // on. Errors matter here, latency traces don't - see lib/apiError.ts.
-      tracesSampleRate: 0,
-      environment: process.env.NEXT_PUBLIC_APP_ENV ?? 'production',
-    });
-  }
-
-  if (process.env.NEXT_RUNTIME === 'edge') {
-    Sentry.init({
-      dsn,
-      // Performance tracing off - GlitchTip's free-tier event quota (1,000/mo)
-      // was 99% consumed by trace events (2,138 in one month) vs 14 real
-      // error issues, throttling the exact error-alerting apiError() relies
-      // on. Errors matter here, latency traces don't - see lib/apiError.ts.
-      tracesSampleRate: 0,
-      environment: process.env.NEXT_PUBLIC_APP_ENV ?? 'production',
-    });
+  if (process.env.NEXT_RUNTIME === 'nodejs' || process.env.NEXT_RUNTIME === 'edge') {
+    Sentry.init(monitoringOptions());
   }
 }
 

--- a/lib/monitoring.ts
+++ b/lib/monitoring.ts
@@ -1,0 +1,246 @@
+/**
+ * Shared GlitchTip/Sentry configuration for all three runtimes.
+ *
+ * Error reporting was already wired before this file existed - `instrumentation.ts`
+ * (node + edge), `instrumentation-client.ts` (browser), and `lib/apiError.ts` for
+ * the ~25 routes that catch their own errors and would otherwise never reach the
+ * error boundary. Issue #51 asked for monitoring to be *added*; it was already
+ * there and live in production. What was actually missing were three of the five
+ * things that issue asked for, and this file is where they live so client, server
+ * and edge cannot drift apart:
+ *
+ *   1. environment separation that does not break table selection (see below)
+ *   2. a release tag, so "did this start with v2026.08.06.3?" is answerable
+ *   3. PII scrubbing before an event leaves the process
+ *
+ * Deliberately NOT here: performance tracing. `tracesSampleRate` stays 0. Trace
+ * events once consumed 99% of GlitchTip's 1,000/month free quota - 2,138 traces
+ * against 14 real error issues - which throttled the error alerting this exists
+ * for. Adding tracing back means paying for a plan or losing errors.
+ */
+
+/**
+ * The environment label on every event.
+ *
+ * READ THIS BEFORE "FIXING" THE QA LABEL BY SETTING NEXT_PUBLIC_APP_ENV=qa.
+ *
+ * `NEXT_PUBLIC_APP_ENV` is not a label - it is a switch. `lib/tables.ts` does:
+ *
+ *     const p = process.env.NEXT_PUBLIC_APP_ENV === 'dev' ? 'lhq_dev_' : 'lhq_';
+ *
+ * so anything that is not exactly `'dev'` selects PRODUCTION table names. The qa
+ * service therefore has to run with `NEXT_PUBLIC_APP_ENV=dev`, and it reports its
+ * errors as "dev" as a side effect. This has already gone wrong once: qa was set
+ * to `qa` at one point and pointed at the `lhq_*` tables while using the dev
+ * database (docs/INFRASTRUCTURE.md §4b).
+ *
+ * So the error-tracker environment gets its OWN variable. Set
+ * `NEXT_PUBLIC_SENTRY_ENV=qa` on the qa service and its events separate from dev's
+ * without touching which tables it reads. Everywhere else can leave it unset.
+ *
+ * This matters more here than it would elsewhere: qa and dev share one Supabase
+ * project, so their errors genuinely look alike. The environment tag is the only
+ * thing that tells them apart.
+ */
+export function monitoringEnvironment(): string {
+  return process.env.NEXT_PUBLIC_SENTRY_ENV
+    || process.env.NEXT_PUBLIC_APP_ENV
+    || 'production';
+}
+
+/**
+ * The deployed commit, or undefined when it cannot be known.
+ *
+ * Render exposes `RENDER_GIT_COMMIT` at build time. `next.config.ts` copies it to
+ * `NEXT_PUBLIC_RELEASE` so the browser bundle carries it too - a server-only value
+ * would tag half the events and leave the other half unversioned, which is worse
+ * than none because it looks like it works.
+ *
+ * Undefined rather than a placeholder on purpose: a literal "unknown" release
+ * groups every untagged deploy together and reads like a real one.
+ */
+export function monitoringRelease(): string | undefined {
+  return process.env.NEXT_PUBLIC_RELEASE || undefined;
+}
+
+/* A v4 UUID, which is what every user id and row id in this app looks like. */
+const UUID = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
+const EMAIL = /[^\s/?&=]+@[^\s/?&=]+\.[a-z]{2,}/gi;
+
+/**
+ * Header names dropped outright. Lowercased before comparison - Next normalises
+ * incoming headers but `onRequestError` hands them through as received, so both
+ * `Authorization` and `authorization` turn up in practice.
+ *
+ * `apikey` is the Supabase anon key. It is publishable and RLS is the real
+ * boundary, so this is not a breach - but an error tracker is not where it should
+ * accumulate, and a reader who finds a key in a bug report cannot tell which kind
+ * it is.
+ */
+const DROP_HEADERS = new Set([
+  'authorization', 'cookie', 'set-cookie', 'apikey', 'x-api-key',
+  'x-supabase-auth', 'proxy-authorization', 'x-cron-secret',
+]);
+
+/**
+ * Strip identifiers out of a URL or path.
+ *
+ * Two jobs at once. The obvious one is privacy: this app puts user ids and row
+ * ids directly in paths (`/api/hypotheses/<uuid>`), and query strings carry coin
+ * symbols and occasionally an email.
+ *
+ * The less obvious one is that it makes the error tracker usable. Without it,
+ * one broken route produces a separate issue per user id, and 400 issues that are
+ * all the same bug look like 400 bugs. Collapsing to `/api/hypotheses/:id` is
+ * what makes "this route is throwing" visible at all.
+ */
+export function scrubUrl(url: string): string {
+  if (!url) return url;
+  const [path, query] = url.split('?');
+  const cleanPath = path.replace(UUID, ':id').replace(EMAIL, ':email');
+  // The query string goes entirely. Nothing in this app puts anything in a query
+  // parameter that is worth the risk of keeping - and "keep the safe ones" needs
+  // an allowlist that some future route will forget to update.
+  return query ? `${cleanPath}?<redacted>` : cleanPath;
+}
+
+/** Redact identifiers in free text - error messages, breadcrumb strings. */
+export function scrubText(text: string): string {
+  return text.replace(UUID, ':id').replace(EMAIL, ':email');
+}
+
+/** `Array.prototype.map` passes (value, index, array); scrubText's second
+ *  parameter would silently become the index if passed directly. */
+const scrubLine = (line: string) => (typeof line === 'string' ? scrubText(line) : line);
+
+/**
+ * The subset of a Sentry event this touches.
+ *
+ * Structural rather than imported from the SDK because `scrubEvent` is generic
+ * over whatever it is handed - Sentry's `ErrorEvent` and `TransactionEvent` are
+ * different types with the same relevant shape, and the unit tests pass plain
+ * object literals. Naming only the fields we read keeps a version bump that adds
+ * a field from turning into a type error here.
+ */
+type StackFrame = {
+  context_line?: string;
+  pre_context?: string[];
+  post_context?: string[];
+  vars?: Record<string, unknown>;
+};
+
+type ScrubbableEvent = {
+  request?: { url?: string; headers?: Record<string, unknown>; query_string?: unknown; cookies?: unknown; data?: unknown };
+  user?: Record<string, unknown>;
+  breadcrumbs?: ({ message?: string; data?: Record<string, unknown> } | undefined)[];
+  exception?: { values?: { value?: string; stacktrace?: { frames?: StackFrame[] } }[] };
+  message?: string;
+};
+
+/**
+ * Last thing that runs before an event leaves the process.
+ *
+ * Exported and pure so it can be unit-tested without a browser or a network -
+ * see `__tests__/monitoringScrub.test.mts`. A scrubber that is only exercised by
+ * real traffic is one nobody finds out is broken until after the leak.
+ *
+ * Mutates and returns the event rather than cloning: Sentry hands us the object
+ * it is about to serialise, and a clone that misses a field it did not know about
+ * would silently drop context. Dropping what we name is safer than keeping only
+ * what we name here, because the shape is the SDK's, not ours.
+ */
+export function scrubEvent<T>(event: T): T {
+  const e = event as ScrubbableEvent;
+
+  if (e.request) {
+    if (typeof e.request.url === 'string') {
+      e.request.url = scrubUrl(e.request.url);
+    }
+    delete e.request.query_string;
+    delete e.request.cookies;
+    // Request bodies can hold anything a user typed - journal notes, an email on
+    // a sign-in attempt. There is no version of this worth keeping.
+    delete e.request.data;
+    if (e.request.headers) {
+      for (const name of Object.keys(e.request.headers)) {
+        if (DROP_HEADERS.has(name.toLowerCase())) delete e.request.headers[name];
+      }
+    }
+  }
+
+  /* The user id is deliberately KEPT. It is the difference between "someone hit
+     this" and "every user hits this", and it is already the primary key we would
+     use to reproduce. Email and IP are not - those identify a person rather than
+     a row, and neither helps debug anything. */
+  if (e.user) {
+    delete e.user.email;
+    delete e.user.ip_address;
+    delete e.user.username;
+  }
+
+  if (typeof e.message === 'string') e.message = scrubText(e.message);
+
+  for (const value of e.exception?.values ?? []) {
+    if (typeof value.value === 'string') value.value = scrubText(value.value);
+
+    /* Stack frames carry SOURCE CODE, not just line numbers - the SDK's
+       contextLines integration attaches the throwing line plus several either
+       side, verbatim. Found while verifying this scrubber end to end: the
+       exception message came through correctly redacted while an email survived
+       in `post_context`, because the surrounding source contained it.
+
+       In that instance the source was the test harness, so it was not a product
+       leak. It is still the right thing to close: these are bytes leaving the
+       process that nothing else inspects, and `vars` (opt-in local-variable
+       capture, off today) would carry runtime values into the same field if it
+       were ever switched on. */
+    for (const frame of value.stacktrace?.frames ?? []) {
+      if (typeof frame.context_line === 'string') frame.context_line = scrubText(frame.context_line);
+      if (Array.isArray(frame.pre_context)) frame.pre_context = frame.pre_context.map(scrubLine);
+      if (Array.isArray(frame.post_context)) frame.post_context = frame.post_context.map(scrubLine);
+      if (frame.vars) {
+        for (const [k, v] of Object.entries(frame.vars)) {
+          if (typeof v === 'string') frame.vars[k] = scrubText(v);
+        }
+      }
+    }
+  }
+
+  for (const crumb of e.breadcrumbs ?? []) {
+    if (!crumb) continue;
+    if (typeof crumb.message === 'string') crumb.message = scrubText(crumb.message);
+    if (crumb.data && typeof crumb.data.url === 'string') crumb.data.url = scrubUrl(crumb.data.url);
+    // Navigation breadcrumbs carry the path on `from`/`to`, not `url`.
+    if (crumb.data && typeof crumb.data.from === 'string') crumb.data.from = scrubUrl(crumb.data.from);
+    if (crumb.data && typeof crumb.data.to === 'string') crumb.data.to = scrubUrl(crumb.data.to);
+  }
+
+  return event;
+}
+
+/**
+ * The options every runtime shares. Spread this, then add runtime-specific keys.
+ *
+ * `sendDefaultPii: false` is the SDK default in v8+, but it is stated explicitly
+ * because it is the single flag that decides whether request headers, cookies and
+ * IPs get attached at all. Leaving it implicit means a future SDK upgrade, or
+ * someone copying an example from the docs that sets it true, changes what leaves
+ * this app with nothing in the diff to argue with.
+ */
+export function monitoringOptions() {
+  return {
+    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+    environment: monitoringEnvironment(),
+    release: monitoringRelease(),
+    // See the file header - this is a quota decision, not an oversight.
+    tracesSampleRate: 0,
+    sendDefaultPii: false,
+    /* Passed by reference rather than wrapped in an arrow. `scrubEvent` is
+       generic in its argument, so it satisfies both hook signatures without
+       importing `ErrorEvent`/`TransactionEvent` - the latter is not re-exported
+       by @sentry/nextjs, and reaching into @sentry/core for a type would add an
+       undeclared dependency on a transitive package. */
+    beforeSend: scrubEvent,
+    beforeSendTransaction: scrubEvent,
+  };
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -79,9 +79,26 @@ const securityHeaders = [
   { key: "Content-Security-Policy", value: csp },
 ];
 
+// Release tag for GlitchTip. Render sets RENDER_GIT_COMMIT during the build; it
+// is not NEXT_PUBLIC_-prefixed, so without this it reaches the server runtime and
+// never the browser bundle - which would tag server errors and leave client
+// errors unversioned. Half-tagged is worse than untagged: it looks like it works.
+//
+// Empty string rather than undefined when absent (local builds, CI) so
+// lib/monitoring.ts's `|| undefined` turns it into "no release" rather than the
+// literal string "undefined" appearing as a release name in the dashboard.
+const release = process.env.RENDER_GIT_COMMIT ?? '';
+
 const nextConfig: NextConfig = {
   // Remove X-Powered-By: Next.js header (don't leak stack info)
   poweredByHeader: false,
+
+  // Values here are ALWAYS inlined into the bundle regardless of prefix - that is
+  // the documented behaviour of this key, and the reason it works for a variable
+  // Render does not prefix for us.
+  env: {
+    NEXT_PUBLIC_RELEASE: release,
+  },
 
   async headers() {
     return [


### PR DESCRIPTION
## Summary

Closes #51, but not the way it was written. **Error monitoring already existed and was already live in production.** Three of the five things that issue asked for were genuinely missing, and this PR adds those.

## First, the correction

#51 opens with:

> **There is no error monitoring in production.** No Sentry, no aggregation, no alerting. Today, if production breaks, the owner notices.

That is not the case. Before this PR:

| | |
|---|---|
| `instrumentation.ts` | `Sentry.init` for the **node** and **edge** runtimes, plus `onRequestError = Sentry.captureRequestError` |
| `instrumentation-client.ts` | `Sentry.init` for the **browser**, plus `captureRouterTransitionStart` |
| `lib/apiError.ts` | `Sentry.captureException` on every call — this is what covers the ~25 routes that catch their own errors and therefore never reach Next's error boundary |
| `app/global-error.tsx` | already present |
| Backend | GlitchTip, not Sentry SaaS |

And it is **switched on in production**, which is the part that mattered. Verified by pulling the deployed bundle rather than by reading env vars:

```
liquidity-hq.com                 DSN present, glitchtip.com, environment "prod"
liquidity-hq-qa.onrender.com     DSN present, glitchtip.com, environment "dev"
```

So the requested item — "add error monitoring" — was already done, including the two things #51 was most specific about: **both runtimes** covered, and `apiError()` closing the swallowed-error gap that the issue's own "failed Supabase call swallowed by a catch" bullet describes.

I am flagging this rather than quietly building the smaller thing, because #51 says "Owner has approved this as the next item" and the approval was given against a description of the work that was not accurate.

## What was actually missing

Of the five requirements #51 listed:

| # | Requirement | Before |
|---|---|---|
| 1 | Both runtimes | ✅ already done |
| 2 | Release tagging | ❌ **missing** |
| 3 | Environment separation | ⚠️ **partial — qa reported as dev** |
| 4 | Scrub PII before it leaves | ❌ **missing entirely** |
| 5 | A real alert path | outside this repo — GlitchTip config, unresolved |

This PR does 2, 3 and 4.

---

## 1. PII scrubbing — there was no `beforeSend` at all

Nothing inspected an event before it left the process. What was going out:

- `Authorization: Bearer <jwt>` and `apikey: <supabase anon key>` on request headers
- cookies, including the Supabase session cookie
- request bodies — journal notes, whatever a user typed
- query strings
- user email, IP and username
- user ids and row ids inline in URLs (`/api/hypotheses/<uuid>`)

`sendDefaultPii` defaults to false, which limits some of this, but it was never stated explicitly — so a version bump or a copied docs example flipping it would have changed what leaves the app with nothing in the diff to argue with. It is now set explicitly.

`lib/monitoring.ts` adds a `beforeSend`/`beforeSendTransaction` that runs on every event. Written as an exported pure function so it can be unit-tested without a browser or a network — **a scrubber only exercised by real traffic is one nobody discovers is broken until after the leak.**

### The user id is kept, deliberately

Email, IP and username go. The **id stays**. It is the difference between "someone hit this" and "every user hits this", and it is the key you would use to reproduce. Dropping it would make the tracker worse at the job it exists for without protecting anything the email does not already cover.

### Scrubbing URLs is also what makes the tracker usable

Collapsing `/api/hypotheses/<uuid>` to `/api/hypotheses/:id` is a privacy fix and a **grouping** fix. Without it one broken route produces one issue per user id, and 400 issues that are all the same bug look like 400 bugs — on a 1,000-event/month quota that is the difference between seeing the problem and hitting the cap.

## 2. Release tagging

No `release` was set, so "did this start with `v2026.08.06.3`?" was unanswerable.

Render exposes `RENDER_GIT_COMMIT` at build time, but it is not `NEXT_PUBLIC_`-prefixed, so it reaches the server runtime and never the browser bundle. `next.config.ts` copies it into `NEXT_PUBLIC_RELEASE` via the `env` key, whose documented behaviour is to inline regardless of prefix.

**Half-tagged would have been worse than untagged** — server errors versioned, client errors not, and it looks like it works.

## 3. Environment separation — the one that needed code, not a dashboard change

qa reported its errors as `dev`. The obvious fix is to set `NEXT_PUBLIC_APP_ENV=qa` on the qa service. **That would have pointed staging at the production tables.**

```ts
// lib/tables.ts
const p = process.env.NEXT_PUBLIC_APP_ENV === 'dev' ? 'lhq_dev_' : 'lhq_';
```

Anything that is not exactly `'dev'` selects production table names. This is not hypothetical — `docs/INFRASTRUCTURE.md` §4b records that `liquidity-hq-qa` was created with `NEXT_PUBLIC_APP_ENV=qa`, pointed at `lhq_*`, and was corrected on 2026-08-05.

So the error tracker gets **its own variable**, `NEXT_PUBLIC_SENTRY_ENV`, falling back to `NEXT_PUBLIC_APP_ENV` and then `production`:

| Service | `NEXT_PUBLIC_APP_ENV` | `NEXT_PUBLIC_SENTRY_ENV` | Reports as |
|---|---|---|---|
| prod | `prod` | unset | `prod` |
| qa | `dev` (**required**) | `qa` | `qa` |
| dev | `dev` | unset | `dev` |

This matters more here than it would elsewhere: **qa and dev share one Supabase project**, so their errors genuinely look alike. The environment tag is the only thing that tells them apart — which is QA's own point in #51's requirement 3.

The trap is documented in three places now: the code, `INFRASTRUCTURE.md` §4b, and a unit test that asserts `SENTRY_ENV=qa` wins while `APP_ENV=dev`.

## 4. Three copies of the config became one

`instrumentation.ts` carried two byte-identical blocks (node and edge) and `instrumentation-client.ts` a third near-copy. They had **already drifted**, and the client was the odd one out — which is exactly the copy that most needed the scrubber, since the client is where user ids appear in URLs.

## Verification — measured, not reasoned about

**Unit tests (15 new, `__tests__/monitoringScrub.test.mts`).** They assert on the *absence* of specific values rather than the presence of a redaction marker, because the failure being guarded against is "the scrubber quietly stops matching a shape", not "the scrubber throws".

**End-to-end, against the real SDK.** The unit tests prove the function is correct and prove nothing about whether Sentry ever calls it. So a harness pointed a real `Sentry.init(monitoringOptions())` at a mock ingest server, captured an exception carrying every sensitive field, and asserted on the bytes that actually left the process:

```
-- must NOT appear --
  clean   user email
  clean   user IP
  clean   username
  clean   auth header
  clean   supabase anon key
  clean   cookie value
  clean   request body
  clean   query token
  clean   raw user id in URL
-- must appear --
  present release tag
  present environment = qa (not dev)
  present collapsed route shape
  present user id kept for grouping
PASS
```

### That harness earned its keep on its first run

It reported the email as **leaked**. It was — in `pre_context`/`post_context`, the **source code lines** the SDK attaches around the throwing frame. The exception message itself had been scrubbed correctly; the source around it had not.

In that instance the source was the harness's own text, so it was **not a product leak** — the harness was measuring itself. But it surfaced a channel nothing was inspecting: stack frames ship verbatim source, and `vars` (opt-in local-variable capture, off today) would carry runtime values through the same field if it were ever enabled. `scrubEvent` now scrubs frames, with a regression test.

The harness was then rewritten so every sensitive literal is assembled at runtime and never appears in its source — otherwise the assertions could never pass for the right reason.

**Release inlining** confirmed against a production build (`RENDER_GIT_COMMIT=deadbeefcafe1234 npm run build`): the commit string and the scrubber both appear in the client bundle.

Gates: `lint` 0 errors / 94 warnings (unchanged) · `tsc` clean · `npm test` **90/90** · `build` clean.

## ⚠️ Environment variables — owner action

| Variable | Where | Value |
|---|---|---|
| `NEXT_PUBLIC_SENTRY_ENV` | `liquidity-hq-qa` **only** | `qa` |
| `NEXT_PUBLIC_RELEASE` | nowhere | not set by hand — `next.config.ts` derives it from Render's `RENDER_GIT_COMMIT` |

Leave `NEXT_PUBLIC_SENTRY_ENV` **unset** on prod and dev. `NEXT_PUBLIC_*` is inlined at build time, so setting it needs a rebuild, not a restart. Nothing breaks if it is never set — qa simply keeps reporting as `dev`, which is today's behaviour.

**Do not set `NEXT_PUBLIC_APP_ENV=qa` to achieve the same thing.** See §4b.

## How to test (QA)

Nothing user-facing changes, so this is verified by reading what arrives in GlitchTip rather than by clicking.

1. **Sanity.** Staging behaves exactly as before — this touches no rendering path. Any visible difference is a bug.
2. **New reports carry a release.** After the next staging deploy, an event in GlitchTip should show a release equal to the deployed commit SHA. Before this, the release field was empty.
3. **Environment tag.** Once `NEXT_PUBLIC_SENTRY_ENV=qa` is set on the qa service **and it is rebuilt**, staging errors appear under `qa` rather than `dev`. Until then they stay `dev` — that is expected, not a failure.
4. **Scrubbing.** Trigger any server error on staging and open the event. There must be no `Authorization` or `apikey` header, no cookies, no request body, and no query string. The URL should read `/api/…/:id` rather than a raw uuid. The user id should still be present.
5. **Table selection is untouched.** The point of the separate variable. On staging, confirm data still reads from the `lhq_dev_*` tables — journal entries, alerts and settings all still load. If anything reads empty, the switch has been changed and that is a stop.

Step 5 is the one I would not skip. It is the failure this design exists to prevent, and it is silent when it happens.

## Risk level

**Low**, with one caveat worth stating rather than burying.

- No rendering path, no route handler, no database access changed.
- Everything added is in the error-reporting path, which is already a no-op when the DSN is unset.
- `beforeSend` returning `null` would drop events silently — it never returns `null`, and the "event with none of those fields passes through unharmed" test exists specifically to catch a future edit that makes it throw or drop.

**Caveat:** the end-to-end verification drove `@sentry/node` directly rather than through a running Next server, so it proves the options and the scrubber work in the real SDK pipeline, not that `instrumentation.ts` hands them over correctly. That last hop is covered by the build check (both artefacts present in the emitted bundle) and by step 4 above, which is the first time it is exercised for real.

## Still open from #51 — not in this PR

**Requirement 5, the alert path.** #51 is right that "an error dashboard nobody opens is not monitoring". That is GlitchTip configuration, outside this repo, and it needs the owner: one notification route to somewhere actually read. Worth doing — it is the difference between the tracker being a record and being a warning.
