### PR TITLE
fix(ci): size the E2E cap from a CI measurement, not a local one - 90 to 120

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,11 +154,33 @@ jobs:
     # per-IP rate limiter into 429s that look like product bugs. Parallelising
     # the contrast file was tried and changed nothing for exactly that reason.
     #
-    # 90 is roughly 2x the current local runtime. A GitHub runner is slower than
-    # the machine that measured ~46, so the headroom is smaller than it looks -
-    # but it is still comfortably below "a hang could hide here for hours".
-    # If the suite grows again, move this WITH the change that grows it.
-    timeout-minutes: 90
+    # 90 -> 120, same day, because 90 was set from LOCAL timings and CI is much
+    # slower. Measured from the cancelled run's own log rather than estimated:
+    #
+    #   contrast.spec.ts   11.6m local   ->   18.6m in CI    (1.6x)
+    #
+    # At the 45-minute cut-off that run had reached test 95 of ~249 and had not
+    # started the mobile project at all, which is the slower half. Extrapolated,
+    # a full CI run is ~80-90 minutes - so 90 would have been a cap the suite
+    # lands exactly on, and the next release would have failed the same way for
+    # the same reason. 120 leaves real headroom instead of nominal headroom.
+    #
+    # Where the time goes, measured per route rather than guessed: the sweep
+    # waits for `networkidle` on every page, which costs ~8s on almost every
+    # route - 8.1 minutes across the 58 loads contrast.spec.ts does. Only ONE
+    # route (/login, whose Turnstile widget never settles) actually hits the 30s
+    # timeout, so this is a steady tax and not a pathological case.
+    #
+    # That 8 minutes is recoverable by replacing the idle wait with a bounded
+    # settle, and it is deliberately NOT done here. Measuring a page before it
+    # has finished rendering silently under-counts violations, which reads as an
+    # improvement and ratchets a baseline down onto a number that was never
+    # true. That change needs a "did it actually render" guard and its own
+    # verification - not a slot on the critical path of a blocked release.
+    #
+    # If the suite grows again, move this WITH the change that grows it, and
+    # size it from a CI measurement rather than a local one.
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
**QA Team**

## Summary

Follow-up to #66, same day. The cap goes **90 → 120**, because 90 was sized from
a **local** measurement and CI is much slower. 90 would have failed the next
release for the same reason 45 failed this one.

Also replaces the guesswork in that comment with measurements.

## Why 90 was wrong

I set 90 from a local full-suite time of ~46 minutes. That was the wrong basis.
Pulling the cancelled run's own log gives the CI figure:

```
contrast.spec.ts     11.6m local   ->   18.6m in CI     (1.6x)
```

And the run's position when the cap hit:

- reached test **95 of ~249**
- had **not started the mobile project**, which is the slower half

Extrapolated, a full CI run is **~80–90 minutes**. So 90 is a cap the suite lands
exactly on — nominal headroom, not real headroom. 120 gives it room.

## Where the time actually goes

Measured per route rather than guessed, because my first theory was wrong and
worth correcting in public:

**I assumed 30-second `networkidle` timeouts dominated.** They don't. Only **one**
route — `/login`, whose Turnstile widget never settles — actually times out.

What is really happening is a **steady ~8s idle wait on almost every route**:

```
routes that never reach networkidle:  1 of 29
time waiting for idle, one theme:     4.0m
both themes (58 page loads):          8.1m
```

So ~8 of `contrast.spec.ts`'s ~11.6 local minutes is waiting, and it is a tax
rather than a pathology.

## Why I am not claiming that 8 minutes here

It is recoverable — swap the idle wait for a bounded settle — and I have
deliberately **not** done it in this PR.

Measuring a page before it has finished rendering **silently under-counts
violations**. That reads as an improvement, and it would ratchet a baseline down
onto a number that was never true. This suite has already hit that exact
vacuous-pass failure three times: an unseeded BOLA test, a cold-start
placeholder, and an unstyled page reporting 3,315 tap targets.

It needs a did-it-render guard and its own verification run. Not a slot on the
critical path of a blocked release.

Tracked; it will come as its own PR with the guard.

## What changed

One number, and a comment that now records CI measurements instead of local
estimates — including the correction above, so the next person does not re-derive
the wrong theory.

## How to test (QA)

Nothing to click. On the next PR into `main`, the E2E job should **complete**
rather than being cancelled, and its duration should read **~80–90 minutes**
against the 120 cap.

If it is cancelled at 120, that is a genuine hang and not this.

## Risk level

**Low.** One CI config number and a comment. No product code, no test logic, no
dependencies, no environment variables.

Gates: n/a — nothing executable changed. `ci.yml` parses; the three
`timeout-minutes` values read `10 / 120 / 5` as intended.

**Not verified:** 120 has not been exercised, since that needs a PR into `main`.
The failure mode if it is still too small is identical to today's and equally
visible — which is exactly why the comment now says to size it from a CI
measurement.

---

**Dev Team**: this supersedes the 90 in #66, which is already on `dev`. Merge
this, then promote `dev` → `qa` — the release is blocked until the cap reaches
`qa`, since #60's head *is* `qa`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
