### PR TITLE
fix(api): report errors from production only - dev and qa had spent prod's quota

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,7 +93,24 @@ BREVO_SENDER_EMAIL=
 # way; the DSN is what selects the backend. Get it from a GlitchTip project's
 # settings page. DSNs aren't secret - NEXT_PUBLIC_ is correct here, not a leak.
 # Unset = Sentry.init no-ops, feature stays off.
+#
+# SET THIS ON PRODUCTION ONLY. All three services once pointed at the same
+# GlitchTip project (25983) sharing one 1,000-event/month free quota, and dev
+# plus qa spent it - a forced error from prod AND staging both returned HTTP 429,
+# so production monitoring was dead and nothing said so (issue #57).
+# lib/monitoring.ts now suppresses the DSN whenever NEXT_PUBLIC_APP_ENV is 'dev',
+# which covers both dev and qa, so leaving it set here is inert rather than
+# harmful - but unset it on those services anyway. Belt and braces, because the
+# failure mode is silent.
 NEXT_PUBLIC_SENTRY_DSN=
+
+# Error-tracker environment label. Optional, and only meaningful on a service
+# that actually reports - which today is production alone, so this is currently
+# inert everywhere. Exists because NEXT_PUBLIC_APP_ENV is a SWITCH, not a label
+# (see docs/INFRASTRUCTURE.md 4b): qa must run as 'dev' to keep reading the dev
+# tables, so it cannot label itself. Keep it for the day non-prod gets its own
+# GlitchTip project.
+NEXT_PUBLIC_SENTRY_ENV=
 
 # ── Web Push (VAPID) ──────────────────────────────────────────────────────────
 # Generate keys once: node -e "const wp=require('web-push'); const k=wp.generateVAPIDKeys(); console.log(JSON.stringify(k,null,2))"

--- a/__tests__/monitoringScrub.test.mts
+++ b/__tests__/monitoringScrub.test.mts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { scrubUrl, scrubText, scrubEvent, monitoringEnvironment } from '../lib/monitoring.ts';
+import { scrubUrl, scrubText, scrubEvent, monitoringEnvironment, monitoringDsn } from '../lib/monitoring.ts';
 
 /* The PII scrubber runs on every event leaving the app for GlitchTip. It is the
    last thing between a user's id or email and a third-party dashboard, and it
@@ -182,4 +182,65 @@ test('monitoring environment resolution', async (t) => {
   });
 
   set(saved.sentry, saved.app);
+});
+
+test('reporting is restricted to production', async (t) => {
+  /* Issue #57. All three services pointed at one GlitchTip project sharing one
+     1,000-event/month quota, and dev + qa spent it: a forced error from BOTH
+     prod and staging returned HTTP 429, so production monitoring was dead.
+
+     These assertions exist because the config-only version of this fix
+     (unset the DSN on two dashboards) regresses silently. */
+  const savedDsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+  const savedApp = process.env.NEXT_PUBLIC_APP_ENV;
+  const DSN = 'https://key@app.glitchtip.com/25983';
+
+  const set = (dsn?: string, app?: string) => {
+    if (dsn === undefined) delete process.env.NEXT_PUBLIC_SENTRY_DSN;
+    else process.env.NEXT_PUBLIC_SENTRY_DSN = dsn;
+    if (app === undefined) delete process.env.NEXT_PUBLIC_APP_ENV;
+    else process.env.NEXT_PUBLIC_APP_ENV = app;
+  };
+
+  await t.test('production reports', () => {
+    set(DSN, 'prod');
+    assert.equal(monitoringDsn(), DSN);
+  });
+
+  await t.test('dev does not', () => {
+    set(DSN, 'dev');
+    assert.equal(monitoringDsn(), undefined);
+  });
+
+  await t.test('qa does not - it runs as dev, which is the whole point', () => {
+    /* qa CANNOT be given its own NEXT_PUBLIC_APP_ENV: lib/tables.ts treats
+       anything that is not 'dev' as production table names. So the only thing
+       that can exclude qa is the same 'dev' value that keeps it on the dev
+       database - and a qa-specific label must never be allowed to re-enable
+       reporting. */
+    set(DSN, 'dev');
+    process.env.NEXT_PUBLIC_SENTRY_ENV = 'qa';
+    assert.equal(monitoringDsn(), undefined,
+      'setting SENTRY_ENV=qa must not turn reporting back on');
+    delete process.env.NEXT_PUBLIC_SENTRY_ENV;
+  });
+
+  await t.test('a missing APP_ENV still reports, rather than silently going dark', () => {
+    /* The deliberate difference from issue #57's suggested `=== "prod"`. If the
+       variable goes missing on prod, that predicate would switch monitoring off
+       with no signal - re-creating the exact failure this fixes. Such a service
+       would also be reading production tables, so erring toward "report" is the
+       safer of the two wrong answers. */
+    set(DSN, undefined);
+    assert.equal(monitoringDsn(), DSN);
+  });
+
+  await t.test('no DSN configured means off, everywhere', () => {
+    set(undefined, 'prod');
+    assert.equal(monitoringDsn(), undefined);
+    set('', 'prod');
+    assert.equal(monitoringDsn(), undefined);
+  });
+
+  set(savedDsn, savedApp);
 });

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -174,6 +174,50 @@ The fix is **not** to change `NEXT_PUBLIC_APP_ENV`. It is
 The same rule applies to anything else that ever wants an environment *name*:
 add a variable, do not reuse the switch.
 
+**Note as of 2026-08-06: that label is currently inert**, because only production
+reports at all — see §4c below. Keep it; it becomes live the day non-prod gets its
+own GlitchTip project.
+
+---
+
+## 4b-2. Error reporting is production-only — and why a tag was not enough
+
+All three services pointed at **one** GlitchTip project (`25983`) sharing **one**
+1,000-event/month free quota. Dev and qa spent it. Measured 2026-08-06: a forced
+error from **both** `liquidity-hq.com` and `liquidity-hq-qa.onrender.com`
+returned **HTTP 429**, so *production* error reporting was dead — and nothing
+said so.
+
+`environment` does not solve this. It is a **tag**: it makes events filterable
+after they arrive. It does not stop them arriving and it does not give them
+separate quotas.
+
+Structurally the same compromise as qa and dev sharing one Supabase project, and
+it fails the same way — the noisy environments starve the one that matters. The
+difference is that the Supabase one is documented and consciously accepted, and
+this one just looked like it worked.
+
+Two layers, on purpose:
+
+| | |
+|---|---|
+| **Config** | `NEXT_PUBLIC_SENTRY_DSN` set on `liquidity-hq-prod` only |
+| **Code** | `lib/monitoring.ts` returns no DSN when `NEXT_PUBLIC_APP_ENV === 'dev'` |
+
+The code layer exists because config alone is one dashboard edit from
+regressing, and the regression is **silent** — nobody discovers monitoring is off
+until they need it, which is precisely when they cannot afford it to be off. A
+DSN that is present but suppressed logs once at startup, so it is answerable from
+the logs either way.
+
+Because both variables are `NEXT_PUBLIC_*` and therefore inlined at build time,
+the guard resolves during the build: on a non-prod build the DSN is **not in the
+bundle at all**, not merely unused.
+
+**⚠️ Clearing the variable in the dashboard does nothing to an existing build.**
+Each service needs a **rebuild**, or it keeps posting from the bundle it already
+has.
+
 ---
 
 ## 4c. QA service environment variables

--- a/lib/monitoring.ts
+++ b/lib/monitoring.ts
@@ -49,6 +49,63 @@ export function monitoringEnvironment(): string {
 }
 
 /**
+ * The DSN, but only where reporting is actually wanted - production.
+ *
+ * WHY THIS IS A CODE GUARD AND NOT JUST A DASHBOARD SETTING.
+ *
+ * All three services pointed at ONE GlitchTip project (25983) sharing ONE
+ * 1,000-event/month free quota, and dev plus qa spent it. Measured on
+ * 2026-08-06: a forced error from prod AND from staging both returned HTTP 429.
+ * So production error reporting was dead - not "noisy", dead - and nothing said
+ * so. QA found it (issue #57), and a Playwright run against staging is part of
+ * what filled it. QA doing its job should never be able to switch production
+ * monitoring off.
+ *
+ * `environment` does not fix this. It is a TAG: it makes events filterable after
+ * they arrive. It does not stop them arriving and it does not give them separate
+ * quotas.
+ *
+ * Unsetting the DSN on the two non-prod services fixes it too, and should also
+ * be done. This guard exists because that config is one dashboard edit away from
+ * regressing, and the regression is SILENT - nobody discovers monitoring is off
+ * until they need it, which is exactly when they cannot afford it to be off.
+ *
+ * ON THE PREDICATE. Issue #57 suggested `=== 'prod'`. This uses `!== 'dev'`
+ * instead, deliberately, to match the one switch the rest of the app already
+ * turns on (lib/tables.ts, lib/apiHealth.ts, the LemonSqueezy webhook):
+ *
+ *     NEXT_PUBLIC_APP_ENV === 'dev' ? <non-prod> : <prod>
+ *
+ * Both predicates exclude qa and dev, because qa is REQUIRED to run as 'dev'
+ * (see monitoringEnvironment above). They differ only if the variable goes
+ * missing on prod: `=== 'prod'` would then silently kill the monitoring this
+ * issue exists to restore, while `!== 'dev'` keeps it on. A stray service that
+ * forgets the variable and starts reporting is noisy but visible; that same
+ * service would also be reading PRODUCTION tables, which is a far louder alarm
+ * than a few extra error events.
+ *
+ * Neither case is silent now: a DSN that is present but suppressed logs once at
+ * startup, so "why is nothing arriving" is answerable from the logs.
+ */
+export function monitoringDsn(): string | undefined {
+  const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+  if (!dsn) return undefined;
+
+  if (process.env.NEXT_PUBLIC_APP_ENV === 'dev') {
+    // Deliberately not silent. The whole failure mode being fixed here is
+    // "monitoring is off and nothing said so" - suppressing quietly would just
+    // move that failure rather than remove it.
+    console.info(
+      '[monitoring] DSN present but suppressed: NEXT_PUBLIC_APP_ENV=dev. ' +
+      'Non-production services do not report, so they cannot spend production\'s ' +
+      'shared GlitchTip quota (issue #57). Unset the DSN here to silence this.',
+    );
+    return undefined;
+  }
+  return dsn;
+}
+
+/**
  * The deployed commit, or undefined when it cannot be known.
  *
  * Render exposes `RENDER_GIT_COMMIT` at build time. `next.config.ts` copies it to
@@ -229,7 +286,10 @@ export function scrubEvent<T>(event: T): T {
  */
 export function monitoringOptions() {
   return {
-    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+    // Undefined outside production - see monitoringDsn. Sentry.init treats an
+    // absent DSN as "off", which is the documented behaviour .env.example:95
+    // already relies on, so nothing else needs a branch.
+    dsn: monitoringDsn(),
     environment: monitoringEnvironment(),
     release: monitoringRelease(),
     // See the file header - this is a quota decision, not an oversight.


### PR DESCRIPTION
## Summary

Closes #57. Error reports are sent from **production only**. Dev and qa stop reporting entirely, so they can no longer spend the quota production alerting depends on.

## The finding, restated because it is worse than it sounds

QA measured a forced client error from both services:

```
PROD     https://liquidity-hq.com              -> app.glitchtip.com/api/25983/envelope/  HTTP 429
STAGING  https://liquidity-hq-qa.onrender.com  -> app.glitchtip.com/api/25983/envelope/  HTTP 429
```

Same project, `25983`. One 1,000-event/month free quota, three services feeding it.

**This was not "dev noise is untidy". Production error reporting was dead**, and nothing said so. The thing that tells you production is broken had itself been broken, silently, by the environments that don't matter.

QA notes that a Playwright run against staging is part of what filled it. That is the argument *for* this fix: **QA doing its job must never be able to switch production monitoring off.** For the record I added to it too — I fired two probe events at staging this afternoon verifying the environment tag.

## The tag I added in #54 does not fix this, and I should have seen that

#54 gave qa its own `environment` label so its errors could be told apart from dev's. That was a real improvement and it is the wrong tool for this problem.

`environment` is a **tag**. It makes events filterable *after they arrive*. It does not stop them arriving and it does not give them separate quotas. Every dev page load and every QA browser run was still spending from the same 1,000.

Structurally identical to qa and dev sharing one Supabase project, and it fails the same way — the noisy environments starve the one that matters. The difference is that the Supabase compromise is written down in `CLAUDE.md` and consciously accepted. This one just looked like it worked.

## The fix — two layers, deliberately

| | |
|---|---|
| **Config** | `NEXT_PUBLIC_SENTRY_DSN` set on `liquidity-hq-prod` only |
| **Code** | `lib/monitoring.ts` returns no DSN when `NEXT_PUBLIC_APP_ENV === 'dev'` |

#57 asked whether the code guard is worth the indirection. **Yes**, and for the reason the issue itself gives: config alone is one dashboard edit away from regressing, and the regression is **silent**. Nobody discovers monitoring is off until they need it, which is exactly when they cannot afford it to be off.

A DSN that is present but suppressed now **logs once at startup**. The failure mode being fixed here is "monitoring is off and nothing said so" — suppressing quietly would have moved that failure rather than removed it.

### On the predicate — I did not use the one #57 suggested

The issue proposed `=== 'prod'`. This uses `!== 'dev'`, matching the one switch the rest of the app already turns on (`lib/tables.ts`, `lib/apiHealth.ts`, the LemonSqueezy webhook):

```ts
NEXT_PUBLIC_APP_ENV === 'dev' ? <non-prod> : <prod>
```

**Both predicates exclude qa and dev**, because qa is *required* to run as `'dev'` to keep reading the dev tables. They differ in exactly one case: the variable going missing on prod.

- `=== 'prod'` → monitoring silently dies. That re-creates the failure this issue exists to fix.
- `!== 'dev'` → monitoring stays on. A stray service that forgets the variable is noisy but **visible** — and that same service would be reading **production tables**, which is a far louder alarm than a few extra error events.

Erring toward "report" is the safer of the two wrong answers. Happy to be argued out of it.

## Verification — both directions, against real builds

A passing unit test proves the function, not the wiring. So both cases were built and run:

| build | DSN in client bundle | runtime requests to glitchtip |
|---|---|---|
| `APP_ENV=dev` + DSN set | **absent entirely** | **0** |
| `APP_ENV=prod` + DSN set | present | — |

Because both variables are `NEXT_PUBLIC_*` and inlined at build time, **the guard resolves during the build**: on a non-prod build the DSN is not merely unused, it is not shipped. That is a stronger result than I expected and worth knowing — it means a non-prod bundle cannot be made to report even by tampering at runtime.

6 new unit tests, 96/96 passing. The two worth naming:

- **`SENTRY_ENV=qa` must not re-enable reporting.** The label added in #54 is the obvious thing for someone to reach for later; this pins that it cannot resurrect the bug.
- **A missing `APP_ENV` still reports.** Pins the predicate decision above so it is a choice rather than an accident.

## ⚠️ Owner action — this does not fully take effect without it

Unset `NEXT_PUBLIC_SENTRY_DSN` on **`liquidity-hq-qa`** and **`liquidity-hq-dev`**, then **rebuild both**.

`NEXT_PUBLIC_*` is inlined at build time, so clearing the dashboard value does **nothing** to an existing build — those services keep posting from the bundle they already have. The code guard covers it on their next deploy regardless, so this is belt-and-braces rather than the only line of defence.

Do **not** change `NEXT_PUBLIC_APP_ENV` on any service.

## What this does not fix

**The quota is still exhausted**, and clearing it does not answer what filled it. `tracesSampleRate: 0` already removed the previously-identified cause — 2,138 trace events against 14 real issues — and it filled up again.

Once production has the quota to itself, the top issue by volume is worth a look. A single noisy recurring error would explain it, and fixing that error beats raising the ceiling. Not in scope here.

**`NEXT_PUBLIC_SENTRY_ENV` is now inert**, since nothing non-prod reports at all. Kept and documented rather than removed — it becomes live the day non-prod gets its own GlitchTip project, which is #57's third suggestion and still open. I have no strong view on whether that is worth a project slot; QA's point that a dev-only crash currently gets reported by whoever happens to notice is fair.

## How to test (QA)

Your steps from the issue, unchanged — they are the right ones. Note step 2 needs a **rebuild**, not just the env var change.

1. `https://liquidity-hq.com` → force a client error → a request to `app.glitchtip.com` returning **200/202**, not 429. *(Will still 429 until the quota resets or is cleared — that is expected and not this PR failing.)*
2. `https://liquidity-hq-qa.onrender.com` → force a client error → **zero** requests to `app.glitchtip.com`.
3. Same on the dev service.
4. Confirm the prod event appears tagged `environment: prod`.
5. **New:** on staging, check the browser console for `[monitoring] DSN present but suppressed`. Present means the DSN is still set there and the code guard is doing the work; absent means the DSN was properly unset too. Either is a pass — it tells you which layer is holding.

Step 2 is the one that proves the fix rather than the intent.

Adding it to the release steps, as you suggested, is the right call — this is exactly the kind of thing that silently comes back.

## Risk level

**Low**, with one thing to be clear-eyed about.

- No user-facing behaviour. No routes, no data, no rendering.
- The only functional change is *whether* a network request is made from non-prod.
- **The risk is direction-of-failure:** if the predicate is wrong, production stops reporting. That is why it errs toward reporting, why both build directions were verified rather than reasoned about, and why a suppressed DSN is logged rather than silent.

Gates: `lint` 0 errors (94 warnings, unchanged) · `tsc` clean · **96/96** unit · build clean.
