### PR TITLE
test(qa): light-theme contrast + service worker coverage

### DIFF
--- a/qa/TEST_GAPS.md
+++ b/qa/TEST_GAPS.md
@@ -219,17 +219,44 @@ Recorded here rather than hidden, because the suite is code and has defects too.
 
 ---
 
-## 🟢 10. No production error monitoring
+## 🔴 10. Error monitoring is installed and capturing nothing
 
-Not a test gap, but it belongs on the same list because it is the only item here
-that catches bugs **nobody thought to look for**.
+**CORRECTED 2026-08-06.** This section previously said "There is no Sentry, no
+error aggregation, no alert." That was **wrong**, and written without reading
+`pendings/OPS_ROADMAP.md:46`, which documents the opposite.
 
-Today, if production breaks, the owner notices. There is no Sentry, no error
-aggregation, no alert. Every other line in this file describes something QA
-imagined; this one covers everything QA did not.
+Error monitoring exists: `@sentry/nextjs` 10.67.0, wired through
+`instrumentation.ts` (server + edge) and `instrumentation-client.ts` (client),
+pointed at **GlitchTip**, environment-tagged from `NEXT_PUBLIC_APP_ENV`, with
+`tracesSampleRate: 0` set deliberately after traces ate 99% of the free quota.
 
-**To close:** Sentry free tier, one afternoon. **Value per hour spent: the
-highest on this page.**
+The real finding is worse than the gap that was imagined:
+
+```
+POST https://app.glitchtip.com/api/25983/envelope/   ->  429 Too Many Requests
+```
+
+Measured on staging across four page loads — **every request, no exceptions**.
+The event quota is exhausted, so every error the app reports is rejected and
+dropped.
+
+That is worse than having none, because none is at least honest. This appears in
+the dependency list, in the ops doc, and in the network tab, and captures
+nothing. Anyone asking "do we have error monitoring?" gets *yes*.
+
+Likely cause: `NEXT_PUBLIC_SENTRY_DSN` is one variable and `environment` is a
+tag, not a separate quota — so if `dev`, `qa` and `prod` share a DSN, dev noise
+and QA traffic spend production's 1,000 events a month. Structurally the same
+trap as §7, and with the same consequence: the noisy environments starve the one
+that matters.
+
+**To close:** a separate DSN for prod, or `beforeSend` dropping non-prod events
+before they spend quota. Filed as issue #51.
+
+**The lesson, recorded because it is the more useful part:** this file's job is
+to say what is *not* covered, and its first version asserted a gap that did not
+exist. A claim about the absence of something needs the same evidence as a claim
+about its presence — check the repo before writing "there is no X".
 
 ---
 
@@ -239,7 +266,7 @@ Ranked by value per unit of effort, not by severity:
 
 | | Item | Effort | Why this order |
 |---|---|---|---|
-| 1 | §10 error monitoring | hours | Free, and it catches unknown unknowns |
+| 1 | §10 GlitchTip 429 | hours | Monitoring exists but drops every event — it is the only thing here that catches bugs nobody predicted, and right now it catches none |
 | 2 | §3 light theme | hours | Harness exists, runs once, just needs a second pass |
 | 3 | §8 offline/PWA | ½ day | Self-contained, no fixtures needed |
 | 4 | §2 visual, static routes only | 1 day | Immediate value, not blocked on §1 |

--- a/qa/e2e/_shared.ts
+++ b/qa/e2e/_shared.ts
@@ -169,6 +169,52 @@ export const BASELINE = {
      */
     grokChat: 1,
   },
+
+  /**
+   * Colour contrast, WCAG 2.2 SC 1.4.3, Level AA, per axe's `color-contrast`
+   * rule. Measured on staging (57a6766) 2026-08-06, all 32 routes, 1440x900.
+   *
+   * WHY THIS TRACKS DISTINCT COLOURS AND NOT VIOLATION COUNT.
+   * Two full runs an hour apart gave 938 and 1001 raw violations - the same
+   * build, the same routes. The difference is market data: /scanner alone
+   * contributed 539, and how many rows of coloured numbers render depends on
+   * what the market is doing. A baseline that drifts by 60 on its own cannot
+   * detect a regression, which is the exact failure issue #46 identified in
+   * tapTargetsUnder24.
+   *
+   * Distinct failing foreground colours is stable across both runs at 56,
+   * because 500 rows of the same unreadable green is still one token to fix.
+   * It also matches what a fix actually looks like: nobody fixes 1001 elements,
+   * they fix a handful of tokens.
+   */
+  contrast: {
+    /**
+     * Dark theme: ZERO, verified. Hard assert, not a ratchet - dark is clean
+     * today and must stay clean. If this goes non-zero, a token regressed.
+     */
+    darkViolations: 0,
+    /**
+     * Light theme: 56 distinct foreground colours fail.
+     *
+     * Light had NEVER been measured in a browser before 2026-08-06 - it was
+     * carried as "not verified" in every release note since 2026-08-05. It is
+     * badly broken, and it is one story rather than 56: the semantic green
+     * (#34d399, #4ade80, #6ee7b7...), the semantic red (#f87171, #fca5a5,
+     * #fcbcbc...) and the muted greys (#8a8a8a, #8e8e93, #a0a0a0...) were
+     * chosen against the near-black dark background and reused unchanged on
+     * light. Worst measured: 1.39:1 against a 4.5:1 floor.
+     *
+     * That matters more than a normal contrast bug on this product, because
+     * green and red ARE how price direction is communicated - and the four
+     * worst routes (/scanner, /funding, /liq, /markets) are the dense numeric
+     * screens where those colours carry the meaning.
+     *
+     * Filed for dev. Ratchet DOWN as light-mode token variants land; the fix
+     * belongs in the [data-theme="light"] block on the foreground tokens, NOT
+     * on the backgrounds - lightening those would break dark, which is clean.
+     */
+    lightDistinctColours: 56,
+  },
   /** §6.4 - pages with no <h1>, desktop. */
   pagesWithoutH1: 13,
   /** §6.2 - pages emitting <link rel="canonical">. Target is ALL of them. */

--- a/qa/e2e/_shared.ts
+++ b/qa/e2e/_shared.ts
@@ -189,10 +189,38 @@ export const BASELINE = {
    */
   contrast: {
     /**
-     * Dark theme: ZERO, verified. Hard assert, not a ratchet - dark is clean
-     * today and must stay clean. If this goes non-zero, a token regressed.
+     * Dark theme: 5 distinct failing foreground colours.
+     *
+     * CORRECTION. This was briefly recorded as 0 and hard-asserted, on a
+     * staging sweep that reported zero dark violations across all 32 routes.
+     * That measurement was incomplete, not wrong: running the same rule against
+     * a local build surfaced real failures on states staging never rendered -
+     *
+     *   /news          3.07:1  #585d6d on #06070a  .nfeed-empty (EMPTY state)
+     *   /econ-calendar 2.10:1  #414551 on #06070a  (EMPTY state)
+     *   /hours         2.77:1  #eff6f2 on #5ca279  ("current hour" badge)
+     *   /hours         4.05:1  #f4f1e8 on #91711d  (a second badge tone)
+     *
+     * - because staging had news and calendar data loaded and local did not,
+     * and because which /hours badge is highlighted depends on the time of day.
+     *
+     * This is qa/TEST_GAPS.md §1 (market data and the clock cannot be
+     * controlled) demonstrated on QA's own measurement. Two honest sweeps of the
+     * same rule against the same code disagreed, because they saw different
+     * application states. Neither number is the truth; the union is closer, and
+     * even the union is only "every state we happened to render".
+     *
+     * So dark is NOT proven clean, and this is a ratchet like everything else.
+     * Empty states are the interesting part: they are what a new user sees.
+     *
+     * 13, measured against a LOCAL production build (15 total violations) -
+     * deliberately not the staging figure. CI runs `npm run build && npm start`
+     * in the runner, so a local build is the environment this assertion will
+     * actually face. Staging reported 0 for the reason above; if you re-measure
+     * there and get a small number, that is the same sampling difference and not
+     * a fix.
      */
-    darkViolations: 0,
+    darkDistinctColours: 13,
     /**
      * Light theme: 56 distinct foreground colours fail.
      *
@@ -211,9 +239,20 @@ export const BASELINE = {
      *
      * Filed for dev. Ratchet DOWN as light-mode token variants land; the fix
      * belongs in the [data-theme="light"] block on the foreground tokens, NOT
-     * on the backgrounds - lightening those would break dark, which is clean.
+     * on the backgrounds - lightening those would break dark.
+     *
+     * 57 against a LOCAL production build (990 total violations); staging gave
+     * 56 (1001). That the DISTINCT count moved by one across two environments
+     * with completely different data, while the raw violation count moved by 11,
+     * is the evidence this metric was chosen on: the raw number is noise, the
+     * token count is signal. Local is the baseline because CI builds and serves
+     * locally, so that is the environment this assertion actually faces.
+     *
+     * Worst ratios measured, all far below the 4.5:1 floor:
+     *   #86efac 1.24:1 · #fbbf24 1.33:1 · #fcbcbc 1.39:1 · #34d399 1.43:1
+     * Highest volume: #8a8a8a (196), #f87171 (191), #34d399 (170).
      */
-    lightDistinctColours: 56,
+    lightDistinctColours: 57,
   },
   /** §6.4 - pages with no <h1>, desktop. */
   pagesWithoutH1: 13,

--- a/qa/e2e/contrast.spec.ts
+++ b/qa/e2e/contrast.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect } from '@playwright/test';
+import type { Browser, Page } from '@playwright/test';
+import { ROUTES, BASELINE } from './_shared';
+
+/**
+ * Colour contrast — WCAG 2.2 SC 1.4.3, Level AA — on BOTH themes.
+ *
+ * The app ships a light theme and it had never been measured in a browser. Not
+ * "measured once and stale" — never. Every contrast number QA has ever reported,
+ * including the fixes pinned in __tests__/contrastTokens.test.mts, describes dark
+ * mode, and that unit test would pass today with light mode as broken as it is.
+ *
+ * Measured on staging 2026-08-06: dark 0 violations, light 1001 across 56
+ * distinct foreground colours.
+ *
+ * Using axe's `color-contrast` rule rather than a hand-rolled sweep, for the
+ * reason issue #46 established: the rule already models the large-text
+ * threshold, font weight, opacity and pseudo-elements, and — the part that
+ * matters most — it reports what it could NOT determine as `incomplete` instead
+ * of silently passing it. A hand-rolled sweep has no way to say "I could not
+ * tell", so it says "fine".
+ */
+
+/** Seed the theme and prove it applied before measuring anything. */
+async function themedPage(browser: Browser, theme: 'dark' | 'light'): Promise<{ page: Page; close: () => Promise<void> }> {
+  const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  // app/layout.tsx runs an inline script that reads localStorage BEFORE
+  // hydration and stamps data-theme, so seeding the key is enough — no click on
+  // a theme toggle, and no race with hydration.
+  await ctx.addInitScript((t) => { try { localStorage.setItem('theme', t); } catch { /* private mode */ } }, theme);
+  const page = await ctx.newPage();
+  page.on('dialog', d => d.dismiss());
+  return { page, close: () => ctx.close() };
+}
+
+interface Violation { route: string; fg: string; bg: string; ratio: number; target: string }
+
+async function measure(page: Page, theme: string, route: string): Promise<Violation[] | null> {
+  await page.goto(route, { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle', { timeout: 30_000 }).catch(() => { /* long-poll routes never idle */ });
+
+  // Return null rather than [] when the theme did not take. An empty array here
+  // would be scored as "no violations", which is how a broken measurement turns
+  // into a clean report — the exact vacuous-pass failure this suite has hit
+  // three times (unseeded BOLA, a cold-start placeholder, an unstyled page).
+  const applied = await page.getAttribute('html', 'data-theme');
+  if (applied !== theme) return null;
+
+  await page.addScriptTag({ path: require.resolve('axe-core/axe.min.js') });
+  const found = await page.evaluate(async () => {
+    // @ts-expect-error injected at runtime
+    const res = await window.axe.run(document, { runOnly: { type: 'rule', values: ['color-contrast'] } });
+    return res.violations.flatMap((v: { nodes: { target: string[]; any?: { message?: string }[] }[] }) =>
+      v.nodes.map(n => {
+        const msg = n.any?.[0]?.message || '';
+        const m = /contrast of ([\d.]+).*foreground color: (#[0-9a-f]{3,8}), background color: (#[0-9a-f]{3,8})/i.exec(msg);
+        return m
+          ? { fg: m[2].toLowerCase(), bg: m[3].toLowerCase(), ratio: Number(m[1]), target: n.target.join(' ').slice(0, 80) }
+          : null;
+      }).filter(Boolean));
+  }) as Omit<Violation, 'route'>[];
+
+  return found.map(f => ({ ...f, route }));
+}
+
+test.describe('colour contrast', () => {
+  test.beforeEach(({ }, testInfo) => {
+    test.skip(testInfo.project.name === 'mobile', 'same tokens as desktop; mobile doubles runtime for no extra signal');
+  });
+
+  /**
+   * Dark is clean and must stay clean. Hard assert, deliberately not a ratchet:
+   * there is no known-failing count to carry, so any failure is a regression.
+   */
+  test('dark theme has no contrast violations', async ({ browser }, testInfo) => {
+    test.setTimeout(600_000);
+    const { page, close } = await themedPage(browser, 'dark');
+    const all: Violation[] = [];
+    const skipped: string[] = [];
+    try {
+      for (const route of ROUTES) {
+        const found = await measure(page, 'dark', route);
+        if (found === null) { skipped.push(route); continue; }
+        all.push(...found);
+      }
+    } finally { await close(); }
+
+    expect(skipped, `theme never applied on these routes — measurement invalid, not clean: ${skipped.join(', ')}`).toEqual([]);
+    testInfo.attach('contrast-dark.txt', {
+      body: all.map(v => `${v.route}  ${v.ratio}:1  ${v.fg} on ${v.bg}  ${v.target}`).join('\n') || '(none)',
+      contentType: 'text/plain',
+    });
+
+    expect(
+      all.length,
+      `Dark theme contrast violations: ${BASELINE.contrast.darkViolations} -> ${all.length}. ` +
+      `Dark was clean when measured on 2026-08-06, so this is a regression, not a backlog. ` +
+      `Do not raise this baseline.\n` +
+      all.slice(0, 15).map(v => `  ${v.route}  ${v.ratio}:1  ${v.fg} on ${v.bg}`).join('\n'),
+    ).toBe(BASELINE.contrast.darkViolations);
+  });
+
+  /**
+   * Light is broken; this holds the line while it gets fixed.
+   *
+   * Asserts on DISTINCT FOREGROUND COLOURS, not violation count. Two full runs
+   * an hour apart on the same build gave 938 and 1001 raw violations, because
+   * /scanner contributes ~539 and that depends on how many rows of market data
+   * happen to render. A number that drifts by 60 on its own cannot detect
+   * anything. Distinct colours was 56 in both runs — and it is also the shape of
+   * the actual fix, since nobody repaints 1001 elements, they retune a token.
+   */
+  test('light theme failing colours do not increase', async ({ browser }, testInfo) => {
+    test.setTimeout(600_000);
+    const { page, close } = await themedPage(browser, 'light');
+    const all: Violation[] = [];
+    const skipped: string[] = [];
+    try {
+      for (const route of ROUTES) {
+        const found = await measure(page, 'light', route);
+        if (found === null) { skipped.push(route); continue; }
+        all.push(...found);
+      }
+    } finally { await close(); }
+
+    expect(skipped, `theme never applied on these routes — measurement invalid, not clean: ${skipped.join(', ')}`).toEqual([]);
+
+    const byColour = new Map<string, { n: number; worst: number }>();
+    for (const v of all) {
+      const e = byColour.get(v.fg) ?? { n: 0, worst: Infinity };
+      byColour.set(v.fg, { n: e.n + 1, worst: Math.min(e.worst, v.ratio) });
+    }
+    const ranked = [...byColour].sort((a, b) => b[1].n - a[1].n);
+
+    testInfo.attach('contrast-light.txt', {
+      body: `${all.length} violations across ${byColour.size} distinct foreground colours\n\n`
+        + ranked.map(([fg, e]) => `${String(e.n).padStart(4)}  ${fg}  worst ${e.worst.toFixed(2)}:1`).join('\n'),
+      contentType: 'text/plain',
+    });
+
+    expect(
+      byColour.size,
+      `Light theme: ${BASELINE.contrast.lightDistinctColours} -> ${byColour.size} distinct failing colours ` +
+      `(${all.length} total violations — that raw number drifts with market data, which is why it is not asserted).\n` +
+      `Fix belongs in the [data-theme="light"] block on the FOREGROUND tokens. Do not lighten the ` +
+      `backgrounds — dark is clean and that would break it.\n` +
+      ranked.slice(0, 12).map(([fg, e]) => `  ${String(e.n).padStart(4)}  ${fg}  worst ${e.worst.toFixed(2)}:1`).join('\n'),
+    ).toBeLessThanOrEqual(BASELINE.contrast.lightDistinctColours);
+  });
+});

--- a/qa/e2e/contrast.spec.ts
+++ b/qa/e2e/contrast.spec.ts
@@ -69,10 +69,22 @@ test.describe('colour contrast', () => {
   });
 
   /**
-   * Dark is clean and must stay clean. Hard assert, deliberately not a ratchet:
-   * there is no known-failing count to carry, so any failure is a regression.
+   * Dark, tracked the same way as light and for the same reason.
+   *
+   * This started as a hard `toBe(0)` on the strength of a staging sweep that
+   * reported zero. That was an incomplete sample rather than a clean result: a
+   * local run of the identical rule found failures on /news and /econ-calendar
+   * EMPTY states, and on the /hours "current hour" badge — states staging never
+   * rendered because it had data loaded and because the highlighted hour
+   * depends on the time of day.
+   *
+   * Two honest sweeps of the same code disagreed because they saw different
+   * application states. That is qa/TEST_GAPS.md §1 landing on QA's own work, and
+   * it is why this is a ratchet and why the empty-state failures are worth more
+   * attention than their count suggests — an empty state is what a new user sees
+   * before any data arrives.
    */
-  test('dark theme has no contrast violations', async ({ browser }, testInfo) => {
+  test('dark theme failing colours do not increase', async ({ browser }, testInfo) => {
     test.setTimeout(600_000);
     const { page, close } = await themedPage(browser, 'dark');
     const all: Violation[] = [];
@@ -86,18 +98,28 @@ test.describe('colour contrast', () => {
     } finally { await close(); }
 
     expect(skipped, `theme never applied on these routes — measurement invalid, not clean: ${skipped.join(', ')}`).toEqual([]);
+
+    const colours = new Map<string, { n: number; worst: number; where: string }>();
+    for (const v of all) {
+      const e = colours.get(v.fg) ?? { n: 0, worst: Infinity, where: v.route };
+      colours.set(v.fg, { n: e.n + 1, worst: Math.min(e.worst, v.ratio), where: e.where });
+    }
+
     testInfo.attach('contrast-dark.txt', {
-      body: all.map(v => `${v.route}  ${v.ratio}:1  ${v.fg} on ${v.bg}  ${v.target}`).join('\n') || '(none)',
+      body: `${all.length} violations across ${colours.size} distinct colours\n\n`
+        + all.map(v => `${v.route}  ${v.ratio}:1  ${v.fg} on ${v.bg}  ${v.target}`).join('\n'),
       contentType: 'text/plain',
     });
 
     expect(
-      all.length,
-      `Dark theme contrast violations: ${BASELINE.contrast.darkViolations} -> ${all.length}. ` +
-      `Dark was clean when measured on 2026-08-06, so this is a regression, not a backlog. ` +
-      `Do not raise this baseline.\n` +
-      all.slice(0, 15).map(v => `  ${v.route}  ${v.ratio}:1  ${v.fg} on ${v.bg}`).join('\n'),
-    ).toBe(BASELINE.contrast.darkViolations);
+      colours.size,
+      `Dark theme: ${BASELINE.contrast.darkDistinctColours} -> ${colours.size} distinct failing colours ` +
+      `(${all.length} total violations).\n` +
+      `Known at baseline: empty-state text on /news and /econ-calendar, and the /hours badges. ` +
+      `If this went UP, check whether a new application STATE rendered rather than assuming a token ` +
+      `changed — this sweep only ever sees the states that happened to render.\n` +
+      [...colours].map(([fg, e]) => `  ${String(e.n).padStart(3)}  ${fg}  worst ${e.worst.toFixed(2)}:1`).join('\n'),
+    ).toBeLessThanOrEqual(BASELINE.contrast.darkDistinctColours);
   });
 
   /**

--- a/qa/e2e/offline.spec.ts
+++ b/qa/e2e/offline.spec.ts
@@ -1,0 +1,213 @@
+import { test, expect } from '@playwright/test';
+import type { BrowserContext, Page } from '@playwright/test';
+
+/**
+ * Service worker and offline behaviour — `public/sw.js`.
+ *
+ * Nothing tested this. The worker is registered from components/AppShell.tsx on
+ * every page load, it is the thing standing between a user with no signal and a
+ * browser error page, and two of the comments in it describe bugs that were
+ * found in production and fixed. Those two are the reason this spec exists:
+ * a fix with no test is a fix waiting to be undone.
+ *
+ * What sw.js actually does:
+ *   install   precache '/offline', then skipWaiting()
+ *   activate  delete every cache not named 'lhq-v2', then clients.claim()
+ *   fetch     ONLY navigations. Network-first with cache:'no-cache',
+ *             falling back to the cached /offline page.
+ *
+ * The two load-bearing details, both of which look like details and are not:
+ *
+ *   1. `if (e.request.mode !== 'navigate') return;`  — API calls and assets must
+ *      fail naturally when offline. If the worker ever answers them, an API
+ *      handler gets the offline page's HTML handed to JSON.parse().
+ *
+ *   2. `fetch(e.request, { cache: 'no-cache' })`     — each navigation
+ *      revalidates, so after a deploy the fresh HTML (referencing new hashed JS
+ *      chunks) is picked up rather than a stale HTTP-cached copy. Without it,
+ *      open PWA sessions lag behind releases.
+ */
+
+const SW_CACHE = 'lhq-v2';
+
+/** Wait for the worker to reach `activated` and control the page. */
+async function activeWorker(context: BrowserContext, page: Page): Promise<void> {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  // AppShell registers on mount, so the registration may not exist on first paint.
+  await page.waitForFunction(
+    () => navigator.serviceWorker.controller !== null
+      || navigator.serviceWorker.getRegistration().then(r => !!r?.active) as unknown as boolean,
+    undefined,
+    { timeout: 30_000 },
+  ).catch(() => { /* fall through to the explicit assertion below */ });
+
+  await page.evaluate(async () => {
+    const reg = await navigator.serviceWorker.ready;
+    if (!reg.active) throw new Error('service worker registered but never activated');
+  });
+  expect(context.serviceWorkers().length, 'no service worker in this context').toBeGreaterThan(0);
+}
+
+test.describe('service worker / offline', () => {
+  test.beforeEach(({ }, testInfo) => {
+    test.skip(testInfo.project.name === 'mobile', 'same worker; running both doubles cost for no extra signal');
+  });
+
+  test('registers, activates, and precaches the offline page', async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    try {
+      await activeWorker(context, page);
+
+      const state = await page.evaluate(async (cacheName) => {
+        const names = await caches.keys();
+        const c = await caches.open(cacheName);
+        const offline = await c.match('/offline');
+        return { names, cachedOffline: !!offline, status: offline?.status ?? null };
+      }, SW_CACHE);
+
+      expect(state.names, `expected a "${SW_CACHE}" cache, got: ${state.names.join(', ') || '(none)'}`)
+        .toContain(SW_CACHE);
+      expect(
+        state.cachedOffline,
+        `/offline is not in the ${SW_CACHE} cache. It is the ONLY thing sw.js precaches, so without ` +
+        `it an offline navigation falls through to the browser's error page.`,
+      ).toBe(true);
+    } finally { await context.close(); }
+  });
+
+  test('serves the offline page when a navigation fails', async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    try {
+      await activeWorker(context, page);
+
+      await context.setOffline(true);
+      // Navigate somewhere NOT precached — only /offline is — so this can only
+      // succeed via the worker's fallback.
+      await page.goto('/markets', { waitUntil: 'domcontentloaded' }).catch(() => { /* asserted below */ });
+
+      const body = await page.evaluate(() => document.body.innerText || '');
+      const isBrowserError = /ERR_INTERNET_DISCONNECTED|No internet|can'?t be reached|ERR_FAILED/i.test(body);
+
+      expect(
+        isBrowserError,
+        `Offline navigation reached the BROWSER's error page, so the worker's fallback did not fire. ` +
+        `Users with no signal see a Chrome error instead of the app's offline screen.\n` +
+        `Got: ${body.slice(0, 200)}`,
+      ).toBe(false);
+      expect(
+        body.trim().length,
+        'offline navigation rendered an empty document — neither the offline page nor an error',
+      ).toBeGreaterThan(0);
+    } finally { await context.setOffline(false); await context.close(); }
+  });
+
+  /**
+   * The `e.request.mode !== 'navigate'` guard, which is the one I would most
+   * expect someone to "simplify" away.
+   *
+   * If the worker ever answers a non-navigation request with the offline page,
+   * every API handler in the app receives HTML where it expects JSON. The
+   * failure is not a clean error — it is `JSON.parse` choking on `<!DOCTYPE`,
+   * surfacing somewhere unrelated to the actual cause.
+   */
+  test('does NOT answer API requests with the offline page when offline', async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    try {
+      await activeWorker(context, page);
+      await context.setOffline(true);
+
+      const result = await page.evaluate(async () => {
+        try {
+          const res = await fetch('/api/price-alerts', { headers: { accept: 'application/json' } });
+          const text = await res.text();
+          return { threw: false, status: res.status, looksLikeHtml: /^\s*<(!doctype|html)/i.test(text), sample: text.slice(0, 80) };
+        } catch (e) {
+          // The correct outcome: the request fails at the network layer.
+          return { threw: true, status: null, looksLikeHtml: false, sample: String(e).slice(0, 80) };
+        }
+      });
+
+      expect(
+        result.looksLikeHtml,
+        `An API request was answered with HTML while offline. sw.js must return early for ` +
+        `non-navigation requests, or JSON.parse() in the API handlers is handed the offline page.\n` +
+        `Got: ${result.sample}`,
+      ).toBe(false);
+      expect(
+        result.threw || (result.status ?? 0) >= 400,
+        `An API request offline should fail, not resolve successfully (status ${result.status}). ` +
+        `A "successful" offline API response means the worker is intercepting more than navigations.`,
+      ).toBe(true);
+    } finally { await context.setOffline(false); await context.close(); }
+  });
+
+  /**
+   * The `cache: 'no-cache'` revalidation, which fixed open PWA sessions lagging
+   * behind a deploy. A navigation must actually reach the server rather than
+   * being served from the HTTP cache.
+   */
+  test('navigations revalidate against the server rather than serving a stale copy', async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    try {
+      await activeWorker(context, page);
+
+      let documentRequests = 0;
+      page.on('request', r => { if (r.resourceType() === 'document') documentRequests++; });
+
+      await page.goto('/faq', { waitUntil: 'domcontentloaded' });
+      await page.goto('/about', { waitUntil: 'domcontentloaded' });
+      await page.goto('/faq', { waitUntil: 'domcontentloaded' });
+
+      expect(
+        documentRequests,
+        `Only ${documentRequests} document requests for 3 navigations — one was served without ` +
+        `reaching the network. sw.js passes cache:'no-cache' precisely so a deploy is picked up on ` +
+        `the next load; without it, open sessions keep the old HTML and its old hashed JS chunks.`,
+      ).toBeGreaterThanOrEqual(3);
+    } finally { await context.close(); }
+  });
+
+  /**
+   * The activate handler deletes every cache whose name is not the current one.
+   * That is how a release actually reaches an installed PWA: bump CACHE, old
+   * entries go. If the purge stops working, a stale precached /offline survives
+   * a rename and the mechanism is silently dead.
+   */
+  test('activation purges caches from older versions', async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    try {
+      await activeWorker(context, page);
+
+      // Plant a cache from a pretend older release, then force a fresh activate.
+      await page.evaluate(async () => {
+        const old = await caches.open('lhq-v1-pretend-old');
+        await old.put('/offline', new Response('stale', { headers: { 'content-type': 'text/html' } }));
+      });
+      expect(await page.evaluate(() => caches.keys())).toContain('lhq-v1-pretend-old');
+
+      await page.evaluate(async () => {
+        const reg = await navigator.serviceWorker.getRegistration();
+        await reg?.update();
+      });
+      await page.reload({ waitUntil: 'domcontentloaded' });
+      await page.evaluate(() => navigator.serviceWorker.ready);
+
+      // The worker only purges on activate, which a same-bytes update will not
+      // trigger — so this asserts the CURRENT cache survived and reports what is
+      // there, rather than failing on a condition the browser controls.
+      const names = await page.evaluate(() => caches.keys());
+      expect(names, `the current "${SW_CACHE}" cache must survive an update`).toContain(SW_CACHE);
+      test.info().annotations.push({
+        type: 'note',
+        description: `caches after update: ${names.join(', ')}. The activate purge only runs when the `
+          + `worker BYTES change, so a real check of it belongs in the post-deploy pass: bump CACHE in `
+          + `sw.js and confirm the old name disappears.`,
+      });
+    } finally { await context.close(); }
+  });
+});


### PR DESCRIPTION
## Summary

Two gaps from `qa/TEST_GAPS.md` closed, in the order the owner approved.
No app code.

**Light theme had never been measured in a browser.** Not stale — never run.
Measured now: **990 contrast violations across 57 distinct colours**, worst
**1.24:1** against a 4.5:1 floor. Filed for you as #53.

**The service worker had no coverage at all** — including the two behaviours its
own comments describe as production bugs already fixed.

Branch also carries the `axe target-size` and signed-in a11y work from #47, which
merged while this was in flight.

## What changed

| File | |
|---|---|
| `qa/e2e/contrast.spec.ts` | **new** — axe `color-contrast` over 32 routes × both themes |
| `qa/e2e/offline.spec.ts` | **new** — 5 tests over `public/sw.js` |
| `qa/e2e/_shared.ts` | `contrast` baselines |

7 tests, all passing.

## The light-theme finding

938→1001→990 violations across three runs, but it is **one story, not 990**:
three colour families tuned against the near-black dark background and reused
unchanged on light.

| Family | Worst | Volume |
|---|---|---|
| 🟢 green (price up) `#34d399` `#4ade80` `#86efac` | **1.24:1** | 170 + 49 + 17 |
| 🔴 red (price down) `#f87171` `#fca5a5` `#fcbcbc` | **1.39:1** | 191 + 58 + 31 |
| ⚪ muted greys `#8a8a8a` `#8e8e93` `#a0a0a0` | 2.12:1 | 196 + 56 + 33 |

Green and red are not decoration here — **they are how price direction is
communicated** — and the four worst routes (`/scanner`, `/funding`, `/liq`,
`/markets`) are exactly the dense numeric screens where that meaning lives.

Fix belongs on the **foreground** tokens in the `[data-theme="light"]` block.
Please don't fix it by lightening the backgrounds; that breaks dark.

## I got dark wrong, and the correction is the interesting part

I first recorded dark as **0 violations** and hard-asserted it, from a staging
sweep of all 32 routes. Then the same rule against a local build found:

```
/news           3.07:1   #585d6d on #06070a   .nfeed-empty      EMPTY state
/econ-calendar  2.10:1   #414551 on #06070a                     EMPTY state
/hours          2.77:1   #eff6f2 on #5ca279   "current hour" badge
/hours          4.05:1   #f4f1e8 on #91711d   second badge tone
```

Staging had news and calendar **data loaded**; local didn't, so local rendered
the **empty states**. And which `/hours` badge is highlighted depends on the time
of day.

Neither run was buggy. They saw different application states. That is
`qa/TEST_GAPS.md` §1 — market data and the clock cannot be controlled — landing
on QA's own measurement instead of on the product, and it is the best argument
yet for closing that gap.

**The empty-state ones are worth your attention** despite being few: an empty
state is what a **new user** sees before any data arrives. `#414551` on `#06070a`
is 2.10:1.

Dark is now a ratchet at 13, not a hard zero.

### Why this metric counts colours, not violations

| | staging | local | drift |
|---|---|---|---|
| Raw violations | 1001 | 990 | **11** |
| Distinct colours | 56 | 57 | **1** |

`/scanner` alone contributes ~539, and that depends on how many rows of market
data render. A baseline that drifts by 11 on its own can't detect a regression —
the exact failure you identified in `tapTargetsUnder24` in #46. Distinct tokens
is stable, and it also matches what a fix looks like: nobody repaints 990
elements, they retune a token.

Baselines are from a **local** build, because CI runs `npm run build && npm start`
in the runner. Staging figures are in the comments for context, not asserted.

**Had I shipped the hard `toBe(0)`**, CI would have gone red on any run where the
news feed happened to be empty, and it would have read as a product regression
rather than my bad baseline. Caught only because I ran the spec before opening
this PR.

## The offline spec

Five tests. The two that matter most are the ones guarding behaviour your own
comments flag as already-fixed bugs:

**`e.request.mode !== 'navigate'`** — if the worker ever answers non-navigations,
an API handler gets the offline page's HTML into `JSON.parse()`. The test asserts
an offline API request throws or returns ≥400, and that the body doesn't start
with `<!doctype`.

**`cache: 'no-cache'`** — counts document requests across three navigations and
requires all three to reach the network, so a deploy is picked up rather than an
open PWA session serving stale HTML pointing at old hashed chunks.

Plus: worker registers and activates, `/offline` is precached into `lhq-v2` (the
only thing precached, so without it the fallback has nothing), and an offline
navigation renders the app's offline screen rather than Chrome's error page.

**One thing I could not test, annotated rather than faked:** the activate
handler's cache purge only runs when the worker *bytes* change, which a test
can't force. That test asserts the current cache survives and records that the
real check belongs in the post-deploy pass — bump `CACHE`, confirm the old name
disappears. I'd rather say that than write something that looks like coverage.

## How to test (QA)

```
npx playwright test qa/e2e/contrast.spec.ts qa/e2e/offline.spec.ts --project=desktop
```

7 passed locally. Contrast is slow — 32 routes × 2 themes, ~11 min — so the
per-test timeout is 600s.

## Risk level

**Low.** Test tooling only. No app code, no dependencies, no env vars.

Gates: lint **0 errors** (94 warnings, identical to `dev` tip — none mine), `tsc`
clean, **75/75** unit, production build succeeded.

**Not verified:** neither spec has run in CI, only locally. Contrast adds ~11 min
to a desktop run, which is the main thing to weigh — if that is too slow for the
`main` gate, say so and I'll cut it to the routes that actually carry the failing
tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
