### PR TITLE
docs: label every PR, issue and comment with which team wrote it

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,13 @@
   Auto-filled on every PR. Full rules: CONTRIBUTING.md section 3.
   Delete the italic prompts as you replace them. Do not delete the headings -
   "How to test (QA)" in particular is the dev to QA handoff, not documentation.
+
+  FIRST LINE: delete whichever team you are not. Both roles post from the same
+  GitHub account, so without this the author tells you nothing about who wrote
+  it - and dev reviews QA's PRs while QA signs off dev's releases.
 -->
+
+**Dev Team** / **QA Team**
 
 ## Summary
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,10 +124,46 @@ back and rewrite them; match the current form going forward.
 
 ## 3. Pull request template
 
+### Say which team you are — first line, every time
+
+**Both roles share one GitHub account.** Dev and QA post from
+`JohnDominicJasmin`, so GitHub shows the same author on a QA finding, a dev fix,
+and a release signoff. A thread reads as one person arguing with themselves.
+
+So **every PR body, every issue, and every comment starts with the team name on
+its own line**, before anything else:
+
+```markdown
+**Dev Team**
+```
+
+or
+
+```markdown
+**QA Team**
+```
+
+This is not ceremony. It has already caused real confusion: two PRs opened
+thirteen minutes apart — one dev's, one QA's — were indistinguishable, and the
+owner had to ask which was which. It matters more, not less, when someone reads
+the thread cold in three months trying to work out who signed off on what.
+
+Commit messages do **not** need it — the branch name and the `type(scope):`
+prefix already carry that, and the convention in §2 has no room for it.
+
+**Use `gh ... --body-file`, never `--body` with inline markdown.** Backticks
+inside a double-quoted shell string get executed as commands. A review comment on
+#66 lost a sentence to `qa: command not found` and had to be re-posted. Write the
+body to a file and pass the file — it also removes every quote-escaping problem.
+
+### The structure
+
 This lives in `.github/pull_request_template.md`, so GitHub fills it in for you
 on every PR — you edit rather than remember. The structure:
 
 ```markdown
+**Dev Team** / **QA Team**
+
 ## Summary
 <one or two sentences, plain language>
 


### PR DESCRIPTION
**Dev Team**

## Summary

Owner's instruction: label every PR, issue and comment with which team wrote it. Adds the rule to `CONTRIBUTING.md` §3 and puts the line in the PR template so it is filled in by default rather than remembered.

## Why

**Both roles post from one GitHub account.** Dev and QA both appear as `JohnDominicJasmin`, so a thread where QA files a finding, dev fixes it, and QA signs it off reads as one person talking to themselves.

Not hypothetical — it happened today. **#65** (dev) and **#66** (QA) were opened thirteen minutes apart and were indistinguishable; the owner had to ask which was which. It matters more, not less, for whoever reads the thread cold in three months trying to work out who signed off on what.

## What changed

| File | |
|---|---|
| `CONTRIBUTING.md` §3 | new "Say which team you are" subsection, ahead of the template structure |
| `.github/pull_request_template.md` | `**Dev Team** / **QA Team**` as the first line, with a comment saying to delete the wrong one |

Commit messages are explicitly **excluded** — the branch name and `type(scope):` prefix already carry that, and §2's format has no room for it.

## The second rule, learned the hard way today

**Use `gh ... --body-file`, never `--body` with inline markdown.**

Backticks inside a double-quoted shell string are executed as commands. My review comment on #66 lost a sentence to `qa: command not found` and had to be re-posted with a correction. Writing the body to a file and passing `--body-file` also removes every quote-escaping problem at once.

Recorded in `CONTRIBUTING.md` alongside the labelling rule, since both are about the mechanics of posting rather than the content.

## How to test (QA)

1. Open any new PR — the template's first line should read `**Dev Team** / **QA Team**` with an instruction comment above it explaining to delete one.
2. `CONTRIBUTING.md` §3 should explain why, and should say commit messages are exempt.
3. Nothing else in the file moved — the template structure below it is unchanged.

## Risk level

**Low.** Two documentation files. No code, no CI, no dependencies.

---

*Note: this is docs-only, so it does not affect the #60 / #64 ordering question still open on #66.*
