### PR TITLE
docs(ci): add a staging branch so a signed-off release stops moving

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,27 @@ name: CI
 # a 2,000 min/month allowance - roughly $124/month annualised, and it hard-
 # stopped CI mid-release when the spending limit was hit.
 #
-# The rule now: the ~2 minute job runs on everything. The ~34 minute Playwright
+# The rule now: the ~2 minute job runs on everything. The ~53 minute Playwright
 # suite runs on exactly ONE automatic trigger - a PR into `main`, which is the
 # release, immediately before a production deploy.
+#
+# THE BRANCH FLOW IS FOUR-STAGE as of 2026-08-07:
+#
+#   dev  ->  qa  ->  staging  ->  main
+#    |        |         |           |
+#    |        |         |           production
+#    |        |         release candidate: approved work PARKS here and
+#    |        |         combines into one batch. No deployment of its own.
+#    |        where QA tests and signs off
+#    integration
+#
+# `staging` exists because `qa` was doing two jobs at once - rolling integration
+# AND release candidate. Since the release PR's head IS its base branch, every
+# promotion grew a release QA had already signed off. That happened three times
+# on 2026-08-06 alone. Freezing the candidate on its own branch is the fix.
+#
+# The e2e condition below did not need changing for this: the release PR is now
+# `staging -> main` rather than `qa -> main`, and `base_ref` is `main` either way.
 #
 # NOBODY runs it by hand - not dev, not QA. An earlier draft had QA running it
 # locally on the dev -> qa PR; that was dropped because ordering it correctly
@@ -35,15 +53,15 @@ on:
   # help. `types` is explicit so a label or a title edit can never spend 34
   # minutes; `synchronize` is the one that fires on each push to an open PR.
   pull_request:
-    branches: [dev, qa, main]
+    branches: [dev, qa, staging, main]
     types: [opened, reopened, synchronize, ready_for_review]
 
   push:
-    # `qa` is deliberately ABSENT. CONTRIBUTING section 6 makes dev -> qa
-    # fast-forward only, so the commit landing on qa is bit-identical to one
-    # already tested on dev. Worse, the qa->main release PR stays open for the
-    # whole cycle, so each ff-push to qa ALSO fired `synchronize` on it - one
-    # promotion used to bill three full runs.
+    # `qa` and `staging` are deliberately ABSENT. CONTRIBUTING section 6 makes
+    # every promotion fast-forward only, so the commit landing on either is
+    # bit-identical to one already tested on dev. Worse, the release PR stays
+    # open for the whole cycle, so each ff-push to its base ALSO fired
+    # `synchronize` on it - one promotion used to bill three full runs.
     branches: [dev, main]
 
   # For running the browser suite on demand: re-checking after a flake, or
@@ -131,9 +149,9 @@ jobs:
     # base_ref, not ref_name - on a pull_request event ref_name is "33/merge".
     # base_ref is empty on push and on dispatch, so both fall through.
     #
-    # PRs into `dev` and into `qa` deliberately get the 2-minute job only. What
-    # covers them is QA running this same suite locally when the dev -> qa PR
-    # arrives. See CONTRIBUTING 4b.
+    # PRs into `dev`, `qa` and `staging` deliberately get the 2-minute job only.
+    # The release PR is `staging -> main`, so `base_ref == 'main'` still selects
+    # exactly one gate after the four-branch change. See CONTRIBUTING 4b.
     if: >-
       github.base_ref == 'main' ||
       (github.event_name == 'workflow_dispatch' && inputs.e2e)
@@ -322,8 +340,9 @@ jobs:
     # required check un-forgeable. QA found the hole on release PR #38.
     #
     # The bug: `CI Gate` was a fixed name, so EVERY event that touched a commit
-    # published a check by that name. dev -> qa is fast-forward, so the merge
-    # commit on dev, the head of qa, and the head of the qa -> main release PR
+    # published a check by that name. Every promotion is fast-forward, so the
+    # merge commit on dev, the head of qa, the head of staging and the head of
+    # the staging -> main release PR
     # are all the SAME SHA. A push to dev published `CI Gate: success` on it -
     # successful with E2E SKIPPED, because base_ref is empty on a push. GitHub
     # evaluates required checks per commit, so the release PR showed
@@ -332,7 +351,7 @@ jobs:
     # merge.
     #
     # Deleting the `push: [dev]` trigger would have fixed that one path and left
-    # the hole open: a dev -> qa promotion PR publishes checks against the same
+    # the hole open: a promotion PR publishes checks against the same
     # SHA too, also with E2E skipped. The fix has to be that the name itself
     # cannot appear except on a release PR.
     #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ One logical change per commit. Never `fix bug` / `update stuff` / `wip`.
 **PRs** — always these sections: Summary · What changed · Why · **How to test
 (QA)** · Risk level (Low/Med/High) · Screenshots if UI.
 "How to test" is **mandatory on every PR** — it is the dev→QA handoff. Write it
-for someone on the `qa` staging environment: name the page and what to look at,
+for someone on the `qa` test environment: name the page and what to look at,
 not a branch. Only name a branch when the change is not on `qa` yet.
 
 **Two folders** — dev folder writes code, QA folder tests it; the PR is the
@@ -40,8 +40,8 @@ is checked out on `qa`**. Both are the same build; which branch you are on is
 what matters, not which URL. Say which one a result came from. Never test on
 `main` — it does not have the change yet. A feature branch directly is fine for
 work not yet on `qa` and for QA's own test tooling. Reports are plain pass/fail
-per step. When every step passes, **QA merges `qa` → `main`**, not the feature
-branch. Never test on the dev folder; never develop on the QA folder. **If this session is running in the QA
+per step. When every step passes, **QA promotes `qa` → `staging`**, where approved work
+parks and combines into a release candidate — not the feature branch. Never test on the dev folder; never develop on the QA folder. **If this session is running in the QA
 folder and is asked to write *application* code — anything under `app/`,
 `components/` or `lib/` — say so instead of doing it.**
 
@@ -52,28 +52,46 @@ merges. This is the one case where review runs QA → dev. If a fix needs an
 app-code change, QA reports it as a finding — dev writes it.
 
 **Who merges and deploys — QA, never dev.**
-**QA is the only one who merges `qa` → `main`, and the only one who deploys
-production.** Not with permission, not "just this once", not when QA is busy —
+**QA owns the whole path from `qa` onward: `qa` → `staging` → `main`, and the
+production deploy.** Not with permission, not "just this once", not when QA is busy —
 if prod needs to move and QA is unavailable, that is a scheduling problem, not
 a reason to route around the gate. Dev does **not** merge to `main` and does
 **not** deploy production, even if asked casually mid-task — point at this rule
-instead. Dev's authority stops at `dev` and `qa`: it may merge its own feature
-branches into `dev`, may merge `dev` → `qa`, and may deploy nothing.
+instead. Dev's authority stops at `qa`: it may merge its own feature branches into
+`dev`, may promote `dev` → `qa`, and may deploy nothing. Dev does not touch
+`staging` at all.
 
 Merging is **not** the deploy. Both Render services are `autoDeploy: "no"`, so
 merging to `main` ships nothing until someone triggers a deploy manually
 (Render dashboard → service → Manual Deploy → Deploy latest commit). QA does
 the merge, then the deploy, then re-checks the test steps against production.
 
-**Flow is `dev` → `qa` → `main`.**
+**Flow is `dev` → `qa` → `staging` → `main`.**
+
+Four branches, three deployed sites. `staging` is a branch, not a place — it
+holds the frozen release candidate and has no service of its own.
+
+| Branch | Who promotes into it | What it is for |
+|---|---|---|
+| `dev` | dev | integration; features merge here |
+| `qa` | **dev** | what QA tests and signs off, on liquidity-hq-qa.onrender.com |
+| `staging` | **QA** | approved work parks here and combines into one release |
+| `main` | **QA** | production |
+
+**Why `staging` exists.** `qa` was doing two jobs — rolling integration *and*
+release candidate. Because a release PR's head IS its base branch, every
+promotion silently grew a release QA had already signed off. That happened
+three times on 2026-08-06. Freezing the candidate on its own branch is the fix,
+and it is why dev must never promote into `staging`.
 
 `dev` branch → dev merges its own feature branches in and pushes freely, no
 permission needed. **Deploying the `liquidity-hq-dev` service is different —
 ask first**, it has a ~500 build-hour/month cap prod does not. Verify locally
 by default.
 
-`qa` branch → liquidity-hq-qa.onrender.com, the staging environment QA tests
-against. **Does not auto-deploy** — merge `dev` → `qa`, then trigger the deploy
+`qa` branch → liquidity-hq-qa.onrender.com, the QA test environment. This is
+the only deployed non-production site; `staging` has no service of its own.
+QA tests **Does not auto-deploy** — merge `dev` → `qa`, then trigger the deploy
 manually, and say you have done it. Whoever merges also deploys. Free plan, so
 it sleeps when idle and the first request after that is slow. Uses the
 **dev** Supabase (`wdtjhrilakoitfcezxpx`) — a known compromise, since Supabase's
@@ -99,9 +117,10 @@ saying "done" is the same failure as not finding it.
 owns that environment and a promotion mid-test-run changes the build under the
 tester. "Ok to push?" / "hold" or "go". No answer means go; it is a courtesy,
 not a lock. QA is not reviewing the code — nothing dev writes is independently
-reviewed until QA tests the staging build.
+reviewed until QA tests the build on the qa environment.
 
-**Open the `qa` → `main` release PR immediately after promoting.** It is the
+**Open the `staging` → `main` release PR immediately after promoting to
+`staging`.** QA does this, since QA owns that promotion. It is the
 only thing that tells QA there is anything to test — every feature PR is already
 closed by then. It aggregates the "How to test" steps for the whole release,
 ends with merge/deploy/re-check/tag, and collects every "could not verify

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,7 +217,7 @@ the handoff point between them.**
    the change is not on `qa` yet.
 
 **Dev is not done when the PR is open.** Dev also merges its own feature branch
-into `dev`, promotes `dev` → `qa`, deploys the qa service, and opens the release
+into `dev`, promotes `dev` → `qa`, and deploys the qa service. QA opens the release
 PR that tells QA there is something to test (§7). What dev never does is merge
 to `main` or deploy production — see "Who merges and deploys" below.
 
@@ -290,14 +290,15 @@ on `dev` for a day with nobody wondering why it never reached staging.
    automatically. Wait for it. A red run there means something QA's manual pass
    did not reach, and it blocks the production deploy.
 
-   `qa` → `main`, not the feature branch → `main`. By the time QA is testing,
+   `staging` → `main`, not the feature branch → `main`. By the time QA is testing,
    the change is already on `dev` and `qa`; merging the original feature branch
    straight into `main` would skip whatever else `qa` was validated with, and
    ship a combination nobody tested.
 
 ### Who merges and deploys
 
-**Dev never merges `qa` → `main` and never deploys production.** Not with
+**Dev never promotes into `staging`, never merges to `main`, and never deploys
+production.** Not with
 permission, not "just this once", not when QA is busy. The whole value of the
 gate is that it is never the person who wrote the code.
 
@@ -313,7 +314,7 @@ asserting the "How to test" steps passed, and that assertion is worth the same
 whoever makes it.
 
 Dev's authority stops at `dev` and `qa`. Dev may merge its own feature branches
-into `dev`, may merge `dev` → `qa`, deploys the `qa` service, and deploys
+into `dev`, may promote `dev` → `qa`, deploys the `qa` service, and deploys
 nothing else.
 
 Merging is not the deploy. **No** Render service auto-deploys; all three are
@@ -406,17 +407,27 @@ place it is worth 34 minutes.
 | Push to a feature branch | ✅ ~2 min | — |
 | PR into `dev` | ✅ | — |
 | PR into `qa` | ✅ | — |
+| PR into `staging` | ✅ | — |
 | Push to `dev` or `main` | ✅ | — |
-| **PR into `main`** (the release) | ✅ | ✅ **187 tests, ~34 min** |
+| **PR `staging` → `main`** (the release) | ✅ | ✅ **the full suite, ~53 min** |
 | Manual run (Actions → CI → Run workflow) | ✅ | ✅ if you tick the box |
 
 **One automated browser run per release, immediately before production.**
 
+The four-branch change did not move this gate. The release PR became
+`staging` → `main` instead of `qa` → `main`, and the workflow selects on the
+*base* being `main`, which is true either way.
+
+Measured, so the cost is not a guess: the suite ran **53 minutes with no
+retries** on release 2026-08-06.4, and across the 40 workflow runs around it the
+browser job executed **exactly once**. At one to two releases a week that is
+roughly 200–400 minutes a month against a 2,000 minute allowance.
+
 ### Nobody runs it by hand
 
 Not dev, not QA. Dev's pre-PR gates are the four fast ones — `npm run lint`,
-`npx tsc --noEmit`, `npm test`, `npm run build`. QA's job is manual testing on
-staging, following the PR's "How to test" steps.
+`npx tsc --noEmit`, `npm test`, `npm run build`. QA's job is manual testing on the
+`qa` environment, following the PR's "How to test" steps.
 
 This was deliberated and changed twice. An earlier draft had QA running
 `npm run test:e2e` locally on the promotion PR. It was dropped because it landed
@@ -493,21 +504,47 @@ When in doubt: would a QA person need to look at this? If yes, write the body.
 
 ## 6. Branches and environments
 
-The flow is `dev` → `qa` → `main`.
+The flow is `dev` → `qa` → `staging` → `main`.
 
-| Branch | Environment | Who pushes | Deploys automatically? |
+**Four branches, three deployed sites.** `staging` is a branch, not a place: it
+holds the frozen release candidate and has no service of its own.
+
+| Branch | Environment | Who promotes into it | Deploys automatically? |
 |---|---|---|---|
 | `<type>/<description>` | none | dev | n/a |
 | `dev` | liquidity-hq-dev.onrender.com | dev | **no** — trigger manually |
-| `qa` | **liquidity-hq-qa.onrender.com** | dev merges `dev` → `qa` | **no** — trigger manually |
-| `main` | liquidity-hq.com (production) | **QA** (owner may), never dev | **no** — trigger manually |
+| `qa` | **liquidity-hq-qa.onrender.com** | **dev** merges `dev` → `qa` | **no** — trigger manually |
+| `staging` | none — a frozen pointer | **QA** merges `qa` → `staging` | n/a |
+| `main` | liquidity-hq.com (production) | **QA** merges `staging` → `main` | **no** — trigger manually |
+
+### Why `staging` exists
+
+`qa` was doing two jobs at once: rolling integration **and** release candidate.
+
+A release PR's head **is** its base branch, so every `dev` → `qa` promotion
+silently changed what an open release PR contained. QA would sign off on a set
+of commits and the release would grow underneath them. That happened **three
+times on 2026-08-06**, once after QA had already completed a full manual pass.
+
+Splitting the two jobs fixes it structurally rather than by everyone
+remembering to ask first:
+
+- `qa` keeps moving. Dev promotes into it whenever work is ready.
+- `staging` only moves when **QA** decides a batch is approved and ready to
+  park. Nothing dev does can change what is sitting in a release.
+
+This is also why **dev must never promote into `staging`**. If dev can move it,
+the freeze is not a freeze.
 
 - Feature branches are cut from `dev` and merged back into `dev` via PR.
   **Dev merges its own feature branches into `dev`** — QA ownership starts at
   `main`, not here. Merging a feature branch into `dev` needs no permission
   and no QA pass.
 
-### The `qa` staging environment
+### The `qa` test environment
+
+This is the only deployed non-production site. `staging` has no environment of
+its own — QA tests here, then parks approved work on `staging`.
 
 Merging `dev` → `qa` does **not** deploy. Like prod and dev, this service is
 `autoDeploy: no`, so the branch moving and the environment moving are two
@@ -563,7 +600,7 @@ was cut from `dev` and merged to `main` to bootstrap the convention, and it
 silently carried 13 unrelated QA-scaffolding files onto `main` with it.
 
 - Normal work → cut from `dev`, merge back to `dev`. Reaches `main` later, as
-  part of a reviewed `dev` → `qa` → `main` release.
+  part of a reviewed `dev` → `qa` → `staging` → `main` release.
 - Hotfix or anything that must land on `main` **now** → cut from `main`, then
   merge it back into **both `dev` and `qa`** afterwards, or the next release
   silently reverts it. Merging into `dev` alone is not enough now that `qa`
@@ -587,7 +624,7 @@ git checkout qa && git merge --ff-only dev && git push
 If that command fails, `qa` has diverged and something has gone in the wrong
 way. Fix the divergence rather than forcing the merge — a `qa` that is not a
 prefix of `dev` means "tested on qa" no longer tells you anything about what is
-on `dev`, and the whole `dev` → `qa` → `main` model stops meaning what it says.
+on `dev`, and the whole `dev` → `qa` → `staging` → `main` model stops meaning what it says.
 
 After a release lands on `main`, `qa` keeps whatever it had; the next promotion
 fast-forwards it again from `dev`. Nothing needs resetting.
@@ -597,8 +634,8 @@ fast-forwards it again from `dev`. Nothing needs resetting.
 Once a feature branch is merged, delete it locally and on the remote. A branch
 list that still shows a dozen merged branches makes the two or three that
 matter impossible to find, and it is not obvious from the name which are live.
-`main`, `dev`, `qa` and anything with an open PR are the only branches that
-should exist.
+`main`, `dev`, `qa`, `staging` and anything with an open PR are the only
+branches that should exist.
 
 **If a merge to `main` is ever reverted**, note that the reverted commits stay
 in `main`'s history. Git treats them as already merged, so a later `dev` →
@@ -622,8 +659,8 @@ a cherry-pick, not another merge.
 
 ## 7. Promoting a release
 
-The two merges that actually reach users — `dev` → `qa` and `qa` → `main` — get
-a PR like everything else. They are the merges with the highest blast radius,
+The three merges that carry work forward — `dev` → `qa`, `qa` → `staging` and
+`staging` → `main` — get a PR like everything else. They are the merges with the highest blast radius,
 so they are the wrong place to skip the paper trail. A promotion PR needs no
 essay: a title, a list of what is going out, and the checklist below.
 
@@ -636,7 +673,7 @@ ready.**
 |---|---|
 | New features, additions, refactors, docs | Batched into **one release a week** |
 | Bug fixes | As soon as they are verified — do not wait for the weekly slot |
-| Hotfixes (production is broken) | Immediately, and they skip `qa` — see §6 |
+| Hotfixes (production is broken) | Immediately, and they skip `qa` and `staging` — see §6 |
 
 Merging to `dev` is not affected — that stays continuous. What batches is the
 promotion out of `dev`.
@@ -645,7 +682,7 @@ Two things follow from this, and both are the point rather than side effects:
 
 - **A regression found at the release gate arrives with a week of changes
   attached**, not one. That is the cost of batching, and it is why §4b keeps the
-  full browser suite on the `qa` → `main` PR — the last automated check before a
+  full browser suite on the `staging` → `main` PR — the last automated check before a
   production deploy — rather than dropping it entirely once it came off feature
   PRs.
 - **"It is not urgent" is a real answer.** A feature that misses the weekly slot
@@ -729,16 +766,21 @@ The test to apply before handing over: *if QA finds nothing, was this PR
 finished?* If the honest answer is "no, they would have found the obvious
 thing", it was not ready.
 
-### The release PR is how QA finds out there is work
+### Two PRs, and who opens which
 
-**Immediately after promoting `dev` → `qa`, dev opens a `qa` → `main` PR.** Not
-later, not when the release feels big enough. That PR is the only thing that
-tells QA anything is waiting.
+**Dev, immediately after promoting `dev` → `qa`: open a `dev` → `qa` PR**, or
+say so on the release thread. That PR is the only thing that tells QA anything
+is waiting. Not later, not when the release feels big enough.
+
+**QA, when a batch is approved and ready to park: promote `qa` → `staging` and
+open the `staging` → `main` release PR.** Dev does not open this one and does
+not promote into `staging` — that is the whole point of the branch. If dev can
+move the release candidate, it is not frozen.
 
 This was missing and it silently broke the handoff. Five changes sat on the
-staging site — including the worst Core Web Vital in the product and a bug that
+`qa` site — including the worst Core Web Vital in the product and a bug that
 was getting users' IPs banned — with nothing anywhere saying so. Every
-individual PR had already been merged and closed, `qa` had moved, staging had
+individual PR had already been merged and closed, `qa` had moved, the qa service had
 been redeployed, and QA had no way to know. Promoting without opening this PR is
 deploying into silence.
 
@@ -756,11 +798,13 @@ Keep it open while QA works. It is the thread: failures get reported as comments
 on it, and it stays open until the whole release either ships or is pulled
 apart.
 
-### Before `qa` → `main`
+### Before `staging` → `main`
 
-1. Every "How to test" step passed, on `qa` — not on a feature branch, not on
-   `dev`.
-2. CI green on `qa`.
+0. The candidate is parked: QA has promoted `qa` → `staging`, so what is in the
+   release stopped moving. Nothing dev does can change it from here.
+1. Every "How to test" step passed, on the `qa` environment — not on a feature
+   branch, not on `dev`.
+2. CI green.
 3. **Migrations already applied to production.** Before the deploy, never after.
 4. **Every environment variable the release needs exists on
    `liquidity-hq-prod`.** Check, do not assume.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,11 +13,18 @@ Defined in `render.yaml`. Two Render web services, same codebase:
 | Service | Branch | `NEXT_PUBLIC_APP_ENV` | Database tables |
 |---|---|---|---|
 | `liquidity-hq` (production) | `main` | `prod` | `lhq_*` |
+| `liquidity-hq-qa` | `qa` | `dev` | `lhq_dev_*` |
 | `liquidity-hq-dev` | `dev` | `dev` | `lhq_dev_*` |
+
+**Three services, four branches.** `staging` sits between `qa` and `main` and has
+no service — it is the frozen release candidate, not a place. See
+`CONTRIBUTING.md` §6.
 
 **Correction 2026-08-01:** this previously said both services share one Supabase project - wrong, corrected in `docs/INFRASTRUCTURE.md` §4 after direct confirmation with the owner. There are **two separate Supabase projects**: prod (`liquidity-hq-prod`, ref `qdpwhnvmhqgzijuwopso`) uses unprefixed `lhq_*` tables, dev (`liquidity-hq-dev`, ref `wdtjhrilakoitfcezxpx`) uses `lhq_dev_*`. Every migration is written to run against both. Isolation still comes from the table-name prefix either way, switched in one place: `lib/tables.ts` exports a `T` registry (`T.trades`, `T.user_subscriptions`, ...) that every query goes through. **Never hardcode a table name - always import `T`.**
 
-Workflow rule: all commits land on `dev` (auto-deploys to the dev service), `main` is release-only.
+Workflow rule: all commits land on `dev`, `main` is release-only. Nothing
+auto-deploys — every service is `autoDeploy: no`. Flow is
+`dev` → `qa` → `staging` → `main`; see `CONTRIBUTING.md` §6.
 
 Secrets (`GROK_API_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `LEMONSQUEEZY_WEBHOOK_SECRET`, `TELEGRAM_BOT_TOKEN`, VAPID keys) live in the Render dashboard and `.env.local` - server-side only, never `NEXT_PUBLIC_`. The only intentionally public env vars are the Supabase URL + anon key (safe under RLS), the PostHog key, the VAPID public key, and the Lemon Squeezy checkout URL.
 

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -14,12 +14,12 @@ Four services, one Render account, org workspace shared with unrelated projects 
 |---|---|---|---|---|---|---|
 | `liquidity-hq-prod` | `srv-d8aluf6l51nc73e1ijp0` | starter | Singapore | `main` | `liquidity-hq.onrender.com` | Production. `npm install; npm run build` → `npm start`. |
 | `liquidity-hq-dev` | `srv-d8prs6po3t8c739aepdg` | free | Singapore | `dev` | `liquidity-hq-dev.onrender.com` | Dev integration. Free plan — spins down after inactivity, first request after idle is slow/can fail. |
-| `liquidity-hq-qa` | `srv-d9p42ke1egvs73f8car0` | free | Singapore | `qa` | `liquidity-hq-qa.onrender.com` | **Staging — the environment QA tests against.** `autoDeploy: no`, like the other two: merging `dev` → `qa` moves the branch, not the environment. Uses the **dev** Supabase project (free plan caps the account at 2 active projects, so it has none of its own). Free plan, so it sleeps when idle. |
+| `liquidity-hq-qa` | `srv-d9p42ke1egvs73f8car0` | free | Singapore | `qa` | `liquidity-hq-qa.onrender.com` | **The QA test environment.** Note the branch flow gained a fourth branch on 2026-08-07 (`dev` → `qa` → `staging` → `main`) but NOT a fourth service: `staging` is a frozen release-candidate pointer with no environment of its own, so this stays the only deployed non-production site. `autoDeploy: no`, like the other two: merging `dev` → `qa` moves the branch, not the environment. Uses the **dev** Supabase project (free plan caps the account at 2 active projects, so it has none of its own). Free plan, so it sleeps when idle. |
 | `n8n-workflows` | `srv-d6e4fkq4d50c73b8dpk0` | starter | Singapore | n/a (Docker image `n8nio/n8n:latest`) | `n8n-workflows-6ig6.onrender.com` | Self-hosted n8n instance, 5GB persistent disk. Shared across projects, not LHQ-exclusive. |
 
 All three LHQ services have `autoDeploy: no` — pushing to `main`/`dev` does **not** auto-deploy. Deploys are triggered manually (via Render dashboard, the `mcp__render__trigger_deploy` tool, or `git push` if that ever changes).
 
-`liquidity-hq-qa` is the same: `autoDeploy: no`. **No service in this project auto-deploys.** Whoever merges `dev` → `qa` triggers the qa deploy — normally dev, as part of handing the build to QA. CI runs on `qa` as well (`.github/workflows/ci.yml`), so a merge is checked even though it does not ship by itself.
+`liquidity-hq-qa` is the same: `autoDeploy: no`. **No service in this project auto-deploys.** Whoever merges `dev` → `qa` triggers the qa deploy — normally dev, as part of handing the build to QA. Promoting `qa` → `staging` deploys nothing, because `staging` has no service; it only freezes what the release contains. CI runs on `qa` as well (`.github/workflows/ci.yml`), so a merge is checked even though it does not ship by itself.
 
 `render.yaml` in this repo has **no cron job definitions** — Render's own Cron Jobs feature is not used anywhere for this project (it has no free tier, unlike the alternatives below).
 


### PR DESCRIPTION
**Dev Team**

@QA — this changes your workflow and hands you a branch. Worth reading before it merges.

## Summary

Owner's decision: the flow becomes **`dev` → `qa` → `staging` → `main`**, and **QA owns everything from `qa` onward**.

| Branch | Who promotes into it | What it is for |
|---|---|---|
| `dev` | dev | integration |
| `qa` | **dev** | what QA tests, on liquidity-hq-qa.onrender.com |
| `staging` | **QA** | approved work parks here and combines into one release |
| `main` | **QA** | production |

**Four branches, three deployed sites.** `staging` is a branch, not a place — no Render service, no build hours, no secrets to keep in sync.

## Why — this is your problem, and it is structural

`qa` was doing two jobs at once: rolling integration **and** release candidate. Those conflict.

A release PR's head **is** its base branch. So every `dev` → `qa` promotion silently changed what an open release PR contained. You would sign off on a set of commits and the release would grow underneath you.

**That happened three times yesterday.** Once after you had completed a full manual pass on `fb4fa7c`. Each time I had to post a correction on #60 saying your signoff no longer applied, and one unwind attempt had to be refused by branch protection.

Every one was avoidable by asking first — and asking first is exactly what kept failing. So this fixes it structurally instead:

- `qa` keeps moving. Dev promotes into it freely, no permission needed.
- `staging` only moves when **you** decide a batch is approved and ready to park.
- **Nothing dev does can change what is in a release.**

That is also why dev must never promote into `staging`. If dev can move it, the freeze is not a freeze.

## What this means for you day to day

1. Dev promotes `dev` → `qa` and deploys the qa service, as now.
2. You test on liquidity-hq-qa.onrender.com, as now.
3. **New:** when a batch passes, you promote `qa` → `staging` — `git checkout staging && git merge --ff-only qa && git push`.
4. **New:** you open the `staging` → `main` release PR. Dev does not open this any more.
5. The browser suite runs on that PR, as now. You merge, deploy prod, tag.

Step 3 is the freeze. After it, the release cannot change without you doing it.

## The E2E gate did not move

Worth stating because it is the obvious thing to worry about: the release PR becomes `staging → main` instead of `qa → main`, and the workflow selects on the **base** being `main` — true either way.

```yaml
if: >-
  github.base_ref == 'main' ||
  (github.event_name == 'workflow_dispatch' && inputs.e2e)
```

Unchanged. Confirmed by reading it, not assuming.

## Workflow changes are two lines

- `staging` added to `pull_request.branches`, so PRs into it get the fast gates.
- `staging` deliberately **not** added to `push.branches` — same reasoning that excluded `qa`: promotions are fast-forward, so the commit landing there is bit-identical to one already tested on `dev`, and a push to a release PR's base also fires `synchronize` on that PR. That is the triple-billing you and I chased in the cost work.

## Naming fix, because the collision would have bitten

The qa **site** was called "the staging environment" throughout the docs. With a `staging` **branch** now existing, that is ambiguous in the worst way — two different things, same word, in a document about which one to test on.

Renamed consistently: the site is **the qa test environment**; `staging` is a branch with no environment.

## Also corrected while aligning

`CONTRIBUTING.md` said the browser suite takes **~34 minutes**. Measured on release 2026-08-06.4 it is **~53 with no retries** — and across the 40 workflow runs around it, the browser job executed **exactly once**. Both figures now reflect measurements rather than the original estimate.

## Files

| File | |
|---|---|
| `.github/workflows/ci.yml` | `staging` in pull_request branches; flow diagram in the header; stale three-branch comments |
| `CLAUDE.md` | flow, ownership table, why `staging` exists |
| `CONTRIBUTING.md` | §4b what-runs-where, §6 branches, §7 who opens which PR |
| `docs/INFRASTRUCTURE.md`, `docs/ARCHITECTURE.md` | service tables — three services, four branches |

Not every "qa" mention changed; most refer to the QA **role**, not the branch.

## ⚠️ Not done here, and it needs sequencing

**The `staging` branch does not exist yet**, and neither does its protection.

Release **#75** is `qa` → `main` and is mid-flight with its browser suite running. Cutting `staging` from `main` before that merges would create a branch that is already behind the release about to land.

So the order is:

1. #75 finishes, you merge and deploy it
2. **then** cut `staging` from `main`
3. branch protection on `staging` matching `qa` — `non_fast_forward` and `deletion` (owner, GitHub settings)
4. the next release runs through the new flow

I will not create the branch until you have shipped #75. Say when.

## How to test (QA)

Nothing to click — this is documentation and two workflow lines.

1. On the next PR into `dev` or `qa`: fast gates only, check reads `CI Gate (advisory)`.
2. On the first `staging` → `main` release PR: browser suite runs, required check reads `CI Gate` with no "advisory".
3. `CONTRIBUTING.md` §6 and §7 should agree with each other and with what you actually do.
4. Nothing in the docs should call the qa site "staging" any more.

## Risk level

**Low.** Documentation plus two lines of workflow triggers. No application code, no dependencies, no environment variables, no migrations.

The real risk is a **process** one, not a code one: if `staging` is created but the protection rules are not applied, it can be force-pushed and the freeze means nothing. That is step 3 above and it is the one I cannot do myself.

Gates: `lint` 0 errors (94 warnings, unchanged) · `tsc` clean · **96/96** unit.
