### PR TITLE
docs(api): correct scheduler and CRON_SECRET records against the live dashboards

### DIFF
--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -31,24 +31,44 @@ Account: `console.cron-job.org` (external, separate login — not in this repo, 
 
 | Job name | Target | Schedule | Status | Auth | Purpose |
 |---|---|---|---|---|---|
-| `liquidity hq` | `https://liquidity-hq.onrender.com/` | every 5 min | **Active**, succeeding | none | Keep-alive / uptime ping for prod root. |
-| `LiquidityHQ` | `https://liquidity-hq.onrender.com/api/telegram/alert` | every 5 min (`*/5 * * * *`, tz Asia/Manila) | **Active**, succeeding | none (no custom headers sent) | The actual Telegram/Web Push alert scanner — RSI, EMA crosses, whale trades, OI spikes, news, fear/greed. See `docs/ARCHITECTURE.md` §7. |
-| `LiquidityHQ - macro-alert` | `https://liquidity-hq.onrender.com/api/macro-alert` | every 5 min (`*/5 * * * *`, tz Asia/Manila) | **Active**, confirmed succeeding (200 OK, first tick 2026-07-19 6:25 PM) | none | Economic-calendar event alerts (FOMC/NFP/CPI/etc). Wired 2026-07-19 — see §8, was previously the confirmed gap. |
-| `LiquidityHQ - signals/track` | `https://liquidity-hq.onrender.com/api/signals/track` | every 15 min (`*/15 * * * *`, tz Asia/Manila) | **Active**, route confirmed live via direct curl (200 OK) same day; first scheduled tick pending at creation time | none | Live EMA Ribbon signal detection + resolution (majors, 1h/4h) feeding `/live-tracking`. Wired 2026-07-19 — see §8, was previously the confirmed gap. |
+| `liquidity hq` | `https://liquidity-hq.com/` | every 5 min | **Active**, succeeding | none | Keep-alive / uptime ping for prod root. |
+| `LiquidityHQ` | `https://liquidity-hq.com/api/telegram/alert` | every 5 min (`*/5 * * * *`, tz Asia/Manila) | **Active**, succeeding | none (no custom headers sent) | The actual Telegram/Web Push alert scanner — RSI, EMA crosses, whale trades, OI spikes, news, fear/greed. See `docs/ARCHITECTURE.md` §7. |
+| `LiquidityHQ - macro-alert` | `https://liquidity-hq.com/api/macro-alert` | every 5 min (`*/5 * * * *`, tz Asia/Manila) | **Active**, confirmed succeeding (200 OK, first tick 2026-07-19 6:25 PM) | none | Economic-calendar event alerts (FOMC/NFP/CPI/etc). Wired 2026-07-19 — see §8, was previously the confirmed gap. |
+| `LiquidityHQ - signals/track` | `https://liquidity-hq.com/api/signals/track` | every 15 min (`*/15 * * * *`, tz Asia/Manila) | **Active**, route confirmed live via direct curl (200 OK) same day; first scheduled tick pending at creation time | none | Live EMA Ribbon signal detection + resolution (majors, 1h/4h) feeding `/live-tracking`. Wired 2026-07-19 — see §8, was previously the confirmed gap. |
 | `LiquidityHQ - trial reminder` | `https://liquidity-hq.com/api/trial-reminder` | daily 09:00 (`0 9 * * *`, tz Asia/Manila) | **Active**, created 2026-08-07; endpoint verified by direct curl the same day (no header → 401, wrong header → 401, real header → `200 {"ok":true,"sent":0}`) | `x-cron-secret` header | Emails anyone within 2 days of their 14-day trial expiring. Trial START was announced twice (welcome email + countdown banner) but the END was silent - this is the only notice that reaches a user who is not signed in. Route is `checkCronAuth`-gated and fails CLOSED, so without this job it silently never runs. |
 | `n8nreq` | `https://n8n-workflows-6ig6.onrender.com` | (was recurring) | **Inactive** (disabled) | none | Old keep-alive ping for the n8n service. Last ran 2026-03-10. |
+| `dev liquidity hq environment` | `https://liquidity-hq-dev.onrender.com/` | (was recurring) | **Inactive** (disabled), last run **failed** | none | Old keep-alive ping for dev (free-tier spin-down mitigation). Last ran 2026-07-01, failed. |
 | **`LiquidityHQ - news ingest`** | `https://liquidity-hq.com/api/news/ingest` (**POST**) | every 1 min (`* * * * *`) | **Active** - verified 2026-08-01 against prod: newest `lhq_news` row 1.3 min old, and 11 of 12 feeds reported a fresh per-source health result 30 seconds prior. (This row previously read "Needs creating" long after the job existed.) | `x-cron-secret` header | Fetches the RSS feeds + Finnhub news once and writes new rows to `lhq_news`. Clients no longer poll for news at all; they subscribe to that table over Supabase Realtime (`components/NewsProvider.tsx`). Without this job the ticker only ever shows whatever was last ingested. |
-| **`LiquidityHQ - econ snapshot`** | `https://liquidity-hq.com/api/econ-calendar/ingest` (**POST**) | hourly (`0 * * * *`) | **Active** | `x-cron-secret` header | Two jobs. (1) Writes the economic calendar into `lhq_econ_snapshot` for push delivery - `/api/econ-calendar` itself stays live, since `/econ-calendar`, `EconCalendarWidget` and `api/macro-alert` read it directly. (2) **Runs the API-health alert sweep** (`lib/healthAlert.ts`) - emails the owner when a tracked dependency has failed 3 checks in a row, and again when it recovers. The sweep rides this job because it needs an hourly schedule and this is the only hourly cron; giving it its own route would have repeated `api/ops/spike-alert`, which was built 2026-07-25, never wired, and is still dead. If this job is ever deleted or repointed, health alerting silently stops - the calendar snapshot going stale would be the visible symptom, the missing alerts would not be. |
+| **`LiquidityHQ - econ snapshot`** | `https://liquidity-hq.com/api/econ-calendar/ingest` (**POST**) | hourly (`0 * * * *`) | **Active** | `x-cron-secret` header | Two jobs. (1) Writes the economic calendar into `lhq_econ_snapshot` for push delivery - `/api/econ-calendar` itself stays live, since `/econ-calendar`, `EconCalendarWidget` and `api/macro-alert` read it directly. (2) **Runs the API-health alert sweep** (`lib/healthAlert.ts`) - emails the owner when a tracked dependency has failed 3 checks in a row, and again when it recovers. The sweep rides this job because it needs an hourly schedule and this is the only hourly cron; giving it its own route would have repeated `api/ops/spike-alert`, which was built 2026-07-25 and sat unwired for two weeks (it is wired now, via n8n — see §3). If this job is ever deleted or repointed, health alerting silently stops - the calendar snapshot going stale would be the visible symptom, the missing alerts would not be. |
 
 **Both new jobs must be POST, not GET** - cron-job.org defaults to GET, and these
 routes only export `POST`, so a GET returns 405 and the job will look "successful"
 in some dashboards while never ingesting anything. Set the method explicitly and
 confirm the response body is `{"ok":true,...}`.
 
-**Target hostname corrected 2026-08-07:** the live jobs point at the custom domain `https://liquidity-hq.com`, NOT `liquidity-hq.onrender.com` as the older rows above still say. Verified in the dashboard. The onrender.com URLs still resolve, so nothing is broken - but copy the custom domain when adding a job, to match what is actually there.
+**Target hostnames corrected in the rows themselves 2026-08-08.** Every active job
+uses the custom domain `https://liquidity-hq.com`. Four rows previously said
+`liquidity-hq.onrender.com` and carried a footnote saying "the rows above are
+wrong" — the rows are now right and the footnote is gone, because a table nobody
+can trust without reading a correction underneath it is worse than no table.
+Note the asymmetry with §3: **cron-job.org jobs use `liquidity-hq.com`, the n8n
+workflows use `liquidity-hq.onrender.com`.** Both resolve to prod. Copy whichever
+the tool next to it already uses.
 
-All active jobs above target **prod only**. `macro-alert` and `signals/track` were both verified working on dev too via direct curl (`liquidity-hq-dev.onrender.com`, both `200 OK`, `signals/track` genuinely logged a real signal) - the routes work fine there, there's just no cron pointed at dev for them. Confirmed intentional with the user 2026-07-19: dev is staging, doesn't need production alert cadence. Don't re-flag this as a gap.
-| `dev liquidity hq environment` | `https://liquidity-hq-dev.onrender.com/` | (was recurring) | **Inactive** (disabled), last run **failed** | none | Old keep-alive ping for dev (free-tier spin-down mitigation). Last ran 2026-07-01, failed. |
+All active jobs above target **prod only** — re-verified 2026-08-08 by reading the
+full job list in the dashboard (9 rows returned; the dashboard counter
+independently reports 7 enabled + 2 disabled = 9, so nothing is hidden behind a
+folder filter). `macro-alert` and `signals/track` were both verified working on
+dev too via direct curl (`liquidity-hq-dev.onrender.com`, both `200 OK`,
+`signals/track` genuinely logged a real signal) - the routes work fine there,
+there's just no cron pointed at dev for them. Confirmed intentional with the user
+2026-07-19: dev is staging, doesn't need production alert cadence. Don't re-flag
+this as a gap.
+
+**Nothing is scheduled against `liquidity-hq-qa.onrender.com` or
+`liquidity-hq-staging.onrender.com`, in either tool.** Checked 2026-08-08 because
+`CRON_SECRET` turned up set on qa (§4c) and the answer decided whether that was
+cheap to remove or needed a dedicated bot first. It was cheap.
 
 **`CRON_SECRET` IS set on prod, as of the security-audit fixes (`pendings/PENDING.md`: "Cron auth fail-closed, CRON_SECRET set, verified 200 on a live cron run").** This section previously said it was unset — stale, corrected 2026-07-25. `lib/cronAuth.ts`'s `checkCronAuth()` fails CLOSED with no secret configured, so every job in the table above must send a matching `x-cron-secret` header (or `?secret=` query param) or it 401s. Any NEW cron-job.org job or n8n workflow hitting a `checkCronAuth`-gated route needs this header from the start - it will not silently work unauthenticated the way the original jobs briefly did before the fail-closed change shipped.
 
@@ -65,6 +85,22 @@ Project: **Personal** → folder **`liquidityhq`** (`https://n8n-workflows-6ig6.
 | Workflow | Trigger | Action | Status |
 |---|---|---|---|
 | `LHQ - Resolve Alert Outcomes (hourly)` | Schedule Trigger, Custom Cron `0 0 * * * *` (top of every hour) | HTTP Request `GET https://liquidity-hq.onrender.com/api/alert-outcomes/resolve` | Published/active as of 2026-07-19. Resolves the 24h/48h alert-outcome windows for `lhq_alert_fires` (Tier 2 backlog item #10). |
+| `LHQ - AI Spike Alert` | Schedule Trigger | HTTP Request `GET https://liquidity-hq.onrender.com/api/ops/spike-alert` | **Published**, confirmed 2026-08-08. Telegrams the owner once today's xAI spend crosses 80% of `AI_GLOBAL_DAILY_MAX`. Closes the last open item in §8 — that entry claimed this route was "genuinely dead" for two weeks after it had been wired. |
+
+**These are the only two LHQ workflows.** The instance holds 38 in total; the other
+36 belong to unrelated projects (`avmoto-*`, Vapi, Proposal Tracker, Solar ROI,
+demos) and are not LiquidityHQ's. Both LHQ workflows live in the folder linked
+above and both target **prod**.
+
+Scope of that check, stated so it is not over-read: the two LHQ workflows were
+opened and their HTTP Request node URLs read directly. The other 36 were matched
+by name and project only, not opened. A workflow in someone else's project could
+in principle call an LHQ host without saying so in its name.
+
+**Read the node URL from the DOM, not the canvas.** n8n truncates the node
+subtitle to `GET: https://liquidity-hq.onre...` — and a **qa** URL truncates to a
+near-identical string. Anyone eyeballing the canvas to confirm "it points at prod"
+will confirm it either way.
 
 Why n8n over a Render cron job or cron-job.org for this one: Render cron jobs have no free tier (cheapest is a paid `starter` plan); n8n was already running and paid for, so this added zero new billable infrastructure. cron-job.org was the other free option but n8n was chosen since it was already open in this session — no strong reason either way, could be moved to cron-job.org later for consistency with `telegram/alert`.
 
@@ -228,7 +264,7 @@ deliberate exceptions. Set as of 2026-08-05:
 | Variable | Value | Why |
 |---|---|---|
 | `NEXT_PUBLIC_APP_ENV` | `dev` | **Not `qa`** — see §4b |
-| `NEXT_PUBLIC_SENTRY_ENV` | `qa` | The one place qa may call itself qa. Separates its errors from dev's in GlitchTip without touching table selection — see §4b. **Not yet set; needs adding on the qa service** |
+| `NEXT_PUBLIC_SENTRY_ENV` | `qa` | The one place qa may call itself qa. Separates its errors from dev's in GlitchTip without touching table selection — see §4b. **Set — confirmed in the dashboard 2026-08-08** (this row previously read "not yet set") |
 | `NEXT_PUBLIC_APP_URL` | `https://liquidity-hq-qa.onrender.com` | Its own URL, never dev's. Telegram webhook registration and email links build absolute URLs from this |
 | `NEXT_PUBLIC_SUPABASE_URL` / `_ANON_KEY` | dev project `wdtjhrilakoitfcezxpx` | Shares the dev database — see §1 |
 | `SUPABASE_SERVICE_ROLE_KEY` | dev project's | Server routes return empty results without it. `/api/labels` answered `{}` until it was set |
@@ -241,32 +277,86 @@ deliberate exceptions. Set as of 2026-08-05:
 |---|---|
 | `NEXT_PUBLIC_POSTHOG_KEY` | QA test runs would land in product analytics and corrupt the numbers |
 | `LEMONSQUEEZY_WEBHOOK_SECRET` etc. | Payments. Staging has no business holding these |
-| `CRON_SECRET` | Cron routes fail **closed** without it (`lib/cronAuth.ts`), which is the desired state on staging |
+| `CRON_SECRET` | Cron routes fail **closed** without it (`lib/cronAuth.ts`), which is the desired state on any non-prod host. ⚠️ **Currently SET on qa — see below. It should not be.** |
 
 ### Telegram on QA — currently dev's bot, safe only by accident
 
 **`TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID` and `TELEGRAM_WEBHOOK_SECRET` on the
 qa service are copies of dev's.** That is not the intended end state.
 
-Why it has not broken anything yet: registering a webhook goes through
-`/api/telegram/setup-webhook`, which is gated by `checkCronAuth`, and
-`CRON_SECRET` is **unset** on qa. `checkCronAuth` fails **closed** with no secret
-configured, so the route answers 401 and qa cannot re-register the webhook.
-Verified 2026-08-05: `GET /api/telegram/setup-webhook` on qa returns
-`{"error":"Unauthorized"}`.
+Registering a webhook goes through `/api/telegram/setup-webhook`, which is gated
+by `checkCronAuth`. That guard is **all-or-nothing**: `lib/cronAuth.ts` returns
+false when `CRON_SECRET` is unset, so the variable's presence unlocks **all
+ten** cron-guarded routes at once, not just this one —
+`telegram/{setup-webhook,webhook,alert}`, `alert-outcomes/resolve`,
+`econ-calendar/ingest`, `macro-alert`, `news/ingest`, `ops/spike-alert`,
+`signals/track`, `trial-reminder`. Counted from the source
+(`grep -rl checkCronAuth app/api`), not from memory.
 
-**So the safety property is: qa must not have `CRON_SECRET` while it shares
-dev's bot token.** Setting `CRON_SECRET` on qa without first giving it its own
-bot hands qa the ability to point dev's bot at itself, silently stealing every
-alert. That is the bug that already cost a day on this project.
+`api/telegram/bot-info` is **not** in that set and should not be added to it. It
+is public and rate-limited, and deliberately **read-only** — it reports a webhook
+mismatch rather than fixing one. It used to call `setWebhook` itself, which made
+an unauthenticated GET fired by every `/alerts` page load able to repoint where
+Telegram delivers updates; that was the 2026-08-03 hijack. Registration lives in
+`setup-webhook` behind the secret precisely so this route does not need it.
+
+> ### ⚠️ `CRON_SECRET` is currently SET on qa. It should be removed.
+>
+> This section said "unset" from 2026-08-05 until 2026-08-08, and the whole
+> safety argument below rested on that. It was wrong — read from the Render
+> dashboard 2026-08-08. Nobody recalls setting it.
+>
+> **Severity is low, not zero.** The routes still answer 401 to a caller without
+> the header (verified on qa the same day), and the owner confirmed qa's value
+> **differs** from prod's — so prod's schedulers cannot reach qa's routes. It
+> needs someone who knows qa's specific value. But the property the doc claimed
+> was not holding, and nobody noticed for three days.
+>
+> **Remove it from the qa service in Render.** Nothing is scheduled against the
+> qa host in either cron-job.org or n8n — verified 2026-08-08, see §2 — so
+> removal costs nothing and needs no dedicated bot first.
+
+**The rule, stated so it does not need re-deriving.** An environment should have
+`CRON_SECRET` only when **both** hold:
+
+1. **Something on that host legitimately needs to call a cron-guarded route** —
+   either a scheduler pointed at it, or a deliberate one-off operation such as
+   registering that environment's *own* Telegram webhook.
+2. **The environment owns its own side-effect credentials** — bot token, chat id,
+   database, mail sender.
+
+qa fails both today. Nothing is scheduled against it (§2), and the one manual
+operation that would need the secret — webhook registration — is precisely the
+thing that must not happen while the bot belongs to dev. And it borrows dev's bot,
+dev's Supabase and dev's Brevo, so anything its cron routes trigger produces
+effects attributed to **dev**: messages into the real dev chat, rows in the shared
+database, mail from the real sender.
+
+This is a restatement of the older phrasing, *"qa must not have `CRON_SECRET`
+while it shares dev's bot token"* — same conclusion, but that version described
+only condition (2), so it read as though owning a bot were sufficient on its own.
+
+**The one path where qa should get a `CRON_SECRET`** is option B in
+`pendings/PENDING.md` — give qa its own bot, then set a fresh secret different
+from dev's and prod's, then register qa's own webhook. That flips both conditions
+at once and is internally consistent. It is a deliberate migration with an
+accepted consequence (QA runs can then fire real alerts), not a reason to leave a
+secret sitting there today. **Today's state is neither: the secret is set and the
+bot is still dev's — the worst of both.**
+
+The worst case if both parts are ignored: qa points dev's bot at itself and
+silently swallows every alert. That is the bug that already cost a day on this
+project.
 
 What qa can still do today: send outbound messages into the real dev chat during
 test runs. Noisy, not destructive. It cannot receive anything - the webhook
 points at dev - so `/start`, account linking and bot commands are untestable on
-qa either way.
+qa either way. A dedicated QA bot is still worth having for that reason (see
+`pendings/PENDING.md`) — just not as a precondition for the removal above.
 
-The fix is a dedicated QA bot; see `pendings/PENDING.md`. Until then, treat
-`CRON_SECRET` on qa as forbidden rather than merely absent.
+**Same rule, same answer, for `staging`**: nothing scheduled against it, no
+side-effect credentials of its own. `CRON_SECRET` is correctly unset there
+(confirmed 2026-08-08); leave it that way.
 
 `NEXT_PUBLIC_TURNSTILE_SITE_KEY` is domain-locked. Copying dev's value is not
 enough — add `liquidity-hq-qa.onrender.com` to that widget's allowed domains in
@@ -341,15 +431,20 @@ From `package.json`. **Next.js 16.2.6 is explicitly called out in `AGENTS.md` as
 
 ---
 
-## 8. Known Automation Gaps (as of 2026-07-19)
+## 8. Known Automation Gaps (last reviewed 2026-08-08)
 
 - ~~`api/macro-alert` and `api/signals/track` have no confirmed scheduler anywhere~~ — **CLOSED same day**, both wired to cron-job.org. See §2.
 - ~~7 of the 11 `DASHBOARD_SECTIONS` toggles in Settings are inert~~ — **RESOLVED 2026-07-21**. Investigated each of the 7: `session` was a real gating bug (fixed, then removed along with the rest below); the other 6 (`accumulation`, `distribution`, `catalysts`, `gex`, `macro`, `commandments`) referenced widgets that either live on other pages entirely or were never built. Rather than build 6 new dashboard widgets or leave non-functional checkboxes, the user chose to remove the whole "Dashboard Sections" toggle feature - `DASHBOARD_SECTIONS`, `hidden_sections`, and the Settings UI for it no longer exist. `/dashboard` now always renders all its sections unconditionally.
-- **`api/ops/spike-alert` — built 2026-07-25, NOT YET SCHEDULED.** Telegrams
-  the owner (`TELEGRAM_CHAT_ID`) once today's xAI usage crosses 80% of
-  `AI_GLOBAL_DAILY_MAX` (`pendings/SECURITY_AUDIT.md`'s one remaining open
-  item). `checkCronAuth`-gated like the others - needs an `x-cron-secret`
-  header. User is wiring this via n8n (own choice, has an existing similar
-  workflow - see §3), not cron-job.org. Until that workflow exists, this
-  route is genuinely dead - nothing calls it on a schedule yet. Update this
-  entry once it's wired (workflow name, schedule) - don't leave it stale.
+- ~~**`api/ops/spike-alert` — built 2026-07-25, NOT YET SCHEDULED**~~ — **CLOSED.**
+  Wired via n8n as `LHQ - AI Spike Alert` (Schedule Trigger → `GET
+  https://liquidity-hq.onrender.com/api/ops/spike-alert`), Published. See §3.
+  Telegrams the owner (`TELEGRAM_CHAT_ID`) once today's xAI usage crosses 80% of
+  `AI_GLOBAL_DAILY_MAX` — `pendings/SECURITY_AUDIT.md`'s last open item.
+
+  **This entry ended with "don't leave it stale" and was left stale anyway**, for
+  long enough that a later reader (correctly following the instruction at the top
+  of this file) still concluded the route was dead. The instruction was not the
+  weak link — nothing connects wiring a scheduler to editing this file, because
+  the scheduler lives in a tool this repo cannot see. Anything wired outside the
+  repo has to be written down by the person who wired it, in the same sitting, or
+  it is not recorded at all.

--- a/pendings/PENDING.md
+++ b/pendings/PENDING.md
@@ -14,7 +14,7 @@ index, and hence the rule below it.
 | What | Owner | Where |
 |---|---|---|
 | Supabase Pro before real payments — still Free, still **zero backups** | owner | §"YOUR decision", top |
-| `qa` holds **dev's** Telegram token. Safe only while `CRON_SECRET` is unset there | owner, parked | §"QA needs its own Telegram bot" |
+| `qa` holds **dev's** Telegram token — and `CRON_SECRET` **is set there**, which the guard assumed it was not. **Remove it from the qa service** | owner, action needed | §"QA needs its own Telegram bot" |
 | Coinglass v4 — deferred until revenue, **do not re-raise** | decided | §"OPEN — code (mine)" |
 | LemonSqueezy payments | deferred | `pendings/LEMONSQUEEZY.md` |
 
@@ -752,11 +752,12 @@ only so it is not mistaken for handled.
 
 ### 2. `qa` holds dev's Telegram token — parked by your call
 
-See "QA needs its own Telegram bot" near the end of this file. Safe today only
-because `CRON_SECRET` is unset on `qa`, which makes `setup-webhook` fail closed —
-re-verified 2026-08-06, it returns 401. **Do not set `CRON_SECRET` on `qa`** until
-it has its own bot; doing so would let `qa` point dev's bot at itself and silently
-take every alert.
+See "QA needs its own Telegram bot" near the end of this file. **⚠️ `CRON_SECRET`
+IS set on `qa` — corrected 2026-08-08.** This entry said it was unset, and called
+that the reason qa was safe. `setup-webhook` still returns 401 without the header
+and qa's value differs from prod's, so the exposure is low — but the stated safety
+property was not holding. **Remove `CRON_SECRET` from the qa service**; nothing is
+scheduled against that host, so it costs nothing and does not need the bot first.
 
 ### 3. Nothing else is blocking
 
@@ -980,15 +981,24 @@ this app one step closer to its limit, and ATH is just the first one to show it.
 `TELEGRAM_CHAT_ID` and `TELEGRAM_WEBHOOK_SECRET`, copied over when the service
 was configured from dev's environment.
 
-**It is safe today only because `CRON_SECRET` is unset on qa.** Registering a
-webhook goes through `/api/telegram/setup-webhook`, gated by `checkCronAuth`,
-which fails **closed** with no secret configured. Verified: that route returns
-`401 {"error":"Unauthorized"}` on qa.
+**⚠️ Corrected 2026-08-08: `CRON_SECRET` IS set on qa.** This section previously
+said it was unset and called that the reason qa was safe. Read from the Render
+dashboard 2026-08-08; nobody recalls setting it.
 
-**So: do not set `CRON_SECRET` on qa until it has its own bot.** Doing so hands
-qa the ability to point dev's bot at itself and silently steal every alert —
+Registering a webhook goes through `/api/telegram/setup-webhook`, gated by
+`checkCronAuth`, which fails **closed** with no secret configured — so the
+"unset" reasoning was sound, it just stopped describing reality. What still
+holds: that route returns `401 {"error":"Unauthorized"}` to a caller without the
+header, re-verified on qa 2026-08-08, and the owner confirmed qa's value
+**differs** from prod's. So the exposure needs someone who knows qa's specific
+value. Low, not zero.
+
+**So: remove `CRON_SECRET` from qa.** Leaving it set hands anyone who knows that
+value the ability to point dev's bot at itself and silently steal every alert —
 the same failure that already cost a day on this project (see the webhook
-hijack section above).
+hijack section above). Nothing is scheduled against the qa host in either
+cron-job.org or n8n (verified 2026-08-08, `docs/INFRASTRUCTURE.md` §2), so
+removal breaks nothing and does not need the bot below to happen first.
 
 ### What option B needs, when it is picked up
 

--- a/render.yaml
+++ b/render.yaml
@@ -91,9 +91,11 @@ services:
       #                                     runs. Build-time - needs a rebuild.
       # CMC_API_KEY  FINNHUB_KEY  GROK_API_KEY
       #
-      # DELIBERATELY UNSET: NEXT_PUBLIC_SENTRY_DSN (prod only), CRON_SECRET
-      # (the only thing stopping Telegram webhook hijack while non-prod shares
-      # dev's bot token).
+      # DELIBERATELY UNSET: NEXT_PUBLIC_SENTRY_DSN (prod only), CRON_SECRET.
+      # Set CRON_SECRET only where BOTH hold: something on that host legitimately
+      # needs to call a cron-guarded route, AND the environment owns its own
+      # side-effect credentials (bot, database, mail sender). staging has
+      # neither. Full rule and the one exception: docs/INFRASTRUCTURE.md 4c.
       #
       # External settings that had to be updated for this hostname:
       #   Cloudflare Turnstile allowed domains
@@ -122,8 +124,14 @@ services:
       # 'qa' once and pointed at the live production tables.
       - key: NEXT_PUBLIC_APP_ENV
         value: dev
-      # Same dev Supabase project and the same deliberately-unset vars as
-      # staging. Set in the dashboard.
+      # Same dev Supabase project as staging. Set in the dashboard.
+      #
+      # NOT the same deliberately-unset vars, as of 2026-08-08: qa HAS
+      # CRON_SECRET set, which docs/INFRASTRUCTURE.md 4c assumed it did not and
+      # built a safety property on. qa also still holds DEV's Telegram bot token,
+      # so the two together are what that section warns about. Removal is the
+      # agreed action - nothing is scheduled against the qa host in either
+      # cron-job.org or n8n, verified 2026-08-08. Delete this note once it is off.
 
   # ── Dev integration - liquidity-hq-dev.onrender.com. MANUAL trigger. ────────
   # Carries a ~500 build-hour/month cap that prod does not, so deploying this


### PR DESCRIPTION
> Part of #78 — the environment and config drift audit. Discussion, findings and
> the outstanding owner action all live on that issue; this PR is only the doc fix.

**Dev Team**

## Summary

Corrects every claim in the docs that disagreed with the two scheduler
dashboards, after reading both directly for the first time. Closes the
`CRON_SECRET`-on-qa question raised on #78.

Docs, `pendings/` and `render.yaml` comments only. No application code.

## What changed

**`docs/INFRASTRUCTURE.md`**

- **§2** — four job rows said `liquidity-hq.onrender.com`; every active job uses
  `liquidity-hq.com`. Fixed in the rows, and the footnote that used to say "the
  rows above are wrong" is gone. The `dev liquidity hq environment` row had
  drifted *below* the table and was rendering as a stray line; moved back in.
  Added the asymmetry with §3 — cron-job.org uses the custom domain, n8n uses
  `onrender.com` — because copying the wrong one is how this drifted.
- **§3** — added `LHQ - AI Spike Alert`, which was Published in n8n and recorded
  nowhere. Noted that the instance holds 38 workflows and only these two are
  ours, and that node URLs must be read from the DOM: n8n truncates the canvas
  subtitle to `GET: https://liquidity-hq.onre...`, and a **qa** URL truncates to
  a near-identical string.
- **§4c** — `CRON_SECRET` **is set on qa**; this section said it was unset and
  built the Telegram-bot safety argument on that. Rewritten with the current
  state, the severity, and the removal recommendation.
- **§8** — the `ops/spike-alert` entry ended with *"don't leave it stale"* and
  was stale; marked CLOSED with what actually wires it.

**`pendings/PENDING.md`** — three places repeated "safe because `CRON_SECRET` is
unset on qa", including the top-of-file owner-decision table. Corrected, and the
row now reads as an action rather than a parked item.

**`render.yaml`** — the qa block claimed qa had "the same deliberately-unset vars
as staging", which is exactly the thing that turned out to be false.

## Why

The file whose entire purpose is describing what runs *outside* this repo was
the file most out of date with it. §4c asserted a safety property — qa has no
`CRON_SECRET`, so `setup-webhook` fails closed — that had stopped being true,
and nothing in the repo could have caught that.

It also stated the rule **conditionally**: *"qa must not have `CRON_SECRET` while
it shares dev's bot token."* That invites the wrong inference — give qa its own
bot and the prohibition appears to lift. Restated as two conditions that must
**both** hold:

1. Something on that host legitimately needs to call a cron-guarded route — a
   scheduler pointed at it, or a deliberate one-off like registering that
   environment's *own* webhook.
2. The environment owns its own side-effect credentials.

That reconciles with the option-B migration already written in `PENDING.md`,
which is the one path where qa legitimately gets a `CRON_SECRET` — and which the
first draft of this change would have contradicted.

## How to test (QA)

Nothing to exercise in the app — no route, component or build input changed.
Review is reading:

1. **`docs/INFRASTRUCTURE.md` §2** against console.cron-job.org → Cronjobs. Nine
   jobs; seven active all on `liquidity-hq.com`; two inactive.
2. **§3** against n8n → Personal → `liquidityhq`. Two workflows, both Published,
   both targeting prod. Open the HTTP Request node rather than trusting the
   canvas subtitle.
3. **§4c** against Render → `liquidity-hq-qa` → Environment. `CRON_SECRET` is
   present; that is the finding.
4. `render.yaml` still parses (checked here; it is not applied as a Blueprint,
   so nothing deploys from it either way).

## Risk level

**Low.** Documentation only.

Not verified by me, stated plainly:

- **36 of the 38 n8n workflows were not opened.** They belong to unrelated
  projects (`avmoto-*`, Vapi, Proposal Tracker, Solar ROI, demos) and were
  matched by name and project only. One of them could call an LHQ host without
  saying so in its name.
- **qa's `CRON_SECRET` value was not compared to prod's by me** — the owner
  confirmed they differ. Two wrong values return the same 401, so it cannot be
  checked from outside.
- **The `CRON_SECRET` removal has not happened yet.** This PR documents the
  current state and the recommendation. When it is removed, §4c's warning block,
  the `PENDING.md` row and the `render.yaml` note all come out together — the
  note says so.

## Action this PR does not perform

**Remove `CRON_SECRET` from the `liquidity-hq-qa` service in Render.** Owner's
change to make. Nothing is scheduled against the qa host in either tool, so it
costs nothing and does not need a dedicated QA bot first.
