### PR TITLE
fix(ci): raise the E2E cap - 45 minutes no longer fits the suite it guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,11 +137,28 @@ jobs:
     if: >-
       github.base_ref == 'main' ||
       (github.event_name == 'workflow_dispatch' && inputs.e2e)
-    # A full run is ~31 minutes. Without a cap, a genuinely hung run burns to
-    # GitHub's 6-hour default, and a stuck run looks identical to a slow one -
-    # which happened while this suite was being brought up. 45 leaves headroom
-    # for a cold runner without hiding a hang.
-    timeout-minutes: 45
+    # Without a cap, a genuinely hung run burns to GitHub's 6-hour default, and
+    # a stuck run looks identical to a slow one - which happened while this
+    # suite was being brought up. So the cap stays; the number moved.
+    #
+    # 45 -> 90 on 2026-08-07. 45 was sized when a full run was ~31 minutes.
+    # qa/e2e/contrast.spec.ts then added ~11 minutes of genuine coverage - two
+    # sweeps of 32 routes, which is what found the 990-violation light theme
+    # defect - taking a local full run to ~46. In CI the job was cancelled at
+    # 45.3 minutes, which read as a release failure when it was the cap being
+    # too small for the suite it now guards.
+    #
+    # Raised rather than made faster, because the obvious speed-up is not
+    # available: playwright.config.ts pins `workers: 1` on purpose, since
+    # parallel specs multiply Binance/Bybit traffic and trip the app's own
+    # per-IP rate limiter into 429s that look like product bugs. Parallelising
+    # the contrast file was tried and changed nothing for exactly that reason.
+    #
+    # 90 is roughly 2x the current local runtime. A GitHub runner is slower than
+    # the machine that measured ~46, so the headroom is smaller than it looks -
+    # but it is still comfortably below "a hang could hide here for hours".
+    # If the suite grows again, move this WITH the change that grows it.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
 

--- a/qa/e2e/contrast.spec.ts
+++ b/qa/e2e/contrast.spec.ts
@@ -64,6 +64,26 @@ async function measure(page: Page, theme: string, route: string): Promise<Violat
 }
 
 test.describe('colour contrast', () => {
+  /*
+   * NOT parallelised, deliberately, and this note exists so nobody tries it
+   * again as an obvious speed-up.
+   *
+   * This file is the slowest in the suite: two sweeps of 32 routes with an axe
+   * pass each, ~11 minutes. It is what pushed the E2E job to 45.3 minutes
+   * against `timeout-minutes: 45` on release 2026-08-06.4, cancelling the job
+   * mid-run.
+   *
+   * `test.describe.configure({ mode: 'parallel' })` was the first thing tried
+   * and it changes nothing: playwright.config.ts pins `workers: 1`, so the
+   * runner reported "Running 2 tests using 1 worker" and the file still took
+   * 12.1 minutes. That pin is not an oversight - parallel specs multiply
+   * traffic to Binance/Bybit and trip the app's own per-IP rate limiter,
+   * producing 429s that read as product bugs. Buying six minutes by
+   * manufacturing fake failures is a bad trade.
+   *
+   * The cap was raised instead. See the E2E job in .github/workflows/ci.yml.
+   */
+
   test.beforeEach(({ }, testInfo) => {
     test.skip(testInfo.project.name === 'mobile', 'same tokens as desktop; mobile doubles runtime for no extra signal');
   });


### PR DESCRIPTION
## Summary

The release gate on **#60** failed, and it was **my defect, not the release's**.

The E2E job ran **45.3 minutes** against `timeout-minutes: 45`, was cancelled
mid-run, and `CI Gate` then correctly reported failure. Nothing is wrong with the
code under test — I ran the full suite locally against that exact commit and it
passes.

This raises the cap **45 → 90**.

## Why 45 stopped being enough

45 was sized when a full run was ~31 minutes. `qa/e2e/contrast.spec.ts` then
added **~11 minutes** of real coverage — two sweeps of 32 routes — which is what
found the 990-violation light-theme defect that #60 fixes. A local full run is
now **~46 minutes**.

So the cap was smaller than the suite it guards. The gate was not wrong; the
number was stale.

I flagged this risk when the spec landed — *"contrast adds ~11 min to a desktop
run, which is the main thing to weigh"* — and nobody had numbers to act on. Now
we do, at the cost of one failed gate.

## Why raise it instead of making it faster

`test.describe.configure({ mode: 'parallel' })` was the first thing I tried. It
changes **nothing**: the runner reported *"Running 2 tests using 1 worker"* and
the file still took 12.1 minutes.

`playwright.config.ts` pins `workers: 1` on purpose:

> Market data comes from shared third-party APIs (Binance/Bybit). Running specs
> in parallel multiplies that traffic and can trip the app's own per-IP rate
> limiter, producing 429s that look like product bugs.

That reasoning is right and I am not overriding it. Buying six minutes by
manufacturing fake failures is a bad trade — especially on a suite whose whole
job is telling real failures from noise. I have left a comment in
`contrast.spec.ts` recording this, so the next person doesn't retry it.

## Why 90

Roughly 2× the current local runtime. A GitHub runner is slower than the machine
that measured ~46, so the real headroom is thinner than it looks — but still far
below *"a hang could sit here for hours"*, which is the only thing the cap exists
to catch.

**If the suite grows again, move this with the change that grows it.** That is
the rule this PR is the counter-example to.

## Timing — this needs to go in ahead of #60

#60's head **is** the `qa` branch, so the workflow it runs is `qa`'s copy. The
cap cannot take effect on that gate until this reaches `qa`.

So the order is: merge here → promote `dev` → `qa` → #60's head moves → re-run
its gate.

That moves #60's head off `fb4fa7c`, which I have signed off. I am fine with
that **specifically because this changes no product code and no test logic** —
same tests, same assertions, bigger cap. I will confirm the new head contains
exactly this commit and nothing else before merging #60, and say so there.

**#64 stays held** regardless — that one does carry app code and would need its
own pass.

## How to test (QA)

Nothing to click. On the next PR into `main`, the E2E job should **complete**
rather than being cancelled at 45 minutes, and its duration should read
comfortably under 90.

If it is cancelled at 90, that is a genuine hang and not this.

## Risk level

**Low.** One number in CI config, one comment in a spec. No product code, no test
logic, no dependencies, no environment variables.

Gates: `tsc` clean. `contrast.spec.ts` re-run locally after the edit — **2
passed, 12.1m**.

**Not verified:** the 90 has not itself been exercised in CI, since that requires
a PR into `main`. The failure mode if 90 is still too small is identical to
today's and equally visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
