### PR TITLE
fix(chart): make light theme readable - price up/down were near-invisible

### DIFF
--- a/app/alerts/page.tsx
+++ b/app/alerts/page.tsx
@@ -483,24 +483,24 @@ export default function AlertsPage() {
 
   const ALERT_GROUPS: { section: string; items: { key: string; dot: string; title: string; desc: string }[] }[] = [
     { section: t('ALERTS_SECTION_MOMENTUM'), items: [
-      { key: 'rsi',        dot: '#fbbf24', title: t('ALERTS_RSI_TITLE'), desc: t('ALERTS_RSI_DESC') },
-      { key: 'rapid_move', dot: '#fb923c', title: t('ALERTS_RAPID_MOVES_TITLE'),     desc: t('ALERTS_RAPID_MOVES_DESC') },
+      { key: 'rsi',        dot: 'var(--amber)', title: t('ALERTS_RSI_TITLE'), desc: t('ALERTS_RSI_DESC') },
+      { key: 'rapid_move', dot: 'var(--orange)', title: t('ALERTS_RAPID_MOVES_TITLE'),     desc: t('ALERTS_RAPID_MOVES_DESC') },
     ]},
     { section: t('ALERTS_SECTION_FLOW'), items: [
       { key: 'whales',   dot: '#1a7aff', title: t('ALERTS_WHALES_TITLE'),        desc: t('ALERTS_WHALES_DESC') },
-      { key: 'oi_spike', dot: '#fbbf24', title: t('ALERTS_OI_SPIKE_TITLE'), desc: t('ALERTS_OI_SPIKE_DESC') },
-      { key: 'cvd',      dot: '#34d399', title: t('ALERTS_CVD_TITLE'),      desc: t('ALERTS_CVD_DESC') },
+      { key: 'oi_spike', dot: 'var(--amber)', title: t('ALERTS_OI_SPIKE_TITLE'), desc: t('ALERTS_OI_SPIKE_DESC') },
+      { key: 'cvd',      dot: 'var(--green-2)', title: t('ALERTS_CVD_TITLE'),      desc: t('ALERTS_CVD_DESC') },
       { key: 'squeeze',  dot: '#f43f5e', title: t('ALERTS_SQUEEZE_TITLE'), desc: t('ALERTS_SQUEEZE_DESC') },
       { key: 'distribution', dot: '#f97316', title: t('ALERTS_DISTRIBUTION_TITLE'), desc: t('ALERTS_DISTRIBUTION_DESC') },
     ]},
     { section: t('ALERTS_SECTION_NEWS_SENTIMENT'), items: [
-      { key: 'news',               dot: '#f87171', title: t('ALERTS_NEWS_TITLE'),         desc: t('ALERTS_NEWS_DESC') },
+      { key: 'news',               dot: 'var(--red)', title: t('ALERTS_NEWS_TITLE'),         desc: t('ALERTS_NEWS_DESC') },
       { key: 'fear_greed',         dot: '#f97316', title: t('ALERTS_FEAR_GREED_TITLE'), desc: t('ALERTS_FEAR_GREED_DESC') },
       { key: 'sentiment_extremes', dot: '#f43f5e', title: t('ALERTS_SENTIMENT_EXTREMES_TITLE'),    desc: t('ALERTS_SENTIMENT_EXTREMES_DESC') },
     ]},
     { section: t('ALERTS_SECTION_PRICE_SUMMARY'), items: [
       { key: 'price_alerts',  dot: '#9ba4ff', title: t('ALERTS_PRICE_LEVEL_TITLE'), desc: t('ALERTS_PRICE_LEVEL_DESC') },
-      { key: 'daily_summary', dot: '#fbbf24', title: t('ALERTS_DAILY_SUMMARY_TITLE', { time: dailySummaryLocalTime }), desc: t('ALERTS_DAILY_SUMMARY_DESC', { time: dailySummaryLocalTime }) },
+      { key: 'daily_summary', dot: 'var(--amber)', title: t('ALERTS_DAILY_SUMMARY_TITLE', { time: dailySummaryLocalTime }), desc: t('ALERTS_DAILY_SUMMARY_DESC', { time: dailySummaryLocalTime }) },
     ]},
   ];
 
@@ -548,7 +548,7 @@ export default function AlertsPage() {
           ) : isConnected ? (
             <span style={{
               display: 'inline-flex', alignItems: 'center', gap: 5, fontSize: 'var(--fs-caption)', fontWeight: 700,
-              padding: '3px 9px', borderRadius: 20, color: '#34d399',
+              padding: '3px 9px', borderRadius: 20, color: 'var(--green-2)',
               background: '#34d39914', border: '0.5px solid #34d39944',
             }}>
               <span style={{ width: 5, height: 5, borderRadius: '50%', background: '#34d399', boxShadow: '0 0 5px #34d399' }} />
@@ -557,7 +557,7 @@ export default function AlertsPage() {
           ) : (
             <span style={{
               display: 'inline-flex', alignItems: 'center', gap: 5, fontSize: 'var(--fs-caption)', fontWeight: 700,
-              padding: '3px 9px', borderRadius: 20, color: '#f87171',
+              padding: '3px 9px', borderRadius: 20, color: 'var(--red)',
               background: 'transparent', border: '0.5px solid var(--bdr)',
             }}>
               <span style={{ width: 5, height: 5, borderRadius: '50%', background: '#f87171' }} />
@@ -603,7 +603,7 @@ export default function AlertsPage() {
 
             {!webhookOk && (
               <div style={{
-                fontSize: 'var(--fs-caption)', color: '#f87171', marginBottom: 14, padding: '8px 12px',
+                fontSize: 'var(--fs-caption)', color: 'var(--red)', marginBottom: 14, padding: '8px 12px',
                 background: '#f8717114', borderRadius: 6, border: '0.5px solid #f8717144',
               }}>
                 <Warn /> {t('ALERTS_CONNECT_WEBHOOK_WARNING')}
@@ -720,7 +720,7 @@ export default function AlertsPage() {
                       })}
                     </div>
                   ) : (
-                    <div style={{ fontSize: 'var(--fs-caption)', color: '#f87171' }}>
+                    <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--red)' }}>
                       {t('ALERTS_CONNECT_CODE_EXPIRED')}
                     </div>
                   )}
@@ -894,7 +894,7 @@ export default function AlertsPage() {
             {t('ALERTS_COIN_SELECTION_DESC')}
           </div>
           {coinCapMsg && (
-            <div style={{ fontSize: 'var(--fs-caption)', color: '#f87171', marginBottom: 8 }}>
+            <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--red)', marginBottom: 8 }}>
               {coinCapMsg}
             </div>
           )}
@@ -938,7 +938,7 @@ export default function AlertsPage() {
             })()}
           </div>
           {tfCapMsg && (
-            <div style={{ fontSize: 'var(--fs-caption)', color: '#f87171', marginBottom: 8, paddingLeft: 14 }}>
+            <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--red)', marginBottom: 8, paddingLeft: 14 }}>
               {tfCapMsg}
             </div>
           )}
@@ -1072,7 +1072,7 @@ export default function AlertsPage() {
             {t('ALERTS_SIGNAL_DIRECTION_DESC')}
           </div>
           <div style={{ display: 'flex', gap: 8 }}>
-            {([['dir:long', t('ALERTS_DIR_LONG_LABEL'), '#4ade80'], ['dir:short', t('ALERTS_DIR_SHORT_LABEL'), '#f87171']] as const).map(([key, label, col]) => {
+            {([['dir:long', t('ALERTS_DIR_LONG_LABEL'), 'var(--green)'], ['dir:short', t('ALERTS_DIR_SHORT_LABEL'), 'var(--red)']] as const).map(([key, label, col]) => {
               const off = muted.has(key);
               return (
                 <button

--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -1168,7 +1168,7 @@ function ArenaContent() {
       <div style={{ padding: '1rem 0 0.75rem' }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4, flexWrap: 'wrap' }}>
           <div style={{ fontSize: 'var(--fs-section)', fontWeight: 700, color: 'var(--txt)', letterSpacing: '-0.3px' }}>{t('ARENA_PAGE_TITLE')}</div>
-          <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, padding: '3px 8px', borderRadius: 20, background: '#12233f', color: '#5aa3ff', border: '0.5px solid #2a4a7a', letterSpacing: '.05em' }}>{t('ARENA_LIVE_BADGE')}</span>
+          <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, padding: '3px 8px', borderRadius: 20, background: '#12233f', color: 'var(--accent-2)', border: '0.5px solid #2a4a7a', letterSpacing: '.05em' }}>{t('ARENA_LIVE_BADGE')}</span>
         </div>
         <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)' }}>{t('ARENA_PAGE_SUBTITLE')}</div>
       </div>
@@ -1253,7 +1253,7 @@ function ArenaContent() {
           {/* Selected coin chip - left side */}
           <span style={{
             display: 'inline-flex', alignItems: 'center', gap: 5,
-            fontSize: 'var(--fs-caption)', fontWeight: 700, color: '#5aa3ff',
+            fontSize: 'var(--fs-caption)', fontWeight: 700, color: 'var(--accent-2)',
             background: 'rgba(90,163,255,0.1)', padding: '2px 9px 2px 5px',
             borderRadius: 20, border: '0.5px solid rgba(90,163,255,0.2)',
             flexShrink: 0,
@@ -1265,12 +1265,12 @@ function ArenaContent() {
           <span style={{ flex: 1 }} />
           {/* Active signal chips */}
           {sqzCount > 0 && (
-            <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: '#34d399', background: 'rgba(52,211,153,0.1)', padding: '1px 7px', borderRadius: 20, border: '0.5px solid rgba(52,211,153,0.2)' }}>
+            <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: 'var(--green-2)', background: 'rgba(52,211,153,0.1)', padding: '1px 7px', borderRadius: 20, border: '0.5px solid rgba(52,211,153,0.2)' }}>
               ↑ {sqzCount}
             </span>
           )}
           {flushCount > 0 && (
-            <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: '#f87171', background: 'rgba(248,113,113,0.1)', padding: '1px 7px', borderRadius: 20, border: '0.5px solid rgba(248,113,113,0.2)' }}>
+            <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: 'var(--red)', background: 'rgba(248,113,113,0.1)', padding: '1px 7px', borderRadius: 20, border: '0.5px solid rgba(248,113,113,0.2)' }}>
               ↓ {flushCount}
             </span>
           )}
@@ -1316,7 +1316,7 @@ function ArenaContent() {
               padding: '3px 7px', borderRadius: 7, border: '0.5px solid',
               background: notifEnabled ? '#152b1e' : 'transparent',
               borderColor: notifEnabled ? '#266038' : 'rgba(255,255,255,0.08)',
-              color: notifEnabled ? '#7de0a4' : 'var(--txt-dim)',
+              color: notifEnabled ? 'var(--green-soft)' : 'var(--txt-dim)',
               fontSize: 'var(--fs-caption)', cursor: 'pointer', flexShrink: 0, lineHeight: 1,
             }}
           >
@@ -1391,7 +1391,7 @@ function ArenaContent() {
               const isActive    = rowSq.dir !== 'NEUTRAL' && rowSq.score >= 30;
               const icon        = rowSq.dir === 'SHORT_SQ' ? '↑' : rowSq.dir === 'LONG_LIQ' ? '↓' : '';
               const statusLabel = rowSq.dir === 'SHORT_SQ' ? t('ARENA_SCANNER_STATUS_SQUEEZE') : rowSq.dir === 'LONG_LIQ' ? t('ARENA_SCANNER_STATUS_FLUSH') : t('ARENA_SCANNER_STATUS_NEUTRAL');
-              const vsBtcColor  = vsBtc == null ? 'var(--txt3)' : vsBtc >= 2 ? '#34d399' : vsBtc <= -2 ? '#f87171' : 'var(--txt3)';
+              const vsBtcColor  = vsBtc == null ? 'var(--txt3)' : vsBtc >= 2 ? 'var(--green-2)' : vsBtc <= -2 ? 'var(--red)' : 'var(--txt3)';
               return (
                 <button
                   key={c}
@@ -1420,13 +1420,13 @@ function ArenaContent() {
                       bg={isActive ? withAlpha(rowSq.color, '1a') : undefined}
                     />
                     <div>
-                      <div style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: isSelected ? '#5aa3ff' : isActive ? 'var(--txt)' : 'var(--txt3)', lineHeight: 1.2 }}>
+                      <div style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: isSelected ? 'var(--accent-2)' : isActive ? 'var(--txt)' : 'var(--txt3)', lineHeight: 1.2 }}>
                         {c.toUpperCase()}
                       </div>
                       {badges.length > 0 ? (
                         <div style={{ display: 'flex', gap: 3, marginTop: 2, flexWrap: 'wrap' }}>
                           {badges.map(b => {
-                            const col = b.tone === 'good' ? '#34d399' : '#f87171';
+                            const col = b.tone === 'good' ? 'var(--green-2)' : 'var(--red)';
                             return (
                               <span key={b.key} style={{
                                 fontSize: 'var(--fs-caption)', fontWeight: 700, letterSpacing: '.04em',
@@ -1446,7 +1446,7 @@ function ArenaContent() {
                     {price ? '$' + fmtPrice(price) : '-'}
                   </span>
                   {/* 24h % */}
-                  <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 600, fontVariantNumeric: 'tabular-nums', textAlign: 'right', color: change == null ? 'var(--txt3)' : change >= 0 ? '#34d399' : '#f87171' }}>
+                  <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 600, fontVariantNumeric: 'tabular-nums', textAlign: 'right', color: change == null ? 'var(--txt3)' : change >= 0 ? 'var(--green-2)' : 'var(--red)' }}>
                     {change != null ? (change >= 0 ? '+' : '') + change.toFixed(1) + '%' : '-'}
                   </span>
                   {/* vs BTC */}
@@ -1608,7 +1608,7 @@ function ArenaContent() {
                       flex: 1, padding: '7px 12px', fontSize: 'var(--fs-caption)', fontWeight: 700, letterSpacing: '.02em',
                       border: 'none', borderRadius: 8, cursor: 'pointer', transition: 'background .15s, color .15s',
                       background: alertDir === d ? (d === 'above' ? 'var(--green-bg)' : 'var(--red-bg)') : 'transparent',
-                      color: alertDir === d ? (d === 'above' ? '#4ade80' : '#f87171') : 'var(--txt3)',
+                      color: alertDir === d ? (d === 'above' ? 'var(--green)' : 'var(--red)') : 'var(--txt3)',
                     }}
                   >
                     {d === 'above' ? t('ARENA_ALERT_DIR_ABOVE') : t('ARENA_ALERT_DIR_BELOW')}
@@ -1703,7 +1703,7 @@ function ArenaContent() {
       {readError && <div className="arena-err">{readError}</div>}
 
       {result && !dismissedResults.has(selectedCoin) && nowMs - result.analyzedAt < CACHE_MAX_AGE_MS && (() => {
-        const sigCol = result.signal === 'LONG' ? '#34d399' : result.signal === 'LEAN LONG' ? '#86efac' : result.signal === 'SHORT' ? '#f87171' : result.signal === 'LEAN SHORT' ? '#fca5a5' : '#9ca3af';
+        const sigCol = result.signal === 'LONG' ? 'var(--green-2)' : result.signal === 'LEAN LONG' ? 'var(--green-soft)' : result.signal === 'SHORT' ? 'var(--red)' : result.signal === 'LEAN SHORT' ? 'var(--red-soft)' : '#9ca3af';
         const verdictWord = result.signal === 'LONG' ? t('ARENA_VERDICT_LONG') : result.signal === 'LEAN LONG' ? t('ARENA_VERDICT_LEAN_LONG') : result.signal === 'SHORT' ? t('ARENA_VERDICT_SHORT') : result.signal === 'LEAN SHORT' ? t('ARENA_VERDICT_LEAN_SHORT') : t('ARENA_VERDICT_WAIT');
         const sigGrad = result.signal.includes('LONG') ? 'linear-gradient(160deg,#5ff0b0,#34d399)'
           : result.signal.includes('SHORT') ? 'linear-gradient(160deg,#ff9d9d,#f87171)'
@@ -1713,7 +1713,7 @@ function ArenaContent() {
         const rr = entryMid && result.sl && result.tp ? Math.abs((result.tp - entryMid) / (entryMid - result.sl)) : null;
         const coinD = store.coins[selectedCoin];
         const frPct = coinD?.fundingRate != null ? coinD.fundingRate * 100 : null;
-        const GC = '#34d399', RC = '#f87171', NC = 'var(--txt3)';
+        const GC = 'var(--green-2)', RC = 'var(--red)', NC = 'var(--txt3)';
         // Multi-TF: RSI bias across 15m/1h/4h (same math as the MultiTFAlignment card)
         const tfBias = (r: number | null | undefined) => r == null ? 0 : r > 57 ? 1 : r < 43 ? -1 : 0;
         const tfArr = [coinD?.rsi14, coinD?.rsi1h, coinD?.rsi4h].map(tfBias);
@@ -1852,7 +1852,7 @@ function ArenaContent() {
               }}>
                 <span aria-hidden="true" style={{ fontSize: 16, flexShrink: 0 }}>⚠</span>
                 <div>
-                  <div style={{ fontSize: 'var(--fs-caption)', fontWeight: 800, letterSpacing: '.04em', textTransform: 'uppercase', color: '#f87171' }}>
+                  <div style={{ fontSize: 'var(--fs-caption)', fontWeight: 800, letterSpacing: '.04em', textTransform: 'uppercase', color: 'var(--red)' }}>
                     {t('ARENA_STOP_HIT_HEADER')}
                   </div>
                   <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt2)' }}>
@@ -1869,7 +1869,7 @@ function ArenaContent() {
               }}>
                 <span aria-hidden="true" style={{ fontSize: 16, flexShrink: 0 }}>✓</span>
                 <div>
-                  <div style={{ fontSize: 'var(--fs-caption)', fontWeight: 800, letterSpacing: '.04em', textTransform: 'uppercase', color: '#34d399' }}>
+                  <div style={{ fontSize: 'var(--fs-caption)', fontWeight: 800, letterSpacing: '.04em', textTransform: 'uppercase', color: 'var(--green-2)' }}>
                     {t('ARENA_TARGET_HIT_HEADER')}
                   </div>
                   <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt2)' }}>
@@ -1890,7 +1890,7 @@ function ArenaContent() {
                     <span style={{
                       marginLeft: 6, fontSize: 'var(--fs-micro)', fontWeight: 800, letterSpacing: '.06em',
                       textTransform: 'uppercase',
-                      color: result.bias === 'BEARISH' ? '#f87171' : '#34d399',
+                      color: result.bias === 'BEARISH' ? 'var(--red)' : 'var(--green-2)',
                     }}>
                       · {result.bias === 'BEARISH' ? t('ARENA_LEANING_BEARISH_ARROW') : t('ARENA_LEANING_BULLISH_ARROW')}
                     </span>
@@ -1911,7 +1911,7 @@ function ArenaContent() {
                 <div style={{ display: 'flex', alignItems: 'center', gap: 7, padding: '8px 12px 6px', borderBottom: '0.5px solid rgba(255,255,255,0.06)' }}>
                   <span style={{
                     fontSize: 'var(--fs-caption)', fontWeight: 800, letterSpacing: '.05em',
-                    color: result.raidSetup === 'SHORT SQUEEZE' ? '#34d399' : '#f87171',
+                    color: result.raidSetup === 'SHORT SQUEEZE' ? 'var(--green-2)' : 'var(--red)',
                   }}>
                     {t('ARENA_RAID_HEADER', { setup: result.raidSetup })}
                   </span>
@@ -2124,7 +2124,7 @@ function ArenaContent() {
                 {result.patterns.map((p, i) => {
                   const isBull = /bull|higher high|engulf.*bull|hammer|morning/i.test(p);
                   const isBear = /bear|lower high|engulf.*bear|shooting|evening|head.*shoulder|double top/i.test(p);
-                  const col = isBull ? '#34d399' : isBear ? '#f87171' : '#1a7aff';
+                  const col = isBull ? 'var(--green-2)' : isBear ? 'var(--red)' : '#1a7aff';
                   const bg  = isBull ? 'rgba(52,211,153,0.08)' : isBear ? 'rgba(248,113,113,0.08)' : 'rgba(26,122,255,0.08)';
                   const bdr = isBull ? 'rgba(52,211,153,0.25)' : isBear ? 'rgba(248,113,113,0.25)' : 'rgba(26,122,255,0.25)';
                   return (
@@ -2179,7 +2179,7 @@ function ArenaContent() {
                     <span className={`arena-sig-badge badge-${h.signal.toLowerCase().replace(' ', '-')}`} style={{ fontSize: 'var(--fs-caption)' }}>
                       {h.signal === 'LONG' ? t('ARENA_HIST_BADGE_LONG') : h.signal === 'LEAN LONG' ? t('ARENA_HIST_BADGE_LEAN_LONG') : h.signal === 'SHORT' ? t('ARENA_HIST_BADGE_SHORT') : h.signal === 'LEAN SHORT' ? t('ARENA_HIST_BADGE_LEAN_SHORT') : t('ARENA_HIST_BADGE_FLAT')}
                     </span>
-                    <div style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: '#5aa3ff' }}>{t('ARENA_HIST_CONFIDENCE_PCT', { pct: h.confidence })}</div>
+                    <div style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: 'var(--accent-2)' }}>{t('ARENA_HIST_CONFIDENCE_PCT', { pct: h.confidence })}</div>
                   </div>
                   {h.entry && (
                     <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 10 }}>

--- a/app/backtest/page.tsx
+++ b/app/backtest/page.tsx
@@ -326,7 +326,7 @@ export default function BacktestPage() {
       </button>
 
       {error && (
-        <div style={{ color: '#f87171', fontSize: 'var(--fs-caption)', marginBottom: 14 }}>{t('BACKTEST_ERROR_PREFIX', { error })}</div>
+        <div style={{ color: 'var(--red)', fontSize: 'var(--fs-caption)', marginBottom: 14 }}>{t('BACKTEST_ERROR_PREFIX', { error })}</div>
       )}
 
       {!result && !srResult && !smcResult && !ulResult && !running && !srRunning && !smcRunning && !ulRunning && (
@@ -338,8 +338,8 @@ export default function BacktestPage() {
             {([
               { dot: '#1a7aff', labelKey: 'BACKTEST_TOOL_BACKTEST_LABEL',   descKey: 'BACKTEST_TOOL_BACKTEST_DESC' },
               { dot: '#5aa3ff', labelKey: 'BACKTEST_TOOL_RESEARCH_LABEL',   descKey: 'BACKTEST_TOOL_RESEARCH_DESC' },
-              { dot: '#fbbf24', labelKey: 'BACKTEST_TOOL_SMC_LABEL',        descKey: 'BACKTEST_TOOL_SMC_DESC' },
-              { dot: '#f87171', labelKey: 'BACKTEST_TOOL_UNLOCK_LABEL',     descKey: 'BACKTEST_TOOL_UNLOCK_DESC' },
+              { dot: 'var(--amber)', labelKey: 'BACKTEST_TOOL_SMC_LABEL',        descKey: 'BACKTEST_TOOL_SMC_DESC' },
+              { dot: 'var(--red)', labelKey: 'BACKTEST_TOOL_UNLOCK_LABEL',     descKey: 'BACKTEST_TOOL_UNLOCK_DESC' },
             ] as const).map(tool => (
               <div key={tool.labelKey} style={{ padding: '10px 12px', background: 'rgba(255,255,255,0.02)', border: '0.5px solid var(--bdr)', borderRadius: 8 }}>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 7, marginBottom: 5 }}>
@@ -362,8 +362,8 @@ export default function BacktestPage() {
           )}
 
           <div style={{ display: 'flex', gap: 14, flexWrap: 'wrap', marginBottom: 24 }}>
-            <SideCard title={t('BACKTEST_SIDECARD_ANTICHOP_ON')} stats={result.antiChopOn.stats} color="#34d399" />
-            <SideCard title={t('BACKTEST_SIDECARD_ANTICHOP_OFF')} stats={result.antiChopOff.stats} color="#f87171" />
+            <SideCard title={t('BACKTEST_SIDECARD_ANTICHOP_ON')} stats={result.antiChopOn.stats} color="var(--green-2)" />
+            <SideCard title={t('BACKTEST_SIDECARD_ANTICHOP_OFF')} stats={result.antiChopOff.stats} color="var(--red)" />
           </div>
 
           <h2 className="mb-title" style={{ fontSize: 'var(--fs-card-title)', marginBottom: 4 }}>{t('BACKTEST_WT_TUNING_TITLE')}</h2>
@@ -387,11 +387,11 @@ export default function BacktestPage() {
                   const beatsBaseline = isFinite(s.profitFactor) && s.profitFactor > result.antiChopOn.stats.profitFactor;
                   return (
                     <tr key={name}>
-                      <td style={{ fontWeight: 600 }}>{WT_VARIANT_LABEL_KEYS[name] ? t(WT_VARIANT_LABEL_KEYS[name]) : name}{beatsBaseline ? <span style={{ color: '#4ade80' }}> ▲</span> : ''}</td>
+                      <td style={{ fontWeight: 600 }}>{WT_VARIANT_LABEL_KEYS[name] ? t(WT_VARIANT_LABEL_KEYS[name]) : name}{beatsBaseline ? <span style={{ color: 'var(--green)' }}> ▲</span> : ''}</td>
                       <td>{s.totalTrades} ({s.wins}W/{s.losses}L)</td>
-                      <td style={{ color: s.winRate >= 0.5 ? '#34d399' : '#f87171' }}>{fmtPct(s.winRate)}</td>
-                      <td style={{ color: s.avgR >= 0 ? '#34d399' : '#f87171' }}>{fmtR(s.avgR)}</td>
-                      <td style={{ color: beatsBaseline ? '#34d399' : 'var(--txt)' }}>{isFinite(s.profitFactor) ? s.profitFactor.toFixed(2) : '∞'}</td>
+                      <td style={{ color: s.winRate >= 0.5 ? 'var(--green-2)' : 'var(--red)' }}>{fmtPct(s.winRate)}</td>
+                      <td style={{ color: s.avgR >= 0 ? 'var(--green-2)' : 'var(--red)' }}>{fmtR(s.avgR)}</td>
+                      <td style={{ color: beatsBaseline ? 'var(--green-2)' : 'var(--txt)' }}>{isFinite(s.profitFactor) ? s.profitFactor.toFixed(2) : '∞'}</td>
                       <td>-{s.maxDrawdownR.toFixed(2)}R</td>
                     </tr>
                   );
@@ -415,8 +415,8 @@ export default function BacktestPage() {
                     <tr key={c}>
                       <td style={{ fontWeight: 600 }}>{c.toUpperCase()}</td>
                       <td>{s.totalTrades} ({s.wins}W/{s.losses}L)</td>
-                      <td style={{ color: s.winRate >= 0.5 ? '#34d399' : '#f87171' }}>{fmtPct(s.winRate)}</td>
-                      <td style={{ color: s.avgR >= 0 ? '#34d399' : '#f87171' }}>{fmtR(s.avgR)}</td>
+                      <td style={{ color: s.winRate >= 0.5 ? 'var(--green-2)' : 'var(--red)' }}>{fmtPct(s.winRate)}</td>
+                      <td style={{ color: s.avgR >= 0 ? 'var(--green-2)' : 'var(--red)' }}>{fmtR(s.avgR)}</td>
                       <td>{isFinite(s.profitFactor) ? s.profitFactor.toFixed(2) : '∞'}</td>
                     </tr>
                   );
@@ -462,7 +462,7 @@ export default function BacktestPage() {
       </button>
 
       {ofError && (
-        <div style={{ color: '#f87171', fontSize: 'var(--fs-caption)', marginBottom: 14 }}>{t('BACKTEST_OF_ERROR_PREFIX', { error: ofError })}</div>
+        <div style={{ color: 'var(--red)', fontSize: 'var(--fs-caption)', marginBottom: 14 }}>{t('BACKTEST_OF_ERROR_PREFIX', { error: ofError })}</div>
       )}
 
       {ofResult && (
@@ -492,8 +492,8 @@ export default function BacktestPage() {
                     <tr key={c}>
                       <td style={{ fontWeight: 600 }}>{c.toUpperCase()}</td>
                       <td>{s.totalTrades} ({s.wins}W/{s.losses}L)</td>
-                      <td style={{ color: s.winRate >= 0.5 ? '#34d399' : '#f87171' }}>{fmtPct(s.winRate)}</td>
-                      <td style={{ color: s.avgR >= 0 ? '#34d399' : '#f87171' }}>{fmtR(s.avgR)}</td>
+                      <td style={{ color: s.winRate >= 0.5 ? 'var(--green-2)' : 'var(--red)' }}>{fmtPct(s.winRate)}</td>
+                      <td style={{ color: s.avgR >= 0 ? 'var(--green-2)' : 'var(--red)' }}>{fmtR(s.avgR)}</td>
                       <td>{isFinite(s.profitFactor) ? s.profitFactor.toFixed(2) : '∞'}</td>
                     </tr>
                   );
@@ -536,7 +536,7 @@ export default function BacktestPage() {
           disabled={srRunning || !srPrompt.trim()}
           style={{
             background: srRunning || !srPrompt.trim() ? 'rgba(255,255,255,0.06)' : 'rgba(26,122,255,0.12)',
-            color: srRunning || !srPrompt.trim() ? 'var(--txt3)' : '#1a7aff',
+            color: srRunning || !srPrompt.trim() ? 'var(--txt3)' : 'var(--accent)',
             border: `1px solid ${srRunning || !srPrompt.trim() ? 'var(--bdr)' : 'rgba(26,122,255,0.35)'}`,
             borderRadius: 8, padding: '10px 20px', fontSize: 'var(--fs-label)', fontWeight: 700,
             cursor: srRunning || !srPrompt.trim() ? 'default' : 'pointer',
@@ -558,7 +558,7 @@ export default function BacktestPage() {
         )}
       </div>
 
-      {srError && <div style={{ color: '#f87171', fontSize: 'var(--fs-caption)', marginBottom: 14 }}>{srError}</div>}
+      {srError && <div style={{ color: 'var(--red)', fontSize: 'var(--fs-caption)', marginBottom: 14 }}>{srError}</div>}
 
       {srResult && (
         <>
@@ -597,7 +597,7 @@ export default function BacktestPage() {
                   disabled={psRunning}
                   style={{
                     background: psRunning ? 'rgba(255,255,255,0.06)' : 'rgba(52,211,153,0.10)',
-                    color: psRunning ? 'var(--txt3)' : '#34d399',
+                    color: psRunning ? 'var(--txt3)' : 'var(--green-2)',
                     border: `1px solid ${psRunning ? 'var(--bdr)' : 'rgba(52,211,153,0.3)'}`,
                     borderRadius: 8, padding: '8px 16px', fontSize: 'var(--fs-caption)', fontWeight: 700,
                     cursor: psRunning ? 'default' : 'pointer',
@@ -617,7 +617,7 @@ export default function BacktestPage() {
                     }}
                     style={{
                       background: psCopied ? 'rgba(52,211,153,0.12)' : 'rgba(26,122,255,0.10)',
-                      color: psCopied ? '#34d399' : '#1a7aff',
+                      color: psCopied ? 'var(--green-2)' : 'var(--accent)',
                       border: `1px solid ${psCopied ? 'rgba(52,211,153,0.3)' : 'rgba(26,122,255,0.3)'}`,
                       borderRadius: 8, padding: '8px 16px', fontSize: 'var(--fs-caption)', fontWeight: 700, cursor: 'pointer',
                     }}
@@ -633,14 +633,14 @@ export default function BacktestPage() {
                 </>
               )}
             </div>
-            {psError && <div style={{ color: '#f87171', fontSize: 'var(--fs-caption)', marginBottom: 10 }}>{psError}</div>}
+            {psError && <div style={{ color: 'var(--red)', fontSize: 'var(--fs-caption)', marginBottom: 10 }}>{psError}</div>}
             {psResult && (
               <div style={{
                 background: 'rgba(0,0,0,0.3)', border: '0.5px solid var(--bdr)',
                 borderRadius: 8, padding: '12px 14px', overflowX: 'auto',
               }}>
                 <pre style={{
-                  margin: 0, fontSize: 'var(--fs-caption)', color: '#34d399',
+                  margin: 0, fontSize: 'var(--fs-caption)', color: 'var(--green-2)',
                   fontFamily: 'var(--font-mono), monospace', lineHeight: 1.5,
                   whiteSpace: 'pre', overflowX: 'auto',
                 }}>{psResult}</pre>
@@ -688,7 +688,7 @@ export default function BacktestPage() {
           disabled={smcRunning || !smcAsset.trim()}
           style={{
             background: smcRunning || !smcAsset.trim() ? 'rgba(255,255,255,0.06)' : 'rgba(26,122,255,0.12)',
-            color: smcRunning || !smcAsset.trim() ? 'var(--txt3)' : '#1a7aff',
+            color: smcRunning || !smcAsset.trim() ? 'var(--txt3)' : 'var(--accent)',
             border: `1px solid ${smcRunning || !smcAsset.trim() ? 'var(--bdr)' : 'rgba(26,122,255,0.35)'}`,
             borderRadius: 8, padding: '8px 16px', fontSize: 'var(--fs-label)', fontWeight: 700,
             cursor: smcRunning || !smcAsset.trim() ? 'default' : 'pointer',
@@ -706,7 +706,7 @@ export default function BacktestPage() {
         )}
       </div>
 
-      {smcError && <div style={{ color: '#f87171', fontSize: 'var(--fs-caption)', marginBottom: 14 }}>{smcError}</div>}
+      {smcError && <div style={{ color: 'var(--red)', fontSize: 'var(--fs-caption)', marginBottom: 14 }}>{smcError}</div>}
 
       {smcResult && (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginBottom: 8 }}>
@@ -764,7 +764,7 @@ export default function BacktestPage() {
           disabled={ulRunning || !ulSymbol.trim()}
           style={{
             background: ulRunning || !ulSymbol.trim() ? 'rgba(255,255,255,0.06)' : 'rgba(26,122,255,0.12)',
-            color: ulRunning || !ulSymbol.trim() ? 'var(--txt3)' : '#1a7aff',
+            color: ulRunning || !ulSymbol.trim() ? 'var(--txt3)' : 'var(--accent)',
             border: `1px solid ${ulRunning || !ulSymbol.trim() ? 'var(--bdr)' : 'rgba(26,122,255,0.35)'}`,
             borderRadius: 8, padding: '8px 16px', fontSize: 'var(--fs-label)', fontWeight: 700,
             cursor: ulRunning || !ulSymbol.trim() ? 'default' : 'pointer',
@@ -782,7 +782,7 @@ export default function BacktestPage() {
         )}
       </div>
 
-      {ulError && <div style={{ color: '#f87171', fontSize: 'var(--fs-caption)', marginBottom: 14 }}>{ulError}</div>}
+      {ulError && <div style={{ color: 'var(--red)', fontSize: 'var(--fs-caption)', marginBottom: 14 }}>{ulError}</div>}
 
       {ulResult && (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>

--- a/app/briefing/page.tsx
+++ b/app/briefing/page.tsx
@@ -25,8 +25,8 @@ const OI_ICONS: Record<string, string> = {
   strong_up: '▲', strong_down: '▼', weak_up: '△', weak_down: '▽',
 };
 const OI_COLORS: Record<string, string> = {
-  strong_up: '#34d399', strong_down: '#f87171',
-  weak_up: '#fbbf24', weak_down: '#94a3b8',
+  strong_up: 'var(--green-2)', strong_down: 'var(--red)',
+  weak_up: 'var(--amber)', weak_down: 'var(--txt-dim)',
 };
 
 /* Convert decimal hours → "Xh Ym" */
@@ -52,18 +52,18 @@ function tsAgo(ts: number): string {
 
 function rsiColor(rsi: number | null): string {
   if (rsi == null) return 'var(--txt3)';
-  if (rsi >= 70) return '#f87171';
-  if (rsi >= 60) return '#fbbf24';
-  if (rsi <= 30) return '#34d399';
-  if (rsi <= 40) return '#86efac';
+  if (rsi >= 70) return 'var(--red)';
+  if (rsi >= 60) return 'var(--amber)';
+  if (rsi <= 30) return 'var(--green-2)';
+  if (rsi <= 40) return 'var(--green-soft)';
   return 'var(--txt2)';
 }
 
 function volRatioColor(vr: number | null): string {
   if (vr == null) return 'var(--txt3)';
-  if (vr >= 2)   return '#f87171';
-  if (vr >= 1.5) return '#fbbf24';
-  if (vr >= 1.2) return '#86efac';
+  if (vr >= 2)   return 'var(--red)';
+  if (vr >= 1.5) return 'var(--amber)';
+  if (vr >= 1.2) return 'var(--green-soft)';
   return 'var(--txt3)';
 }
 
@@ -320,14 +320,14 @@ export default function MorningBriefing() {
   /* Macro colors */
   const fng      = store.fng;
   const fngColor = fng == null ? 'var(--txt3)'
-    : fng >= 75 ? '#f87171'
-    : fng >= 55 ? '#fbbf24'
-    : fng <= 25 ? '#34d399'
-    : fng <= 45 ? '#86efac'
+    : fng >= 75 ? 'var(--red)'
+    : fng >= 55 ? 'var(--amber)'
+    : fng <= 25 ? 'var(--green-2)'
+    : fng <= 45 ? 'var(--green-soft)'
     : 'var(--txt2)';
 
   const etfFlow  = store.etfNetFlow;
-  const etfColor = etfFlow == null ? 'var(--txt3)' : etfFlow > 0 ? '#34d399' : '#f87171';
+  const etfColor = etfFlow == null ? 'var(--txt3)' : etfFlow > 0 ? 'var(--green-2)' : 'var(--red)';
 
   const dxyChg    = store.dxyChg;
   const dxySig    = dxyChg == null    ? '-'
@@ -335,15 +335,15 @@ export default function MorningBriefing() {
     : dxyChg < -0.2 ? t('BRIEFING_DXY_TAILWIND')
     : t('BRIEFING_DXY_NEUTRAL');
   const dxyColor  = dxyChg == null    ? 'var(--txt3)'
-    : dxyChg > 0.2  ? '#f87171'
-    : dxyChg < -0.2 ? '#34d399'
+    : dxyChg > 0.2  ? 'var(--red)'
+    : dxyChg < -0.2 ? 'var(--green-2)'
     : 'var(--txt3)';
 
   const btcDomHistory = store.btcDomHistory;
   const domTrend = btcDomHistory.length >= 2
     ? btcDomHistory[btcDomHistory.length - 1] > btcDomHistory[0]
-      ? { txt: t('BRIEFING_DOM_ALTS_WEAK'), col: '#fbbf24' }
-      : { txt: t('BRIEFING_DOM_ALTS_ACTIVE'), col: '#34d399' }
+      ? { txt: t('BRIEFING_DOM_ALTS_WEAK'), col: 'var(--amber)' }
+      : { txt: t('BRIEFING_DOM_ALTS_ACTIVE'), col: 'var(--green-2)' }
     : null;
 
   const futureEcon = urgentEcon.filter(e => e.dt.getTime() > nowMs);
@@ -352,12 +352,12 @@ export default function MorningBriefing() {
   /* Yen Watch */
   const jpyStatus = jpyUsd == null ? null
     : jpyUsd >= 160
-      ? { label: t('BRIEFING_YEN_DANGER'), color: '#f87171', bg: 'rgba(248,113,113,0.08)', border: 'rgba(248,113,113,0.25)',
+      ? { label: t('BRIEFING_YEN_DANGER'), color: 'var(--red)', bg: 'rgba(248,113,113,0.08)', border: 'rgba(248,113,113,0.25)',
           desc: t('BRIEFING_YEN_DANGER_DESC') }
     : jpyUsd >= 158
-      ? { label: t('BRIEFING_YEN_WARNING'), color: '#fbbf24', bg: 'rgba(251,191,36,0.06)', border: 'rgba(251,191,36,0.2)',
+      ? { label: t('BRIEFING_YEN_WARNING'), color: 'var(--amber)', bg: 'rgba(251,191,36,0.06)', border: 'rgba(251,191,36,0.2)',
           desc: t('BRIEFING_YEN_WARNING_DESC') }
-      : { label: t('BRIEFING_YEN_SAFE'), color: '#34d399', bg: 'rgba(52,211,153,0.06)', border: 'rgba(52,211,153,0.2)',
+      : { label: t('BRIEFING_YEN_SAFE'), color: 'var(--green-2)', bg: 'rgba(52,211,153,0.06)', border: 'rgba(52,211,153,0.2)',
           desc: t('BRIEFING_YEN_SAFE_DESC') };
   // progress bar: 140 = left edge, 165 = right edge
   const jpyPct        = jpyUsd != null ? Math.max(0, Math.min(100, ((jpyUsd - 140) / 25) * 100)) : 0;
@@ -402,7 +402,7 @@ export default function MorningBriefing() {
         ) : (
           top3Setups.map(({ id, c, sq }, i) => {
             const isLong    = sq.dir === 'SHORT_SQ';
-            const dirColor  = isLong ? '#34d399' : '#f87171';
+            const dirColor  = isLong ? 'var(--green-2)' : 'var(--red)';
             const dirLabel  = isLong ? t('BRIEFING_DIR_LONG') : t('BRIEFING_DIR_SHORT');
             const tags      = c ? getSignalTags(c, sq.dir as 'LONG_LIQ' | 'SHORT_SQ', t) : [];
             const isLast    = i === top3Setups.length - 1;
@@ -484,7 +484,7 @@ export default function MorningBriefing() {
         )}
 
         {briefErr && (
-          <div style={{ fontSize: 'var(--fs-caption)', color: '#f87171', marginTop: 8, display: 'flex', alignItems: 'center', gap: 5 }}><Warn /> {briefErr}</div>
+          <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--red)', marginTop: 8, display: 'flex', alignItems: 'center', gap: 5 }}><Warn /> {briefErr}</div>
         )}
 
         {brief && !generating && (
@@ -518,7 +518,7 @@ export default function MorningBriefing() {
                 key={id}
                 className="mb-cvd-chip"
                 style={{
-                  color:       div === 'bullish' ? '#34d399' : '#f87171',
+                  color:       div === 'bullish' ? 'var(--green-2)' : 'var(--red)',
                   borderColor: div === 'bullish' ? 'rgba(52,211,153,0.4)' : 'rgba(248,113,113,0.4)',
                   background:  div === 'bullish' ? 'rgba(52,211,153,0.08)' : 'rgba(248,113,113,0.08)',
                 }}
@@ -641,11 +641,11 @@ export default function MorningBriefing() {
               <span style={{ position: 'absolute', bottom: 0, left: 0, fontSize: 'var(--fs-caption)', color: 'var(--txt3)' }}>140</span>
               <span style={{
                 position: 'absolute', bottom: 0, left: `${warn158Pct}%`, transform: 'translateX(-50%)',
-                fontSize: 'var(--fs-caption)', color: '#fbbf24', fontWeight: 600,
+                fontSize: 'var(--fs-caption)', color: 'var(--amber)', fontWeight: 600,
               }}>158<Warn size={9} style={{ verticalAlign: '-1px', marginLeft: 1 }} /></span>
               <span style={{
                 position: 'absolute', bottom: 0, left: `${danger160Pct}%`, transform: 'translateX(-50%)',
-                fontSize: 'var(--fs-caption)', color: '#f87171', fontWeight: 600,
+                fontSize: 'var(--fs-caption)', color: 'var(--red)', fontWeight: 600,
               }}>160</span>
               <span style={{ position: 'absolute', bottom: 0, right: 0, fontSize: 'var(--fs-caption)', color: 'var(--txt3)' }}>165</span>
             </div>
@@ -672,20 +672,20 @@ export default function MorningBriefing() {
           if (!c?.price) continue;
           const chips: Chip[] = [];
           if (c.rsi14 != null) {
-            if (c.rsi14 >= 70)      chips.push({ text: t('BRIEFING_TAG_RSI', { value: Math.round(c.rsi14) }), color: '#f87171' });
-            else if (c.rsi14 <= 30) chips.push({ text: t('BRIEFING_TAG_RSI', { value: Math.round(c.rsi14) }), color: '#34d399' });
+            if (c.rsi14 >= 70)      chips.push({ text: t('BRIEFING_TAG_RSI', { value: Math.round(c.rsi14) }), color: 'var(--red)' });
+            else if (c.rsi14 <= 30) chips.push({ text: t('BRIEFING_TAG_RSI', { value: Math.round(c.rsi14) }), color: 'var(--green-2)' });
           }
           if (c.fundingRate != null) {
             const fr = c.fundingRate * 100;
-            if (fr >= 0.05)       chips.push({ text: t('BRIEFING_TAG_FR_POS', { value: fr.toFixed(3) }), color: '#f87171' });
-            else if (fr <= -0.03) chips.push({ text: t('BRIEFING_TAG_FR_NEG_VALUE', { value: fr.toFixed(3) }),  color: '#34d399' });
+            if (fr >= 0.05)       chips.push({ text: t('BRIEFING_TAG_FR_POS', { value: fr.toFixed(3) }), color: 'var(--red)' });
+            else if (fr <= -0.03) chips.push({ text: t('BRIEFING_TAG_FR_NEG_VALUE', { value: fr.toFixed(3) }),  color: 'var(--green-2)' });
           }
           if (c.volRatio != null && c.volRatio >= 1.5)
             chips.push({ text: t('BRIEFING_TAG_VOL', { x: c.volRatio.toFixed(1) }), color: 'var(--accent)' });
-          if (c.oiTrend === 'strong_up')        chips.push({ text: t('BRIEFING_TAG_OI_STRONG_UP'),    color: '#34d399' });
-          else if (c.oiTrend === 'strong_down') chips.push({ text: t('BRIEFING_TAG_OI_STRONG_DOWN'),    color: '#f87171' });
-          if (c.cvdDivergence === 'bullish')    chips.push({ text: t('BRIEFING_TAG_CVD_BULL'), color: '#34d399' });
-          else if (c.cvdDivergence === 'bearish') chips.push({ text: t('BRIEFING_TAG_CVD_BEAR'), color: '#f87171' });
+          if (c.oiTrend === 'strong_up')        chips.push({ text: t('BRIEFING_TAG_OI_STRONG_UP'),    color: 'var(--green-2)' });
+          else if (c.oiTrend === 'strong_down') chips.push({ text: t('BRIEFING_TAG_OI_STRONG_DOWN'),    color: 'var(--red)' });
+          if (c.cvdDivergence === 'bullish')    chips.push({ text: t('BRIEFING_TAG_CVD_BULL'), color: 'var(--green-2)' });
+          else if (c.cvdDivergence === 'bearish') chips.push({ text: t('BRIEFING_TAG_CVD_BEAR'), color: 'var(--red)' });
           if (chips.length > 0) byCoins.push({ id, label: COIN_LABELS[id], chips });
         }
 
@@ -762,13 +762,13 @@ export default function MorningBriefing() {
           <div key={i} className="mb-event-row">
             <div className="mb-event-tag" style={{
               background: isPast ? 'rgba(100,100,100,0.15)' : lh < 2 ? 'rgba(248,113,113,0.15)' : 'rgba(251,191,36,0.1)',
-              color: isPast ? 'var(--txt3)' : lh < 2 ? '#f87171' : '#fbbf24',
+              color: isPast ? 'var(--txt3)' : lh < 2 ? 'var(--red)' : 'var(--amber)',
             }}>
               {isPast ? '✓ ' : ''}{e.type}
             </div>
             <div className="mb-event-name">{e.name}</div>
             <div className="mb-event-time" style={{
-              color: isPast ? 'var(--txt3)' : lh < 1 ? '#f87171' : lh < 6 ? '#fbbf24' : 'var(--txt3)',
+              color: isPast ? 'var(--txt3)' : lh < 1 ? 'var(--red)' : lh < 6 ? 'var(--amber)' : 'var(--txt3)',
             }}>
               {isPast ? `${Math.round(-lh * 60)}m ago` : lh < 0.017 ? 'NOW' : `in ${hToHM(lh)}`}
             </div>
@@ -784,7 +784,7 @@ export default function MorningBriefing() {
                 : e.style === 'speech'
                 ? 'rgba(96,165,250,0.1)'
                 : 'var(--accent-bg)',
-              color: e.style === 'crypto' ? '#34d399' : e.style === 'speech' ? '#60a5fa' : 'var(--accent)',
+              color: e.style === 'crypto' ? 'var(--green-2)' : e.style === 'speech' ? 'var(--accent-2)' : 'var(--accent)',
             }}>
               {e.tag}
             </div>
@@ -797,7 +797,7 @@ export default function MorningBriefing() {
           <div key={i} className="mb-event-row">
             <div className="mb-event-tag" style={{
               background: w.side === 'BUY' ? 'rgba(52,211,153,0.12)' : 'rgba(248,113,113,0.12)',
-              color: w.side === 'BUY' ? '#34d399' : '#f87171',
+              color: w.side === 'BUY' ? 'var(--green-2)' : 'var(--red)',
             }}>
               {t('BRIEFING_WHALE_PREFIX', { side: w.side })}
             </div>

--- a/app/correlation/page.tsx
+++ b/app/correlation/page.tsx
@@ -103,15 +103,15 @@ function cellColor(r: number | null, diag: boolean): string {
 /* ── alt season signal ── */
 interface AltSig { labelKey: LabelKey; descKey: LabelKey | null; avg: number | null; color: string; bg: string; }
 function altSignal(avg: number | null): AltSig {
-  if (avg == null) return { labelKey: 'CORRELATION_ALT_SIG_LOADING_LABEL', descKey: null, avg, color: '#a0a0a0', bg: 'transparent' };
+  if (avg == null) return { labelKey: 'CORRELATION_ALT_SIG_LOADING_LABEL', descKey: null, avg, color: 'var(--txt-dim)', bg: 'transparent' };
   if (avg < 0.30)  return {
     labelKey: 'CORRELATION_ALT_SIG_ALT_SEASON_LABEL',
-    color: '#34d399', bg: 'rgba(52,211,153,0.08)',
+    color: 'var(--green-2)', bg: 'rgba(52,211,153,0.08)',
     descKey: 'CORRELATION_ALT_SIG_ALT_SEASON_DESC', avg,
   };
   if (avg < 0.55)  return {
     labelKey: 'CORRELATION_ALT_SIG_MIXED_LABEL',
-    color: '#fbbf24', bg: 'rgba(251,191,36,0.07)',
+    color: 'var(--amber)', bg: 'rgba(251,191,36,0.07)',
     descKey: 'CORRELATION_ALT_SIG_MIXED_DESC', avg,
   };
   if (avg < 0.75)  return {
@@ -121,7 +121,7 @@ function altSignal(avg: number | null): AltSig {
   };
   return {
     labelKey: 'CORRELATION_ALT_SIG_LOCKSTEP_LABEL',
-    color: '#f87171', bg: 'rgba(248,113,113,0.07)',
+    color: 'var(--red)', bg: 'rgba(248,113,113,0.07)',
     descKey: 'CORRELATION_ALT_SIG_LOCKSTEP_DESC', avg,
   };
 }
@@ -311,8 +311,8 @@ export default function CorrelationHeatmap() {
             </div>
             <div className="corr-scroll-hint">{t('CORRELATION_SCROLL_HINT')}</div>
             <div className="corr-legend">
-              <span style={{ color: '#34d399' }}>{t('CORRELATION_LEGEND_GREEN_LABEL')}</span> = {t('CORRELATION_LEGEND_GREEN_DESC')} &nbsp;·&nbsp;
-              <span style={{ color: '#f87171' }}>{t('CORRELATION_LEGEND_RED_LABEL')}</span> = {t('CORRELATION_LEGEND_RED_DESC')} &nbsp;·&nbsp;
+              <span style={{ color: 'var(--green-2)' }}>{t('CORRELATION_LEGEND_GREEN_LABEL')}</span> = {t('CORRELATION_LEGEND_GREEN_DESC')} &nbsp;·&nbsp;
+              <span style={{ color: 'var(--red)' }}>{t('CORRELATION_LEGEND_RED_LABEL')}</span> = {t('CORRELATION_LEGEND_RED_DESC')} &nbsp;·&nbsp;
               {t('CORRELATION_LEGEND_BRIGHTNESS_HINT')}
             </div>
           </div>
@@ -332,7 +332,7 @@ export default function CorrelationHeatmap() {
                     }}
                   />
                 </div>
-                <span className="corr-pair-val" style={{ color: r >= 0 ? '#34d399' : '#f87171' }}>
+                <span className="corr-pair-val" style={{ color: r >= 0 ? 'var(--green-2)' : 'var(--red)' }}>
                   {r >= 0 ? '+' : ''}{r.toFixed(2)}
                 </span>
               </div>
@@ -359,7 +359,7 @@ export default function CorrelationHeatmap() {
                     }}
                   />
                 </div>
-                <span className="corr-pair-val" style={{ color: r >= 0 ? '#34d399' : '#f87171' }}>
+                <span className="corr-pair-val" style={{ color: r >= 0 ? 'var(--green-2)' : 'var(--red)' }}>
                   {r >= 0 ? '+' : ''}{r.toFixed(2)}
                 </span>
               </div>

--- a/app/econ-calendar/page.tsx
+++ b/app/econ-calendar/page.tsx
@@ -65,8 +65,8 @@ function calcDelta(actual?: string, estimate?: string): { text: string; positive
    painted the whole calendar in the LOW style. See lib/classify.ts.
    LOW's colour also failed AA on its own (#6b7280 = 3.77:1). */
 const IMPACT_CFG: Record<EconImpact, { color: string; bg: string; border: string; accent: string }> = {
-  HIGH:   { color: '#f87171', bg: 'rgba(248,113,113,0.14)', border: 'rgba(248,113,113,0.35)', accent: '#f87171' },
-  MEDIUM: { color: '#fbbf24', bg: 'rgba(251,191,36,0.12)',  border: 'rgba(251,191,36,0.3)',   accent: '#fbbf24' },
+  HIGH:   { color: 'var(--red)', bg: 'rgba(248,113,113,0.14)', border: 'rgba(248,113,113,0.35)', accent: 'var(--red)' },
+  MEDIUM: { color: 'var(--amber)', bg: 'rgba(251,191,36,0.12)',  border: 'rgba(251,191,36,0.3)',   accent: 'var(--amber)' },
   LOW:    { color: 'var(--txt-dim)', bg: 'rgba(107,114,128,0.10)', border: 'rgba(107,114,128,0.25)', accent: 'rgba(107,114,128,0.4)' },
 };
 
@@ -153,7 +153,7 @@ export default function EconCalendarPage() {
 
       {loading && <LoadingState message={t('ECON_CALENDAR_LOADING')} />}
       {failed && (
-        <div style={{ color: '#f87171', fontSize: 'var(--fs-label)', padding: '20px 0', textAlign: 'center' }}>{t('ECON_CALENDAR_LOAD_ERROR')}</div>
+        <div style={{ color: 'var(--red)', fontSize: 'var(--fs-label)', padding: '20px 0', textAlign: 'center' }}>{t('ECON_CALENDAR_LOAD_ERROR')}</div>
       )}
       {!loading && !failed && sorted.length === 0 && (
         <div style={{ color: 'var(--txt3)', fontSize: 'var(--fs-label)', padding: '40px 0', textAlign: 'center' }}>{t('ECON_CALENDAR_NO_EVENTS')}</div>
@@ -237,7 +237,7 @@ export default function EconCalendarPage() {
                     </div>
 
                     {/* CONSENSUS */}
-                    <div style={{ fontSize: 'var(--fs-caption)', color: e.estimate ? '#fbbf24' : 'var(--txt3)', fontVariantNumeric: 'tabular-nums', fontWeight: e.estimate ? 500 : 400 }}>
+                    <div style={{ fontSize: 'var(--fs-caption)', color: e.estimate ? 'var(--amber)' : 'var(--txt3)', fontVariantNumeric: 'tabular-nums', fontWeight: e.estimate ? 500 : 400 }}>
                       {e.estimate || '-'}
                     </div>
 
@@ -245,7 +245,7 @@ export default function EconCalendarPage() {
                     <div style={{
                       fontSize: 'var(--fs-caption)', fontWeight: 700, fontVariantNumeric: 'tabular-nums',
                       color: e.actual
-                        ? (delta ? (delta.positive ? '#34d399' : '#f87171') : '#34d399')
+                        ? (delta ? (delta.positive ? 'var(--green-2)' : 'var(--red)') : 'var(--green-2)')
                         : 'var(--txt3)',
                     }}>
                       {e.actual || '-'}
@@ -254,7 +254,7 @@ export default function EconCalendarPage() {
                     {/* DELTA */}
                     <div style={{
                       fontSize: 'var(--fs-caption)', fontWeight: 600, fontVariantNumeric: 'tabular-nums',
-                      color: delta ? (delta.positive ? '#34d399' : '#f87171') : 'var(--txt3)',
+                      color: delta ? (delta.positive ? 'var(--green-2)' : 'var(--red)') : 'var(--txt3)',
                     }}>
                       {delta?.text || '-'}
                     </div>

--- a/app/funding/page.tsx
+++ b/app/funding/page.tsx
@@ -54,9 +54,9 @@ async function fetchBybitFR(sym: string): Promise<FRPoint[]> {
 
 /* ── formatting ── */
 function frColor(r: number): string {
-  if (r >= 0.0005) return '#f87171';
-  if (r <= -0.0003) return '#34d399';
-  return '#a0a0a0';
+  if (r >= 0.0005) return 'var(--red)';
+  if (r <= -0.0003) return 'var(--green-2)';
+  return 'var(--txt-dim)';
 }
 function frFmt(r: number): string {
   return (r >= 0 ? '+' : '') + (r * 100).toFixed(4) + '%';
@@ -76,7 +76,7 @@ function frSignal(r: number): FRSignal {
     id: 'longs_overcrowded',
     crowdKey: 'FUNDING_SIG_LONGS_OVERCROWDED_CROWD', hintKey: 'FUNDING_SIG_LONGS_OVERCROWDED_HINT',
     labelKey: 'FUNDING_SIG_LONGS_OVERCROWDED_LABEL',
-    color: '#f87171', bg: 'rgba(248,113,113,0.09)',
+    color: 'var(--red)', bg: 'rgba(248,113,113,0.09)',
     actionKey: 'FUNDING_SIG_LONGS_OVERCROWDED_ACTION',
     descKey: 'FUNDING_SIG_LONGS_OVERCROWDED_DESC',
   };
@@ -84,7 +84,7 @@ function frSignal(r: number): FRSignal {
     id: 'longs_heavy',
     crowdKey: 'FUNDING_SIG_LONGS_HEAVY_CROWD', hintKey: 'FUNDING_SIG_LONGS_HEAVY_HINT',
     labelKey: 'FUNDING_SIG_LONGS_HEAVY_LABEL',
-    color: '#fb923c', bg: 'rgba(251,146,60,0.08)',
+    color: 'var(--orange)', bg: 'rgba(251,146,60,0.08)',
     actionKey: 'FUNDING_SIG_LONGS_HEAVY_ACTION',
     descKey: 'FUNDING_SIG_LONGS_HEAVY_DESC',
   };
@@ -92,7 +92,7 @@ function frSignal(r: number): FRSignal {
     id: 'longs_dominant',
     crowdKey: 'FUNDING_SIG_LONGS_DOMINANT_CROWD', hintKey: 'FUNDING_SIG_LONGS_DOMINANT_HINT',
     labelKey: 'FUNDING_SIG_LONGS_DOMINANT_LABEL',
-    color: '#fbbf24', bg: 'rgba(251,191,36,0.07)',
+    color: 'var(--amber)', bg: 'rgba(251,191,36,0.07)',
     actionKey: 'FUNDING_SIG_LONGS_DOMINANT_ACTION',
     descKey: 'FUNDING_SIG_LONGS_DOMINANT_DESC',
   };
@@ -108,7 +108,7 @@ function frSignal(r: number): FRSignal {
     id: 'balanced',
     crowdKey: 'FUNDING_SIG_BALANCED_CROWD', hintKey: 'FUNDING_SIG_BALANCED_HINT',
     labelKey: 'FUNDING_SIG_BALANCED_LABEL',
-    color: '#a0a0a0', bg: 'rgba(255,255,255,0.04)',
+    color: 'var(--txt-dim)', bg: 'rgba(255,255,255,0.04)',
     actionKey: 'FUNDING_SIG_BALANCED_ACTION',
     descKey: 'FUNDING_SIG_BALANCED_DESC',
   };
@@ -116,7 +116,7 @@ function frSignal(r: number): FRSignal {
     id: 'shorts_dominant',
     crowdKey: 'FUNDING_SIG_SHORTS_DOMINANT_CROWD', hintKey: 'FUNDING_SIG_SHORTS_DOMINANT_HINT',
     labelKey: 'FUNDING_SIG_SHORTS_DOMINANT_LABEL',
-    color: '#86efac', bg: 'rgba(134,239,172,0.07)',
+    color: 'var(--green-soft)', bg: 'rgba(134,239,172,0.07)',
     actionKey: 'FUNDING_SIG_SHORTS_DOMINANT_ACTION',
     descKey: 'FUNDING_SIG_SHORTS_DOMINANT_DESC',
   };
@@ -124,7 +124,7 @@ function frSignal(r: number): FRSignal {
     id: 'shorts_crowded',
     crowdKey: 'FUNDING_SIG_SHORTS_CROWDED_CROWD', hintKey: 'FUNDING_SIG_SHORTS_CROWDED_HINT',
     labelKey: 'FUNDING_SIG_SHORTS_CROWDED_LABEL',
-    color: '#34d399', bg: 'rgba(52,211,153,0.09)',
+    color: 'var(--green-2)', bg: 'rgba(52,211,153,0.09)',
     actionKey: 'FUNDING_SIG_SHORTS_CROWDED_ACTION',
     descKey: 'FUNDING_SIG_SHORTS_CROWDED_DESC',
   };
@@ -132,7 +132,7 @@ function frSignal(r: number): FRSignal {
     id: 'shorts_overcrowded',
     crowdKey: 'FUNDING_SIG_SHORTS_OVERCROWDED_CROWD', hintKey: 'FUNDING_SIG_SHORTS_OVERCROWDED_HINT',
     labelKey: 'FUNDING_SIG_SHORTS_OVERCROWDED_LABEL',
-    color: '#34d399', bg: 'rgba(52,211,153,0.13)',
+    color: 'var(--green-2)', bg: 'rgba(52,211,153,0.13)',
     actionKey: 'FUNDING_SIG_SHORTS_OVERCROWDED_ACTION',
     descKey: 'FUNDING_SIG_SHORTS_OVERCROWDED_DESC',
   };
@@ -410,17 +410,17 @@ export default function FundingHistory() {
 
             {/* Summary chips */}
             <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 10 }}>
-              <span style={{ fontSize: 'var(--fs-caption)', padding: '2px 7px', borderRadius: 10, background: 'rgba(248,113,113,0.10)', color: '#f87171', border: '0.5px solid rgba(248,113,113,0.25)', fontWeight: 700 }}>
-                <Tip iconColor="#f87171" text={t('FUNDING_CONTRARIAN_SHORT_TIP')}>
+              <span style={{ fontSize: 'var(--fs-caption)', padding: '2px 7px', borderRadius: 10, background: 'rgba(248,113,113,0.10)', color: 'var(--red)', border: '0.5px solid rgba(248,113,113,0.25)', fontWeight: 700 }}>
+                <Tip iconColor="var(--red)" text={t('FUNDING_CONTRARIAN_SHORT_TIP')}>
                   {t('FUNDING_CONTRARIAN_SHORT_COUNT', { count: shortSignals.length, plural: shortSignals.length !== 1 ? 's' : '' })}
                 </Tip>
               </span>
-              <span style={{ fontSize: 'var(--fs-caption)', padding: '2px 7px', borderRadius: 10, background: 'rgba(52,211,153,0.10)', color: '#34d399', border: '0.5px solid rgba(52,211,153,0.25)', fontWeight: 700 }}>
-                <Tip iconColor="#34d399" text={t('FUNDING_CONTRARIAN_LONG_TIP')}>
+              <span style={{ fontSize: 'var(--fs-caption)', padding: '2px 7px', borderRadius: 10, background: 'rgba(52,211,153,0.10)', color: 'var(--green-2)', border: '0.5px solid rgba(52,211,153,0.25)', fontWeight: 700 }}>
+                <Tip iconColor="var(--green-2)" text={t('FUNDING_CONTRARIAN_LONG_TIP')}>
                   {t('FUNDING_CONTRARIAN_LONG_COUNT', { count: longSignals.length, plural: longSignals.length !== 1 ? 's' : '' })}
                 </Tip>
               </span>
-              <span style={{ fontSize: 'var(--fs-caption)', padding: '2px 7px', borderRadius: 10, background: 'rgba(26,122,255,0.10)', color: '#1a7aff', border: '0.5px solid rgba(26,122,255,0.25)', fontWeight: 700 }}>
+              <span style={{ fontSize: 'var(--fs-caption)', padding: '2px 7px', borderRadius: 10, background: 'rgba(26,122,255,0.10)', color: 'var(--accent)', border: '0.5px solid rgba(26,122,255,0.25)', fontWeight: 700 }}>
                 <Tip iconColor="#1a7aff" text={t('FUNDING_CARRY_ARB_TIP')}>
                   {t('FUNDING_CARRY_ARB_COUNT', { count: arbs.length })}
                 </Tip>
@@ -442,17 +442,17 @@ export default function FundingHistory() {
                   </span>
                   <span style={{ flex: 1 }} />
                   {contraShort && (
-                    <span style={{ fontSize: 'var(--fs-caption)', padding: '1px 5px', borderRadius: 3, background: 'rgba(248,113,113,0.12)', color: '#f87171', fontWeight: 700, flexShrink: 0 }}>
+                    <span style={{ fontSize: 'var(--fs-caption)', padding: '1px 5px', borderRadius: 3, background: 'rgba(248,113,113,0.12)', color: 'var(--red)', fontWeight: 700, flexShrink: 0 }}>
                       {t('FUNDING_BADGE_SHORT_LABEL')}
                     </span>
                   )}
                   {contraLong && (
-                    <span style={{ fontSize: 'var(--fs-caption)', padding: '1px 5px', borderRadius: 3, background: 'rgba(52,211,153,0.12)', color: '#34d399', fontWeight: 700, flexShrink: 0 }}>
+                    <span style={{ fontSize: 'var(--fs-caption)', padding: '1px 5px', borderRadius: 3, background: 'rgba(52,211,153,0.12)', color: 'var(--green-2)', fontWeight: 700, flexShrink: 0 }}>
                       {t('FUNDING_BADGE_LONG_LABEL')}
                     </span>
                   )}
                   {carryArb && (
-                    <span style={{ fontSize: 'var(--fs-caption)', padding: '1px 5px', borderRadius: 3, background: 'rgba(26,122,255,0.10)', color: '#1a7aff', fontWeight: 600, flexShrink: 0 }}>
+                    <span style={{ fontSize: 'var(--fs-caption)', padding: '1px 5px', borderRadius: 3, background: 'rgba(26,122,255,0.10)', color: 'var(--accent)', fontWeight: 600, flexShrink: 0 }}>
                       {t('FUNDING_BADGE_ARB_LABEL')}
                     </span>
                   )}
@@ -503,11 +503,11 @@ export default function FundingHistory() {
           {/* Market lean summary */}
           <div className="frh-summary-bar">
             <span className="frh-summary-heading">{t('FUNDING_MARKET_LEAN_HEADING')}</span>
-            <span className="frh-summary-item" style={{ color: '#f87171' }}>
+            <span className="frh-summary-item" style={{ color: 'var(--red)' }}>
               <span className="frh-summary-count">{longCnt}</span> {t('FUNDING_LONG_HEAVY_LABEL')}
             </span>
             <span className="frh-summary-sep">·</span>
-            <span className="frh-summary-item" style={{ color: '#34d399' }}>
+            <span className="frh-summary-item" style={{ color: 'var(--green-2)' }}>
               <span className="frh-summary-count">{shortCnt}</span> {t('FUNDING_SHORT_HEAVY_LABEL')}
             </span>
             <span className="frh-summary-sep">·</span>
@@ -621,7 +621,7 @@ export default function FundingHistory() {
                     {(() => {
                       const s = getStats(selected);
                       return s?.extremes ? (
-                        <span style={{ fontSize: 'var(--fs-caption)', color: '#fbbf24', display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                        <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--amber)', display: 'inline-flex', alignItems: 'center', gap: 4 }}>
                           <Warn size={12} /> {t('FUNDING_EXTREME_COUNT', { count: s.extremes, plural: s.extremes > 1 ? 's' : '' })}
                         </span>
                       ) : null;
@@ -652,8 +652,8 @@ export default function FundingHistory() {
                     </div>
                 }
                 <div className="frh-legend">
-                  <span style={{ color: '#f87171' }}>{t('FUNDING_LEGEND_POSITIVE_LABEL')}</span> = {t('FUNDING_LEGEND_POSITIVE_DESC')} &nbsp;·&nbsp;
-                  <span style={{ color: '#34d399' }}>{t('FUNDING_LEGEND_NEGATIVE_LABEL')}</span> = {t('FUNDING_LEGEND_NEGATIVE_DESC')}
+                  <span style={{ color: 'var(--red)' }}>{t('FUNDING_LEGEND_POSITIVE_LABEL')}</span> = {t('FUNDING_LEGEND_POSITIVE_DESC')} &nbsp;·&nbsp;
+                  <span style={{ color: 'var(--green-2)' }}>{t('FUNDING_LEGEND_NEGATIVE_LABEL')}</span> = {t('FUNDING_LEGEND_NEGATIVE_DESC')}
                 </div>
               </div>
             </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -80,6 +80,14 @@
   --green:     #4ade80;
   --green-bg:  rgba(74,222,128,0.08);
   --green-bdr: rgba(74,222,128,0.22);
+  /* Emerald-400. A second green that means the same thing as --green and was
+     hardcoded in ~190 places, so light theme could never reach it (issue #53).
+     It exists as its own token ONLY so the dark theme is unchanged by that fix:
+     folding it into --green would have altered dark mode in 45 components,
+     which is a design decision, not a contrast fix.
+     Worth collapsing into --green deliberately at some point. Two greens for
+     one meaning is the reason this got missed in the first place. */
+  --green-2:   #34d399;
   /* Weaker-signal tier (e.g. "slightly high funding" vs "very high") - a
      paler version of --green/--red so the two tiers stay visually distinct. */
   --green-soft: #86efac;
@@ -1144,9 +1152,9 @@ body.ticker-on .breaking-alert { top: calc(84px + var(--banner-h)); }
   border-color: rgba(248, 113, 113, 0.4) !important;
   border-left: 2px solid #f87171 !important;
 }
-.nc-urgent .nc-tag    { color: #f87171 !important; }
-.nc-urgent .nc-time   { color: #f87171 !important; }
-.nc-urgent .nc-impact { color: #f87171; font-weight: 800; letter-spacing: 0.02em; }
+.nc-urgent .nc-tag    { color: var(--red) !important; }
+.nc-urgent .nc-time   { color: var(--red) !important; }
+.nc-urgent .nc-impact { color: var(--red); font-weight: 800; letter-spacing: 0.02em; }
 
 /* ── SCANNER ── */
 .scanner    { background: var(--bg1); border: 0.5px solid var(--bdr); border-radius: var(--radius-card); padding: 1.1rem; margin-bottom: 10px; box-shadow: var(--nm-raise); }
@@ -1204,7 +1212,7 @@ body.ticker-on .breaking-alert { top: calc(84px + var(--banner-h)); }
 .cf-time.on  { background: var(--green-bg);  color: var(--green);  border-color: var(--green-bdr);  }
 .cf-trap.on  { background: var(--red-bg);    color: var(--red);    border-color: var(--red-bdr);    }
 .cf-psych.on { background: var(--amber-bg);  color: var(--amber);  border-color: var(--amber-bdr);  }
-.cf-fav.on   { background: rgba(251,191,36,.1); color: #fbbf24; border-color: rgba(251,191,36,.3); }
+.cf-fav.on   { background: rgba(251,191,36,.1); color: var(--amber); border-color: rgba(251,191,36,.3); }
 .secret  { background: var(--bg1); border: 0.5px solid var(--bdr); border-radius: var(--radius-card); padding: 12px 14px; margin-bottom: 8px; box-shadow: var(--nm-raise-sm); }
 .s-num   { font-size: var(--fs-data); font-weight: 600; color: var(--txt3); margin-bottom: 3px; letter-spacing: .05em; text-transform: uppercase; display: flex; align-items: center; gap: 6px; }
 .s-name  { font-size: var(--fs-label); font-weight: 600; color: var(--txt); margin-bottom: 4px; }
@@ -1224,7 +1232,7 @@ body.ticker-on .breaking-alert { top: calc(84px + var(--banner-h)); }
 .pb-star   { background: none; border: none; cursor: pointer; font-size: var(--fs-label); color: var(--txt3); line-height: 1;
              min-width: 24px; min-height: 24px; padding: 0 2px;
              display: inline-flex; align-items: center; justify-content: center; }
-.pb-star.on { color: #fbbf24; }
+.pb-star.on { color: var(--amber); }
 
 /* ── CLUSTER TRACKER (legacy) ── */
 .ct-stat-lbl { font-size: var(--fs-caption); color: var(--txt3); margin-top: 2px; }
@@ -1237,7 +1245,7 @@ body.ticker-on .breaking-alert { top: calc(84px + var(--banner-h)); }
   background: rgba(251,191,36,0.07); border: 0.5px solid rgba(251,191,36,0.25);
   border-radius: 8px; padding: 8px 10px; margin-bottom: 10px;
 }
-.arena-override-notice strong { color: #fbbf24; font-weight: 700; }
+.arena-override-notice strong { color: var(--amber); font-weight: 700; }
 
 /* ── FLAT "Watch For" block ── */
 
@@ -1254,7 +1262,7 @@ body.ticker-on .breaking-alert { top: calc(84px + var(--banner-h)); }
 .arena-fire-btn:not(:disabled):hover { background: rgba(26,122,255,0.12); border-color: var(--accent); }
 .arena-fire-btn:not(:disabled):active { transform: scale(0.98); }
 /* Quick mode button - green tint */
-.arena-quick-btn { background: rgba(52,211,153,0.08) !important; border-color: rgba(52,211,153,0.3) !important; color: #34d399 !important; }
+.arena-quick-btn { background: rgba(52,211,153,0.08) !important; border-color: rgba(52,211,153,0.3) !important; color: var(--green-2) !important; }
 .arena-quick-btn:not(:disabled):hover { box-shadow: 0 4px 20px rgba(52,211,153,0.15) !important; border-color: #34d399 !important; }
 /* Deep button - locked state (not signed in) */
 /* "Locked" styling for the Quick/Deep Research buttons when signed out.
@@ -1298,9 +1306,9 @@ body.ticker-on .breaking-alert { top: calc(84px + var(--banner-h)); }
 
 .arena-sig-badge { font-size: var(--fs-caption); font-weight: 700; padding: 5px 14px; border-radius: 8px; font-family: var(--font-mono), monospace; letter-spacing: .04em; }
 .badge-long       { background: var(--green-bg); color: var(--green); border: 0.5px solid var(--green-bdr); }
-.badge-lean-long  { background: rgba(52,211,153,0.07); color: #86efac; border: 0.5px solid rgba(52,211,153,0.25); }
+.badge-lean-long  { background: rgba(52,211,153,0.07); color: var(--green-soft); border: 0.5px solid rgba(52,211,153,0.25); }
 .badge-short      { background: var(--red-bg);   color: var(--red);   border: 0.5px solid var(--red-bdr); }
-.badge-lean-short { background: rgba(248,113,113,0.07); color: #fca5a5; border: 0.5px solid rgba(248,113,113,0.25); }
+.badge-lean-short { background: rgba(248,113,113,0.07); color: var(--red-soft); border: 0.5px solid rgba(248,113,113,0.25); }
 .badge-flat       { background: var(--bg3);      color: var(--txt3);  border: 0.5px solid var(--bdr); }
 @media (max-width: 480px) {
 }
@@ -1334,7 +1342,7 @@ body.ticker-on .breaking-alert { top: calc(84px + var(--banner-h)); }
 .av-lv:hover { background: rgba(255,255,255,0.04); }
 .av-lv-k { font-size: var(--fs-micro); color: var(--txt3); text-transform: uppercase; letter-spacing: .05em; margin-bottom: 3px; }
 .av-lv-v { font-family: var(--font-mono), monospace; font-size: 13px; font-weight: 700; color: var(--txt); }
-.av-lv-v.gr { color: #34d399; } .av-lv-v.rd { color: var(--red); }
+.av-lv-v.gr { color: var(--green-2); } .av-lv-v.rd { color: var(--red); }
 @media (max-width: 560px) { .av-levels { grid-template-columns: 1fr 1fr; } .av-lv:nth-child(2) { border-right: none; } }
 /* wait-for - single inline row, matches mockup .waitfor exactly */
 .av-waitfor { font-size: var(--fs-caption); color: var(--txt2); background: rgba(251,191,36,0.06); border: 0.5px solid rgba(251,191,36,0.2); border-radius: 8px; padding: 7px 11px; display: flex; gap: 7px; align-items: flex-start; margin-bottom: 8px; }
@@ -1383,7 +1391,7 @@ body.ticker-on .breaking-alert { top: calc(84px + var(--banner-h)); }
 .pbox { background: var(--purple-bg); border: 0.5px solid var(--purple-bdr); border-radius: var(--radius-card); padding: 10px 14px; margin-bottom: 10px; }
 .pt   { font-size: var(--fs-caption); font-weight: 700; color: var(--purple); margin-bottom: 3px; }
 .pb   { font-size: var(--fs-label); color: var(--txt2); line-height: 1.5; }
-.rb   { font-size: var(--fs-label); color: #fca5a5; line-height: 1.5; }
+.rb   { font-size: var(--fs-label); color: var(--red-soft); line-height: 1.5; }
 .div  { border-top: 0.5px solid var(--bdr); margin: 8px 0; }
 .row  { display: flex; gap: 12px; align-items: flex-start; }
 .num  { width: 26px; height: 26px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: var(--fs-caption); font-weight: 700; flex-shrink: 0; margin-top: 1px; }
@@ -1710,7 +1718,7 @@ body.ticker-on .breaking-alert { top: calc(84px + var(--banner-h)); }
   white-space: nowrap; cursor: help; flex-shrink: 0;
 }
 .klc-tool-btn:hover { border-color: var(--purple); color: var(--txt2); }
-.klc-tool-btn.on    { background: var(--purple-bg); border-color: var(--purple); color: #5aa3ff; }
+.klc-tool-btn.on    { background: var(--purple-bg); border-color: var(--purple); color: var(--accent-2); }
 .klc-fullscreen-btn { color: var(--txt3) !important; margin-left: 4px; }
 .klc-fullscreen-btn:hover { color: var(--txt2) !important; border-color: var(--purple) !important; }
 .klc-sep { width: 0.5px; height: 16px; background: var(--bdr); margin: 0 2px; flex-shrink: 0; }
@@ -1994,7 +2002,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   padding: 5px 11px; border-radius: 20px;
   border: 0.5px solid rgba(26,122,255,0.22);
   background: rgba(26,122,255,0.06);
-  color: #5aa3ff; cursor: pointer;
+  color: var(--accent-2); cursor: pointer;
   white-space: normal; text-align: left; line-height: 1.35;
   transition: background 0.14s, border-color 0.14s, color 0.14s;
   animation: fadeInUp 0.15s ease;
@@ -2050,8 +2058,8 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 }
 
 .liq-section-hdr { display: flex; align-items: center; gap: 8px; padding: 7px 14px; font-size: var(--fs-caption); font-weight: 700; letter-spacing: 0.02em; }
-.liq-section-hdr-short { color: #34d399; background: rgba(52,211,153,0.06); border-bottom: 0.5px solid rgba(52,211,153,0.12); }
-.liq-section-hdr-long  { color: #f87171; background: rgba(248,113,113,0.06); border-top: 0.5px solid rgba(248,113,113,0.12); border-bottom: 0.5px solid rgba(248,113,113,0.12); }
+.liq-section-hdr-short { color: var(--green-2); background: rgba(52,211,153,0.06); border-bottom: 0.5px solid rgba(52,211,153,0.12); }
+.liq-section-hdr-long  { color: var(--red); background: rgba(248,113,113,0.06); border-top: 0.5px solid rgba(248,113,113,0.12); border-bottom: 0.5px solid rgba(248,113,113,0.12); }
 .liq-section-sub { font-size: var(--fs-caption); font-weight: 500; opacity: 0.75; text-transform: none; letter-spacing: 0; }
 
 .liq-current-bar { display: flex; align-items: center; gap: 10px; padding: 12px 14px; background: rgba(26,122,255,0.09); border-top: 1px solid rgba(26,122,255,0.28); border-bottom: 1px solid rgba(26,122,255,0.28); border-left: 3px solid var(--purple); margin: 2px 0; }
@@ -2201,7 +2209,16 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   /* Typography */
   --txt:  #111318;
   --txt2: #44475A;
-  --txt3: #63656F; /* was #888B99 (3.39:1 - fails AA). AA on white/card/canvas: 5.80/5.22/4.81 */
+  /* was #888B99 (3.39:1), then #63656F - which cleared white/card/canvas but
+     measured 4.14:1 on the darker light surfaces (--bg4 #d8dadd and the tinted
+     panel #dae2ee). Issue #53 found those in use. Worst case now 4.60:1. */
+  --txt3: #5C5E68;
+  /* --txt-dim had NO light value at all - it was declared once in :root and
+     inherited its dark grey (#8a8a8a) straight into light mode, where it scored
+     2.72:1 on white. The single largest source of light-theme contrast failures
+     in issue #53: 190 of 882. AA on white/card/canvas/bg3/bg4:
+     6.48/5.84/5.38/5.19/4.63 - clears the floor on every light surface. */
+  --txt-dim: #5E5E5E;
   --bdr:  rgba(0,0,0,0.08);
   --bdr2: rgba(0,0,0,0.14);
 
@@ -2213,7 +2230,9 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 
   /* Accent - darker blue for legibility on white */
   --accent:     #0052CC;
-  --accent-2:   #0066E8;
+  /* was #0066E8 - 3.03:1 on the canvas #e8eaed, which is where the footer
+     divider label and the markets sort buttons sit. */
+  --accent-2:   #0052CC;
   --accent-dim: rgba(0,82,204,0.10);
   --accent-bg:  rgba(0,82,204,0.07);
   --accent-bdr: rgba(0,82,204,0.22);
@@ -2224,9 +2243,16 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   --purple-bg:  var(--accent-bg);
   --purple-bdr: var(--accent-bdr);
 
-  --green:     #047857;
-  --green-bg:  rgba(4,120,87,0.07);
-  --green-bdr: rgba(4,120,87,0.20);
+  /* was #047857 - 3.92:1 on --bg4 and on the green-tinted panels this actually
+     lands on (#d4dedf, #d2e9e2). Darkened to clear AA on every measured light
+     surface; worst case now 4.66:1. This is the "price up" colour, so it is the
+     one that most needs to be readable rather than merely present. */
+  --green:     #046B4E;
+  --green-bg:  rgba(4,107,78,0.07);
+  --green-bdr: rgba(4,107,78,0.20);
+  /* Same audited green as --green. The dark theme's two greens both mean "up";
+     light needs only one that passes, so they converge here. */
+  --green-2:   var(--green);
   /* No paler "soft" tier here - the dark-mode pastel greens/reds (#86efac/
      #fca5a5) fail AA on light backgrounds, and a from-scratch pale shade
      that still clears 4.5:1 is barely distinguishable from --green/--red
@@ -2236,7 +2262,8 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   --red-bg:  rgba(185,28,28,0.07);
   --red-bdr: rgba(185,28,28,0.20);
   --red-soft: var(--red);
-  --amber:     #B45309;
+  /* was #B45309 - 3.59:1 on --bg4 and the amber-tinted panel #f3eee0. */
+  --amber:     #8F4508;
   --amber-2:   #92400E;
   --amber-dim: rgba(180,83,9,0.12);
   --amber-bg:  rgba(180,83,9,0.07);
@@ -2407,8 +2434,8 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   padding: 2px 8px; border-radius: 20px; font-size: var(--fs-caption); font-weight: 700;
   border: 0.5px solid;
 }
-.scan-badge-bull { color: #34d399; background: rgba(52,211,153,0.1);  border-color: rgba(52,211,153,0.25); }
-.scan-badge-bear { color: #f87171; background: rgba(248,113,113,0.1); border-color: rgba(248,113,113,0.25); }
+.scan-badge-bull { color: var(--green-2); background: rgba(52,211,153,0.1);  border-color: rgba(52,211,153,0.25); }
+.scan-badge-bear { color: var(--red); background: rgba(248,113,113,0.1); border-color: rgba(248,113,113,0.25); }
 .scan-badge-neu  { color: var(--txt3); background: var(--bg3); border-color: var(--bdr); }
 
 .scan-stats {
@@ -2489,8 +2516,8 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 
 .liqfeed-row-coin  { font-weight: 700; font-size: var(--fs-caption); }
 .liqfeed-row-side  { font-size: var(--fs-caption); font-weight: 700; padding: 2px 6px; border-radius: 4px; text-align: center; }
-.liqfeed-row-side-long  { color: #f87171; background: rgba(248,113,113,0.12); }
-.liqfeed-row-side-short { color: #34d399; background: rgba(52,211,153,0.12);  }
+.liqfeed-row-side-long  { color: var(--red); background: rgba(248,113,113,0.12); }
+.liqfeed-row-side-short { color: var(--green-2); background: rgba(52,211,153,0.12);  }
 .liqfeed-row-usd   { font-weight: 700; font-size: var(--fs-caption); text-align: right; }
 .liqfeed-row-price { color: var(--txt3); font-size: var(--fs-data); text-align: right; }
 .liqfeed-row-time  { color: var(--txt3); font-size: var(--fs-caption); text-align: right; }
@@ -2507,9 +2534,9 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .liq-cascade-icon  { font-size: 1.25rem; flex-shrink: 0; }
 .liq-cascade-body  { display: flex; flex-wrap: wrap; align-items: center; gap: 4px; }
 .liq-cascade-label { font-size: var(--fs-micro); font-weight: 800; letter-spacing: .06em; text-transform: uppercase; }
-.liq-cascade-long  .liq-cascade-label { color: #f87171; }
-.liq-cascade-short .liq-cascade-label { color: #34d399; }
-.liq-cascade-mixed .liq-cascade-label { color: #1a7aff; }
+.liq-cascade-long  .liq-cascade-label { color: var(--red); }
+.liq-cascade-short .liq-cascade-label { color: var(--green-2); }
+.liq-cascade-mixed .liq-cascade-label { color: var(--accent); }
 .liq-cascade-amt   { font-size: var(--fs-caption); font-weight: 700; color: var(--txt); }
 .liq-cascade-coins { font-size: var(--fs-caption); color: var(--txt3); }
 
@@ -2556,7 +2583,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   padding: 1px 4px; border-radius: 3px; margin-right: 4px;
 }
 .liq-src-bn { background: rgba(240,165,0,0.15); color: #f0a500; }
-.liq-src-bb { background: rgba(90,163,255,0.15); color: #5aa3ff; }
+.liq-src-bb { background: rgba(90,163,255,0.15); color: var(--accent-2); }
 
 @media (max-width: 480px) {
   .liqfeed-header { flex-wrap: wrap; gap: 2px 0; }
@@ -2890,13 +2917,13 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .cf-signal:last-child { border-bottom: none; }
 .cf-signal.cf-hit { background: rgba(52,211,153,.03); }
 .cf-signal-icon { width: 18px; height: 18px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 0.625rem; font-weight: 800; flex-shrink: 0; background: var(--bg3); color: var(--txt3); border: 0.5px solid var(--bdr); }
-.cf-icon-hit    { background: rgba(52,211,153,.15); color: #34d399; border-color: rgba(52,211,153,.3); }
+.cf-icon-hit    { background: rgba(52,211,153,.15); color: var(--green-2); border-color: rgba(52,211,153,.3); }
 .cf-signal-body { flex: 1; display: flex; align-items: center; gap: 6px; }
 .cf-signal-label  { font-size: var(--fs-label); color: var(--txt2); }
 .cf-hit .cf-signal-label { color: var(--txt); }
 .cf-signal-strong { font-size: var(--fs-micro); font-weight: 700; padding: 1px 5px; border-radius: 4px; background: rgba(26,122,255,.12); color: var(--purple); border: 0.5px solid var(--purple-bdr); letter-spacing: .04em; text-transform: uppercase; }
 .cf-signal-detail { font-size: var(--fs-caption); color: var(--txt3); font-variant-numeric: tabular-nums; }
-.cf-detail-hit    { color: #34d399; font-weight: 600; }
+.cf-detail-hit    { color: var(--green-2); font-weight: 600; }
 .cf-actions { display: flex; gap: 8px; }
 .cf-action-btn { flex: 1; padding: 12px; border-radius: 12px; font-size: var(--fs-label); font-weight: 700; cursor: pointer; transition: box-shadow .15s; }
 .cf-action-grok    { border: 0.5px solid var(--purple-bdr); background: rgba(26,122,255,.1); color: var(--purple); }
@@ -2957,7 +2984,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 @media (max-width: 480px) {
 }
 
-.reasoning-link { color: #1a7aff; text-decoration: underline; text-underline-offset: 2px; word-break: break-all; }
+.reasoning-link { color: var(--accent); text-decoration: underline; text-underline-offset: 2px; word-break: break-all; }
 .reasoning-link:hover { color: #b3bbff; }
 
 /* ── MORNING BRIEFING ──────────────────────────────────────────────────── */
@@ -3064,7 +3091,13 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .frh-signal      { display: flex; align-items: flex-start; gap: 10px; padding: 10px 12px; border-radius: var(--radius-card); border: 0.5px solid; margin-bottom: 12px; }
 .frh-signal-top   { display: flex; align-items: center; flex-wrap: wrap; gap: 6px; margin-bottom: 4px; }
 .frh-signal-label { font-size: var(--fs-label); font-weight: 700; }
-.frh-signal-action { font-size: var(--fs-caption); font-weight: 600; opacity: 0.85; }
+/* opacity: 0.85 removed. It multiplied whatever colour was passed in, so the
+   rendered value was never the token's audited one - --txt-dim (#8a8a8a) came
+   out as #767677 over the dark canvas, 4.43:1 against the 4.5 floor. Caught by
+   measuring dark before and after the issue #53 sweep, which is the only reason
+   a 0.07 shortfall was visible at all. Sixth instance of this pattern in this
+   file; opacity on text is a contrast bug waiting for the colour to change. */
+.frh-signal-action { font-size: var(--fs-caption); font-weight: 600; }
 .frh-signal-desc   { font-size: var(--fs-caption); color: var(--txt2); line-height: 1.6; }
 
 [data-theme="light"] .frh-row:hover { background: rgba(0,0,0,0.03) !important; }
@@ -3091,7 +3124,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   margin: 2px 0 10px;
 }
 .usage-auth-link {
-  color: #5aa3ff; text-decoration: none; font-weight: 600;
+  color: var(--accent-2); text-decoration: none; font-weight: 600;
   padding: 4px 2px; display: inline-flex; align-items: center;
 }
 .usage-auth-link:hover { text-decoration: underline; }
@@ -3253,7 +3286,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   padding: 4px 9px; border-radius: 6px; font-size: var(--fs-caption);
   background: var(--bg2); border: 0.5px solid var(--bdr); color: var(--txt3); cursor: pointer;
 }
-.st-preset.on { background: var(--purple-bg); border-color: var(--purple); color: #5aa3ff; }
+.st-preset.on { background: var(--purple-bg); border-color: var(--purple); color: var(--accent-2); }
 
 /* At-risk line */
 .st-at-risk { font-size: var(--fs-caption); color: var(--txt3); }
@@ -3304,7 +3337,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .st-save-btn {
   padding: 8px 16px; border-radius: 8px;
   background: var(--purple-bg); border: 0.5px solid var(--purple);
-  color: #5aa3ff; font-size: var(--fs-caption); font-weight: 600; cursor: pointer;
+  color: var(--accent-2); font-size: var(--fs-caption); font-weight: 600; cursor: pointer;
 }
 .st-save-btn:hover { background: var(--purple); color: #fff; }
 .st-save-btn:disabled { opacity: 0.5; cursor: default; }
@@ -3313,7 +3346,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .st-signout-btn {
   margin-top: 10px; padding: 8px 16px; border-radius: 8px;
   background: rgba(248,113,113,0.1); border: 0.5px solid rgba(248,113,113,0.3);
-  color: #f87171; font-size: var(--fs-caption); font-weight: 600; cursor: pointer;
+  color: var(--red); font-size: var(--fs-caption); font-weight: 600; cursor: pointer;
 }
 .st-signout-btn:hover { background: rgba(248,113,113,0.18); }
 
@@ -3327,7 +3360,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   border-radius: 8px; background: var(--bg2); border: 0.5px solid var(--bdr);
   color: var(--txt2); font-size: var(--fs-caption); font-weight: 600; text-decoration: none;
 }
-.st-link-btn:hover { border-color: var(--purple); color: #5aa3ff; }
+.st-link-btn:hover { border-color: var(--purple); color: var(--accent-2); }
 
 /* Usage mini-bars */
 .st-usage-row   { display: flex; align-items: center; gap: 8px; }
@@ -3341,12 +3374,12 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   position: fixed; bottom: 24px; right: 24px; z-index: 9999;
   padding: 10px 16px; border-radius: 10px;
   font-size: var(--fs-label); font-weight: 600;
-  background: rgba(52,211,153,0.15); border: 0.5px solid rgba(52,211,153,0.4); color: #34d399;
+  background: rgba(52,211,153,0.15); border: 0.5px solid rgba(52,211,153,0.4); color: var(--green-2);
   animation: stToastIn 0.2s ease;
   pointer-events: none;
 }
 .st-save-toast.saving { background: rgba(255,255,255,0.06); border-color: var(--bdr); color: var(--txt3); }
-.st-save-toast.error  { background: rgba(248,113,113,0.15); border-color: rgba(248,113,113,0.4); color: #f87171; }
+.st-save-toast.error  { background: rgba(248,113,113,0.15); border-color: rgba(248,113,113,0.4); color: var(--red); }
 @keyframes stToastIn  { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
 
 [data-theme="light"] .st-section { background: #fff; }
@@ -4111,7 +4144,7 @@ body.consent-pending .gchat-fab { visibility: hidden; }
 .abs-level-lbl    { font-size: var(--fs-caption); font-weight: 600; color: var(--txt3); flex-shrink: 0; }
 .abs-level-val    { font-size: var(--fs-data); font-weight: 600; color: var(--txt2); }
 .abs-mtf          { display: flex; align-items: center; gap: 6px; padding: 6px 14px; font-size: var(--fs-caption); color: var(--txt3); border-bottom: 0.5px solid var(--bdr); }
-.abs-mtf-badge    { font-size: var(--fs-caption); font-weight: 700; padding: 1px 6px; border-radius: 4px; background: rgba(52,211,153,0.1); color: #34d399; border: 0.5px solid rgba(52,211,153,0.3); flex-shrink: 0; }
+.abs-mtf-badge    { font-size: var(--fs-caption); font-weight: 700; padding: 1px 6px; border-radius: 4px; background: rgba(52,211,153,0.1); color: var(--green-2); border: 0.5px solid rgba(52,211,153,0.3); flex-shrink: 0; }
 .abs-footer       { padding: 6px 14px 8px; font-size: var(--fs-caption); color: var(--txt3); line-height: 1.5; }
 
 /* ── OI SPIKE SCANNER ────────────────────────────────────────────────── */
@@ -4194,7 +4227,7 @@ body.landing {
   color: #f2f2f7;
   opacity: 0.85;
 }
-.lp-loading-logo span { color: #1a7aff; }
+.lp-loading-logo span { color: var(--accent); }
 .lp-loading-spin {
   width: 36px;
   height: 36px;
@@ -4385,7 +4418,7 @@ body.landing {
 .lp-plan-features   { list-style: none; padding: 0; margin: 0 0 24px; display: flex; flex-direction: column; gap: 10px; }
 .lp-plan-features li { font-size: var(--fs-label); color: var(--txt2); display: flex; align-items: center; gap: 9px; }
 .lp-check           { color: #22c55e; font-size: 0.8125rem; font-weight: 700; flex-shrink: 0; }
-.lp-check-pro       { color: #1a7aff; }
+.lp-check-pro       { color: var(--accent); }
 .lp-x               { color: var(--txt3); font-size: 0.8125rem; flex-shrink: 0; }
 .lp-plan-cta        { display: block; text-align: center; padding: 12px; border-radius: var(--radius-card); font-size: var(--fs-label); font-weight: 700; text-decoration: none; transition: opacity .15s; }
 .lp-plan-cta-free   { background: rgba(255,255,255,.07); border: 0.5px solid var(--bdr); color: var(--txt); }

--- a/app/hours/page.tsx
+++ b/app/hours/page.tsx
@@ -199,7 +199,7 @@ export default function BestHours() {
         <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', textAlign: 'center' }}>
           {t('HOURS_NOW_PREFIX')}<span suppressHydrationWarning style={{ color: 'var(--txt2)', fontWeight: 600 }}>{pad(h12)}:{pad(m)} {ampm} {localZoneAbbr()}</span>
           {mounted && win && <span style={{ marginLeft: 8, color: win.color, fontWeight: 600 }}>{t('HOURS_DOT_SEPARATOR')} {win.name}</span>}
-          {mounted && dead && <span style={{ marginLeft: 8, color: '#f87171', fontWeight: 600 }}>{t('HOURS_DOT_DEAD_ZONE')}</span>}
+          {mounted && dead && <span style={{ marginLeft: 8, color: 'var(--red)', fontWeight: 600 }}>{t('HOURS_DOT_DEAD_ZONE')}</span>}
         </div>
       </div>
 

--- a/app/liq/page.tsx
+++ b/app/liq/page.tsx
@@ -124,7 +124,7 @@ function fmtUsd(v: number): string {
 /* ─── Estimated band row ───────────────────────────────────────────────────── */
 function BandRow({ b }: { b: Band }) {
   const isLong = b.side === 'long';
-  const accent = isLong ? '#f87171' : '#34d399';
+  const accent = isLong ? 'var(--red)' : 'var(--green-2)';
   return (
     <div className={`liq-row${b.isMagnet ? ' liq-row-magnet' : ''}`} role="row">
       <span className="liq-row-price">{fmtP(b.price)}</span>
@@ -197,7 +197,7 @@ function RealClusters({ clusters, currentPrice }: { clusters: Bucket[]; currentP
           <span style={{
             fontSize: 'var(--fs-caption)', fontWeight: 700, letterSpacing: '.06em',
             padding: '2px 7px', borderRadius: 10,
-            background: 'rgba(52,211,153,0.12)', color: '#34d399',
+            background: 'rgba(52,211,153,0.12)', color: 'var(--green-2)',
             border: '0.5px solid rgba(52,211,153,0.25)',
           }}>{t('LIQ_CLUSTERS_LIVE_BADGE')}</span>
         </div>
@@ -221,7 +221,7 @@ function RealClusters({ clusters, currentPrice }: { clusters: Bucket[]; currentP
           const longPct  = maxTotal > 0 ? (c.longUsd  / maxTotal) * 100 : 0;
           const shortPct = maxTotal > 0 ? (c.shortUsd / maxTotal) * 100 : 0;
           const isAbove  = c.price > currentPrice;
-          const domCol   = c.longUsd > c.shortUsd ? '#f87171' : '#34d399';
+          const domCol   = c.longUsd > c.shortUsd ? 'var(--red)' : 'var(--green-2)';
           const distUsd  = currentPrice > 0 ? Math.abs(c.price - currentPrice) : 0;
           return (
             <div key={c.price} style={{
@@ -338,9 +338,9 @@ export default function LiqPage() {
   /* Bias */
   const bias = bands
     ? bands.totalLongM > bands.totalShortM * 1.15
-      ? { txt: t('LIQ_BIAS_LONG_HEAVY'), sub: t('LIQ_BIAS_LONG_HEAVY_SUB'), col: '#f87171' }
+      ? { txt: t('LIQ_BIAS_LONG_HEAVY'), sub: t('LIQ_BIAS_LONG_HEAVY_SUB'), col: 'var(--red)' }
       : bands.totalShortM > bands.totalLongM * 1.15
-      ? { txt: t('LIQ_BIAS_SHORT_HEAVY'), sub: t('LIQ_BIAS_SHORT_HEAVY_SUB'), col: '#34d399' }
+      ? { txt: t('LIQ_BIAS_SHORT_HEAVY'), sub: t('LIQ_BIAS_SHORT_HEAVY_SUB'), col: 'var(--green-2)' }
       : { txt: t('LIQ_BIAS_BALANCED'), sub: t('LIQ_BIAS_BALANCED_SUB'), col: 'var(--txt-dim)' }
     : null;
 
@@ -444,7 +444,7 @@ export default function LiqPage() {
               <div className="liq-stat-label">{t('LIQ_STAT_LONG_ACCOUNTS')}</div>
               <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginTop: 2 }}>
                 <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
-                  <span style={{ fontSize: '1.25rem', fontWeight: 800, color: '#f87171', fontVariantNumeric: 'tabular-nums' }}>
+                  <span style={{ fontSize: '1.25rem', fontWeight: 800, color: 'var(--red)', fontVariantNumeric: 'tabular-nums' }}>
                     {((bybitPos?.longRatio ?? cd.longRatio ?? 0.5) * 100).toFixed(0)}%
                   </span>
                   <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)' }}>{t('LIQ_STAT_BYBIT_PERIOD', { period: bybitPos ? RANGE_TO_BYBIT_PERIOD[range] : '1h' })}</span>
@@ -479,7 +479,7 @@ export default function LiqPage() {
               <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'flex-end', marginTop: 2 }}>
                 <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
                   <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)' }}>{t('LIQ_STAT_BYBIT_PERIOD', { period: bybitPos ? RANGE_TO_BYBIT_PERIOD[range] : '1h' })}</span>
-                  <span style={{ fontSize: '1.25rem', fontWeight: 800, color: '#34d399', fontVariantNumeric: 'tabular-nums' }}>
+                  <span style={{ fontSize: '1.25rem', fontWeight: 800, color: 'var(--green-2)', fontVariantNumeric: 'tabular-nums' }}>
                     {((bybitPos?.shortRatio ?? cd.shortRatio ?? 0.5) * 100).toFixed(0)}%
                   </span>
                 </div>
@@ -497,7 +497,7 @@ export default function LiqPage() {
 
           {/* ══ LIQUIDATION DELTA - net long vs short liquidation $ (15min window) ══ */}
           {cd.liqDelta != null && cd.liqLongUsd != null && cd.liqShortUsd != null ? (() => {
-            const netCol = cd.liqDelta! > 0 ? '#f87171' : cd.liqDelta! < 0 ? '#34d399' : 'var(--txt3)';
+            const netCol = cd.liqDelta! > 0 ? 'var(--red)' : cd.liqDelta! < 0 ? 'var(--green-2)' : 'var(--txt3)';
             const netTxt = cd.liqDelta! > 0
               ? t('LIQ_DELTA_NET_LONGS')
               : cd.liqDelta! < 0
@@ -533,7 +533,7 @@ export default function LiqPage() {
             const hasDivergence    = longSqueezeRisk || shortSqueezeRisk;
 
             const whaleSide = whaleLong > whaleShort ? 'long' : 'short';
-            const accentW   = whaleSide === 'long' ? '#f87171' : '#34d399';
+            const accentW   = whaleSide === 'long' ? 'var(--red)' : 'var(--green-2)';
 
             return (
               <div style={{
@@ -574,14 +574,14 @@ export default function LiqPage() {
                   </div>
                   <div style={{ display: 'flex', justifyContent: 'space-between' }}>
                     <div>
-                      <span style={{ fontSize: '1.125rem', fontWeight: 800, color: '#f87171', fontVariantNumeric: 'tabular-nums' }}>
+                      <span style={{ fontSize: '1.125rem', fontWeight: 800, color: 'var(--red)', fontVariantNumeric: 'tabular-nums' }}>
                         {(whaleLong * 100).toFixed(0)}%
                       </span>
                       <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', marginLeft: 5 }}>{t('LIQ_WHALE_LONG_SUFFIX')}</span>
                     </div>
                     <div style={{ textAlign: 'right' }}>
                       <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', marginRight: 5 }}>{t('LIQ_WHALE_SHORT_SUFFIX')}</span>
-                      <span style={{ fontSize: '1.125rem', fontWeight: 800, color: '#34d399', fontVariantNumeric: 'tabular-nums' }}>
+                      <span style={{ fontSize: '1.125rem', fontWeight: 800, color: 'var(--green-2)', fontVariantNumeric: 'tabular-nums' }}>
                         {(whaleShort * 100).toFixed(0)}%
                       </span>
                     </div>
@@ -637,7 +637,7 @@ export default function LiqPage() {
             <div className="liq-current-bar">
               <span className="liq-current-dot" />
               <span className="liq-current-price">{fmtP(cd.price)}</span>
-              <span className="liq-current-chg" style={{ color: (cd.change ?? 0) >= 0 ? '#34d399' : '#f87171' }}>
+              <span className="liq-current-chg" style={{ color: (cd.change ?? 0) >= 0 ? 'var(--green-2)' : 'var(--red)' }}>
                 {(cd.change ?? 0) >= 0 ? '▲' : '▼'}{Math.abs(cd.change ?? 0).toFixed(2)}%
               </span>
               <span className="liq-current-tag">{t('LIQ_HEATMAP_LIVE_TAG')}</span>
@@ -658,11 +658,11 @@ export default function LiqPage() {
             <div className="liq-howto-title">{t('LIQ_LEGEND_TITLE')}</div>
             <div className="liq-howto-row">
               <span className="liq-howto-dot" style={{ background: '#34d399' }} />
-              <span><strong style={{ color: '#34d399' }}>{t('LIQ_LEGEND_SHORT_BOLD')}</strong> - {t('LIQ_LEGEND_SHORT_TEXT')}</span>
+              <span><strong style={{ color: 'var(--green-2)' }}>{t('LIQ_LEGEND_SHORT_BOLD')}</strong> - {t('LIQ_LEGEND_SHORT_TEXT')}</span>
             </div>
             <div className="liq-howto-row">
               <span className="liq-howto-dot" style={{ background: '#f87171' }} />
-              <span><strong style={{ color: '#f87171' }}>{t('LIQ_LEGEND_LONG_BOLD')}</strong> - {t('LIQ_LEGEND_LONG_TEXT')}</span>
+              <span><strong style={{ color: 'var(--red)' }}>{t('LIQ_LEGEND_LONG_BOLD')}</strong> - {t('LIQ_LEGEND_LONG_TEXT')}</span>
             </div>
             <div className="liq-howto-row">
               <span style={{ flexShrink: 0 }}>◆</span>

--- a/app/live-tracking/page.tsx
+++ b/app/live-tracking/page.tsx
@@ -94,7 +94,7 @@ export default function LiveTrackingPage() {
 
       {loading && <LoadingState message={t('LIVE_TRACKING_LOADING')} />}
       {error && (
-        <div style={{ color: '#f87171', fontSize: 'var(--fs-caption)' }}>
+        <div style={{ color: 'var(--red)', fontSize: 'var(--fs-caption)' }}>
           {t('LIVE_TRACKING_ERROR', {
             message: error.kind === 'not-configured'
               ? t('LIVE_TRACKING_ERROR_SUPABASE_NOT_CONFIGURED')
@@ -113,7 +113,7 @@ export default function LiveTrackingPage() {
       {!loading && !error && rows && rows.length > 0 && (
         <>
           <div style={{ display: 'flex', gap: 14, flexWrap: 'wrap', marginBottom: 24 }}>
-            <SideCard title={t('LIVE_TRACKING_LIVE_SIDECARD_TITLE')} stats={stats} color="#34d399" />
+            <SideCard title={t('LIVE_TRACKING_LIVE_SIDECARD_TITLE')} stats={stats} color="var(--green-2)" />
           </div>
 
           <h2 className="mb-title" style={{ fontSize: 'var(--fs-card-title)', marginBottom: 8 }}>{t('LIVE_TRACKING_PER_COIN_BREAKDOWN')}</h2>
@@ -133,8 +133,8 @@ export default function LiveTrackingPage() {
                     <tr key={coin}>
                       <td style={{ fontWeight: 600 }}>{coin.toUpperCase()}</td>
                       <td>{s.totalTrades} ({s.wins}W/{s.losses}L/{s.open} open)</td>
-                      <td style={{ color: s.winRate >= 0.5 ? '#34d399' : '#f87171' }}>{fmtPct(s.winRate)}</td>
-                      <td style={{ color: s.avgR >= 0 ? '#34d399' : '#f87171' }}>{fmtR(s.avgR)}</td>
+                      <td style={{ color: s.winRate >= 0.5 ? 'var(--green-2)' : 'var(--red)' }}>{fmtPct(s.winRate)}</td>
+                      <td style={{ color: s.avgR >= 0 ? 'var(--green-2)' : 'var(--red)' }}>{fmtR(s.avgR)}</td>
                       <td>{isFinite(s.profitFactor) ? s.profitFactor.toFixed(2) : '∞'}</td>
                     </tr>
                   );
@@ -153,7 +153,7 @@ export default function LiveTrackingPage() {
               </thead>
               <tbody>
                 {recent.map(r => {
-                  const statusCol = r.outcome === 'win' ? '#34d399' : r.outcome === 'loss' ? '#f87171' : 'var(--txt3)';
+                  const statusCol = r.outcome === 'win' ? 'var(--green-2)' : r.outcome === 'loss' ? 'var(--red)' : 'var(--txt3)';
                   const statusLabel = r.outcome === 'win' ? t('LIVE_TRACKING_STATUS_WIN', { multiple: r.r_multiple != null ? '+' + r.r_multiple.toFixed(2) + 'R' : '' })
                     : r.outcome === 'loss' ? t('LIVE_TRACKING_STATUS_LOSS')
                     : t('LIVE_TRACKING_STATUS_OPEN');
@@ -161,7 +161,7 @@ export default function LiveTrackingPage() {
                     <tr key={r.id}>
                       <td style={{ fontWeight: 600 }}>{r.coin.toUpperCase()}</td>
                       <td>{r.tf.toUpperCase()}</td>
-                      <td style={{ color: r.dir === 'long' ? '#34d399' : '#f87171' }}>{r.dir.toUpperCase()}</td>
+                      <td style={{ color: r.dir === 'long' ? 'var(--green-2)' : 'var(--red)' }}>{r.dir.toUpperCase()}</td>
                       <td>${r.entry_price.toLocaleString(undefined, { maximumFractionDigits: 4 })}</td>
                       <td style={{ fontSize: 'var(--fs-caption)', opacity: 0.6 }}>{new Date(r.signal_time).toLocaleString()}</td>
                       <td style={{ color: statusCol, fontWeight: 600 }}>{statusLabel}</td>

--- a/app/markets/page.tsx
+++ b/app/markets/page.tsx
@@ -18,15 +18,15 @@ function topSignal(d: ReturnType<typeof useMarket>['store']['coins'][CoinId]): {
   if (!d) return { key: null, col: 'var(--txt-dim)' };
   if (d.fundingRate != null) {
     const fr = d.fundingRate * 100;
-    if (fr >= 0.04) return { key: 'MARKETS_SIGNAL_LONGS_OVERCROWDED', col: '#f87171' };
-    if (fr <= -0.02) return { key: 'MARKETS_SIGNAL_SHORTS_SQUEEZED', col: '#34d399' };
+    if (fr >= 0.04) return { key: 'MARKETS_SIGNAL_LONGS_OVERCROWDED', col: 'var(--red)' };
+    if (fr <= -0.02) return { key: 'MARKETS_SIGNAL_SHORTS_SQUEEZED', col: 'var(--green-2)' };
   }
-  if (d.cvdDivergence === 'bullish') return { key: 'MARKETS_SIGNAL_SMART_BUYERS', col: '#34d399' };
-  if (d.cvdDivergence === 'bearish') return { key: 'MARKETS_SIGNAL_SMART_SELLERS', col: '#f87171' };
-  if (d.oiTrend === 'strong_up')   return { key: 'MARKETS_SIGNAL_NEW_BUYERS', col: '#34d399' };
-  if (d.oiTrend === 'strong_down') return { key: 'MARKETS_SIGNAL_NEW_SELLERS', col: '#f87171' };
-  if (d.oiTrend === 'weak_up')     return { key: 'MARKETS_SIGNAL_SHORT_COVERING', col: '#fbbf24' };
-  if (d.oiTrend === 'weak_down')   return { key: 'MARKETS_SIGNAL_LONGS_EXITING', col: '#94a3b8' };
+  if (d.cvdDivergence === 'bullish') return { key: 'MARKETS_SIGNAL_SMART_BUYERS', col: 'var(--green-2)' };
+  if (d.cvdDivergence === 'bearish') return { key: 'MARKETS_SIGNAL_SMART_SELLERS', col: 'var(--red)' };
+  if (d.oiTrend === 'strong_up')   return { key: 'MARKETS_SIGNAL_NEW_BUYERS', col: 'var(--green-2)' };
+  if (d.oiTrend === 'strong_down') return { key: 'MARKETS_SIGNAL_NEW_SELLERS', col: 'var(--red)' };
+  if (d.oiTrend === 'weak_up')     return { key: 'MARKETS_SIGNAL_SHORT_COVERING', col: 'var(--amber)' };
+  if (d.oiTrend === 'weak_down')   return { key: 'MARKETS_SIGNAL_LONGS_EXITING', col: 'var(--txt-dim)' };
   return { key: 'MARKETS_SIGNAL_NONE', col: 'var(--txt-dim)' };
 }
 
@@ -69,8 +69,8 @@ export default function MarketsPage() {
         cmp = (GRADE_ORDER[ga] ?? 5) - (GRADE_ORDER[gb] ?? 5);
       }
       if (sort === 'signal') {
-        const sa = topSignal(da).col === '#34d399' ? 0 : topSignal(da).col === '#f87171' ? 2 : 1;
-        const sb = topSignal(db).col === '#34d399' ? 0 : topSignal(db).col === '#f87171' ? 2 : 1;
+        const sa = topSignal(da).col === 'var(--green-2)' ? 0 : topSignal(da).col === 'var(--red)' ? 2 : 1;
+        const sb = topSignal(db).col === 'var(--green-2)' ? 0 : topSignal(db).col === 'var(--red)' ? 2 : 1;
         cmp = sa - sb;
       }
       return sortAsc ? cmp : -cmp;
@@ -86,8 +86,8 @@ export default function MarketsPage() {
   const rangeStart = rows.length === 0 ? 0 : pageSafe * PAGE_SIZE + 1;
   const rangeEnd   = Math.min(rows.length, pageSafe * PAGE_SIZE + PAGE_SIZE);
 
-  const bullCount = COINS.filter(id => topSignal(store.coins[id]).col === '#34d399').length;
-  const bearCount = COINS.filter(id => topSignal(store.coins[id]).col === '#f87171').length;
+  const bullCount = COINS.filter(id => topSignal(store.coins[id]).col === 'var(--green-2)').length;
+  const bearCount = COINS.filter(id => topSignal(store.coins[id]).col === 'var(--red)').length;
 
   function handleSort(key: SortKey) {
     if (sort === key) setSortAsc(v => !v);
@@ -105,11 +105,11 @@ export default function MarketsPage() {
   }
 
   const GRADE_STYLE: Record<string, { bg: string; col: string }> = {
-    A: { bg: 'rgba(52,211,153,0.15)',  col: '#34d399' },
-    B: { bg: 'rgba(96,165,250,0.15)',  col: '#60a5fa' },
+    A: { bg: 'rgba(52,211,153,0.15)',  col: 'var(--green-2)' },
+    B: { bg: 'rgba(96,165,250,0.15)',  col: 'var(--accent-2)' },
     C: { bg: 'rgba(245,158,11,0.15)',  col: '#f59e0b' },
-    D: { bg: 'rgba(248,113,113,0.15)', col: '#f87171' },
-    F: { bg: 'rgba(239,68,68,0.15)',   col: '#ef4444' },
+    D: { bg: 'rgba(248,113,113,0.15)', col: 'var(--red)' },
+    F: { bg: 'rgba(239,68,68,0.15)',   col: 'var(--red)' },
   };
 
   return (
@@ -151,8 +151,8 @@ export default function MarketsPage() {
             </div>
           </div>
           <div className="mkt-mono" style={{ marginLeft: 'auto', display: 'flex', gap: 14, fontSize: 'var(--fs-caption)' }}>
-            <span style={{ color: '#34d399' }}>{t('MARKETS_BULLISH_COUNT', { count: bullCount })}</span>
-            <span style={{ color: '#f87171' }}>{t('MARKETS_BEARISH_COUNT', { count: bearCount })}</span>
+            <span style={{ color: 'var(--green-2)' }}>{t('MARKETS_BULLISH_COUNT', { count: bullCount })}</span>
+            <span style={{ color: 'var(--red)' }}>{t('MARKETS_BEARISH_COUNT', { count: bearCount })}</span>
             <span style={{ color: 'var(--txt3)' }}>{t('MARKETS_NEUTRAL_COUNT', { count: COINS.length - bullCount - bearCount })}</span>
           </div>
         </div>
@@ -230,7 +230,7 @@ export default function MarketsPage() {
           const sig    = topSignal(d);
           const tbp    = d?.takerBuyRatio != null ? Math.round(d.takerBuyRatio * 100) : 50;
           const gradeStyle = GRADE_STYLE[health.grade] ?? GRADE_STYLE.F;
-          const barCol = tbp >= 55 ? '#34d399' : tbp <= 45 ? '#f87171' : '#555';
+          const barCol = tbp >= 55 ? 'var(--green-2)' : tbp <= 45 ? 'var(--red)' : '#555';
           const badgeCol = coinBadgeColor(id);
 
           return (
@@ -280,7 +280,7 @@ export default function MarketsPage() {
               {/* Change */}
               <div className="mkt-mono" style={{
                 textAlign: 'right', fontSize: 'var(--fs-caption)', fontWeight: 700,
-                color: up ? '#34d399' : '#f87171',
+                color: up ? 'var(--green-2)' : 'var(--red)',
               }}>
                 {up ? '+' : ''}{chg.toFixed(2)}%
               </div>

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -108,8 +108,8 @@ function SentimentBadge({ headline }: { headline: string }) {
   const coins = getCoinsInHeadline(headline);
   const prefix = coins.length === 1 ? `${coins[0]}: ` : '';
   const cfg = s === 'bullish'
-    ? { bg: 'rgba(52,211,153,0.12)',  border: 'rgba(52,211,153,0.3)',   color: '#34d399', label: t('NEWS_SENTIMENT_BULLISH', { prefix }) }
-    : { bg: 'rgba(248,113,113,0.12)', border: 'rgba(248,113,113,0.3)',  color: '#f87171', label: t('NEWS_SENTIMENT_BEARISH', { prefix }) };
+    ? { bg: 'rgba(52,211,153,0.12)',  border: 'rgba(52,211,153,0.3)',   color: 'var(--green-2)', label: t('NEWS_SENTIMENT_BULLISH', { prefix }) }
+    : { bg: 'rgba(248,113,113,0.12)', border: 'rgba(248,113,113,0.3)',  color: 'var(--red)', label: t('NEWS_SENTIMENT_BEARISH', { prefix }) };
   return (
     <span style={{
       display: 'inline-flex', alignItems: 'center',
@@ -143,7 +143,7 @@ function CoinBuzzBar({ mentions }: { mentions: { symbol: string; total: number; 
         const pctBull = m.total > 0 ? m.bullish / m.total : 0;
         const pctBear = m.total > 0 ? m.bearish / m.total : 0;
         const sentiment = pctBull >= 0.55 ? 'bull' : pctBear >= 0.55 ? 'bear' : 'mix';
-        const col = sentiment === 'bull' ? '#34d399' : sentiment === 'bear' ? '#f87171' : '#94a3b8';
+        const col = sentiment === 'bull' ? 'var(--green-2)' : sentiment === 'bear' ? 'var(--red)' : 'var(--txt-dim)';
         const arrow = sentiment === 'bull' ? ' ↗' : sentiment === 'bear' ? ' ↘' : '';
         return (
           <span key={m.symbol} style={{
@@ -170,23 +170,23 @@ const SOURCE_COLORS: Record<string, string> = {
   'Reuters':          '#f59e0b',
   'Reuters World':    '#f59e0b',
   'Reuters Business': '#f59e0b',
-  'AP News':          '#60a5fa',
-  'AP Business':      '#60a5fa',
+  'AP News':          'var(--accent-2)',
+  'AP Business':      'var(--accent-2)',
   'BBC World':        '#e11d48',
   'BBC Business':     '#e11d48',
   'CoinDesk':         '#1a7aff',
-  'CoinTelegraph':    '#34d399',
-  'Decrypt':          '#fb923c',
+  'CoinTelegraph':    'var(--green-2)',
+  'Decrypt':          'var(--orange)',
   'The Block':        '#38bdf8',
   'CryptoSlate':      '#818cf8',
-  'Bitcoin Magazine': '#fbbf24',
-  'Finnhub':          '#94a3b8',
+  'Bitcoin Magazine': 'var(--amber)',
+  'Finnhub':          'var(--txt-dim)',
 };
 
 /* ── Card type config ── */
 const TYPE_CFG: Record<'red' | 'amber' | 'purple', { dot: string; labelKey: LabelKey; accentBg: string }> = {
-  red:    { dot: '#f87171', labelKey: 'NEWS_TYPE_BADGE_BREAKING', accentBg: 'rgba(248,113,113,0.08)'  },
-  amber:  { dot: '#fbbf24', labelKey: 'NEWS_TYPE_BADGE_MACRO',    accentBg: 'rgba(251,191,36,0.07)'  },
+  red:    { dot: 'var(--red)', labelKey: 'NEWS_TYPE_BADGE_BREAKING', accentBg: 'rgba(248,113,113,0.08)'  },
+  amber:  { dot: 'var(--amber)', labelKey: 'NEWS_TYPE_BADGE_MACRO',    accentBg: 'rgba(251,191,36,0.07)'  },
   purple: { dot: '#1a7aff', labelKey: 'NEWS_TYPE_BADGE_CRYPTO',   accentBg: 'rgba(26,122,255,0.07)' },
 };
 
@@ -610,7 +610,7 @@ export default function NewsPage() {
                   const past = e.h < 0;
                   const timeLocal = e.dt.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', hour12: false });
                   const note = ECON_NOTES[e.type];
-                  const borderColor = urgent ? '#f87171' : soon ? '#fbbf24' : 'var(--purple)';
+                  const borderColor = urgent ? 'var(--red)' : soon ? 'var(--amber)' : 'var(--purple)';
                   return (
                     <div key={ei} style={{
                       display: 'grid', gridTemplateColumns: '70px 1fr 72px 72px 72px 52px',
@@ -620,7 +620,7 @@ export default function NewsPage() {
                       opacity: past && !urgent ? 0.55 : 1,
                       alignItems: 'start',
                     }}>
-                      <span style={{ fontSize: 'var(--fs-caption)', color: urgent ? '#f87171' : soon ? '#fbbf24' : 'var(--txt2)', fontWeight: 600, paddingTop: 1 }}>
+                      <span style={{ fontSize: 'var(--fs-caption)', color: urgent ? 'var(--red)' : soon ? 'var(--amber)' : 'var(--txt2)', fontWeight: 600, paddingTop: 1 }}>
                         {urgent ? t('NEWS_EVENTS_NOW_BADGE') : timeLocal}
                       </span>
                       <div>
@@ -631,7 +631,7 @@ export default function NewsPage() {
                       <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt2)', textAlign: 'right', paddingTop: 1 }}>{e.estimate ?? '-'}</span>
                       <span style={{ fontSize: 'var(--fs-caption)', fontWeight: e.actual ? 700 : 400, color: e.actual ? 'var(--green)' : 'var(--txt3)', textAlign: 'right', paddingTop: 1 }}>{e.actual ?? '-'}</span>
                       <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 1 }}>
-                        <span style={{ fontSize: 'var(--fs-caption)', padding: '2px 6px', borderRadius: 4, background: 'rgba(239,68,68,0.15)', color: '#f87171', fontWeight: 700, letterSpacing: '0.03em' }}>{t('NEWS_EVENTS_IMPACT_HIGH')}</span>
+                        <span style={{ fontSize: 'var(--fs-caption)', padding: '2px 6px', borderRadius: 4, background: 'rgba(239,68,68,0.15)', color: 'var(--red)', fontWeight: 700, letterSpacing: '0.03em' }}>{t('NEWS_EVENTS_IMPACT_HIGH')}</span>
                       </div>
                     </div>
                   );

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -33,7 +33,7 @@ export default function NotFound() {
         </Link>
         <Link href="/liq" style={{
           padding: '9px 18px', borderRadius: 10, fontSize: 'var(--fs-label)', fontWeight: 700,
-          color: '#34d399', background: 'rgba(52,211,153,0.08)',
+          color: 'var(--green-2)', background: 'rgba(52,211,153,0.08)',
           border: '0.5px solid rgba(52,211,153,0.3)', textDecoration: 'none',
         }}>
           {t('NOT_FOUND_LIQUIDATION_MAP_LINK')}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -402,7 +402,7 @@ export default function SettingsPage() {
         {settings.account_size > 0 && settings.risk_pct > 0 && (
           <div className="st-at-risk">
             {t('SETTINGS_AT_RISK_PREFIX')}{' '}
-            <strong style={{ color: '#f87171' }}>
+            <strong style={{ color: 'var(--red)' }}>
               ${(settings.account_size * settings.risk_pct / 100).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
             </strong>
           </div>

--- a/components/AbsorptionDetector.tsx
+++ b/components/AbsorptionDetector.tsx
@@ -277,21 +277,21 @@ export default function AbsorptionDetector({ coin, onData }: Props) {
       <div className="abs-card">
         <div className="abs-header">
           <span className="abs-title">{t('ABSORPTION_DETECTOR_TITLE')}</span>
-          <span style={{ fontSize: 'var(--fs-caption)', color: '#f87171' }}>{t('ABSORPTION_DETECTOR_FAILED')}</span>
+          <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--red)' }}>{t('ABSORPTION_DETECTOR_FAILED')}</span>
         </div>
       </div>
     );
   }
 
   const d       = data!;
-  const typeCol = d.type === 'accumulation' ? '#34d399'
-                : d.type === 'distribution' ? '#f87171'
+  const typeCol = d.type === 'accumulation' ? 'var(--green-2)'
+                : d.type === 'distribution' ? 'var(--red)'
                 : '#9ca3af';
   const typeBg  = d.type === 'accumulation' ? 'rgba(52,211,153,0.10)'
                 : d.type === 'distribution' ? 'rgba(248,113,113,0.10)'
                 : 'rgba(156,163,175,0.06)';
   const barCol  = d.score >= 70 ? typeCol
-                : d.score >= 45 ? '#fbbf24'
+                : d.score >= 45 ? 'var(--amber)'
                 : '#4b5563';
 
   return (

--- a/components/AccumulationTracker.tsx
+++ b/components/AccumulationTracker.tsx
@@ -77,7 +77,7 @@ export default function AccumulationTracker() {
       .slice(0, MAX_ROWS);
   }, [store.coins]);
 
-  const scoreCol = (s: number) => s >= 75 ? '#4ade80' : s >= 60 ? '#a3e635' : '#fbbf24';
+  const scoreCol = (s: number) => s >= 75 ? 'var(--green)' : s >= 60 ? '#a3e635' : 'var(--amber)';
 
   return (
     <div style={{
@@ -165,7 +165,7 @@ export default function AccumulationTracker() {
               </span>
               <span className="at-change" style={{
                 fontSize: 'var(--fs-caption)', fontWeight: 600, flexShrink: 0, width: 48, textAlign: 'right',
-                color: r.change >= 0 ? '#4ade80' : '#f87171', fontVariantNumeric: 'tabular-nums',
+                color: r.change >= 0 ? 'var(--green)' : 'var(--red)', fontVariantNumeric: 'tabular-nums',
               }}>
                 {r.change >= 0 ? '+' : ''}{r.change.toFixed(2)}%
               </span>

--- a/components/AlertOutcomes.tsx
+++ b/components/AlertOutcomes.tsx
@@ -119,7 +119,7 @@ export default function AlertOutcomes() {
               key={r.key}
               label={`${r.label} (${r.count})`}
               value={`${(r.winRate * 100).toFixed(0)}% · ${fmtPct(r.avgPct)}`}
-              color={r.winRate >= 0.5 ? '#34d399' : '#f87171'}
+              color={r.winRate >= 0.5 ? 'var(--green-2)' : 'var(--red)'}
             />
           ))}
         </div>

--- a/components/BacktestStatsUI.tsx
+++ b/components/BacktestStatsUI.tsx
@@ -65,11 +65,11 @@ export function SideCard({ title, stats, color }: { title: string; stats: Displa
       <div style={{ fontSize: 'var(--fs-label)', fontWeight: 700, color, marginBottom: 10, letterSpacing: '0.02em' }}>{title}</div>
       <EquityCurve data={stats.equityCurve} color={color} />
       <div style={{ marginTop: 10 }}>
-        <StatRow label={t('BACKTEST_STATS_UI_LABEL_WIN_RATE')} tip={t('BACKTEST_STATS_UI_TIP_WIN_RATE')} value={fmtPct(stats.winRate)} color={stats.winRate >= 0.5 ? '#34d399' : '#f87171'} />
+        <StatRow label={t('BACKTEST_STATS_UI_LABEL_WIN_RATE')} tip={t('BACKTEST_STATS_UI_TIP_WIN_RATE')} value={fmtPct(stats.winRate)} color={stats.winRate >= 0.5 ? 'var(--green-2)' : 'var(--red)'} />
         <StatRow label={t('BACKTEST_STATS_UI_LABEL_TRADES')} value={t('BACKTEST_STATS_UI_TRADES_VALUE', { total: String(stats.totalTrades), wins: String(stats.wins), losses: String(stats.losses), open: String(stats.open) })} />
         <StatRow label={t('BACKTEST_STATS_UI_LABEL_PROFIT_FACTOR')} tip={t('BACKTEST_STATS_UI_TIP_PROFIT_FACTOR')} value={isFinite(stats.profitFactor) ? stats.profitFactor.toFixed(2) : '∞'} />
-        <StatRow label={t('BACKTEST_STATS_UI_LABEL_AVG_R')} tip={t('BACKTEST_STATS_UI_TIP_AVG_R')} value={fmtR(stats.avgR)} color={stats.avgR >= 0 ? '#34d399' : '#f87171'} />
-        <StatRow label={t('BACKTEST_STATS_UI_LABEL_MAX_DRAWDOWN')} tip={t('BACKTEST_STATS_UI_TIP_MAX_DRAWDOWN')} value={`-${stats.maxDrawdownR.toFixed(2)}R`} color="#f87171" />
+        <StatRow label={t('BACKTEST_STATS_UI_LABEL_AVG_R')} tip={t('BACKTEST_STATS_UI_TIP_AVG_R')} value={fmtR(stats.avgR)} color={stats.avgR >= 0 ? 'var(--green-2)' : 'var(--red)'} />
+        <StatRow label={t('BACKTEST_STATS_UI_LABEL_MAX_DRAWDOWN')} tip={t('BACKTEST_STATS_UI_TIP_MAX_DRAWDOWN')} value={`-${stats.maxDrawdownR.toFixed(2)}R`} color="var(--red)" />
       </div>
     </div>
   );

--- a/components/BtcRiskLevel.tsx
+++ b/components/BtcRiskLevel.tsx
@@ -24,14 +24,14 @@ export default function BtcRiskLevel() {
   if (fng != null) {
     const s = (fng / 100) * 33;
     total += s; maxPossible += 33;
-    const c = fng > 70 ? '#f87171' : fng < 30 ? '#34d399' : '#fbbf24';
+    const c = fng > 70 ? 'var(--red)' : fng < 30 ? 'var(--green-2)' : 'var(--amber)';
     signals.push({ id: 'fng', label: t('BTC_RISK_LEVEL_FNG_LABEL'), value: String(fng), score: s, max: 33, color: c });
   }
 
   if (btcRsi != null) {
     const s = clamp((btcRsi - 30) / 50, 0, 1) * 33;
     total += s; maxPossible += 33;
-    const c = btcRsi > 70 ? '#f87171' : btcRsi < 30 ? '#34d399' : '#fbbf24';
+    const c = btcRsi > 70 ? 'var(--red)' : btcRsi < 30 ? 'var(--green-2)' : 'var(--amber)';
     signals.push({ id: 'rsi', label: t('BTC_RISK_LEVEL_RSI_LABEL'), value: btcRsi.toFixed(1), score: s, max: 33, color: c });
   }
 
@@ -40,7 +40,7 @@ export default function BtcRiskLevel() {
     // Positive funding = longs overcrowded = dump risk. Negative = shorts paying = not dump risk.
     const s = pct > 0 ? clamp(btcFr / 0.001, 0, 1) * 34 : 0;
     total += s; maxPossible += 34;
-    const c = pct > 0.05 ? '#f87171' : pct < -0.02 ? '#34d399' : '#fbbf24';
+    const c = pct > 0.05 ? 'var(--red)' : pct < -0.02 ? 'var(--green-2)' : 'var(--amber)';
     const sign = pct >= 0 ? '+' : '';
     signals.push({ id: 'funding', label: t('BTC_RISK_LEVEL_FUNDING_LABEL'), value: `${sign}${pct.toFixed(4)}%`, score: s, max: 34, color: c });
   }
@@ -49,10 +49,10 @@ export default function BtcRiskLevel() {
 
   const { label, color } = score == null
     ? { label: t('BTC_RISK_LEVEL_UNKNOWN'), color: 'var(--txt3)' }
-    : score <= 30 ? { label: t('BTC_RISK_LEVEL_LOW'),      color: '#34d399' }
-    : score <= 55 ? { label: t('BTC_RISK_LEVEL_MODERATE'), color: '#fbbf24' }
-    : score <= 75 ? { label: t('BTC_RISK_LEVEL_HIGH'),     color: '#fb923c' }
-    :               { label: t('BTC_RISK_LEVEL_EXTREME'),  color: '#f87171' };
+    : score <= 30 ? { label: t('BTC_RISK_LEVEL_LOW'),      color: 'var(--green-2)' }
+    : score <= 55 ? { label: t('BTC_RISK_LEVEL_MODERATE'), color: 'var(--amber)' }
+    : score <= 75 ? { label: t('BTC_RISK_LEVEL_HIGH'),     color: 'var(--orange)' }
+    :               { label: t('BTC_RISK_LEVEL_EXTREME'),  color: 'var(--red)' };
 
   return (
     <div style={{
@@ -93,10 +93,10 @@ export default function BtcRiskLevel() {
             <div style={{ height: '100%', borderRadius: 99, width: score + '%', background: color, transition: 'width .4s' }} />
           </div>
           <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 4 }}>
-            <span style={{ fontSize: 'var(--fs-caption)', color: '#34d399' }}>{t('BTC_RISK_LEVEL_BAR_LOW')}</span>
-            <span style={{ fontSize: 'var(--fs-caption)', color: '#fbbf24' }}>{t('BTC_RISK_LEVEL_BAR_MODERATE')}</span>
+            <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--green-2)' }}>{t('BTC_RISK_LEVEL_BAR_LOW')}</span>
+            <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--amber)' }}>{t('BTC_RISK_LEVEL_BAR_MODERATE')}</span>
             <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--orange)' }}>{t('BTC_RISK_LEVEL_BAR_HIGH')}</span>
-            <span style={{ fontSize: 'var(--fs-caption)', color: '#f87171' }}>{t('BTC_RISK_LEVEL_BAR_EXTREME')}</span>
+            <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--red)' }}>{t('BTC_RISK_LEVEL_BAR_EXTREME')}</span>
           </div>
         </div>
       )}

--- a/components/CoinHeatmap.tsx
+++ b/components/CoinHeatmap.tsx
@@ -22,10 +22,10 @@ const CAT: Record<Cat, readonly CoinId[]> = {
 
 function changeColor(chg: number | null): { bg: string; text: string } {
   if (chg == null) return { bg: 'rgba(255,255,255,0.04)', text: 'var(--txt-dim)' };
-  if (chg >=  10) return { bg: 'rgba(52,211,153,0.30)',  text: '#34d399' };
-  if (chg >=   5) return { bg: 'rgba(52,211,153,0.22)',  text: '#6ee7b7' };
-  if (chg >=   2) return { bg: 'rgba(52,211,153,0.13)',  text: '#86efac' };
-  if (chg >=   0) return { bg: 'rgba(52,211,153,0.07)',  text: '#4ade80' };
+  if (chg >=  10) return { bg: 'rgba(52,211,153,0.30)',  text: 'var(--green-2)' };
+  if (chg >=   5) return { bg: 'rgba(52,211,153,0.22)',  text: 'var(--green-soft)' };
+  if (chg >=   2) return { bg: 'rgba(52,211,153,0.13)',  text: 'var(--green-soft)' };
+  if (chg >=   0) return { bg: 'rgba(52,211,153,0.07)',  text: 'var(--green)' };
   /* The red ramp used to darken the text (#fca5a5 -> #f87171 -> #ef4444 ->
      #dc2626) at the same time as it made the tile background a more opaque red
      (0.07 -> 0.38). Both moving together collapses the contrast exactly where
@@ -37,9 +37,9 @@ function changeColor(chg: number | null): { bg: string; text: string } {
      The green side has the same shape but does not fail (its worst bucket is
      5.71:1) because green is inherently light; left as-is rather than churning
      a passing palette, but the same rule applies if that ramp is ever extended. */
-  if (chg >= -2)  return { bg: 'rgba(248,113,113,0.07)', text: '#fca5a5' };
-  if (chg >= -5)  return { bg: 'rgba(248,113,113,0.15)', text: '#fcbcbc' };
-  if (chg >= -10) return { bg: 'rgba(248,113,113,0.25)', text: '#fecaca' };
+  if (chg >= -2)  return { bg: 'rgba(248,113,113,0.07)', text: 'var(--red-soft)' };
+  if (chg >= -5)  return { bg: 'rgba(248,113,113,0.15)', text: 'var(--red-soft)' };
+  if (chg >= -10) return { bg: 'rgba(248,113,113,0.25)', text: 'var(--red-soft)' };
   return              { bg: 'rgba(248,113,113,0.38)',     text: '#fee2e2' };
 }
 
@@ -149,12 +149,12 @@ export default function CoinHeatmap() {
           <Tip text={t('COIN_HEATMAP_TOOLTIP')}>{t('COIN_HEATMAP_TITLE')}</Tip>
         </span>
         {positiveCount > 0 && (
-          <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, padding: '2px 7px', borderRadius: 20, color: '#34d399', background: 'rgba(52,211,153,0.1)', border: '0.5px solid rgba(52,211,153,0.25)' }}>
+          <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, padding: '2px 7px', borderRadius: 20, color: 'var(--green-2)', background: 'rgba(52,211,153,0.1)', border: '0.5px solid rgba(52,211,153,0.25)' }}>
             ↑ {positiveCount}
           </span>
         )}
         {negativeCount > 0 && (
-          <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, padding: '2px 7px', borderRadius: 20, color: '#f87171', background: 'rgba(248,113,113,0.1)', border: '0.5px solid rgba(248,113,113,0.25)' }}>
+          <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, padding: '2px 7px', borderRadius: 20, color: 'var(--red)', background: 'rgba(248,113,113,0.1)', border: '0.5px solid rgba(248,113,113,0.25)' }}>
             ↓ {negativeCount}
           </span>
         )}
@@ -247,9 +247,9 @@ export default function CoinHeatmap() {
       }}>
         <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)', marginRight: 4 }}>{t('COIN_HEATMAP_SCALE_LABEL')}</span>
         {[
-          { label: '>+10%', c: '#34d399' }, { label: '+5%', c: '#6ee7b7' },
-          { label: '+2%', c: '#86efac' },   { label: '0', c: 'var(--txt-dim)' },
-          { label: '-2%', c: '#fca5a5' },   { label: '-5%', c: '#fcbcbc' },
+          { label: '>+10%', c: 'var(--green-2)' }, { label: '+5%', c: 'var(--green-soft)' },
+          { label: '+2%', c: 'var(--green-soft)' },   { label: '0', c: 'var(--txt-dim)' },
+          { label: '-2%', c: 'var(--red-soft)' },   { label: '-5%', c: 'var(--red-soft)' },
           { label: '<-10%', c: '#fee2e2' },
         ].map(({ label, c }) => (
           <span key={label} style={{ fontSize: 'var(--fs-caption)', color: c, fontWeight: 600 }}>{label}</span>

--- a/components/ConfluenceScore.tsx
+++ b/components/ConfluenceScore.tsx
@@ -17,11 +17,11 @@ import { computeSectorRotation, isAlt } from '@/lib/sectorRotation';
 import type { PASignal } from '@/lib/priceAction';
 
 const VERDICT_CONFIG: Record<string, { labelKey: LabelKey; color: string }> = {
-  STRONG_BULL:  { labelKey: 'CONFLUENCE_SCORE_VERDICT_STRONG_BULL',  color: '#34d399' },
-  LEANING_BULL: { labelKey: 'CONFLUENCE_SCORE_VERDICT_LEANING_BULL', color: '#86efac' },
+  STRONG_BULL:  { labelKey: 'CONFLUENCE_SCORE_VERDICT_STRONG_BULL',  color: 'var(--green-2)' },
+  LEANING_BULL: { labelKey: 'CONFLUENCE_SCORE_VERDICT_LEANING_BULL', color: 'var(--green-soft)' },
   MIXED:        { labelKey: 'CONFLUENCE_SCORE_VERDICT_MIXED',        color: 'var(--txt-dim)' },
-  LEANING_BEAR: { labelKey: 'CONFLUENCE_SCORE_VERDICT_LEANING_BEAR', color: '#fca5a5' },
-  STRONG_BEAR:  { labelKey: 'CONFLUENCE_SCORE_VERDICT_STRONG_BEAR',  color: '#f87171' },
+  LEANING_BEAR: { labelKey: 'CONFLUENCE_SCORE_VERDICT_LEANING_BEAR', color: 'var(--red-soft)' },
+  STRONG_BEAR:  { labelKey: 'CONFLUENCE_SCORE_VERDICT_STRONG_BEAR',  color: 'var(--red)' },
 };
 
 export default function ConfluenceScore(
@@ -135,7 +135,7 @@ export default function ConfluenceScore(
   const result = computeConfluence(factors);
   const cfg = VERDICT_CONFIG[result.verdict];
   const macro = computeMacroRisk(econEvents, jpyUsd);
-  const macroCol = macro.level === 'danger' ? '#f87171' : macro.level === 'caution' ? '#fbbf24' : null;
+  const macroCol = macro.level === 'danger' ? 'var(--red)' : macro.level === 'caution' ? 'var(--amber)' : null;
 
   return (
     <div className="sms-card">
@@ -176,8 +176,8 @@ export default function ConfluenceScore(
         {factors.map((f, i) => {
           const isPenalty = f.kind === 'penalty';
           const active = isPenalty ? f.active : f.dir !== 'neutral';
-          const col = isPenalty ? (f.active ? '#fbbf24' : 'var(--txt3)')
-            : f.dir === 'bull' ? '#34d399' : f.dir === 'bear' ? '#f87171' : 'var(--txt3)';
+          const col = isPenalty ? (f.active ? 'var(--amber)' : 'var(--txt3)')
+            : f.dir === 'bull' ? 'var(--green-2)' : f.dir === 'bear' ? 'var(--red)' : 'var(--txt3)';
           const valueText = isPenalty
             ? (f.active ? t('CONFLUENCE_SCORE_PENALTY_ACTIVE', { weight: f.weight }) : t('CONFLUENCE_SCORE_PENALTY_CLEAR'))
             : (f.dir === 'neutral' ? '-' : `${f.dir === 'bull' ? '▲' : '▼'} ${f.weight}`);

--- a/components/CycleChart.tsx
+++ b/components/CycleChart.tsx
@@ -15,8 +15,8 @@ interface CycleData {
 
 const CYCLES: { key: '2016' | '2020' | '2024'; color: string }[] = [
   { key: '2016', color: 'var(--orange)' },
-  { key: '2020', color: '#fbbf24' },
-  { key: '2024', color: '#34d399' },
+  { key: '2020', color: 'var(--amber)' },
+  { key: '2024', color: 'var(--green-2)' },
 ];
 
 const CYCLE_LEGEND_KEY: Record<'2016' | '2020' | '2024', LabelKey> = {
@@ -115,7 +115,7 @@ export default function CycleChart() {
         </div>
       )}
       {err && (
-        <div style={{ padding: '20px 14px', fontSize: 'var(--fs-caption)', color: '#f87171' }}>{t('CYCLE_CHART_LOAD_ERROR', { err })}</div>
+        <div style={{ padding: '20px 14px', fontSize: 'var(--fs-caption)', color: 'var(--red)' }}>{t('CYCLE_CHART_LOAD_ERROR', { err })}</div>
       )}
 
       {/* SVG chart */}

--- a/components/CycleDayCounter.tsx
+++ b/components/CycleDayCounter.tsx
@@ -35,7 +35,7 @@ export default function CycleDayCounter() {
   const pastPeak     = day > PEAK_WINDOW.end;
   const prePeak      = day < PEAK_WINDOW.start;
 
-  const dotColor = inPeakWindow ? '#fbbf24' : pastPeak ? '#f87171' : '#34d399';
+  const dotColor = inPeakWindow ? 'var(--amber)' : pastPeak ? 'var(--red)' : 'var(--green-2)';
   const label    = inPeakWindow ? t('CYCLE_DAY_COUNTER_ZONE_IN_PEAK') : pastPeak ? t('CYCLE_DAY_COUNTER_ZONE_POST_PEAK') : t('CYCLE_DAY_COUNTER_ZONE_PRE_PEAK');
   const phasePct = Math.min(Math.max((day / PEAK_WINDOW.end) * 100, 0), 100);
 
@@ -85,7 +85,7 @@ export default function CycleDayCounter() {
             background: inPeakWindow
               ? 'linear-gradient(90deg, #34d399, #fbbf24)'
               : pastPeak
-                ? '#f87171'
+                ? 'var(--red)'
                 : 'linear-gradient(90deg, #34d399, #34d399cc)',
             transition: 'width .4s',
           }} />
@@ -93,7 +93,7 @@ export default function CycleDayCounter() {
         {/* Peak window markers */}
         <div style={{ position: 'relative', height: 12, marginTop: 2 }}>
           <span style={{
-            position: 'absolute', fontSize: '0.6875rem', color: '#fbbf24',
+            position: 'absolute', fontSize: '0.6875rem', color: 'var(--amber)',
             left: `${(PEAK_WINDOW.start / PEAK_WINDOW.end) * 100}%`,
             transform: 'translateX(-50%)',
           }}>▲</span>
@@ -105,19 +105,19 @@ export default function CycleDayCounter() {
         {prePeak && (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
             <span style={{ fontSize: 'var(--fs-micro)', color: 'var(--txt3)', textTransform: 'uppercase', letterSpacing: '.06em', fontWeight: 600 }}>{t('CYCLE_DAY_COUNTER_DAYS_TO_PEAK_LABEL')}</span>
-            <span suppressHydrationWarning style={{ fontSize: 'var(--fs-data)', fontWeight: 700, color: '#34d399', fontVariantNumeric: 'tabular-nums' }}>{PEAK_WINDOW.start - day}</span>
+            <span suppressHydrationWarning style={{ fontSize: 'var(--fs-data)', fontWeight: 700, color: 'var(--green-2)', fontVariantNumeric: 'tabular-nums' }}>{PEAK_WINDOW.start - day}</span>
           </div>
         )}
         {inPeakWindow && (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
             <span style={{ fontSize: 'var(--fs-micro)', color: 'var(--txt3)', textTransform: 'uppercase', letterSpacing: '.06em', fontWeight: 600 }}>{t('CYCLE_DAY_COUNTER_DAYS_IN_PEAK_LABEL')}</span>
-            <span suppressHydrationWarning style={{ fontSize: 'var(--fs-data)', fontWeight: 700, color: '#fbbf24', fontVariantNumeric: 'tabular-nums' }}>{day - PEAK_WINDOW.start}</span>
+            <span suppressHydrationWarning style={{ fontSize: 'var(--fs-data)', fontWeight: 700, color: 'var(--amber)', fontVariantNumeric: 'tabular-nums' }}>{day - PEAK_WINDOW.start}</span>
           </div>
         )}
         {pastPeak && (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
             <span style={{ fontSize: 'var(--fs-micro)', color: 'var(--txt3)', textTransform: 'uppercase', letterSpacing: '.06em', fontWeight: 600 }}>{t('CYCLE_DAY_COUNTER_DAYS_PAST_PEAK_LABEL')}</span>
-            <span suppressHydrationWarning style={{ fontSize: 'var(--fs-data)', fontWeight: 700, color: '#f87171', fontVariantNumeric: 'tabular-nums' }}>{day - PEAK_WINDOW.end}</span>
+            <span suppressHydrationWarning style={{ fontSize: 'var(--fs-data)', fontWeight: 700, color: 'var(--red)', fontVariantNumeric: 'tabular-nums' }}>{day - PEAK_WINDOW.end}</span>
           </div>
         )}
         <div style={{ display: 'flex', flexDirection: 'column', gap: 1 }}>

--- a/components/DistributionTracker.tsx
+++ b/components/DistributionTracker.tsx
@@ -129,7 +129,7 @@ export default function DistributionTracker() {
               </span>
               <span style={{
                 fontSize: 'var(--fs-caption)', fontWeight: 600, flexShrink: 0, width: 48, textAlign: 'right',
-                color: r.change >= 0 ? '#4ade80' : '#f87171', fontVariantNumeric: 'tabular-nums',
+                color: r.change >= 0 ? 'var(--green)' : 'var(--red)', fontVariantNumeric: 'tabular-nums',
               }}>
                 {r.change >= 0 ? '+' : ''}{r.change.toFixed(2)}%
               </span>

--- a/components/DrawdownChart.tsx
+++ b/components/DrawdownChart.tsx
@@ -13,11 +13,11 @@ interface AthEntry {
 
 function drawdownColor(pct: number): string {
   const abs = Math.abs(pct);
-  if (abs >= 80) return '#ef4444';
-  if (abs >= 60) return '#f87171';
-  if (abs >= 40) return '#fb923c';
-  if (abs >= 20) return '#fbbf24';
-  return '#34d399';
+  if (abs >= 80) return 'var(--red)';
+  if (abs >= 60) return 'var(--red)';
+  if (abs >= 40) return 'var(--orange)';
+  if (abs >= 20) return 'var(--amber)';
+  return 'var(--green-2)';
 }
 
 function fmtDate(iso: string): string {
@@ -80,7 +80,7 @@ export default function DrawdownChart() {
           <Tip text={t('DRAWDOWN_CHART_TOOLTIP')}>{t('DRAWDOWN_CHART_TITLE')}</Tip>
         </span>
         {nearAth > 0 && (
-          <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, padding: '2px 7px', borderRadius: 20, color: '#34d399', background: 'rgba(52,211,153,0.1)', border: '0.5px solid rgba(52,211,153,0.25)' }}>
+          <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, padding: '2px 7px', borderRadius: 20, color: 'var(--green-2)', background: 'rgba(52,211,153,0.1)', border: '0.5px solid rgba(52,211,153,0.25)' }}>
             {t('DRAWDOWN_CHART_NEAR_ATH_BADGE', { count: nearAth })}
           </span>
         )}
@@ -107,7 +107,7 @@ export default function DrawdownChart() {
         </div>
       )}
       {err && (
-        <div style={{ padding: '16px 14px', fontSize: 'var(--fs-caption)', color: '#f87171' }}>{t('DRAWDOWN_CHART_ERROR', { error: err })}</div>
+        <div style={{ padding: '16px 14px', fontSize: 'var(--fs-caption)', color: 'var(--red)' }}>{t('DRAWDOWN_CHART_ERROR', { error: err })}</div>
       )}
 
       {/* Bar chart rows */}
@@ -126,7 +126,7 @@ export default function DrawdownChart() {
               <div key={c}>
                 {/* Coin label + values */}
                 <div style={{ display: 'flex', alignItems: 'baseline', gap: 6, marginBottom: 3 }}>
-                  <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: isNear ? '#34d399' : 'var(--txt)', width: 40, flexShrink: 0 }}>
+                  <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: isNear ? 'var(--green-2)' : 'var(--txt)', width: 40, flexShrink: 0 }}>
                     {c.toUpperCase()}
                   </span>
                   <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 800, color: col, fontVariantNumeric: 'tabular-nums', minWidth: 52 }}>
@@ -166,11 +166,11 @@ export default function DrawdownChart() {
       {/* Footer */}
       <div style={{ padding: '5px 14px 8px', borderTop: '0.5px solid rgba(255,255,255,0.05)', display: 'flex', gap: 10, flexWrap: 'wrap' }}>
         {([
-          { labelKey: 'DRAWDOWN_CHART_LEGEND_UNDER_20', col: '#34d399' },
-          { labelKey: 'DRAWDOWN_CHART_LEGEND_20_40', col: '#fbbf24' },
-          { labelKey: 'DRAWDOWN_CHART_LEGEND_40_60', col: '#fb923c' },
-          { labelKey: 'DRAWDOWN_CHART_LEGEND_60_80', col: '#f87171' },
-          { labelKey: 'DRAWDOWN_CHART_LEGEND_OVER_80', col: '#ef4444' },
+          { labelKey: 'DRAWDOWN_CHART_LEGEND_UNDER_20', col: 'var(--green-2)' },
+          { labelKey: 'DRAWDOWN_CHART_LEGEND_20_40', col: 'var(--amber)' },
+          { labelKey: 'DRAWDOWN_CHART_LEGEND_40_60', col: 'var(--orange)' },
+          { labelKey: 'DRAWDOWN_CHART_LEGEND_60_80', col: 'var(--red)' },
+          { labelKey: 'DRAWDOWN_CHART_LEGEND_OVER_80', col: 'var(--red)' },
         ] as const).map(({ labelKey, col }) => (
           <span key={labelKey} style={{ fontSize: 'var(--fs-caption)', color: col, fontWeight: 600 }}>{t(labelKey)}</span>
         ))}

--- a/components/DryPowder.tsx
+++ b/components/DryPowder.tsx
@@ -24,9 +24,9 @@ const CACHE_TTL = 4 * 60 * 60 * 1000;
 type LoadState = DPData | null | 'loading' | 'error' | 'unauth' | 'locked';
 
 const SIGNAL_META: Record<string, { col: string; bg: string; bdr: string; icon: string }> = {
-  EXPANDING:   { col: '#34d399', bg: 'rgba(52,211,153,0.10)',  bdr: 'rgba(52,211,153,0.3)',  icon: '↑' },
-  CONTRACTING: { col: '#f87171', bg: 'rgba(248,113,113,0.10)', bdr: 'rgba(248,113,113,0.3)', icon: '↓' },
-  NEUTRAL:     { col: '#fbbf24', bg: 'rgba(251,191,36,0.10)',  bdr: 'rgba(251,191,36,0.3)',  icon: '→' },
+  EXPANDING:   { col: 'var(--green-2)', bg: 'rgba(52,211,153,0.10)',  bdr: 'rgba(52,211,153,0.3)',  icon: '↑' },
+  CONTRACTING: { col: 'var(--red)', bg: 'rgba(248,113,113,0.10)', bdr: 'rgba(248,113,113,0.3)', icon: '↓' },
+  NEUTRAL:     { col: 'var(--amber)', bg: 'rgba(251,191,36,0.10)',  bdr: 'rgba(251,191,36,0.3)',  icon: '→' },
 };
 
 function parseDPSection(text: string, key: string): string {
@@ -56,7 +56,7 @@ function Sparkline({ series }: { series: number[] }) {
     return `${x.toFixed(1)},${y.toFixed(1)}`;
   }).join(' ');
   const rising = series[series.length - 1] >= series[0];
-  const col    = rising ? '#34d399' : '#f87171';
+  const col    = rising ? 'var(--green-2)' : 'var(--red)';
   return (
     <svg width={W} height={H} style={{ display: 'block', flexShrink: 0 }}>
       <polyline points={pts} fill="none" stroke={col} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" opacity="0.85" />
@@ -173,7 +173,7 @@ export default function DryPowder() {
               callback keeps `t` out of that callback's dependencies - it had to
               be omitted there, which froze the message to first-render's
               language and left it stale after a locale switch. */}
-          <div style={{ fontSize: 'var(--fs-caption)', color: '#f87171', marginBottom: 6 }}>{errMsg || t('DRY_POWDER_FETCH_FAILED')}</div>
+          <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--red)', marginBottom: 6 }}>{errMsg || t('DRY_POWDER_FETCH_FAILED')}</div>
           <button
             onClick={fetchData}
             style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', background: 'transparent', border: '0.5px solid var(--bdr)', borderRadius: 4, padding: '3px 8px', cursor: 'pointer' }}
@@ -198,7 +198,7 @@ export default function DryPowder() {
                   </span>
                   <span style={{
                     fontSize: 'var(--fs-caption)', fontWeight: 700, fontFamily: 'var(--font-mono), monospace',
-                    color: chg30Up ? '#34d399' : '#f87171',
+                    color: chg30Up ? 'var(--green-2)' : 'var(--red)',
                   }}>
                     {t('DRY_POWDER_30D_CHANGE', { pct: chg30 })}
                   </span>

--- a/components/EMASignal.tsx
+++ b/components/EMASignal.tsx
@@ -6,10 +6,10 @@ import { withAlpha } from '@/lib/color';
 import { SkeletonBar } from '@/components/Skeleton';
 
 const VERDICT_CONFIG: Record<StrategyVerdict, { label: string; color: string; bg: string; border: string }> = {
-  LONG_SETUP:     { label: '▲ LONG SETUP',     color: '#34d399', bg: 'rgba(52,211,153,0.08)',  border: 'rgba(52,211,153,0.25)'  },
-  SHORT_SETUP:    { label: '▼ SHORT SETUP',    color: '#f87171', bg: 'rgba(248,113,113,0.08)', border: 'rgba(248,113,113,0.25)' },
-  TRENDING_LONG:  { label: '↗ TRENDING LONG',  color: '#86efac', bg: 'rgba(134,239,172,0.06)', border: 'rgba(134,239,172,0.2)'  },
-  TRENDING_SHORT: { label: '↘ TRENDING SHORT', color: '#fca5a5', bg: 'rgba(252,165,165,0.06)', border: 'rgba(252,165,165,0.2)'  },
+  LONG_SETUP:     { label: '▲ LONG SETUP',     color: 'var(--green-2)', bg: 'rgba(52,211,153,0.08)',  border: 'rgba(52,211,153,0.25)'  },
+  SHORT_SETUP:    { label: '▼ SHORT SETUP',    color: 'var(--red)', bg: 'rgba(248,113,113,0.08)', border: 'rgba(248,113,113,0.25)' },
+  TRENDING_LONG:  { label: '↗ TRENDING LONG',  color: 'var(--green-soft)', bg: 'rgba(134,239,172,0.06)', border: 'rgba(134,239,172,0.2)'  },
+  TRENDING_SHORT: { label: '↘ TRENDING SHORT', color: 'var(--red-soft)', bg: 'rgba(252,165,165,0.06)', border: 'rgba(252,165,165,0.2)'  },
   /* #6b7280 was 4.01:1 - the same grey-500 the econ calendar used for its
      (never-reachable) LOW bucket. FREEZE is a live signal state, not a
      placeholder, so it takes the AA-safe neutral. */
@@ -87,7 +87,7 @@ export default function EMASignal({ signal, tf = '4h', coin }: Props) {
   // than it's won.
   const weak = isSetup && signal.weakEdge;
   const cfg = weak
-    ? { label: `${VERDICT_CONFIG[v].label} · WEAK EDGE`, color: '#fbbf24', bg: 'rgba(251,191,36,0.08)', border: 'rgba(251,191,36,0.25)' }
+    ? { label: `${VERDICT_CONFIG[v].label} · WEAK EDGE`, color: 'var(--amber)', bg: 'rgba(251,191,36,0.08)', border: 'rgba(251,191,36,0.25)' }
     : VERDICT_CONFIG[v];
   const canExplain = coin && !signal.loading && signal.verdict !== 'LOADING';
 
@@ -111,7 +111,7 @@ export default function EMASignal({ signal, tf = '4h', coin }: Props) {
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
           {!signal.loading && signal.chopRegime && (() => {
-            const col = signal.chopRegime === 'choppy' ? '#fbbf24' : signal.chopRegime === 'trending' ? '#34d399' : '#8e8e93';
+            const col = signal.chopRegime === 'choppy' ? 'var(--amber)' : signal.chopRegime === 'trending' ? 'var(--green-2)' : 'var(--txt-dim)';
             const label = signal.chopRegime === 'choppy' ? 'CHOPPY' : signal.chopRegime === 'trending' ? 'TRENDING' : 'MIXED';
             return (
               <span
@@ -169,7 +169,7 @@ export default function EMASignal({ signal, tf = '4h', coin }: Props) {
         }}>
           {signal.conditions.map((c, i) => {
             const pass = c.pass;
-            const col  = pass === true ? '#34d399' : pass === false ? '#f87171' : 'var(--txt-dim)';
+            const col  = pass === true ? 'var(--green-2)' : pass === false ? 'var(--red)' : 'var(--txt-dim)';
             const bg   = pass === true ? 'rgba(52,211,153,0.07)' : pass === false ? 'rgba(248,113,113,0.07)' : 'rgba(255,255,255,0.02)';
             const icon = pass === true ? '✓' : pass === false ? '✗' : '-';
             return (
@@ -207,7 +207,7 @@ export default function EMASignal({ signal, tf = '4h', coin }: Props) {
           borderRadius: 7,
         }}>
           <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', marginRight: 4 }}>Levels:</span>
-          <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: '#f87171' }}>
+          <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: 'var(--red)' }}>
             SL ${fmt(signal.sl)}
           </span>
           <span style={{ fontSize: '0.6875rem', color: 'var(--txt-dim)' }}>·</span>
@@ -215,7 +215,7 @@ export default function EMASignal({ signal, tf = '4h', coin }: Props) {
             Entry ~${fmt(signal.ema20_4h)} (20 EMA)
           </span>
           <span style={{ fontSize: '0.6875rem', color: 'var(--txt-dim)' }}>·</span>
-          <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: '#34d399' }}>
+          <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: 'var(--green-2)' }}>
             TP ${fmt(signal.tp)} (2:1)
           </span>
         </div>
@@ -229,8 +229,8 @@ export default function EMASignal({ signal, tf = '4h', coin }: Props) {
           paddingTop: 8,
           borderTop: '0.5px solid var(--bdr)',
         }}>
-          <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)' }}>Fast avg <b style={{ color: '#fbbf24' }}>${fmt(signal.ema9_4h)}</b></span>
-          <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)' }}>Mid avg <b style={{ color: '#60a5fa' }}>${fmt(signal.ema20_4h ?? null)}</b></span>
+          <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)' }}>Fast avg <b style={{ color: 'var(--amber)' }}>${fmt(signal.ema9_4h)}</b></span>
+          <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)' }}>Mid avg <b style={{ color: 'var(--accent-2)' }}>${fmt(signal.ema20_4h ?? null)}</b></span>
           <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)' }}>Slow avg <b style={{ color: '#f97316' }}>${fmt(signal.ema50_4h ?? null)}</b></span>
           <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)' }}>Daily trend <b style={{ color: 'var(--accent)' }}>${fmt(signal.sma200_1d ?? null)}</b></span>
         </div>
@@ -247,7 +247,7 @@ export default function EMASignal({ signal, tf = '4h', coin }: Props) {
             {signal.recentStats.wins} wins / {signal.recentStats.losses} losses
           </b>
           {' · '}
-          <b style={{ color: signal.recentStats.netR >= 0 ? '#34d399' : '#f87171' }}>
+          <b style={{ color: signal.recentStats.netR >= 0 ? 'var(--green-2)' : 'var(--red)' }}>
             {signal.recentStats.netR >= 0 ? '+' : ''}{signal.recentStats.netR.toFixed(1)}R
           </b>
           {signal.recentStats.open > 0 ? ` · ${signal.recentStats.open} open` : ''}
@@ -267,7 +267,7 @@ export default function EMASignal({ signal, tf = '4h', coin }: Props) {
             borderRadius: 7,
             fontSize: 'var(--fs-caption)',
             fontWeight: 600,
-            color: '#5aa3ff',
+            color: 'var(--accent-2)',
             cursor: 'pointer',
             letterSpacing: '.02em',
             transition: 'background 0.15s',
@@ -283,7 +283,7 @@ export default function EMASignal({ signal, tf = '4h', coin }: Props) {
       )}
 
       {signal.error && (
-        <div style={{ fontSize: 'var(--fs-caption)', color: '#f87171', marginTop: 6 }}>{signal.error}</div>
+        <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--red)', marginTop: 6 }}>{signal.error}</div>
       )}
     </div>
   );

--- a/components/EconCalendarWidget.tsx
+++ b/components/EconCalendarWidget.tsx
@@ -17,7 +17,7 @@ type TFn = (key: LabelKey, vars?: Record<string, string | number>) => string;
 /* LOW was #6b7280 = 3.77:1 on the rail card - and since econImpactKey did not
    exist, EVERY row used it regardless of real impact. See lib/classify.ts. */
 const IMPACT_COLOR: Record<EconImpact, string> = {
-  HIGH: '#f87171', MEDIUM: '#fbbf24', LOW: 'var(--txt-dim)',
+  HIGH: 'var(--red)', MEDIUM: 'var(--amber)', LOW: 'var(--txt-dim)',
 };
 
 const MAX_ROWS = 5;

--- a/components/GexTable.tsx
+++ b/components/GexTable.tsx
@@ -19,7 +19,7 @@ export default function GexTable() {
   const gexLoaded = btcNetGex !== null && btcGexLevels.length > 0;
   const isLongGamma = (btcNetGex ?? 0) >= 0;
 
-  const gexCol     = isLongGamma ? '#34d399' : '#f87171';
+  const gexCol     = isLongGamma ? 'var(--green-2)' : 'var(--red)';
   const gexBg      = isLongGamma ? 'rgba(52,211,153,0.12)' : 'rgba(248,113,113,0.12)';
   const gexBorder  = isLongGamma ? 'rgba(52,211,153,0.3)'  : 'rgba(248,113,113,0.3)';
 
@@ -84,10 +84,10 @@ export default function GexTable() {
             }
           }
 
-          const leanColor = lean === 'bull' ? '#34d399' : lean === 'bear' ? '#f87171' : '#9ca3af';
+          const leanColor = lean === 'bull' ? 'var(--green-2)' : lean === 'bear' ? 'var(--red)' : '#9ca3af';
           const leanLabel = lean === 'bull' ? t('GEX_TABLE_LEAN_BULLISH') : lean === 'bear' ? t('GEX_TABLE_LEAN_BEARISH') : t('GEX_TABLE_LEAN_NEUTRAL');
           const regimeLabel = isLongGamma ? t('GEX_TABLE_REGIME_RANGING') : t('GEX_TABLE_REGIME_TRENDING');
-          const regimeColor = isLongGamma ? '#34d399' : '#f87171';
+          const regimeColor = isLongGamma ? 'var(--green-2)' : 'var(--red)';
           const regimeDesc  = isLongGamma
             ? t('GEX_TABLE_REGIME_DESC_RANGING')
             : t('GEX_TABLE_REGIME_DESC_TRENDING');
@@ -149,7 +149,7 @@ export default function GexTable() {
           {btcGexLevels.map(({ strike, gex }) => {
             const pct   = maxAbsGex > 0 ? Math.abs(gex) / maxAbsGex * 100 : 0;
             const col   = gex >= 0 ? 'rgba(52,211,153,0.65)' : 'rgba(248,113,113,0.65)';
-            const vcol  = gex >= 0 ? '#34d399' : '#f87171';
+            const vcol  = gex >= 0 ? 'var(--green-2)' : 'var(--red)';
             const isAtm = spotPrice > 0 && Math.abs(strike - spotPrice) / spotPrice < 0.005;
             return (
               <div key={strike} className={`gex-row${isAtm ? ' gex-row-atm' : ''}`}>

--- a/components/GlobalMacroContext.tsx
+++ b/components/GlobalMacroContext.tsx
@@ -28,9 +28,9 @@ const CACHE_TTL = 2 * 60 * 60 * 1000; // 2 hours
 type LoadState = MacroData | null | 'loading' | 'error' | 'unauth';
 
 const SIGNAL_META: Record<string, { col: string; bg: string; bdr: string; labelKey: LabelKey }> = {
-  RISK_ON:  { col: '#34d399', bg: 'rgba(52,211,153,0.10)',  bdr: 'rgba(52,211,153,0.3)',  labelKey: 'GLOBAL_MACRO_CONTEXT_SIGNAL_RISK_ON'  },
-  RISK_OFF: { col: '#f87171', bg: 'rgba(248,113,113,0.10)', bdr: 'rgba(248,113,113,0.3)', labelKey: 'GLOBAL_MACRO_CONTEXT_SIGNAL_RISK_OFF' },
-  NEUTRAL:  { col: '#fbbf24', bg: 'rgba(251,191,36,0.10)',  bdr: 'rgba(251,191,36,0.3)',  labelKey: 'GLOBAL_MACRO_CONTEXT_SIGNAL_NEUTRAL'  },
+  RISK_ON:  { col: 'var(--green-2)', bg: 'rgba(52,211,153,0.10)',  bdr: 'rgba(52,211,153,0.3)',  labelKey: 'GLOBAL_MACRO_CONTEXT_SIGNAL_RISK_ON'  },
+  RISK_OFF: { col: 'var(--red)', bg: 'rgba(248,113,113,0.10)', bdr: 'rgba(248,113,113,0.3)', labelKey: 'GLOBAL_MACRO_CONTEXT_SIGNAL_RISK_OFF' },
+  NEUTRAL:  { col: 'var(--amber)', bg: 'rgba(251,191,36,0.10)',  bdr: 'rgba(251,191,36,0.3)',  labelKey: 'GLOBAL_MACRO_CONTEXT_SIGNAL_NEUTRAL'  },
 };
 
 function parseMacroSection(text: string, key: string): string {
@@ -42,7 +42,7 @@ function parseMacroSection(text: string, key: string): string {
 function chgColor(chg: number, invertBullish = false) {
   const pos = invertBullish ? chg < 0 : chg > 0;
   if (Math.abs(chg) < 0.05) return 'var(--txt3)';
-  return pos ? '#34d399' : '#f87171';
+  return pos ? 'var(--green-2)' : 'var(--red)';
 }
 
 function chgStr(chg: number) {
@@ -155,7 +155,7 @@ export default function GlobalMacroContext() {
               callback keeps `t` out of that callback's dependencies - it had to
               be omitted there, which froze the message to first-render's
               language and left it stale after a locale switch. */}
-          <div style={{ fontSize: 'var(--fs-caption)', color: '#f87171', marginBottom: 6 }}>{errMsg || t('GLOBAL_MACRO_CONTEXT_FETCH_FAILED')}</div>
+          <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--red)', marginBottom: 6 }}>{errMsg || t('GLOBAL_MACRO_CONTEXT_FETCH_FAILED')}</div>
           <button onClick={fetchData} style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', background: 'transparent', border: '0.5px solid var(--bdr)', borderRadius: 4, padding: '3px 8px', cursor: 'pointer' }}>{t('GLOBAL_MACRO_CONTEXT_RETRY')}</button>
         </div>
       )}

--- a/components/GrokChat.tsx
+++ b/components/GrokChat.tsx
@@ -672,7 +672,7 @@ export default function GrokChat() {
                   {searchRemaining !== null && (
                     <span style={{
                       fontSize: 'var(--fs-caption)',
-                      color: searchRemaining === 0 ? '#ff9a92' : searchRemaining === 1 ? '#f59e0b' : '#666',
+                      color: searchRemaining === 0 ? 'var(--red-soft)' : searchRemaining === 1 ? '#f59e0b' : '#666',
                       opacity: liveSearch ? 1 : 0.5,
                       fontVariantNumeric: 'tabular-nums',
                     }}>
@@ -787,9 +787,9 @@ export default function GrokChat() {
             {/* Rate-limit / error status bar - sits between coins and messages, not in chat stream */}
             {error && (
               <div style={{ padding: '6px 14px', borderBottom: '1px solid rgba(255,255,255,0.06)', background: 'rgba(255,154,146,0.06)', lineHeight: 1.6 }}>
-                <div style={{ fontSize: 'var(--fs-caption)', color: '#ff9a92', display: 'flex', alignItems: 'center', gap: 5 }}><Warn size={12} /> {error}</div>
+                <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--red-soft)', display: 'flex', alignItems: 'center', gap: 5 }}><Warn size={12} /> {error}</div>
                 {rateLimited && (
-                  <Link href="/upgrade" style={{ fontSize: 'var(--fs-caption)', color: '#5aa3ff', textDecoration: 'underline' }}>
+                  <Link href="/upgrade" style={{ fontSize: 'var(--fs-caption)', color: 'var(--accent-2)', textDecoration: 'underline' }}>
                     Upgrade to Pro for higher limits →
                   </Link>
                 )}
@@ -808,8 +808,8 @@ export default function GrokChat() {
                   </div>
                   {user ? (
                     <>
-                      <div style={{ fontSize: 'var(--fs-label)', fontWeight: 600, color: '#a0a0a0' }}>Ask anything about</div>
-                      <div style={{ fontSize: 'var(--fs-card-title)', fontWeight: 700, color: '#5aa3ff', margin: '2px 0 6px' }}>
+                      <div style={{ fontSize: 'var(--fs-label)', fontWeight: 600, color: 'var(--txt-dim)' }}>Ask anything about</div>
+                      <div style={{ fontSize: 'var(--fs-card-title)', fontWeight: 700, color: 'var(--accent-2)', margin: '2px 0 6px' }}>
                         {coin.toUpperCase()}/USDT
                       </div>
                       <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)' }}>
@@ -820,7 +820,7 @@ export default function GrokChat() {
                     <>
                       <div style={{ fontSize: 'var(--fs-label)', fontWeight: 600, color: 'var(--txt3)' }}>Sign in to use LiquidityAI</div>
                       <button
-                        style={{ marginTop: 10, fontSize: 'var(--fs-caption)', color: '#5aa3ff', background: 'none', border: '0.5px solid #5aa3ff44', borderRadius: 8, padding: '6px 16px', cursor: 'pointer' }}
+                        style={{ marginTop: 10, fontSize: 'var(--fs-caption)', color: 'var(--accent-2)', background: 'none', border: '0.5px solid #5aa3ff44', borderRadius: 8, padding: '6px 16px', cursor: 'pointer' }}
                         onClick={() => setShowLoginModal(true)}
                       >
                         Sign In →

--- a/components/HigherTfMoveBadge.tsx
+++ b/components/HigherTfMoveBadge.tsx
@@ -60,7 +60,7 @@ export default function HigherTfMoveBadge({ coin, tf, signalDir }: Props) {
 
   const pumped = changePct > 0;
   const agrees = signalDir != null && ((pumped && signalDir === 'long') || (!pumped && signalDir === 'short'));
-  const col = '#fbbf24';
+  const col = 'var(--amber)';
 
   return (
     <div style={{

--- a/components/HypothesisTracker.tsx
+++ b/components/HypothesisTracker.tsx
@@ -37,21 +37,21 @@ interface Evidence {
 
 const STATUS_META: Record<string, { labelKey: LabelKey; col: string; bg: string }> = {
   active:        { labelKey: 'HYPOTHESIS_TRACKER_STATUS_ACTIVE',       col: '#1a7aff', bg: 'rgba(26,122,255,0.12)' },
-  confirmed:     { labelKey: 'HYPOTHESIS_TRACKER_STATUS_CONFIRMED',    col: '#34d399', bg: 'rgba(52,211,153,0.12)' },
-  disconfirmed:  { labelKey: 'HYPOTHESIS_TRACKER_STATUS_DISCONFIRMED', col: '#f87171', bg: 'rgba(248,113,113,0.12)' },
-  expired:       { labelKey: 'HYPOTHESIS_TRACKER_STATUS_EXPIRED',      col: '#94a3b8', bg: 'rgba(148,163,184,0.10)' },
+  confirmed:     { labelKey: 'HYPOTHESIS_TRACKER_STATUS_CONFIRMED',    col: 'var(--green-2)', bg: 'rgba(52,211,153,0.12)' },
+  disconfirmed:  { labelKey: 'HYPOTHESIS_TRACKER_STATUS_DISCONFIRMED', col: 'var(--red)', bg: 'rgba(248,113,113,0.12)' },
+  expired:       { labelKey: 'HYPOTHESIS_TRACKER_STATUS_EXPIRED',      col: 'var(--txt-dim)', bg: 'rgba(148,163,184,0.10)' },
 };
 
 const VERDICT_META: Record<string, { col: string }> = {
-  CONFIRMED:    { col: '#34d399' },
-  DISCONFIRMED: { col: '#f87171' },
-  UNCLEAR:      { col: '#fbbf24' },
+  CONFIRMED:    { col: 'var(--green-2)' },
+  DISCONFIRMED: { col: 'var(--red)' },
+  UNCLEAR:      { col: 'var(--amber)' },
 };
 
 const EV_META: Record<string, { icon: string; col: string; labelKey: LabelKey }> = {
-  supporting: { icon: '↑', col: '#34d399', labelKey: 'HYPOTHESIS_TRACKER_EV_SUPPORTING' },
-  against:    { icon: '↓', col: '#f87171', labelKey: 'HYPOTHESIS_TRACKER_EV_AGAINST' },
-  neutral:    { icon: '→', col: '#94a3b8', labelKey: 'HYPOTHESIS_TRACKER_EV_NEUTRAL' },
+  supporting: { icon: '↑', col: 'var(--green-2)', labelKey: 'HYPOTHESIS_TRACKER_EV_SUPPORTING' },
+  against:    { icon: '↓', col: 'var(--red)', labelKey: 'HYPOTHESIS_TRACKER_EV_AGAINST' },
+  neutral:    { icon: '→', col: 'var(--txt-dim)', labelKey: 'HYPOTHESIS_TRACKER_EV_NEUTRAL' },
 };
 
 function fmtDate(iso: string) {
@@ -325,7 +325,7 @@ export default function HypothesisTracker() {
           </div>
 
           {cfError && (
-            <div style={{ fontSize: 'var(--fs-caption)', color: '#f87171', marginBottom: 8 }}>{cfError}</div>
+            <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--red)', marginBottom: 8 }}>{cfError}</div>
           )}
           <button
             onClick={createHypothesis}
@@ -598,7 +598,7 @@ export default function HypothesisTracker() {
                     ))}
                     <button
                       onClick={() => deleteHypothesis(h.id)}
-                      style={{ marginLeft: 'auto', background: 'none', border: 'none', cursor: 'pointer', color: '#f87171', fontSize: 'var(--fs-caption)', opacity: 0.6, padding: '3px 0' }}
+                      style={{ marginLeft: 'auto', background: 'none', border: 'none', cursor: 'pointer', color: 'var(--red)', fontSize: 'var(--fs-caption)', opacity: 0.6, padding: '3px 0' }}
                     >
                       {t('HYPOTHESIS_TRACKER_DELETE_BUTTON')}
                     </button>

--- a/components/KLineProChart.tsx
+++ b/components/KLineProChart.tsx
@@ -133,7 +133,7 @@ const DARK: Record<string, unknown> = {
     },
   },
   overlay: {
-    line: { color: '#5aa3ff', size: 1 },
+    line: { color: 'var(--accent-2)', size: 1 },
   },
   indicator: {
     tooltip: { showRule: 'follow_cross' },
@@ -248,10 +248,10 @@ let structureOverlayRegistered = false;
    fast timeframes for volatile coins (PEPE/BONK 15m, where EMA200's 200-bar
    lookback still reaches a real multi-day-old price level). */
 const EMA_PERIODS = [
-  { period: 9,   color: '#fbbf24', size: 1   },  // gold
+  { period: 9,   color: 'var(--amber)', size: 1   },  // gold
   { period: 20,  color: '#60a5fa', size: 1.5 },  // blue
   { period: 50,  color: '#f97316', size: 1.5 },  // orange
-  { period: 200, color: '#1a7aff', size: 2   },  // blue (thicker)
+  { period: 200, color: 'var(--accent)', size: 2   },  // blue (thicker)
 ] as const;
 
 interface EmaPoint { timestamp: number; value: number; }
@@ -651,7 +651,7 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
       // in the app (marketStore rsi14/rsi1h/rsi4h/rsiDaily), instead of the
       // built-in indicator's default 3-line [6,12,24] preset.
       chart.createIndicator(
-        { name: 'RSI', calcParams: [14], styles: { lines: [{ color: '#5aa3ff', size: 1.5 }] } },
+        { name: 'RSI', calcParams: [14], styles: { lines: [{ color: 'var(--accent-2)', size: 1.5 }] } },
         { pane: { id: 'rsi_pane', height: 110, minHeight: 30 } }
       );
 
@@ -912,7 +912,7 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
               // Crisp amber ring
               { type: 'polygon', attrs: { coordinates: ring(9) }, styles: { style: 'stroke', borderColor: '#f59e0b', borderSize: 1.5 } },
               // Center diamond accent
-              { type: 'polygon', attrs: { coordinates: [{ x: cx, y: cy - 3 }, { x: cx + 3, y: cy }, { x: cx, y: cy + 3 }, { x: cx - 3, y: cy }] }, styles: { style: 'fill', color: '#fcd34d' } },
+              { type: 'polygon', attrs: { coordinates: [{ x: cx, y: cy - 3 }, { x: cx + 3, y: cy }, { x: cx, y: cy + 3 }, { x: cx - 3, y: cy }] }, styles: { style: 'fill', color: 'var(--amber-2)' } },
               // Directional chevron (two line segments)
               { type: 'line', attrs: { coordinates: [v[0], v[1]] }, styles: { color: '#fde68a', size: 1.5 } },
               { type: 'line', attrs: { coordinates: [v[1], v[2]] }, styles: { color: '#fde68a', size: 1.5 } },
@@ -1601,13 +1601,13 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
       explanation: nearSR.type === 'support'
         ? "Squeeze + support confluence (separate from the chart's own Buy/Sell signal). Price is sitting on a tested support level while shorts are being squeezed out. High-probability long zone - watch for a confirmation candle before entering."
         : "Squeeze + resistance confluence (separate from the chart's own Buy/Sell signal). Price is pressing against tested resistance while longs are getting flushed. High-probability short zone - watch for a rejection candle before entering.",
-      color: '#fbbf24', bg: 'rgba(251,191,36,0.10)', bdr: 'rgba(251,191,36,0.28)',
+      color: 'var(--amber)', bg: 'rgba(251,191,36,0.10)', bdr: 'rgba(251,191,36,0.28)',
     };
     return {
       label: 'Setup Forming',
       detail: `Near ${nearSR.type} (${nearSR.touches} touches) · Squeeze ${sq.score}/100`,
       explanation: `Squeeze + ${nearSR.type} confluence (separate from the chart's own Buy/Sell signal) - the squeeze and the ${nearSR.type} level aren't lined up yet. Watch for direction confirmation - don't jump in early.`,
-      color: '#1a7aff', bg: 'rgba(26,122,255,0.10)', bdr: 'rgba(26,122,255,0.28)',
+      color: 'var(--accent)', bg: 'rgba(26,122,255,0.10)', bdr: 'rgba(26,122,255,0.28)',
     };
   })();
 

--- a/components/LiqFeed.tsx
+++ b/components/LiqFeed.tsx
@@ -406,7 +406,7 @@ export default function LiqFeed({ onClusters, coinFilter }: { onClusters?: (clus
       <div className="liqfeed-stats">
         <div className="liqfeed-stat">
           <span className="liqfeed-stat-lbl">{t('LIQ_FEED_STAT_LONGS')}</span>
-          <span className="liqfeed-stat-val" style={{ color: '#f87171' }}>{fmtUSD(stats.longUsd)}</span>
+          <span className="liqfeed-stat-val" style={{ color: 'var(--red)' }}>{fmtUSD(stats.longUsd)}</span>
         </div>
         <div className="liqfeed-stat-sep" />
         <div className="liqfeed-stat" style={{ textAlign: 'center' }}>
@@ -416,7 +416,7 @@ export default function LiqFeed({ onClusters, coinFilter }: { onClusters?: (clus
         <div className="liqfeed-stat-sep" />
         <div className="liqfeed-stat" style={{ textAlign: 'right' }}>
           <span className="liqfeed-stat-lbl">{t('LIQ_FEED_STAT_SHORTS')}</span>
-          <span className="liqfeed-stat-val" style={{ color: '#34d399' }}>{fmtUSD(stats.shortUsd)}</span>
+          <span className="liqfeed-stat-val" style={{ color: 'var(--green-2)' }}>{fmtUSD(stats.shortUsd)}</span>
         </div>
       </div>
 
@@ -428,8 +428,8 @@ export default function LiqFeed({ onClusters, coinFilter }: { onClusters?: (clus
             <div className="liqfeed-bias-bar liqfeed-bias-short" style={{ width: `${(stats.shortUsd / totalUsd) * 100}%` }} />
           </div>
           <div className="liqfeed-bias-label">
-            {longDom  && <span style={{ color: '#f87171', display: 'inline-flex', alignItems: 'center', gap: 5 }}><Warn /> {t('LIQ_FEED_BIAS_LONG_DOM')}</span>}
-            {shortDom && <span style={{ color: '#34d399' }}>{t('LIQ_FEED_BIAS_SHORT_DOM')}</span>}
+            {longDom  && <span style={{ color: 'var(--red)', display: 'inline-flex', alignItems: 'center', gap: 5 }}><Warn /> {t('LIQ_FEED_BIAS_LONG_DOM')}</span>}
+            {shortDom && <span style={{ color: 'var(--green-2)' }}>{t('LIQ_FEED_BIAS_SHORT_DOM')}</span>}
             {!longDom && !shortDom && <span style={{ color: 'var(--txt3)' }}>{t('LIQ_FEED_BIAS_BALANCED')}</span>}
           </div>
         </>
@@ -469,7 +469,7 @@ export default function LiqFeed({ onClusters, coinFilter }: { onClusters?: (clus
                 <span className="liq-cluster-amt">{fmtUSD(c.total)}</span>
                 <span
                   className="liq-cluster-dom"
-                  style={{ color: c.longUsd > c.shortUsd ? '#f87171' : '#34d399' }}
+                  style={{ color: c.longUsd > c.shortUsd ? 'var(--red)' : 'var(--green-2)' }}
                 >
                   {c.longUsd > c.shortUsd ? t('LIQ_FEED_DOM_LONG_ABBR') : t('LIQ_FEED_DOM_SHORT_ABBR')}
                 </span>
@@ -497,7 +497,7 @@ export default function LiqFeed({ onClusters, coinFilter }: { onClusters?: (clus
         {displayed.map(ev => {
           const isLong = ev.side === 'LONG';
           const isBig  = ev.usd >= MIN_ALERT;
-          const accent = isLong ? '#f87171' : '#34d399';
+          const accent = isLong ? 'var(--red)' : 'var(--green-2)';
           return (
             <div
               key={ev.id}
@@ -508,7 +508,7 @@ export default function LiqFeed({ onClusters, coinFilter }: { onClusters?: (clus
               <span className={`liqfeed-row-side liqfeed-row-side-${isLong ? 'long' : 'short'}`}>
                 {isLong ? t('LIQ_FEED_ROW_LONG') : t('LIQ_FEED_ROW_SHORT')}
               </span>
-              <span className="liqfeed-row-usd" style={{ color: isBig ? accent : '#8e8e93' }}>
+              <span className="liqfeed-row-usd" style={{ color: isBig ? accent : 'var(--txt-dim)' }}>
                 {fmtUSD(ev.usd)}
               </span>
               <span className="liqfeed-row-price">{fmtEventPrice(ev.price)}</span>

--- a/components/LiqHeatmap.tsx
+++ b/components/LiqHeatmap.tsx
@@ -59,7 +59,7 @@ export default function LiqHeatmap({ levels, currentPrice }: Props) {
       : ((currentPrice - l.price)  / currentPrice * 100);
     const barW = Math.round((l.amount / maxAmt) * 100);
     // above = short liq = green (bulls squeeze up); below = long liq = red (bears dump)
-    const color = side === 'above' ? '#34d399' : '#f87171';
+    const color = side === 'above' ? 'var(--green-2)' : 'var(--red)';
     const bg    = side === 'above' ? 'rgba(52,211,153,0.12)' : 'rgba(248,113,113,0.12)';
 
     return (
@@ -92,7 +92,7 @@ export default function LiqHeatmap({ levels, currentPrice }: Props) {
       {/* Short liq clusters - above price */}
       {above.length > 0 && (
         <>
-          <div style={{ fontSize: 'var(--fs-micro)', fontWeight: 700, color: '#34d399', letterSpacing: '.06em', textTransform: 'uppercase', marginBottom: 4 }}>
+          <div style={{ fontSize: 'var(--fs-micro)', fontWeight: 700, color: 'var(--green-2)', letterSpacing: '.06em', textTransform: 'uppercase', marginBottom: 4 }}>
             {t('LIQ_HEATMAP_SHORT_SECTION_LABEL')}
           </div>
           {above.map((l, i) => <Row key={i} l={l} side="above" />)}
@@ -115,7 +115,7 @@ export default function LiqHeatmap({ levels, currentPrice }: Props) {
       {below.length > 0 && (
         <>
           {below.map((l, i) => <Row key={i} l={l} side="below" />)}
-          <div style={{ fontSize: 'var(--fs-micro)', fontWeight: 700, color: '#f87171', letterSpacing: '.06em', textTransform: 'uppercase', marginTop: 4 }}>
+          <div style={{ fontSize: 'var(--fs-micro)', fontWeight: 700, color: 'var(--red)', letterSpacing: '.06em', textTransform: 'uppercase', marginTop: 4 }}>
             {t('LIQ_HEATMAP_LONG_SECTION_LABEL')}
           </div>
         </>

--- a/components/MarketConditionsWidget.tsx
+++ b/components/MarketConditionsWidget.tsx
@@ -36,7 +36,7 @@ function FngGauge({ value }: { value: number | null }) {
     <svg width={168} height={92} viewBox="0 0 200 108" style={{ flexShrink: 0 }}>
       <defs>
         <linearGradient id="fngGaugeGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-          <stop offset="0%"   stopColor="#ef4444" />
+          <stop offset="0%"   stopColor="var(--red)" />
           <stop offset="25%"  stopColor="#f97316" />
           <stop offset="50%"  stopColor="#facc15" />
           <stop offset="75%"  stopColor="#a3e635" />
@@ -118,7 +118,7 @@ export default function MarketConditionsWidget() {
 
   const delta = fng != null && fngPrev != null ? fng - fngPrev : null;
 
-  const rsiCol   = rsi == null ? 'var(--txt3)' : rsi >= 70 ? '#f87171' : rsi <= 30 ? '#34d399' : '#fbbf24';
+  const rsiCol   = rsi == null ? 'var(--txt3)' : rsi >= 70 ? 'var(--red)' : rsi <= 30 ? 'var(--green-2)' : 'var(--amber)';
   const rsiLabel = rsi == null ? '-' : rsi >= 70 ? t('MARKET_CONDITIONS_WIDGET_RSI_OVERBOUGHT') : rsi <= 30 ? t('MARKET_CONDITIONS_WIDGET_RSI_OVERSOLD') : t('MARKET_CONDITIONS_WIDGET_RSI_NEUTRAL');
 
   return (
@@ -186,8 +186,8 @@ export default function MarketConditionsWidget() {
                 <div style={{ width: `${shortPct}%`, background: '#f87171' }} />
               </div>
               <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 'var(--fs-caption)' }}>
-                <span style={{ color: '#34d399', fontWeight: 600 }}>{t('MARKET_CONDITIONS_WIDGET_LONG_PCT', { pct: longPct.toFixed(1) })}</span>
-                <span style={{ color: '#f87171', fontWeight: 600 }}>{t('MARKET_CONDITIONS_WIDGET_SHORT_PCT', { pct: shortPct.toFixed(1) })}</span>
+                <span style={{ color: 'var(--green-2)', fontWeight: 600 }}>{t('MARKET_CONDITIONS_WIDGET_LONG_PCT', { pct: longPct.toFixed(1) })}</span>
+                <span style={{ color: 'var(--red)', fontWeight: 600 }}>{t('MARKET_CONDITIONS_WIDGET_SHORT_PCT', { pct: shortPct.toFixed(1) })}</span>
               </div>
             </>
           );

--- a/components/MarketStructure.tsx
+++ b/components/MarketStructure.tsx
@@ -106,8 +106,8 @@ function fmtP(n: number): string {
 /* ── Event colour helpers ── */
 function evCol(ev: StructureEvent): string {
   return ev.type === 'CHoCH'
-    ? (ev.dir === 'bullish' ? '#1a7aff' : '#f87171')
-    : (ev.dir === 'bullish' ? '#34d399' : '#f87171');
+    ? (ev.dir === 'bullish' ? '#1a7aff' : 'var(--red)')
+    : (ev.dir === 'bullish' ? 'var(--green-2)' : 'var(--red)');
 }
 function evBg(ev: StructureEvent): string {
   return ev.type === 'CHoCH'
@@ -198,7 +198,7 @@ export default function MarketStructure({ coin, onData }: Props) {
       <div className="ms-card">
         <div className="ms-header">
           <span className="ms-title">{t('MARKET_STRUCTURE_TITLE')}</span>
-          <span style={{ fontSize: 'var(--fs-caption)', color: '#f87171' }}>{t('MARKET_STRUCTURE_FAILED')}</span>
+          <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--red)' }}>{t('MARKET_STRUCTURE_FAILED')}</span>
         </div>
       </div>
     );
@@ -206,7 +206,7 @@ export default function MarketStructure({ coin, onData }: Props) {
 
   const d  = data!;
   const le = d.lastEvent;
-  const biasCol = d.bias === 'BULLISH' ? '#34d399' : d.bias === 'BEARISH' ? '#f87171' : '#9ca3af';
+  const biasCol = d.bias === 'BULLISH' ? 'var(--green-2)' : d.bias === 'BEARISH' ? 'var(--red)' : '#9ca3af';
 
   return (
     <div className="ms-card">
@@ -236,13 +236,13 @@ export default function MarketStructure({ coin, onData }: Props) {
         {d.lastSwingHigh != null && (
           <div className="ms-level">
             <span className="ms-level-lbl">{t('MARKET_STRUCTURE_SWING_HIGH_LABEL')}</span>
-            <span className="ms-level-val" style={{ color: '#f87171' }}>${fmtP(d.lastSwingHigh)}</span>
+            <span className="ms-level-val" style={{ color: 'var(--red)' }}>${fmtP(d.lastSwingHigh)}</span>
           </div>
         )}
         {d.lastSwingLow != null && (
           <div className="ms-level">
             <span className="ms-level-lbl">{t('MARKET_STRUCTURE_SWING_LOW_LABEL')}</span>
-            <span className="ms-level-val" style={{ color: '#34d399' }}>${fmtP(d.lastSwingLow)}</span>
+            <span className="ms-level-val" style={{ color: 'var(--green-2)' }}>${fmtP(d.lastSwingLow)}</span>
           </div>
         )}
       </div>

--- a/components/MultiTFAlignment.tsx
+++ b/components/MultiTFAlignment.tsx
@@ -13,14 +13,14 @@ function getBias(rsi: number | null): Bias {
 }
 
 function barFill(bias: Bias): string {
-  if (bias === 'bullish') return '#34d399';
-  if (bias === 'bearish') return '#f87171';
+  if (bias === 'bullish') return 'var(--green-2)';
+  if (bias === 'bearish') return 'var(--red)';
   return 'rgba(255,255,255,0.18)';
 }
 
 function valColor(bias: Bias): string {
-  if (bias === 'bullish') return '#34d399';
-  if (bias === 'bearish') return '#f87171';
+  if (bias === 'bullish') return 'var(--green-2)';
+  if (bias === 'bearish') return 'var(--red)';
   return 'var(--txt2)';
 }
 
@@ -28,7 +28,7 @@ function BiasBadge({ bias }: { bias: Bias }) {
   const { t } = useLabels();
   const icon = bias === 'bullish' ? '▲' : bias === 'bearish' ? '▼' : '→';
   const label = bias === 'bullish' ? t('MULTI_TF_ALIGNMENT_BIAS_BULLISH') : bias === 'bearish' ? t('MULTI_TF_ALIGNMENT_BIAS_BEARISH') : t('MULTI_TF_ALIGNMENT_BIAS_NEUTRAL');
-  const color = bias === 'bullish' ? '#34d399' : bias === 'bearish' ? '#f87171' : 'var(--txt3)';
+  const color = bias === 'bullish' ? 'var(--green-2)' : bias === 'bearish' ? 'var(--red)' : 'var(--txt3)';
   const border = bias === 'bullish' ? 'rgba(52,211,153,0.4)' : bias === 'bearish' ? 'rgba(248,113,113,0.4)' : 'rgba(255,255,255,0.15)';
   const bg = bias === 'bullish' ? 'rgba(52,211,153,0.12)' : bias === 'bearish' ? 'rgba(248,113,113,0.12)' : 'transparent';
   return (
@@ -117,7 +117,7 @@ export default function MultiTFAlignment({ coin: coinProp }: { coin?: string }) 
     : 'mixed';
 
   const verdictLabel = verdict === 'bullish' ? t('MULTI_TF_ALIGNMENT_VERDICT_BULLISH') : verdict === 'bearish' ? t('MULTI_TF_ALIGNMENT_VERDICT_BEARISH') : verdict === 'conflicting' ? t('MULTI_TF_ALIGNMENT_VERDICT_CONFLICTING') : t('MULTI_TF_ALIGNMENT_VERDICT_MIXED');
-  const verdictColor = verdict === 'bullish' ? '#34d399' : verdict === 'bearish' ? '#f87171' : verdict === 'conflicting' ? '#fbbf24' : 'var(--txt3)';
+  const verdictColor = verdict === 'bullish' ? 'var(--green-2)' : verdict === 'bearish' ? 'var(--red)' : verdict === 'conflicting' ? 'var(--amber)' : 'var(--txt3)';
   const verdictBorder = verdict === 'bullish' ? 'rgba(52,211,153,0.4)' : verdict === 'bearish' ? 'rgba(248,113,113,0.4)' : verdict === 'conflicting' ? 'rgba(251,191,36,0.4)' : 'rgba(255,255,255,0.18)';
   const verdictBg = verdict === 'bullish' ? 'rgba(52,211,153,0.1)' : verdict === 'bearish' ? 'rgba(248,113,113,0.1)' : verdict === 'conflicting' ? 'rgba(251,191,36,0.1)' : 'transparent';
 

--- a/components/MultiTFSqueezeView.tsx
+++ b/components/MultiTFSqueezeView.tsx
@@ -73,7 +73,7 @@ function computeTFSignal(
 function cellColors(sig: TFSignal): { bg: string; text: string; border: string } {
   if (sig.dir === 'NEUTRAL') return { bg: 'transparent', text: 'var(--txt-dim)', border: 'transparent' };
   const isFlush = sig.dir === 'FLUSH';
-  const base    = isFlush ? '#f87171' : '#34d399';
+  const base    = isFlush ? 'var(--red)' : 'var(--green-2)';
   const alpha   = sig.strength >= 70 ? '28' : sig.strength >= 40 ? '16' : '0c';
   return {
     bg:     withAlpha(base, alpha),
@@ -141,13 +141,13 @@ export default function MultiTFSqueezeView() {
         {totalSqz > 0 && (
           <span style={{
             fontSize: 'var(--fs-caption)', fontWeight: 700, padding: '2px 7px', borderRadius: 20,
-            color: '#34d399', background: 'rgba(52,211,153,0.1)', border: '0.5px solid rgba(52,211,153,0.25)',
+            color: 'var(--green-2)', background: 'rgba(52,211,153,0.1)', border: '0.5px solid rgba(52,211,153,0.25)',
           }}>{t('MULTI_TF_SQUEEZE_VIEW_SQUEEZE_BADGE', { count: totalSqz })}</span>
         )}
         {totalFlush > 0 && (
           <span style={{
             fontSize: 'var(--fs-caption)', fontWeight: 700, padding: '2px 7px', borderRadius: 20,
-            color: '#f87171', background: 'rgba(248,113,113,0.1)', border: '0.5px solid rgba(248,113,113,0.25)',
+            color: 'var(--red)', background: 'rgba(248,113,113,0.1)', border: '0.5px solid rgba(248,113,113,0.25)',
           }}>{t('MULTI_TF_SQUEEZE_VIEW_FLUSH_BADGE', { count: totalFlush })}</span>
         )}
       </div>
@@ -215,7 +215,7 @@ export default function MultiTFSqueezeView() {
             <span style={{
               fontSize: 'var(--fs-caption)', fontWeight: 700,
               color: rowActive
-                ? (dominantDir === 'SQUEEZE' ? '#34d399' : '#f87171')
+                ? (dominantDir === 'SQUEEZE' ? 'var(--green-2)' : 'var(--red)')
                 : 'var(--txt-dim)',
               letterSpacing: '.03em',
             }}>
@@ -287,8 +287,8 @@ export default function MultiTFSqueezeView() {
 
       {/* Footer legend */}
       <div style={{ padding: '6px 14px', borderTop: '0.5px solid rgba(255,255,255,0.05)', display: 'flex', gap: 12, flexWrap: 'wrap' }}>
-        <span style={{ fontSize: 'var(--fs-caption)', color: '#34d399' }}>{t('MULTI_TF_SQUEEZE_VIEW_LEGEND_SQUEEZE')}</span>
-        <span style={{ fontSize: 'var(--fs-caption)', color: '#f87171' }}>{t('MULTI_TF_SQUEEZE_VIEW_LEGEND_FLUSH')}</span>
+        <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--green-2)' }}>{t('MULTI_TF_SQUEEZE_VIEW_LEGEND_SQUEEZE')}</span>
+        <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--red)' }}>{t('MULTI_TF_SQUEEZE_VIEW_LEGEND_FLUSH')}</span>
         <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)' }}>{t('MULTI_TF_SQUEEZE_VIEW_LEGEND_FORMULA')}</span>
       </div>
     </div>

--- a/components/OnChainScore.tsx
+++ b/components/OnChainScore.tsx
@@ -46,7 +46,7 @@ function saveCache(data: OnChainData) {
 }
 
 function ScoreBar({ value, label, weight }: { value: number; label: string; weight: string }) {
-  const col = value >= 65 ? '#34d399' : value <= 40 ? '#f87171' : '#fbbf24';
+  const col = value >= 65 ? 'var(--green-2)' : value <= 40 ? 'var(--red)' : 'var(--amber)';
   return (
     <div style={{ marginBottom: 10 }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 4 }}>
@@ -121,11 +121,11 @@ export default function OnChainScore() {
     }
   }, [user, btcPrice]);
 
-  const verdictCol = data?.verdict === 'BULLISH' ? '#34d399' : data?.verdict === 'BEARISH' ? '#f87171' : '#fbbf24';
-  const compositeCol = (data?.composite_score ?? 50) >= 65 ? '#34d399' : (data?.composite_score ?? 50) <= 40 ? '#f87171' : '#fbbf24';
+  const verdictCol = data?.verdict === 'BULLISH' ? 'var(--green-2)' : data?.verdict === 'BEARISH' ? 'var(--red)' : 'var(--amber)';
+  const compositeCol = (data?.composite_score ?? 50) >= 65 ? 'var(--green-2)' : (data?.composite_score ?? 50) <= 40 ? 'var(--red)' : 'var(--amber)';
 
   const flowIcon = data?.exchange_flow === 'OUTFLOW' ? '↓' : data?.exchange_flow === 'INFLOW' ? '↑' : '→';
-  const flowCol = data?.exchange_flow === 'OUTFLOW' ? '#34d399' : data?.exchange_flow === 'INFLOW' ? '#f87171' : '#fbbf24';
+  const flowCol = data?.exchange_flow === 'OUTFLOW' ? 'var(--green-2)' : data?.exchange_flow === 'INFLOW' ? 'var(--red)' : 'var(--amber)';
 
   return (
     <div style={{
@@ -183,7 +183,7 @@ export default function OnChainScore() {
 
       {/* Error */}
       {error && (
-        <div style={{ padding: '8px 14px', fontSize: 'var(--fs-caption)', color: '#f87171', background: 'rgba(248,113,113,0.06)' }}>
+        <div style={{ padding: '8px 14px', fontSize: 'var(--fs-caption)', color: 'var(--red)', background: 'rgba(248,113,113,0.06)' }}>
           {/* The two sentinels set by the fetch above resolve to labels here;
               anything else is a real message from the server and is shown as-is. */}
           {error === 'REQUEST_FAILED' ? t('ON_CHAIN_SCORE_REQUEST_FAILED')

--- a/components/PositionSizer.tsx
+++ b/components/PositionSizer.tsx
@@ -179,7 +179,7 @@ export default function PositionSizer({ coin }: { coin: CoinId | '' }) {
         </div>
         {account && riskPct && (
           <div className="ps-risk-line">
-            {t('CALC_SIZER_AT_RISK_PREFIX')} <strong style={{ color: '#f87171' }}>{fmtUSD((parseFloat(account) || 0) * ((parseFloat(riskPct) || 0) / 100))}</strong>
+            {t('CALC_SIZER_AT_RISK_PREFIX')} <strong style={{ color: 'var(--red)' }}>{fmtUSD((parseFloat(account) || 0) * ((parseFloat(riskPct) || 0) / 100))}</strong>
           </div>
         )}
       </div>

--- a/components/SessionCountdown.tsx
+++ b/components/SessionCountdown.tsx
@@ -77,7 +77,7 @@ export default function SessionCountdown() {
   }, [nowMs]);
 
   /* colours */
-  const statusCol = current?.color ?? (dead ? '#f87171' : '#48484a');
+  const statusCol = current?.color ?? (dead ? 'var(--red)' : '#48484a');
   const statusBg  = current?.bg    ?? (dead ? 'rgba(248,113,113,0.08)' : 'transparent');
 
   return (
@@ -124,7 +124,7 @@ export default function SessionCountdown() {
       {/* Row 3 - active market holidays (NY/London/Asia/China) - reduced liquidity heads-up */}
       {mounted && holidays.length > 0 && (
         <div className="sc-row-next" style={{ marginTop: 4 }}>
-          <span className="sc-next-label" style={{ color: '#fbbf24' }}>{t('SESSION_COUNTDOWN_HOLIDAY')}</span>
+          <span className="sc-next-label" style={{ color: 'var(--amber)' }}>{t('SESSION_COUNTDOWN_HOLIDAY')}</span>
           <span suppressHydrationWarning style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt2)' }}>
             {holidays.map(h => t('SESSION_COUNTDOWN_HOLIDAY_ITEM', { region: h.region, name: h.name })).join(' · ')}
           </span>

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -143,7 +143,7 @@ export default function SettingsModal({ open, onClose }: Props) {
             </div>
             {settings.account_size > 0 && settings.risk_pct > 0 && (
               <div className="st-at-risk">
-                {t('SETTINGS_AT_RISK_PREFIX')} <strong style={{ color: '#f87171' }}>
+                {t('SETTINGS_AT_RISK_PREFIX')} <strong style={{ color: 'var(--red)' }}>
                   ${(settings.account_size * settings.risk_pct / 100).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                 </strong>
               </div>

--- a/components/SetupScanner.tsx
+++ b/components/SetupScanner.tsx
@@ -86,7 +86,7 @@ function CoinCard({ row, rank }: { row: ScanRow; rank: number }) {
   const { t } = useLabels();
   const cd = row.coin;
   const fr = classifyFunding(cd.fundingRate ?? 0);
-  const frColor = fr.rpm === 'pos' ? '#f87171' : fr.rpm === 'neg' ? '#34d399' : 'var(--txt-dim)';
+  const frColor = fr.rpm === 'pos' ? 'var(--red)' : fr.rpm === 'neg' ? 'var(--green-2)' : 'var(--txt-dim)';
   const dirBg = row.dir === 'LONG_LIQ'
     ? 'rgba(248,113,113,0.06)' : row.dir === 'SHORT_SQ'
     ? 'rgba(52,211,153,0.06)' : 'transparent';
@@ -123,13 +123,13 @@ function CoinCard({ row, rank }: { row: ScanRow; rank: number }) {
         </div>
         <div className="scan-stat">
           <span className="scan-stat-lbl">{t('SETUP_SCANNER_STAT_LONG_PCT')}</span>
-          <span className="scan-stat-val" style={{ color: (cd.longRatio ?? 0) >= 0.6 ? '#f87171' : '#8e8e93' }}>
+          <span className="scan-stat-val" style={{ color: (cd.longRatio ?? 0) >= 0.6 ? 'var(--red)' : 'var(--txt-dim)' }}>
             {fmtRatio(cd.longRatio)}
           </span>
         </div>
         <div className="scan-stat">
           <span className="scan-stat-lbl">{t('SETUP_SCANNER_STAT_SHORT_PCT')}</span>
-          <span className="scan-stat-val" style={{ color: (cd.shortRatio ?? 0) >= 0.6 ? '#34d399' : '#8e8e93' }}>
+          <span className="scan-stat-val" style={{ color: (cd.shortRatio ?? 0) >= 0.6 ? 'var(--green-2)' : 'var(--txt-dim)' }}>
             {fmtRatio(cd.shortRatio)}
           </span>
         </div>
@@ -236,7 +236,7 @@ export default function SetupScanner({ coin: coinProp }: { coin?: CoinId }) {
             <div className="scan-alert scan-alert-bear">
               <span className="scan-alert-icon" style={{ lineHeight: 0 }}><Warn size={14} /></span>
               <span>
-                <strong style={{ color: '#f87171' }}>{highestLongLiq.id.toUpperCase()}</strong>
+                <strong style={{ color: 'var(--red)' }}>{highestLongLiq.id.toUpperCase()}</strong>
                 {' '}{t('SETUP_SCANNER_ALERT_LONG_LIQ', { score: highestLongLiq.score })}
               </span>
             </div>
@@ -245,7 +245,7 @@ export default function SetupScanner({ coin: coinProp }: { coin?: CoinId }) {
             <div className="scan-alert scan-alert-bull">
               
               <span>
-                <strong style={{ color: '#34d399' }}>{highestShortSq.id.toUpperCase()}</strong>
+                <strong style={{ color: 'var(--green-2)' }}>{highestShortSq.id.toUpperCase()}</strong>
                 {' '}{t('SETUP_SCANNER_ALERT_SHORT_SQ', { score: highestShortSq.score })}
               </span>
             </div>
@@ -276,7 +276,7 @@ export default function SetupScanner({ coin: coinProp }: { coin?: CoinId }) {
           style={strongOnly ? {
             background: 'rgba(251,191,36,0.10)',
             borderColor: 'rgba(251,191,36,0.35)',
-            color: '#fbbf24',
+            color: 'var(--amber)',
           } : {}}
           aria-pressed={strongOnly}
           onClick={() => setStrongOnly(v => !v)}
@@ -330,11 +330,11 @@ export default function SetupScanner({ coin: coinProp }: { coin?: CoinId }) {
         <div className="scan-legend-title">{t('SETUP_SCANNER_LEGEND_TITLE')}</div>
         <div className="scan-legend-row">
           <span className="scan-legend-dot" style={{ background: '#f87171' }} />
-          <span><strong style={{ color: '#f87171' }}>{t('SETUP_SCANNER_LEGEND_LONG_LABEL')}</strong> - {t('SETUP_SCANNER_LEGEND_LONG_DESC')}</span>
+          <span><strong style={{ color: 'var(--red)' }}>{t('SETUP_SCANNER_LEGEND_LONG_LABEL')}</strong> - {t('SETUP_SCANNER_LEGEND_LONG_DESC')}</span>
         </div>
         <div className="scan-legend-row">
           <span className="scan-legend-dot" style={{ background: '#34d399' }} />
-          <span><strong style={{ color: '#34d399' }}>{t('SETUP_SCANNER_LEGEND_SHORT_LABEL')}</strong> - {t('SETUP_SCANNER_LEGEND_SHORT_DESC')}</span>
+          <span><strong style={{ color: 'var(--green-2)' }}>{t('SETUP_SCANNER_LEGEND_SHORT_LABEL')}</strong> - {t('SETUP_SCANNER_LEGEND_SHORT_DESC')}</span>
         </div>
         <div className="scan-legend-row">
           <span className="scan-legend-dot" style={{ background: '#606060' }} />

--- a/components/SignalAccuracy.tsx
+++ b/components/SignalAccuracy.tsx
@@ -24,16 +24,16 @@ interface ApiResponse {
 }
 
 function accColor(pct: number): string {
-  if (pct >= 70) return '#34d399';
-  if (pct >= 55) return '#fbbf24';
-  return '#f87171';
+  if (pct >= 70) return 'var(--green-2)';
+  if (pct >= 55) return 'var(--amber)';
+  return 'var(--red)';
 }
 
 function retColor(r: number): string {
-  if (r > 0.5)  return '#34d399';
-  if (r > 0)    return '#6ee7b7';
-  if (r > -0.5) return '#fca5a5';
-  return '#f87171';
+  if (r > 0.5)  return 'var(--green-2)';
+  if (r > 0)    return 'var(--green-soft)';
+  if (r > -0.5) return 'var(--red-soft)';
+  return 'var(--red)';
 }
 
 function accBar(pct: number, color: string) {
@@ -99,7 +99,7 @@ export default function SignalAccuracy() {
         </div>
       )}
       {err && (
-        <div style={{ padding: '16px 14px', fontSize: 'var(--fs-caption)', color: '#f87171' }}>{t('SIGNAL_ACCURACY_LOAD_ERROR')} {err}</div>
+        <div style={{ padding: '16px 14px', fontSize: 'var(--fs-caption)', color: 'var(--red)' }}>{t('SIGNAL_ACCURACY_LOAD_ERROR')} {err}</div>
       )}
 
       {/* Column headers */}
@@ -129,7 +129,7 @@ export default function SignalAccuracy() {
             const col3 = accColor(sig.accuracy3);
             const col6 = accColor(sig.accuracy6);
             const dirIcon = sig.direction === 'long' ? '↑' : '↓';
-            const dirColor = sig.direction === 'long' ? '#34d399' : '#f87171';
+            const dirColor = sig.direction === 'long' ? 'var(--green-2)' : 'var(--red)';
             return (
               <div
                 key={sig.name}

--- a/components/Sparkline.tsx
+++ b/components/Sparkline.tsx
@@ -8,7 +8,7 @@ export default function Sparkline({ points, width = 44, height = 16 }: { points:
   const max = Math.max(...points);
   const span = max - min || 1;
   const up = points[points.length - 1] >= points[0];
-  const col = up ? '#4ade80' : '#f87171';
+  const col = up ? 'var(--green)' : 'var(--red)';
   const step = width / (points.length - 1);
   const coords = points.map((p, i) => {
     const x = i * step;

--- a/components/SpotlightTour.tsx
+++ b/components/SpotlightTour.tsx
@@ -15,7 +15,7 @@ const SANS = "var(--font-sans, 'Figtree', system-ui, sans-serif)";
 // [data-theme="light"] at all. Values below match the app's real light-theme
 // tokens (app/globals.css's [data-theme="light"] block), not guesses.
 const DARK = {
-  ACCENT: '#1a7aff', GREEN: '#4ade80', RED: '#f87171', ORANGE: '#f97316',
+  ACCENT: '#1a7aff', GREEN: 'var(--green)', RED: 'var(--red)', ORANGE: '#f97316',
   BG0: '#07090f', BG1: '#0c0f1c', BG2: '#101324',
   TXT1: '#eef0fa', TXT2: '#9296b5', TXT3: '#4e5374',
   BDR: 'rgba(26,122,255,0.1)', TRACK_BG: 'rgba(26,122,255,0.06)', GRID: 'rgba(26,122,255,0.05)',

--- a/components/StopLossZone.tsx
+++ b/components/StopLossZone.tsx
@@ -145,7 +145,7 @@ export default function StopLossZone({ coin, grokSignal }: { coin: CoinId; grokS
   const tp   = stop ? computeTP(d, bias, stop) : null;
   const rr   = stop && tp ? (tp.distPct / stop.distPct) : null;
 
-  const biasCol = bias === 'long' ? '#34d399' : bias === 'short' ? '#f87171' : 'var(--txt-dim)';
+  const biasCol = bias === 'long' ? 'var(--green-2)' : bias === 'short' ? 'var(--red)' : 'var(--txt-dim)';
 
   // Conflict: technical indicator bias vs Grok AI signal
   const grokUp = grokSignal?.toUpperCase() ?? '';
@@ -165,7 +165,7 @@ export default function StopLossZone({ coin, grokSignal }: { coin: CoinId; grokS
     rows.push(...all.sort((a, b) => b.price - a.price));
   }
 
-  const roleCol   = (role: Row['role']) => role === 'sl' ? '#f87171' : role === 'tp' ? '#34d399' : 'var(--txt)';
+  const roleCol   = (role: Row['role']) => role === 'sl' ? 'var(--red)' : role === 'tp' ? 'var(--green-2)' : 'var(--txt)';
   const roleTint  = (role: Row['role']) => role === 'tp' ? 'rgba(52,211,153,0.07)' : role === 'sl' ? 'rgba(248,113,113,0.07)' : 'transparent';
   const roleLabel = (role: Row['role']) => role === 'sl' ? t('STOP_LOSS_ZONE_ROLE_SL') : role === 'tp' ? t('STOP_LOSS_ZONE_ROLE_TP') : t('STOP_LOSS_ZONE_ROLE_ENTRY');
 

--- a/components/TradeJournal.tsx
+++ b/components/TradeJournal.tsx
@@ -884,7 +884,7 @@ function Inner() {
 
           {/* Leverage */}
           {(() => {
-            const levColor = leverage >= 25 ? '#f87171' : leverage >= 10 ? '#fbbf24' : '#34d399';
+            const levColor = leverage >= 25 ? 'var(--red)' : leverage >= 10 ? 'var(--amber)' : 'var(--green-2)';
             const levPct   = ((leverage - 1) / (125 - 1)) * 100;
             const trackBg  = `linear-gradient(to right, ${levColor} 0%, ${levColor} ${levPct}%, rgba(255,255,255,0.08) ${levPct}%, rgba(255,255,255,0.08) 100%)`;
             return (
@@ -982,11 +982,11 @@ function Inner() {
               background: 'rgba(248,113,113,0.08)', border: '0.5px solid rgba(248,113,113,0.3)',
               borderRadius: 8, padding: '10px 12px', marginBottom: 12,
             }}>
-              <div style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: '#f87171', marginBottom: 6 }}>
+              <div style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: 'var(--red)', marginBottom: 6 }}>
                 {t('TRADE_JOURNAL_LOG_RULE_VIOLATION_TITLE', { plural: activeViolations.length > 1 ? 's' : '' })}
               </div>
               {activeViolations.map(r => (
-                <div key={r.id} style={{ fontSize: 'var(--fs-caption)', color: '#f87171', opacity: 0.85, lineHeight: 1.5 }}>
+                <div key={r.id} style={{ fontSize: 'var(--fs-caption)', color: 'var(--red)', opacity: 0.85, lineHeight: 1.5 }}>
                   · {r.name} ({ruleLabel(r, t)})
                 </div>
               ))}
@@ -1052,7 +1052,7 @@ function Inner() {
                   </span>
                   {trade.leverage != null && trade.leverage > 1 && (
                     <span className="tj-lev-tag" style={{
-                      color:       trade.leverage >= 25 ? '#f87171' : trade.leverage >= 10 ? '#fbbf24' : '#34d399',
+                      color:       trade.leverage >= 25 ? 'var(--red)' : trade.leverage >= 10 ? 'var(--amber)' : 'var(--green-2)',
                       background:  withAlpha(trade.leverage >= 25 ? '#f87171' : trade.leverage >= 10 ? '#fbbf24' : '#34d399', '14'),
                       borderColor: withAlpha(trade.leverage >= 25 ? '#f87171' : trade.leverage >= 10 ? '#fbbf24' : '#34d399', '40'),
                     }}>
@@ -1066,7 +1066,7 @@ function Inner() {
                   {trade.id && violatingTradeIds.has(trade.id) && (
                     <span title={t('TRADE_JOURNAL_HISTORY_RULE_VIOLATION_TITLE')} style={{
                       fontSize: 'var(--fs-caption)', fontWeight: 700, letterSpacing: '0.05em',
-                      background: 'rgba(248,113,113,0.12)', color: '#f87171',
+                      background: 'rgba(248,113,113,0.12)', color: 'var(--red)',
                       border: '0.5px solid rgba(248,113,113,0.3)',
                       borderRadius: 4, padding: '2px 5px',
                     }}>{t('TRADE_JOURNAL_HISTORY_RULE_BADGE')}</span>
@@ -1078,9 +1078,9 @@ function Inner() {
 
               <div className="tj-trade-prices">
                 <div className="tj-tp"><span className="tj-tp-lbl">{t('TRADE_JOURNAL_HISTORY_TP_ENTRY_LABEL')}</span><span className="tj-tp-val">${trade.entry_price.toLocaleString()}</span></div>
-                <div className="tj-tp"><span className="tj-tp-lbl">{t('TRADE_JOURNAL_HISTORY_TP_STOP_LABEL')}</span><span className="tj-tp-val" style={{ color: '#f87171' }}>${trade.stop_loss.toLocaleString()}</span></div>
+                <div className="tj-tp"><span className="tj-tp-lbl">{t('TRADE_JOURNAL_HISTORY_TP_STOP_LABEL')}</span><span className="tj-tp-val" style={{ color: 'var(--red)' }}>${trade.stop_loss.toLocaleString()}</span></div>
                 {trade.take_profit != null && (
-                  <div className="tj-tp"><span className="tj-tp-lbl">{t('TRADE_JOURNAL_HISTORY_TP_TP_LABEL')}</span><span className="tj-tp-val" style={{ color: '#34d399' }}>${trade.take_profit.toLocaleString()}</span></div>
+                  <div className="tj-tp"><span className="tj-tp-lbl">{t('TRADE_JOURNAL_HISTORY_TP_TP_LABEL')}</span><span className="tj-tp-val" style={{ color: 'var(--green-2)' }}>${trade.take_profit.toLocaleString()}</span></div>
                 )}
                 {trade.exit_price != null && (
                   <div className="tj-tp"><span className="tj-tp-lbl">{t('TRADE_JOURNAL_HISTORY_TP_EXIT_LABEL')}</span><span className="tj-tp-val">${trade.exit_price.toLocaleString()}</span></div>
@@ -1088,7 +1088,7 @@ function Inner() {
                 {trade.pnl_usd != null && (
                   <div className="tj-tp">
                     <span className="tj-tp-lbl">{t('TRADE_JOURNAL_HISTORY_TP_PNL_LABEL')}</span>
-                    <span className="tj-tp-val" style={{ color: trade.pnl_usd >= 0 ? '#34d399' : '#f87171' }}>
+                    <span className="tj-tp-val" style={{ color: trade.pnl_usd >= 0 ? 'var(--green-2)' : 'var(--red)' }}>
                       {fmtUSD(trade.pnl_usd)}
                     </span>
                   </div>
@@ -1099,7 +1099,7 @@ function Inner() {
                   return (
                     <div className="tj-tp">
                       <span className="tj-tp-lbl">{t('TRADE_JOURNAL_HISTORY_TP_R_LABEL')}</span>
-                      <span className="tj-tp-val" style={{ color: r >= 0 ? '#34d399' : '#f87171' }}>
+                      <span className="tj-tp-val" style={{ color: r >= 0 ? 'var(--green-2)' : 'var(--red)' }}>
                         {r >= 0 ? '+' : ''}{r.toFixed(2)}R
                       </span>
                     </div>
@@ -1487,7 +1487,7 @@ function Inner() {
                 disabled={shadowLoading}
                 style={{
                   background: shadowLoading ? 'rgba(255,255,255,0.06)' : 'rgba(26,122,255,0.12)',
-                  color: shadowLoading ? 'var(--txt3)' : '#1a7aff',
+                  color: shadowLoading ? 'var(--txt3)' : 'var(--accent)',
                   border: `1px solid ${shadowLoading ? 'var(--bdr)' : 'rgba(26,122,255,0.35)'}`,
                   borderRadius: 8, padding: '10px 20px', fontSize: 'var(--fs-label)', fontWeight: 700,
                   cursor: shadowLoading ? 'default' : 'pointer',
@@ -1509,7 +1509,7 @@ function Inner() {
               </button>
             )}
             {shadowError && (
-              <div style={{ color: '#f87171', fontSize: 'var(--fs-caption)', marginTop: 8 }}>{shadowError}</div>
+              <div style={{ color: 'var(--red)', fontSize: 'var(--fs-caption)', marginTop: 8 }}>{shadowError}</div>
             )}
           </div>
 
@@ -1541,7 +1541,7 @@ function Inner() {
                 disabled={biasLoading}
                 style={{
                   background: biasLoading ? 'rgba(255,255,255,0.06)' : 'rgba(26,122,255,0.12)',
-                  color: biasLoading ? 'var(--txt3)' : '#1a7aff',
+                  color: biasLoading ? 'var(--txt3)' : 'var(--accent)',
                   border: `1px solid ${biasLoading ? 'var(--bdr)' : 'rgba(26,122,255,0.35)'}`,
                   borderRadius: 8, padding: '10px 20px', fontSize: 'var(--fs-label)', fontWeight: 700,
                   cursor: biasLoading ? 'default' : 'pointer',
@@ -1559,7 +1559,7 @@ function Inner() {
               </button>
             )}
             {biasError && (
-              <div style={{ color: '#f87171', fontSize: 'var(--fs-caption)', marginTop: 8 }}>{biasError}</div>
+              <div style={{ color: 'var(--red)', fontSize: 'var(--fs-caption)', marginTop: 8 }}>{biasError}</div>
             )}
           </div>
           {biasAnalysis && <BiasResult text={biasAnalysis} />}
@@ -1590,7 +1590,7 @@ function Inner() {
               onClick={() => setShowThesisForm(v => !v)}
               style={{
                 background: showThesisForm ? 'rgba(255,255,255,0.06)' : 'rgba(26,122,255,0.12)',
-                color: showThesisForm ? 'var(--txt3)' : '#1a7aff',
+                color: showThesisForm ? 'var(--txt3)' : 'var(--accent)',
                 border: `1px solid ${showThesisForm ? 'var(--bdr)' : 'rgba(26,122,255,0.35)'}`,
                 borderRadius: 8, padding: '8px 16px', fontSize: 'var(--fs-caption)', fontWeight: 700, cursor: 'pointer', flexShrink: 0,
               }}
@@ -1653,7 +1653,7 @@ function Inner() {
                 {thesisFormAssumptions.length < 5 && (
                   <button
                     onClick={() => setThesisFormAssumptions(a => [...a, ''])}
-                    style={{ fontSize: 'var(--fs-caption)', color: '#1a7aff', background: 'transparent', border: '0.5px solid rgba(26,122,255,0.3)', borderRadius: 5, padding: '4px 10px', cursor: 'pointer' }}
+                    style={{ fontSize: 'var(--fs-caption)', color: 'var(--accent)', background: 'transparent', border: '0.5px solid rgba(26,122,255,0.3)', borderRadius: 5, padding: '4px 10px', cursor: 'pointer' }}
                   >
                     {t('TRADE_JOURNAL_THESIS_ADD_ASSUMPTION_BUTTON')}
                   </button>
@@ -1672,7 +1672,7 @@ function Inner() {
                 disabled={!thesisFormSymbol.trim() || !thesisFormText.trim() || !thesisFormAssumptions.some(a => a.trim())}
                 style={{
                   display: 'block', marginTop: 14, width: '100%',
-                  background: 'rgba(26,122,255,0.12)', color: '#1a7aff',
+                  background: 'rgba(26,122,255,0.12)', color: 'var(--accent)',
                   border: '1px solid rgba(26,122,255,0.35)', borderRadius: 8,
                   padding: '10px', fontSize: 'var(--fs-label)', fontWeight: 700, cursor: 'pointer',
                 }}
@@ -1690,7 +1690,7 @@ function Inner() {
           <div style={{ display: 'flex', flexDirection: 'column', gap: 12, marginTop: 8 }}>
             {theses.map(thesis => {
               const score     = thesis.lastScore;
-              const scoreCol  = score == null ? 'var(--txt3)' : score >= 8 ? '#34d399' : score >= 5 ? '#fbbf24' : '#f87171';
+              const scoreCol  = score == null ? 'var(--txt3)' : score >= 8 ? 'var(--green-2)' : score >= 5 ? 'var(--amber)' : 'var(--red)';
               const isChecking = checkingThesisId === thesis.id;
               return (
                 <div key={thesis.id} style={{ background: 'var(--bg1)', border: '0.5px solid var(--bdr)', borderRadius: 'var(--radius-card)', padding: '12px 14px' }}>
@@ -1700,7 +1700,7 @@ function Inner() {
                     <span style={{
                       fontSize: 'var(--fs-caption)', padding: '2px 6px', borderRadius: 10, fontWeight: 700,
                       background: thesis.direction === 'LONG' ? 'rgba(52,211,153,0.1)' : 'rgba(248,113,113,0.1)',
-                      color: thesis.direction === 'LONG' ? '#34d399' : '#f87171',
+                      color: thesis.direction === 'LONG' ? 'var(--green-2)' : 'var(--red)',
                       border: `0.5px solid ${thesis.direction === 'LONG' ? 'rgba(52,211,153,0.3)' : 'rgba(248,113,113,0.3)'}`,
                     }}>
                       {thesis.direction}
@@ -1752,7 +1752,7 @@ function Inner() {
                       disabled={isChecking}
                       style={{
                         background: isChecking ? 'rgba(255,255,255,0.06)' : 'rgba(26,122,255,0.10)',
-                        color: isChecking ? 'var(--txt3)' : '#1a7aff',
+                        color: isChecking ? 'var(--txt3)' : 'var(--accent)',
                         border: `0.5px solid ${isChecking ? 'var(--bdr)' : 'rgba(26,122,255,0.3)'}`,
                         borderRadius: 6, padding: '5px 12px', fontSize: 'var(--fs-caption)', fontWeight: 700, cursor: isChecking ? 'default' : 'pointer',
                       }}
@@ -1794,7 +1794,7 @@ function Inner() {
                   </div>
                   <div style={{
                     fontSize: '1.625rem', fontWeight: 800, fontFamily: 'var(--font-mono), monospace',
-                    color: complianceScore.pct >= 80 ? '#34d399' : complianceScore.pct >= 60 ? '#fbbf24' : '#f87171',
+                    color: complianceScore.pct >= 80 ? 'var(--green-2)' : complianceScore.pct >= 60 ? 'var(--amber)' : 'var(--red)',
                   }}>
                     {complianceScore.pct}%
                   </div>
@@ -1804,39 +1804,39 @@ function Inner() {
               <div className="tj-stats-grid">
                 <div className="tj-stat">
                   <div className="tj-stat-lbl"><Tip width={230} text={t('TRADE_JOURNAL_STATS_WIN_RATE_TOOLTIP')}>{t('TRADE_JOURNAL_STATS_WIN_RATE_LABEL')}</Tip></div>
-                  <div className="tj-stat-val" style={{ color: stats.winRate >= 50 ? '#34d399' : '#f87171' }}>
+                  <div className="tj-stat-val" style={{ color: stats.winRate >= 50 ? 'var(--green-2)' : 'var(--red)' }}>
                     {stats.winRate.toFixed(0)}%
                   </div>
                 </div>
                 <div className="tj-stat">
                   <div className="tj-stat-lbl">{t('TRADE_JOURNAL_STATS_TOTAL_PNL_LABEL')}</div>
-                  <div className="tj-stat-val" style={{ color: stats.totalPnL >= 0 ? '#34d399' : '#f87171' }}>
+                  <div className="tj-stat-val" style={{ color: stats.totalPnL >= 0 ? 'var(--green-2)' : 'var(--red)' }}>
                     {fmtUSD(stats.totalPnL)}
                   </div>
                 </div>
                 <div className="tj-stat">
                   <div className="tj-stat-lbl"><Tip width={230} text={t('TRADE_JOURNAL_STATS_AVG_R_TOOLTIP')}>{t('TRADE_JOURNAL_STATS_AVG_R_LABEL')}</Tip></div>
-                  <div className="tj-stat-val" style={{ color: stats.avgR >= 0 ? '#34d399' : '#f87171' }}>
+                  <div className="tj-stat-val" style={{ color: stats.avgR >= 0 ? 'var(--green-2)' : 'var(--red)' }}>
                     {stats.avgR >= 0 ? '+' : ''}{stats.avgR.toFixed(2)}R
                   </div>
                 </div>
                 <div className="tj-stat">
                   <div className="tj-stat-lbl">{t('TRADE_JOURNAL_STATS_RECORD_LABEL')}</div>
                   <div className="tj-stat-val">
-                    <span style={{ color: '#34d399' }}>{stats.wins}W</span>
+                    <span style={{ color: 'var(--green-2)' }}>{stats.wins}W</span>
                     <span style={{ color: 'var(--txt3)' }}> · </span>
-                    <span style={{ color: '#f87171' }}>{stats.losses}L</span>
+                    <span style={{ color: 'var(--red)' }}>{stats.losses}L</span>
                   </div>
                 </div>
                 <div className="tj-stat">
                   <div className="tj-stat-lbl">{t('TRADE_JOURNAL_STATS_CURRENT_STREAK_LABEL')}</div>
-                  <div className="tj-stat-val" style={{ color: stats.streak.dir === 'W' ? '#34d399' : stats.streak.dir === 'L' ? '#f87171' : 'var(--txt3)' }}>
+                  <div className="tj-stat-val" style={{ color: stats.streak.dir === 'W' ? 'var(--green-2)' : stats.streak.dir === 'L' ? 'var(--red)' : 'var(--txt3)' }}>
                     {stats.streak.dir === 'W' ? `${stats.streak.current}W` : stats.streak.dir === 'L' ? `${stats.streak.current}L` : '-'}
                   </div>
                 </div>
                 <div className="tj-stat">
                   <div className="tj-stat-lbl">{t('TRADE_JOURNAL_STATS_BEST_WIN_STREAK_LABEL')}</div>
-                  <div className="tj-stat-val" style={{ color: stats.streak.bestWin > 0 ? '#34d399' : 'var(--txt3)' }}>
+                  <div className="tj-stat-val" style={{ color: stats.streak.bestWin > 0 ? 'var(--green-2)' : 'var(--txt3)' }}>
                     {stats.streak.bestWin > 0 ? `${stats.streak.bestWin}W` : '-'}
                   </div>
                 </div>
@@ -1853,13 +1853,13 @@ function Inner() {
                 const y = (v: number) => H - PAD - ((v - minV) / range) * (H - PAD * 2);
                 const polyline = pts.map((p, i) => `${x(i)},${y(p.value)}`).join(' ');
                 const lastV    = pts[pts.length - 1].value;
-                const lineCol  = lastV >= 0 ? '#34d399' : '#f87171';
+                const lineCol  = lastV >= 0 ? 'var(--green-2)' : 'var(--red)';
                 const zeroY    = y(0);
                 return (
                   <div className="tj-breakdown" style={{ marginBottom: 0 }}>
                     <div className="tj-breakdown-title" style={{ display: 'flex', justifyContent: 'space-between' }}>
                       <span>{t('TRADE_JOURNAL_STATS_EQUITY_CURVE_LABEL')}</span>
-                      <span style={{ color: lastV >= 0 ? '#34d399' : '#f87171', fontWeight: 700 }}>
+                      <span style={{ color: lastV >= 0 ? 'var(--green-2)' : 'var(--red)', fontWeight: 700 }}>
                         {lastV >= 0 ? '+' : ''}{lastV.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                       </span>
                     </div>
@@ -1890,7 +1890,7 @@ function Inner() {
                         <div className="tj-breakdown-bar" style={{ width: `${wr}%` }} />
                       </div>
                       <span className="tj-breakdown-sub">{wr.toFixed(0)}% · {d.wins}/{d.total}</span>
-                      <span className="tj-breakdown-pnl" style={{ color: d.pnl >= 0 ? '#34d399' : '#f87171' }}>{fmtUSD(d.pnl)}</span>
+                      <span className="tj-breakdown-pnl" style={{ color: d.pnl >= 0 ? 'var(--green-2)' : 'var(--red)' }}>{fmtUSD(d.pnl)}</span>
                     </div>
                     );
                   })}
@@ -1904,7 +1904,7 @@ function Inner() {
                     <div key={s} className="tj-breakdown-row">
                       <span className="tj-breakdown-name">{s}</span>
                       <span className="tj-breakdown-sub">{t('TRADE_JOURNAL_STATS_TRADES_COUNT', { wins: d.wins, total: d.total })}</span>
-                      <span className="tj-breakdown-pnl" style={{ color: (d.wins/d.total) >= 0.5 ? '#34d399' : '#f87171' }}>
+                      <span className="tj-breakdown-pnl" style={{ color: (d.wins/d.total) >= 0.5 ? 'var(--green-2)' : 'var(--red)' }}>
                         {((d.wins/d.total)*100).toFixed(0)}% WR
                       </span>
                     </div>

--- a/components/UsageRings.tsx
+++ b/components/UsageRings.tsx
@@ -7,10 +7,10 @@ const R = 21; // ring radius
 const C = 2 * Math.PI * R; // arc circumference
 
 const RINGS = [
-  { id: 'quick',    labelKey: 'USAGE_RINGS_QUICK',    color: '#34d399', used: 'quick_used',     limit: 'quick_limit'     },
-  { id: 'deep',     labelKey: 'USAGE_RINGS_DEEP',     color: '#5aa3ff', used: 'deep_used',      limit: 'deep_limit'      },
-  { id: 'chat',     labelKey: 'USAGE_RINGS_CHAT',     color: '#60a5fa', used: 'chat_used',      limit: 'chat_limit'      },
-  { id: 'search',   labelKey: 'USAGE_RINGS_SEARCH',   color: '#1a7aff', used: 'search_used',    limit: 'search_limit'    },
+  { id: 'quick',    labelKey: 'USAGE_RINGS_QUICK',    color: 'var(--green-2)', used: 'quick_used',     limit: 'quick_limit'     },
+  { id: 'deep',     labelKey: 'USAGE_RINGS_DEEP',     color: 'var(--accent-2)', used: 'deep_used',      limit: 'deep_limit'      },
+  { id: 'chat',     labelKey: 'USAGE_RINGS_CHAT',     color: 'var(--accent-2)', used: 'chat_used',      limit: 'chat_limit'      },
+  { id: 'search',   labelKey: 'USAGE_RINGS_SEARCH',   color: 'var(--accent)', used: 'search_used',    limit: 'search_limit'    },
   { id: 'briefing', labelKey: 'USAGE_RINGS_BRIEFING', color: '#f59e0b', used: 'briefing_used',  limit: 'briefing_limit'  },
   // Shared budget across all 11 one-shot tools. Pro-only, so this ring is
   // filtered out below when the limit is 0 - free is capped per tool and has
@@ -32,7 +32,7 @@ export default function UsageRings({ usage }: { usage: GrokUsageInfo }) {
           const limit     = usage[limitKey] ?? 0;
           const remaining = limit - used;
           const pct       = limit > 0 ? used / limit : 0;
-          const col       = pct >= 0.9 ? '#f87171' : pct >= 0.7 ? '#fbbf24' : color;
+          const col       = pct >= 0.9 ? 'var(--red)' : pct >= 0.7 ? 'var(--amber)' : color;
           const offset    = C * (1 - pct);
           return (
             <div key={id} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6 }}>

--- a/components/VolatilityRegime.tsx
+++ b/components/VolatilityRegime.tsx
@@ -13,9 +13,9 @@ interface HVData {
 }
 
 const REGIME_META: Record<'low' | 'neutral' | 'high', { labelKey: LabelKey; col: string; bg: string; bdr: string; hintKey: LabelKey }> = {
-  low:     { labelKey: 'VOLATILITY_REGIME_LABEL_LOW',     col: '#34d399', bg: 'rgba(52,211,153,0.10)',  bdr: 'rgba(52,211,153,0.3)',  hintKey: 'VOLATILITY_REGIME_HINT_LOW' },
-  neutral: { labelKey: 'VOLATILITY_REGIME_LABEL_NEUTRAL', col: '#fbbf24', bg: 'rgba(251,191,36,0.10)',  bdr: 'rgba(251,191,36,0.3)',  hintKey: 'VOLATILITY_REGIME_HINT_NEUTRAL' },
-  high:    { labelKey: 'VOLATILITY_REGIME_LABEL_HIGH',    col: '#f87171', bg: 'rgba(248,113,113,0.10)', bdr: 'rgba(248,113,113,0.3)', hintKey: 'VOLATILITY_REGIME_HINT_HIGH' },
+  low:     { labelKey: 'VOLATILITY_REGIME_LABEL_LOW',     col: 'var(--green-2)', bg: 'rgba(52,211,153,0.10)',  bdr: 'rgba(52,211,153,0.3)',  hintKey: 'VOLATILITY_REGIME_HINT_LOW' },
+  neutral: { labelKey: 'VOLATILITY_REGIME_LABEL_NEUTRAL', col: 'var(--amber)', bg: 'rgba(251,191,36,0.10)',  bdr: 'rgba(251,191,36,0.3)',  hintKey: 'VOLATILITY_REGIME_HINT_NEUTRAL' },
+  high:    { labelKey: 'VOLATILITY_REGIME_LABEL_HIGH',    col: 'var(--red)', bg: 'rgba(248,113,113,0.10)', bdr: 'rgba(248,113,113,0.3)', hintKey: 'VOLATILITY_REGIME_HINT_HIGH' },
 };
 
 const CACHE_KEY = 'lhq_vol_regime';

--- a/components/WhaleTradesFeed.tsx
+++ b/components/WhaleTradesFeed.tsx
@@ -208,7 +208,7 @@ export default function WhaleTradesFeed() {
             >
               <span className="wf-row-coin"  style={{ color: accent }}>{trade.coin}</span>
               <span className={`wf-row-side wf-row-side-${isBuy ? 'buy' : 'sell'}`}>{badge}</span>
-              <span className="wf-row-usd"   style={{ color: isBig ? accent : '#8e8e93' }}>
+              <span className="wf-row-usd"   style={{ color: isBig ? accent : 'var(--txt-dim)' }}>
                 {fmtUSD(trade.usd)}
               </span>
               <span className="wf-row-price">${trade.price.toLocaleString('en-US', { maximumFractionDigits: 2 })}</span>

--- a/lib/color.ts
+++ b/lib/color.ts
@@ -1,4 +1,4 @@
-/** Applies alpha to any CSS color - a hex literal ('#34d399') or a custom
+/** Applies alpha to any CSS color - a hex literal ('var(--green-2)') or a custom
     property (`var(--green)`) - via color-mix. String concatenation like
     `color + '44'` only works when color is a bare hex literal; it silently
     breaks (invalid CSS) the moment that literal is swapped for a var().

--- a/lib/distribution.ts
+++ b/lib/distribution.ts
@@ -83,5 +83,5 @@ export function computeDistributionScore(d: DistributionInputs): DistributionSco
 }
 
 export function distributionColor(score: number): string {
-  return score >= 75 ? '#f87171' : score >= 60 ? '#fb923c' : '#fbbf24';
+  return score >= 75 ? 'var(--red)' : score >= 60 ? 'var(--orange)' : 'var(--amber)';
 }

--- a/lib/marketStore.ts
+++ b/lib/marketStore.ts
@@ -270,9 +270,9 @@ export function computeSqueezeScore(coin: CoinData | undefined): {
 
   // ── Gate: ≥2 independent signals required to label as Flush / Squeeze ─────
   if (longRisk > shortRisk && longSignals >= 2)
-    return { score, dir: 'LONG_LIQ', label: 'Long liquidation risk ↓', color: '#ff9a92' };
+    return { score, dir: 'LONG_LIQ', label: 'Long liquidation risk ↓', color: 'var(--red-soft)' };
   if (shortRisk > longRisk && shortSignals >= 2)
-    return { score, dir: 'SHORT_SQ', label: 'Short squeeze ↑', color: '#7de0a4' };
+    return { score, dir: 'SHORT_SQ', label: 'Short squeeze ↑', color: 'var(--green-soft)' };
   return { score, dir: 'NEUTRAL', label: 'Balanced', color: 'var(--txt-dim)' };
 }
 
@@ -321,9 +321,9 @@ export function computeCoinHealth(coin: CoinData | undefined): {
 
   const color =
     grade === 'A' ? '#f0c070' :   // gold
-    grade === 'B' ? '#34d399' :   // green
-    grade === 'C' ? '#94a3b8' :   // gray
-    grade === 'D' ? '#fb923c' :   // orange
+    grade === 'B' ? 'var(--green-2)' :   // green
+    grade === 'C' ? 'var(--txt-dim)' :   // gray
+    grade === 'D' ? 'var(--orange)' :   // orange
                     '#475569';    // muted (F)
 
   const label =

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -164,7 +164,17 @@ export function isDead(d: Date): boolean {
   return mins >= 240 && mins < 420;
 }
 
-// Priority order matters - first match wins
+/* Priority order matters - first match wins.
+ *
+ * The colours below are deliberately hardcoded and deliberately NOT theme
+ * tokens. Each row pairs a foreground with its OWN explicit dark background,
+ * and .session-pill applies both together. Because the background is fixed, the
+ * pair is already correct in BOTH themes.
+ *
+ * Swapping the foreground for a token breaks that: the light-theme token is a
+ * dark colour and the background stays dark. Measured during the issue #53 sweep
+ * - .session-pill dropped to 2.30:1 before this was reverted. If a colour here
+ * needs to change, change the pair. */
 export function getCurrentWindow(d: Date): Window | null {
   if (isGodTier(d))    return { name: 'God Tier',     label: 'Sun 15:00–19:00 UTC',    color: '#f0c070', bg: '#3d2e00' };
   if (isPrime(d))      return { name: 'Prime',        label: 'Daily 18:00–21:00 UTC',   color: '#7de0a4', bg: '#152b1e' };


### PR DESCRIPTION
## Summary

Closes #53. Light theme had **882** unreadable pieces of text; it now has **45**. Dark theme is unchanged — verified against a real rebuild, not assumed.

| | Before | After |
|---|---|---|
| **Light** | 882 | **45** (−95%) |
| **Dark** | 9 | **9** — per-route identical |

Worst measured pair was **1.39:1** against a 4.5:1 floor. That is not "hard to read", it is very nearly invisible — and it landed on the two colours this product uses to say which way the price moved. A light-mode user was reading direction by position alone.

## Why light mode could never have been fixed in CSS

The light theme already had a properly audited palette — `--green: #047857`, `--red: #B91C1C`, `--txt3`. It was not being used.

**~590 colours were hardcoded as hex literals**, most of them inside component inline styles:

```tsx
<span style={{ color: (cd.longRatio ?? 0) >= 0.6 ? '#f87171' : '#8e8e93' }}>
```

No stylesheet can reach that. `[data-theme="light"]` can redefine every token in the file and this line still renders the dark-mode pastel on a white card. That is the whole bug.

## Four causes, in order of size

### 1. `--txt-dim` had no light value at all — 190 of the 882

Declared once in `:root` and inherited its dark grey (`#8a8a8a`) straight into light mode, at **2.72:1** on white. **One missing line was 22% of the issue.**

My own token, added during the earlier contrast pass. I added it to `:root` and never gave it a light counterpart.

### 2. ~590 hardcoded hex literals — `app/`, `components/` **and `lib/`**

Replaced with the token that already holds the **identical dark value**, which is what makes this safe — in dark mode the computed colour does not change at all:

| hex | token | dark value |
|---|---|---|
| `#f87171` | `var(--red)` | `#f87171` ✅ |
| `#fca5a5` | `var(--red-soft)` | `#fca5a5` ✅ |
| `#4ade80` | `var(--green)` | `#4ade80` ✅ |
| `#86efac` | `var(--green-soft)` | `#86efac` ✅ |
| `#fbbf24` | `var(--amber)` | `#fbbf24` ✅ |
| `#fb923c` | `var(--orange)` | `#fb923c` ✅ |
| `#5aa3ff` | `var(--accent-2)` | `#5aa3ff` ✅ |
| `#8a8a8a` | `var(--txt-dim)` | `#8a8a8a` ✅ |

`lib/` mattered: `lib/marketStore.ts` and `lib/distribution.ts` return colour strings that end up in inline styles, and the first sweep missed them entirely.

### 3. Four light tokens were themselves below the floor

Measured, not assumed. Each failed on the darker light surfaces it actually lands on:

| token | was | measured worst | now | now worst |
|---|---|---|---|---|
| `--green` | `#047857` | **3.92** | `#046B4E` | 4.66 |
| `--accent-2` | `#0066E8` | **3.03** | `#0052CC` | 4.87 |
| `--txt3` | `#63656F` | **4.14** | `#5C5E68` | 4.60 |
| `--amber` | `#B45309` | **3.59** | `#8F4508` | 4.96 |

`--txt3` is the interesting one: it was fixed once already (from `#888B99`) and the fix was verified against white/card/canvas only. It still failed on `--bg4` and on the tinted panels. **Same failure mode as the `--txt2` gap in #44** — a colour "passes" only for the specific pairs someone checked.

### 4. `.frh-signal-action` multiplied its colour by `opacity: 0.85`

So the rendered value was never the token's audited one. **Sixth instance of that pattern in this file.** See the verification section — this one was caught by the dark-mode comparison, not by the light sweep.

## Two decisions worth reviewing rather than rubber-stamping

**`--green-2` is a new token** holding `#34d399` (emerald-400) — a second green that means exactly what `--green` means and was hardcoded in ~190 places.

It exists **only** so this fix leaves dark mode alone. Folding it into `--green` would have changed dark mode in 45 components, and that is a design decision, not a contrast fix. Collapsing the two greens is worth doing deliberately later — two greens for one meaning is precisely why this got missed.

**The pale tiers are not exact dark matches.** `#ff9a92`, `#fcbcbc`, `#fecaca`, `#7de0a4`, `#6ee7b7`, `#94a3b8`, `#8f919c`, `#60a5fa`, `#ef4444` each shift the dark value slightly *within its own family* — e.g. `#ff9a92` → `#fca5a5`, both pale reds meaning "down". Accepted because they were unreachable by any stylesheet otherwise, and because inventing nine more tokens would entrench the sprawl that caused this. **This is the one place dark mode changes**, and only by a shade within the same colour family.

## What was deliberately NOT swapped — each would have broken something

**Canvas.** `ctx.fillStyle = 'var(--red)'` is not a colour. Canvas does not resolve CSS variables; the shape renders black or nothing. `app/funding/page.tsx:205` is exactly this:

```ts
ctx.fillStyle = last >= 0 ? '#f87171' : '#34d399';
```

Any line touching a 2d context is skipped, and `KLineProChart.tsx` is excluded whole — it already reads `data-theme` itself for this reason.

**Backgrounds, borders, SVG `fill`/`stroke`.** Swapping those inverts them in light mode — a pale red tint becomes a dark red block with unreadable text on it. They were also never flagged: every violation here is a **foreground** colour. 23 lines were skipped on this rule.

**`lib/session.ts`.** Each row pairs a foreground with its **own explicit dark background** and `.session-pill` applies both together, so it was already correct in both themes. I swapped it, measured `.session-pill` at **2.30:1**, and reverted it. The file now carries a comment explaining why it must stay hardcoded.

## Verification

Production build, axe-core `color-contrast` across 12 routes, both themes, with `data-theme` asserted as actually applied before each measurement.

```
light   882 -> 45     (-95%)
dark      9 ->  9     unchanged, per-route identical
```

Per route, light:

| route | before | after |
|---|---:|---:|
| `/scanner` | 595 | **1** |
| `/funding` | 80 | 21 |
| `/liq` | 80 | 10 |
| `/markets` | 43 | **0** |
| `/arena` | 31 | 4 |
| `/briefing` | 27 | 2 |
| `/dashboard` | 14 | **0** |
| `/settings` | 8 | 7 |
| `/` | 0 | 0 |

### The dark "before" number is a real rebuild, and it earned its keep

I stashed the work, rebuilt at the pre-change commit, and measured dark there. It came back **9**. My changed build measured **10**.

That one extra was `.frh-signal-action` at **4.43:1** — I had introduced it by mapping `#a0a0a0` (a lighter grey) to `--txt-dim` (`#8a8a8a`), which the rule's `opacity: 0.85` then multiplied down past the floor. A 0.07 shortfall on one element, invisible to any before/after that did not actually rebuild the old code.

Fixed at the cause by removing the opacity, and dark is back to 9 with identical per-route numbers.

**This is the check I have skipped before and been caught by.** Worth stating plainly: without it I would have shipped this claiming dark was untouched.

### A note on the issue's own numbers

#53's title says 1001 and its body table says 938; I measured 882. The difference is route coverage — QA swept 32 routes, I swept 12. The **shape** matches exactly: same three colour families, same worst offenders, `/scanner` dominant. Not a disagreement.

## What is left — 45, recorded rather than hidden

A long tail of **28 distinct one-off colours with no token family**:

- brand colours — `#627eea` (Ethereum), `#f3ba2f` (Binance)
- chart accents — `#22d3ee`, `#f97316`, `#f472b6`, `#d4b483`
- near-white text blended over near-white panels — `.frh-sig-hint`, `.gex-insight` (1.06–1.12:1, these are a different bug: text that is nearly the same colour as its own background)

Each needs its own decision rather than a mapping, and **none of them is a price direction**. Concentrated on `/funding` (21) and `/liq` (10).

QA is adding a two-theme contrast spec in #55 that tracks **distinct failing colours** rather than raw violation count — that is the right shape for this tail, and it is why I have not invented a ratchet here.

## How to test (QA)

1. **Light theme, the main claim.** Switch to light (Settings → Appearance, or the theme toggle). Open `/scanner`, `/markets`, `/funding`, `/liq`. Every green and red number should be **clearly readable** on the white cards. Before, they were pale pastels that mostly vanished.
2. **Dark theme, the guarantee.** Switch back to dark and go through the same four pages. **Nothing should look different.** The one exception, and the only place to look hard: pale red/green tiers may be a shade different — e.g. a "LEAN SHORT" pill. Same family, same meaning.
3. **The canvas charts still paint.** `/funding` has a canvas chart with red/green fills, and `/liq` and the main price chart are chart libraries. If any of them renders **black or blank**, a CSS variable has reached a canvas and that is a stop.
4. **Session pill.** Top bar, `/dashboard`. It should read normally in both themes — it is the one thing I broke and reverted mid-way, so it is worth a look.
5. **Backgrounds did not invert.** Coloured dots, tinted pills, progress bars. A pale tint that has become a solid dark block is a bug.
6. **Light theme on the darker surfaces.** `/settings` and any panel on the grey canvas rather than a white card — the four darkened tokens are what this exercises.

Step 3 is the one I would not skip. It is silent when it fails.

## Risk level

**Medium.** Not because any single change is risky, but because there are 58 files and the sweep was partly mechanical.

- No logic, no data, no routes, no API. Colour values only.
- Dark mode measured identical, which covers the majority of usage.
- The mechanical passes were narrow by construction: only `color:` properties, only lines with no canvas/background/border/fill/stroke context, with two files excluded whole.
- **The residual risk is a colour I swapped that lands somewhere axe never measured** — a hover state, a state behind an interaction, a route outside the 12 swept. Steps 2, 3 and 5 above are aimed at exactly that.

Nine of the swapped colours are not exact dark matches (listed above). That is a real, if small, dark-mode change and it is the thing to disagree with me about if you are going to disagree with something.
