### PR TITLE
fix(auth): announce login errors and chat replies to screen readers

### DIFF
--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -101,7 +101,11 @@ export default function ForgotPasswordPage() {
               />
             )}
 
-            {error && <div className="login-error">{error}</div>}
+            {/* Always rendered, empty until there is an error, so the live
+                region exists before the text arrives. WCAG 2.2 SC 4.1.3.
+                The original claim in the audit named /login only; this page
+                does the same thing and has no live region either. */}
+            <div className="login-error" role="alert">{error}</div>
 
             {/* No display override here - .login-back-btn centres its own text
                 via inline-flex, and `display: block` would defeat that. */}

--- a/app/globals.css
+++ b/app/globals.css
@@ -3806,6 +3806,16 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   background: var(--red-bg); border: 0.5px solid var(--red-bdr);
   border-radius: 8px; padding: 8px 12px; margin-top: 12px; line-height: 1.5;
 }
+/* The container is now rendered ALWAYS, carrying role="alert", and is empty
+   until there is an error - see the comment in app/login/page.tsx.
+   Hidden by collapsing it rather than by `display: none`, deliberately:
+   display:none removes a node from the accessibility tree entirely, so the live
+   region would not exist at the moment the error arrives, which is the exact
+   problem being fixed. Zero-size with no paint is invisible to sighted users
+   and still present for assistive tech. */
+.login-error:empty {
+  padding: 0; margin: 0; border: 0; background: none;
+}
 
 /* Magic link sent success */
 .login-success { display: flex; flex-direction: column; align-items: center; gap: 10px; text-align: center; padding: 8px 0; }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -295,7 +295,19 @@ function LoginInner() {
                 />
               )}
 
-              {error && <div className="login-error">{error}</div>}
+              {/* Rendered unconditionally, empty until there is an error.
+                  WCAG 2.2 SC 4.1.3 Status Messages (AA): this used to be
+                  `{error && <div className="login-error">}` with no role, so a
+                  screen reader user submitted, heard nothing, and had no way to
+                  tell whether anything had happened.
+                  The container must be in the DOM BEFORE the text arrives - a
+                  live region inserted at the same moment as its content is
+                  unreliably announced, which is why this is not simply
+                  `role="alert"` bolted onto the conditional version.
+                  `.login-error:empty` collapses it visually without
+                  `display: none`, which would remove it from the accessibility
+                  tree and reintroduce the bug. */}
+              <div className="login-error" role="alert">{error}</div>
 
               <button
                 className="login-back-btn"
@@ -398,7 +410,9 @@ function LoginInner() {
                 />
               )}
 
-              {pwError && <div className="login-error">{pwError}</div>}
+              {/* Same as the magic-link form above - always present, empty
+                  until it has something to say. See that comment. */}
+              <div className="login-error" role="alert">{pwError}</div>
 
               <button
                 className="login-back-btn"

--- a/components/GrokChat.tsx
+++ b/components/GrokChat.tsx
@@ -797,7 +797,27 @@ export default function GrokChat() {
             )}
 
             {/* Messages */}
-            <div className="gchat-msgs" ref={msgsRef}>
+            {/* WCAG 2.2 SC 4.1.3 Status Messages (AA). A reply streams in here
+                and was never announced - a screen reader user asked a question
+                and had no way to know an answer had arrived, or whether the
+                model was still thinking.
+
+                `polite`, not `assertive`: the reply arrives token by token, and
+                assertive would interrupt the user on every chunk. Polite waits
+                for a pause, which is what you want for a streaming answer.
+
+                aria-atomic="false" so only the newly added text is read rather
+                than the whole conversation being re-announced on each update -
+                the difference between "here is the new sentence" and "here is
+                everything again" once a thread is a few messages long. */}
+            <div
+              className="gchat-msgs"
+              ref={msgsRef}
+              role="log"
+              aria-live="polite"
+              aria-atomic="false"
+              aria-relevant="additions text"
+            >
               {msgs.length === 0 && (
                 <div className="gchat-empty">
                   <div style={{ marginBottom: 8, lineHeight: 0, color: 'var(--accent)' }}>

--- a/qa/e2e/_shared.ts
+++ b/qa/e2e/_shared.ts
@@ -161,13 +161,17 @@ export const BASELINE = {
      * submits, hears nothing, and cannot tell whether anything happened.
      * The original claim named /login only.
      */
-    authForms: 3,
+    authForms: 0,   /* was 3. Fixed: all three containers are now rendered
+                       unconditionally with role="alert", so the live region
+                       exists before the text arrives. Lowered in the same
+                       commit as the fix, per the instruction above. */
     /**
      * 1 - .gchat-msgs in components/GrokChat.tsx has neither aria-live nor
      * role, and the whole .gchat-panel contains zero live regions. A reply
      * streams in silently.
      */
-    grokChat: 1,
+    grokChat: 0,    /* was 1. Fixed: .gchat-msgs carries role="log" +
+                       aria-live="polite". */
   },
 
   /**


### PR DESCRIPTION
## Summary

Closes #49. Sign-in errors and Ask AI replies are now announced to screen readers instead of appearing in silence.

**WCAG 2.2 SC 4.1.3 Status Messages, Level AA** — something important happens, it is shown on screen, and assistive technology is never told. The user is left waiting for a result that already arrived.

| | before | after |
|---|---|---|
| `BASELINE.unannouncedStatus.authForms` | 3 | **0** |
| `BASELINE.unannouncedStatus.grokChat` | 1 | **0** |

Both lowered in this commit, as #49 instructs. They can now only be raised by a regression.

## What was broken

**Three auth forms, not one.** The original audit named `/login`. Measured, it is the `/login` password form, the `/login` magic-link form, **and `/forgot-password`** — all three rendered the error into a bare `<div>` with no `role` and no `aria-live`, and those pages carried **zero** live regions anywhere, so nothing else could have picked it up.

A blind user submitted, heard nothing, and had no way to tell whether the form was broken, still working, or had rejected their password.

**The chat panel had the same shape.** A reply streams into `.gchat-msgs`, which had neither `aria-live` nor `role`, and the whole `.gchat-panel` contained no live region. Ask a question, get silence, with no way to know whether the answer arrived or the model was still thinking.

## The part that is not just adding an attribute

**The container must exist before the text does.**

The markup was:

```tsx
{error && <div className="login-error">{error}</div>}
```

The element appears at the same instant as its content. A live region inserted *together with* its text is unreliably announced — assistive technology has nothing to observe a change on.

**Bolting `role="alert"` onto that conditional would have passed review, passed QA's spec, and still failed for some users.** That is the trap in this fix.

So the container is rendered unconditionally and is empty until it has something to say:

```tsx
<div className="login-error" role="alert">{error}</div>
```

```css
.login-error:empty { padding: 0; margin: 0; border: 0; background: none; }
```

Collapsed rather than hidden, deliberately. **`display: none` removes a node from the accessibility tree entirely**, so the live region would not exist at the moment the error arrives — recreating the exact bug being fixed.

## The chat: `polite`, not `assertive`

`role="log"` + `aria-live="polite"`. The reply arrives token by token; `assertive` would interrupt the user on every chunk. Polite waits for a pause, which is what a streaming answer wants.

Plus `aria-atomic="false"` and `aria-relevant="additions text"`, so only the newly added text is read rather than the whole conversation being re-announced on each update — the difference between "here is the new sentence" and "here is everything again" once a thread is a few messages long.

## Verification — QA's spec passes, and that was not enough

`qa/e2e/a11y-auth.spec.ts` is **6/6** with both baselines at zero.

But that spec asserts `role`/`aria-live` are present *once an error is showing*, which the naive conditional fix would also satisfy. So the ordering and the paint were measured separately, on a production build:

```
before any error   role=alert  text=""  height=0px   display=block
after the error    role=alert  text="Please complete…"  height=54px

container exists BEFORE any error ............ PASS
carries role=alert up front .................. PASS
empty and paints nothing up front ............ PASS
NOT display:none (would leave the a11y tree) . PASS
text arrives in the SAME element ............. PASS
```

And from **Chrome's own accessibility tree**, not from reading the DOM:

```
role=alert   live=assertive   ignored=false
```

A live region from first paint, not from first error. That is the claim, and it is the one QA's spec cannot make.

## Flagged, not fixed

`/login`'s submit button is `disabled` until Turnstile returns a token, but the password field's `onEnter` reaches the handler regardless — so the `disabled` attribute is decorative.

**Not a security hole.** `submitPassword` does its own `!pwCaptchaToken` check and bails, so the captcha still gates the request. But it *reads* like the gate and is not, and if anyone relaxes that in-handler check on the assumption the disabled button covers it, the gate disappears silently.

Changing submission gating is a bigger and riskier change than this accessibility fix and does not belong in the same commit. #49 left it as my call — I am leaving it visible rather than quietly touching it.

## How to test (QA)

1. **`/login`, password form.** Click "Use password instead", enter anything, press Enter. With a screen reader running (Windows: Narrator, `Ctrl`+`Win`+`Enter`) the error should be **read out as it appears**.
2. **`/login`, magic-link form.** Same, submitting an address that will fail.
3. **`/forgot-password`.** Same. This is the one the original audit missed.
4. **Nothing changed visually.** With no screen reader, all three pages should look **exactly** as before — in particular, no empty box or extra gap above the button when there is no error. That is the risk of making the container permanent, and it is the thing to look at hardest.
5. **Ask AI.** Open the panel, send a message. The reply should be read out as it streams, and should **not** re-read the whole conversation on each update.
6. **Your spec.** `npx playwright test qa/e2e/a11y-auth.spec.ts --project=desktop` — 6/6, with both baselines now at 0.

Step 4 is the one that fails silently for sighted users.

## Risk level

**Low.**

- Three `<div>`s and one CSS rule on the auth pages; four attributes on one chat container.
- No logic, no data, no routes, no submission behaviour.
- The only way this is visible to a sighted user is if `:empty` fails to collapse the container — hence step 4.

Gates: `lint` 0 errors (94 warnings, unchanged) · `tsc` clean · **96/96** unit · build clean.

---

⚠️ **Note on CI:** GitHub Actions has been degraded for the last few hours — three runs today failed at `Set up job` with `Service Unavailable`, and the queue is currently backed up. If the checks on this PR look red or never start, check whether the runner even booted before reading it as a code failure.
