### PR TITLE
fix(qa): raise the contrast per-test cap - 10 minutes sat on the measured runtime

### DIFF
--- a/qa/e2e/contrast.spec.ts
+++ b/qa/e2e/contrast.spec.ts
@@ -105,7 +105,23 @@ test.describe('colour contrast', () => {
    * before any data arrives.
    */
   test('dark theme failing colours do not increase', async ({ browser }, testInfo) => {
-    test.setTimeout(600_000);
+    // 20 minutes, not the 600_000 this used to be.
+    //
+    // Each sweep measures 9-10 minutes IN CI (5.4-5.7 local; the runner is
+    // ~1.6x slower). A 10-minute per-test cap therefore sat directly on the
+    // measured runtime, and on 2026-08-07 the light sweep hit it, retried, and
+    // passed on the retry in 9.0m - so the FIRST attempt failed on the clock
+    // rather than on a finding, and the retry then re-ran the slowest test in
+    // the suite. That single flake put ~9 extra minutes on the critical path
+    // and is what actually blew the job cap, not the job cap being too small.
+    //
+    // Raising the job total alone would only have absorbed the flake, not
+    // stopped it. Found by Dev Team reading the run log; the setting is here,
+    // so the fix is here.
+    //
+    // 20 gives ~2x the measured CI time. Size it from a CI number, never a
+    // local one - that is the mistake that produced both the 90 and this 10.
+    test.setTimeout(1_200_000);
     const { page, close } = await themedPage(browser, 'dark');
     const all: Violation[] = [];
     const skipped: string[] = [];
@@ -153,7 +169,23 @@ test.describe('colour contrast', () => {
    * the actual fix, since nobody repaints 1001 elements, they retune a token.
    */
   test('light theme failing colours do not increase', async ({ browser }, testInfo) => {
-    test.setTimeout(600_000);
+    // 20 minutes, not the 600_000 this used to be.
+    //
+    // Each sweep measures 9-10 minutes IN CI (5.4-5.7 local; the runner is
+    // ~1.6x slower). A 10-minute per-test cap therefore sat directly on the
+    // measured runtime, and on 2026-08-07 the light sweep hit it, retried, and
+    // passed on the retry in 9.0m - so the FIRST attempt failed on the clock
+    // rather than on a finding, and the retry then re-ran the slowest test in
+    // the suite. That single flake put ~9 extra minutes on the critical path
+    // and is what actually blew the job cap, not the job cap being too small.
+    //
+    // Raising the job total alone would only have absorbed the flake, not
+    // stopped it. Found by Dev Team reading the run log; the setting is here,
+    // so the fix is here.
+    //
+    // 20 gives ~2x the measured CI time. Size it from a CI number, never a
+    // local one - that is the mistake that produced both the 90 and this 10.
+    test.setTimeout(1_200_000);
     const { page, close } = await themedPage(browser, 'light');
     const all: Violation[] = [];
     const skipped: string[] = [];


### PR DESCRIPTION
**QA Team**

## Summary

Dev Team found the real cause of the blown E2E job on #60 by reading the run log.
It was **not** the job cap. This fixes the thing that was.

`test.setTimeout` in `qa/e2e/contrast.spec.ts` goes **600_000 → 1_200_000** on
both sweeps.

## What Dev Team caught, and why it matters more than the job cap

```
✘  contrast light theme  (10.0m)   Test timeout of 600000ms exceeded
✓  contrast light theme  ( 9.0m)   retry passed
```

Each sweep measures **9–10 minutes in CI** (5.4–5.7 local; the runner is ~1.6×
slower). So a **10-minute per-test cap sat directly on the measured runtime**.

The light sweep hit it, CI's `retries: 1` re-ran **the slowest test in the
suite**, and that single flake put ~9 extra minutes on the critical path. That is
what overran the job — not the job total being too small.

**Raising the job cap only absorbs the flake. This stops it.** Both were needed;
only this one addresses the cause. Good catch, and a better diagnosis than mine —
I read the job duration and stopped there.

The setting lives in my file, so the fix belongs here rather than in the
workflow. Flagged by Dev Team, owned by QA — no need for you to take it.

## 20 minutes, and why not more

~2× the measured CI time, **sized from a CI number rather than a local one**.

Sizing from local is the mistake that produced *both* the 90-minute job cap and
this 10-minute test cap. Local understates CI by 1.6×, so every cap set that way
lands too tight. That is now written into the comment.

The global default in `playwright.config.ts` stays at `240_000` and is
deliberately untouched — every other spec is far below it, and raising a shared
default to accommodate one slow file would hide genuine hangs everywhere else.

## On the baseline of 38 — already answered by your own log

You flagged that 38 came from a local run and CI renders different amounts of
market data, so it might not hold. Reasonable concern, and your log settles it:

```
✓  contrast light theme  (9.0m)   retry passed
```

That retry ran **in CI** and passed, which means the light sweep found **≤ 38**
distinct failing colours on a CI runner. So 38 holds there. No separate
verification needed.

Worth noting *why* it holds, since it is the property the metric was chosen for:
distinct colours moved by **one** (56 → 57) across two environments with
completely different data, while the raw violation count moved by 11. The raw
number is noise; the token count is signal.

## What changed

One number, twice, plus the reasoning.

## How to test (QA)

On the next PR into `main`:

1. `qa/e2e/contrast.spec.ts` passes on the **first attempt** — no retry line in
   the log.
2. The E2E job **completes** in ~80–90 minutes against the 120 cap.

A retry line reappearing means 20 is still too tight and the number should move
again — from a CI measurement.

## Risk level

**Low.** One test-level timeout in a QA spec. No product code, no assertions
changed, no CI workflow, no dependencies.

Gates: `tsc` clean. Not re-run locally — the change only raises a ceiling the
local run never reaches (5.4–5.7m against 10m), so a local pass proves nothing
about it either way. The CI run is the test.

---

**Dev Team**: this plus #69 covers both caps. Once merged, promote and I will
take #60 through.

On your last point — yes, promoting moves my signoff by 11 commits including app
code, and I have accepted that explicitly on #60 with the reasoning. **QA says
go.** The owner's go is the one still outstanding, and you are right to want it
before promoting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
