### PR TITLE
docs(api): record CRON_SECRET removal from qa

### DIFF
--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -277,7 +277,7 @@ deliberate exceptions. Set as of 2026-08-05:
 |---|---|
 | `NEXT_PUBLIC_POSTHOG_KEY` | QA test runs would land in product analytics and corrupt the numbers |
 | `LEMONSQUEEZY_WEBHOOK_SECRET` etc. | Payments. Staging has no business holding these |
-| `CRON_SECRET` | Cron routes fail **closed** without it (`lib/cronAuth.ts`), which is the desired state on any non-prod host. ⚠️ **Currently SET on qa — see below. It should not be.** |
+| `CRON_SECRET` | Cron routes fail **closed** without it (`lib/cronAuth.ts`), which is the desired state on any non-prod host. Was wrongly set on qa 2026-08-05 → 2026-08-08; removed, see below |
 
 ### Telegram on QA — currently dev's bot, safe only by accident
 
@@ -300,21 +300,24 @@ an unauthenticated GET fired by every `/alerts` page load able to repoint where
 Telegram delivers updates; that was the 2026-08-03 hijack. Registration lives in
 `setup-webhook` behind the secret precisely so this route does not need it.
 
-> ### ⚠️ `CRON_SECRET` is currently SET on qa. It should be removed.
+> ### ✅ Resolved 2026-08-08 — `CRON_SECRET` removed from qa
 >
-> This section said "unset" from 2026-08-05 until 2026-08-08, and the whole
-> safety argument below rested on that. It was wrong — read from the Render
-> dashboard 2026-08-08. Nobody recalls setting it.
+> It had been **set** on qa while this section claimed it was unset, from
+> 2026-08-05 until 2026-08-08. The whole safety argument below rested on that
+> claim. Removed by the owner and redeployed (`dep-d9r0mvn40ujc73986dfg`, live
+> 16:46 UTC); confirmed absent in the Render dashboard afterwards — 22 variables
+> where there were 23, with Telegram, VAPID and Brevo untouched.
 >
-> **Severity is low, not zero.** The routes still answer 401 to a caller without
-> the header (verified on qa the same day), and the owner confirmed qa's value
-> **differs** from prod's — so prod's schedulers cannot reach qa's routes. It
-> needs someone who knows qa's specific value. But the property the doc claimed
-> was not holding, and nobody noticed for three days.
+> **How it was found, since the same trap will recur.** Not by a test and not by
+> the app — by reading the dashboard directly after two external probes of mine
+> returned confident nonsense. There is no automated check that any environment's
+> variables match what this file says, which is the gap issue #78 exists to close.
 >
-> **Remove it from the qa service in Render.** Nothing is scheduled against the
-> qa host in either cron-job.org or n8n — verified 2026-08-08, see §2 — so
-> removal costs nothing and needs no dedicated bot first.
+> **Why the route could not tell us.** `checkCronAuth` fails closed, so
+> `/api/telegram/setup-webhook` answers `401` whether the secret is absent, wrong,
+> or the wrong length. Before and after removal look identical from outside. Any
+> future check of this has to read the dashboard — probing the endpoint proves
+> nothing in either direction.
 
 **The rule, stated so it does not need re-deriving.** An environment should have
 `CRON_SECRET` only when **both** hold:

--- a/pendings/PENDING.md
+++ b/pendings/PENDING.md
@@ -14,7 +14,7 @@ index, and hence the rule below it.
 | What | Owner | Where |
 |---|---|---|
 | Supabase Pro before real payments — still Free, still **zero backups** | owner | §"YOUR decision", top |
-| `qa` holds **dev's** Telegram token — and `CRON_SECRET` **is set there**, which the guard assumed it was not. **Remove it from the qa service** | owner, action needed | §"QA needs its own Telegram bot" |
+| `qa` holds **dev's** Telegram token. `CRON_SECRET` was wrongly set there and has been **removed** (2026-08-08), so the guard holds again | owner, parked | §"QA needs its own Telegram bot" |
 | Coinglass v4 — deferred until revenue, **do not re-raise** | decided | §"OPEN — code (mine)" |
 | LemonSqueezy payments | deferred | `pendings/LEMONSQUEEZY.md` |
 
@@ -752,12 +752,11 @@ only so it is not mistaken for handled.
 
 ### 2. `qa` holds dev's Telegram token — parked by your call
 
-See "QA needs its own Telegram bot" near the end of this file. **⚠️ `CRON_SECRET`
-IS set on `qa` — corrected 2026-08-08.** This entry said it was unset, and called
-that the reason qa was safe. `setup-webhook` still returns 401 without the header
-and qa's value differs from prod's, so the exposure is low — but the stated safety
-property was not holding. **Remove `CRON_SECRET` from the qa service**; nothing is
-scheduled against that host, so it costs nothing and does not need the bot first.
+See "QA needs its own Telegram bot" near the end of this file. **`CRON_SECRET`
+had been set on `qa` — this entry claimed it was unset and called that the reason
+qa was safe. Removed 2026-08-08**, confirmed absent in the Render dashboard after
+the redeploy, so the guard holds again. The bot itself is still dev's, so this
+stays parked rather than resolved.
 
 ### 3. Nothing else is blocking
 

--- a/render.yaml
+++ b/render.yaml
@@ -124,14 +124,14 @@ services:
       # 'qa' once and pointed at the live production tables.
       - key: NEXT_PUBLIC_APP_ENV
         value: dev
-      # Same dev Supabase project as staging. Set in the dashboard.
+      # Same dev Supabase project and the same deliberately-unset vars as
+      # staging. Set in the dashboard.
       #
-      # NOT the same deliberately-unset vars, as of 2026-08-08: qa HAS
-      # CRON_SECRET set, which docs/INFRASTRUCTURE.md 4c assumed it did not and
-      # built a safety property on. qa also still holds DEV's Telegram bot token,
-      # so the two together are what that section warns about. Removal is the
-      # agreed action - nothing is scheduled against the qa host in either
-      # cron-job.org or n8n, verified 2026-08-08. Delete this note once it is off.
+      # CRON_SECRET was wrongly set here 2026-08-05 to 2026-08-08 while
+      # docs/INFRASTRUCTURE.md 4c asserted it was unset and built a safety
+      # property on that. Removed. It matters more on qa than on dev because qa
+      # holds DEV's Telegram bot token - it does not own the bot it could
+      # re-point. Keep it unset until qa has its own bot.
 
   # ── Dev integration - liquidity-hq-dev.onrender.com. MANUAL trigger. ────────
   # Carries a ~500 build-hour/month cap that prod does not, so deploying this


### PR DESCRIPTION
**Dev Team**

Part of #78.

## Summary
qa's `CRON_SECRET` is removed and redeployed. Replaces today's warning blocks with the resolved state.

## What changed
- `INFRASTRUCTURE.md` §4c — warning block → resolved, with the deploy id and the post-removal dashboard count
- `PENDING.md` — owner-decision row and the parked-item entry
- `render.yaml` — qa block note

Two things kept deliberately, because both will trip someone again:
- **Probing the endpoint cannot detect this in either direction.** `checkCronAuth` fails closed on absent, wrong, and wrong-length alike — 401 before and after. Only the dashboard answers it.
- **It mattered more on qa than dev** because qa does not own the bot it could re-point.

## Why
The notes said "delete this note once it is off". It is off.

## How to test (QA)
Docs and comments only — nothing to exercise. Read §4c against Render → `liquidity-hq-qa` → Environment and confirm `CRON_SECRET` is absent (22 variables).

## Risk level
**Low.** Documentation only. Verified: deploy `dep-d9r0mvn40ujc73986dfg` live 16:46 UTC, variable confirmed absent afterwards, Telegram/VAPID/Brevo untouched.