### PR TITLE
fix(alerts): darken the Sign In button so white text clears AA

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3139,13 +3139,33 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 }
 .auth-gate-title { font-size: var(--fs-card-title); font-weight: 700; color: var(--txt); }
 .auth-gate-desc  { font-size: var(--fs-caption); color: var(--txt3); line-height: 1.6; max-width: 280px; }
+/* Issue #56. White on --purple (which aliases --accent, #1a7aff) measured
+   3.98:1 against the 4.5:1 floor - the primary call to action on the signed-out
+   auth gate was the least readable thing on the page.
+
+   --accent-solid exists for exactly this: --accent is for text, borders and
+   glows; --accent-solid is for a filled surface UNDER white text. Same rule as
+   .lp-btn-primary, .consent-accept and .desktop-nav-item.on already follow.
+   White on #1668e3 = 5.09:1.
+
+   The hover was the half the issue did not catch, and fixing only the base
+   colour would have left it failing: brightness(1.15) on #1668e3 lands on
+   #1978ff = 4.06:1, still under the floor. axe measures the resting state only,
+   so a hover that fails is invisible to the sweep that found this.
+   Darkening instead of brightening keeps it passing (#135cc8 = 6.19:1) and is
+   the more conventional direction for a filled button anyway.
+
+   Light theme does not redefine --accent-solid, so it inherits #1668e3 there -
+   5.09:1, which passes. Deliberately not adding a light-theme override in this
+   change: several other elements already render --accent-solid in light mode
+   and altering it would move all of them for a one-button fix. */
 .auth-gate-btn {
   margin-top: 6px; padding: 9px 26px; border-radius: 10px;
-  background: var(--purple); color: #fff;
+  background: var(--accent-solid); color: #fff;
   font-size: var(--fs-label); font-weight: 600; text-decoration: none; letter-spacing: -0.1px;
   transition: filter 0.15s; display: inline-block;
 }
-.auth-gate-btn:hover { filter: brightness(1.15); }
+.auth-gate-btn:hover { filter: brightness(0.88); }
 
 /* ── SETTINGS MODAL ──────────────────────────────────────────────────────── */
 .smod-backdrop {
@@ -3339,7 +3359,11 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   background: var(--purple-bg); border: 0.5px solid var(--purple);
   color: var(--accent-2); font-size: var(--fs-caption); font-weight: 600; cursor: pointer;
 }
-.st-save-btn:hover { background: var(--purple); color: #fff; }
+/* Same defect as .auth-gate-btn, found by sweeping for the pattern rather than
+   fixing the one element issue #56 named: white text on --purple (= --accent,
+   #1a7aff) is 3.98:1. Only on hover, so axe's resting-state sweep never saw it.
+   --accent-solid is the filled-surface token: 5.09:1. */
+.st-save-btn:hover { background: var(--accent-solid); color: #fff; }
 .st-save-btn:disabled { opacity: 0.5; cursor: default; }
 
 /* Sign out */


### PR DESCRIPTION
## Summary

Closes #56. The "Sign In" button on the signed-out alerts gate goes from **3.98:1 to 5.09:1**. One other element with the identical defect fixed in the same sweep.

| | before | after |
|---|---|---|
| `.auth-gate-btn` resting | **3.98** | 5.09 |
| `.auth-gate-btn` hover | **3.36** | 6.19 |
| `.st-save-btn` hover | **3.98** | 5.09 |

## The fix

White on `--purple` — which aliases `--accent`, `#1a7aff`. The token that exists for this is `--accent-solid` (`#1668e3`):

> `--accent` for text, borders, glows and rgba tints; `--accent-solid` wherever the blue is the background under white text.

`.lp-btn-primary`, `.consent-accept` and `.desktop-nav-item.on` already follow that rule. This element and one other did not.

## ⚠️ The half the issue did not catch

**Fixing only the reported element would have left it failing.**

`filter: brightness(1.15)` on the corrected colour lands on `#1978ff` = **4.06:1** — still under the floor. And it was worse before: brightening `#1a7aff` gave **3.36:1**.

**axe samples the resting state**, so a button that passes at rest and fails on hover reads as completely clean to the sweep that found this. Hover now darkens instead of brightening — `#135cc8` = 6.19:1 — which is the more conventional direction for a filled button anyway.

## Swept, not spot-fixed

`.st-save-btn:hover` (settings page Save) had the identical defect: white on `--purple`, 3.98:1, **also hover-only**, therefore also invisible to axe.

Every other `background: var(--purple)` in the file is a dot, bar or badge with no text on it — except one light-theme ticker badge at 6.82:1, which is fine.

That sweep is the point. The issue named one element; the pattern had two, and the second would have sat there until someone measured a hover state, which nothing currently does.

## Deliberately not changed

Light theme does not redefine `--accent-solid`, so it inherits `#1668e3` there — **5.09:1**, passes. Adding a light-specific override would move several other elements that already render that token in light mode, which is a bigger change than this issue warrants.

## Verification

Measured in a browser, **both themes and both states**, by screenshotting the button and reading its centre pixel — the composited colour with `filter` applied, not the declared value:

```
dark   resting 5.05:1   hover 5.04:1
light  resting 5.09:1   hover 6.19:1
```

**One honest note on that table:** the dark hover sample came back at essentially the resting colour, so the darkening does not appear to have been captured in that run — the light row at 6.19:1 is what demonstrates the filter working. The rule is not theme-conditional and dark passes at 5.05:1 either way, so the claim holds regardless of which was sampled. Flagging it rather than presenting four clean numbers.

## How to test (QA)

1. **Sign out**, open `/alerts`. The blue "Sign In" button should look slightly deeper; white text should read cleanly.
2. **Hover it.** It should get **darker** now, not lighter. That reversal is intentional and is the fix for the state axe cannot see.
3. **`/settings`**, hover the Save button — same, darker rather than brighter.
4. **Light theme**, same two checks. Nothing should look wrong there either.
5. Re-run your `/alerts` sweep — that page should now have **zero** A/AA violations of any rule.

## Risk level

**Low.** Two CSS declarations. No layout, no logic, no other selector.

Gates: `lint` 0 errors (94 warnings, unchanged) · `tsc` clean · **96/96** unit · build clean.

---

⚠️ CI note: GitHub Actions has been dropping jobs for hours (`abandoned`, zero steps run). If checks here look red, check whether the runner booted before reading it as a code failure.