### PR TITLE
test(qa): ratchet the light-theme contrast baseline 57 -> 38

### DIFF
--- a/qa/e2e/_shared.ts
+++ b/qa/e2e/_shared.ts
@@ -252,7 +252,21 @@ export const BASELINE = {
      *   #86efac 1.24:1 · #fbbf24 1.33:1 · #fcbcbc 1.39:1 · #34d399 1.43:1
      * Highest volume: #8a8a8a (196), #f87171 (191), #34d399 (170).
      */
-    lightDistinctColours: 57,
+    /* 57 -> 38, lowered by the fix in #58 rather than by a re-measurement.
+       Verified by running THIS spec with that change merged in, all 32 routes:
+       990 total violations -> 65, and 57 distinct colours -> 38. Dark measured
+       13 on the same sweep, identical to the baseline above, which is what
+       proves a 58-file change left dark alone.
+
+       Worth noting the ratio, because it is this metric working rather than a
+       contradiction: violations fell 93% while distinct colours fell 33%. The
+       high-volume families (#f87171 191, #8a8a8a 196, #34d399 170) collapsed to
+       zero; what remains is a long tail where each colour appears 1-7 times -
+       brand colours (#627eea Ethereum, #f3ba2f Binance), chart accents, and
+       near-white text on near-white panels. Each needs its own decision, not a
+       token mapping. The count is the harder number to move, which is exactly
+       why it is the one asserted. */
+    lightDistinctColours: 38,
   },
   /** §6.4 - pages with no <h1>, desktop. */
   pagesWithoutH1: 13,


### PR DESCRIPTION
## Summary

One-line follow-up to #58, which merged before this commit landed on the branch.

`dev` currently has the light-theme fix **and** the pre-fix baseline. That combination is the worst of both: the test passes, and it would keep passing while someone reintroduced **19 broken colours**.

| | `dev` today | reality | this PR |
|---|---|---|---|
| `lightDistinctColours` | 57 | **38** | 38 |
| `darkDistinctColours` | 13 | 13 | 13 (unchanged) |

## Why 38

Measured by running `qa/e2e/contrast.spec.ts` — QA's own spec, QA's own route list — with #58 merged in. All 32 routes, both themes:

```
light   990 violations / 57 distinct colours  ->  65 / 38
dark     15 violations / 13 distinct colours  ->  15 / 13
```

QA's comment in that file asks for exactly this: *"Ratchet DOWN as light-mode token variants land."*

**Dark being identical across the full 32-route sweep** is the number that matters most here — #58 touched 58 files, and this is the evidence it left dark mode alone at QA's route coverage rather than only at the 12 routes I swept while developing it.

## The ratio looks wrong and isn't

Violations fell **93%** (990 → 65) while distinct colours fell only **33%** (57 → 38).

That is the metric working rather than a contradiction. The high-volume families collapsed to zero — `#f87171` was 191 occurrences, `#8a8a8a` 196, `#34d399` 170 — and what remains is a long tail where each colour appears 1–7 times: brand colours (`#627eea` Ethereum, `#f3ba2f` Binance), chart accents, and near-white text on near-white panels.

Distinct colours is the **harder** number to move, which is why it is the one asserted rather than the raw count that drifted by 60 between two runs of the same build.

## How to test (QA)

```
npx playwright test qa/e2e/contrast.spec.ts --project=desktop
```

~11 min, should pass. It should now fail if light-theme contrast regresses by even one new colour — which it would not have done before this change.

## Risk level

**Low.** One number in a test baseline. No app code, no dependencies, no environment variables.

Gates: lint 0 errors (94 warnings, unchanged) · tsc clean · 90/90 unit · build clean.