### PR TITLE
docs(infra): correct §1 prose that still denied the fourth service

### DIFF
--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -29,9 +29,25 @@ Anything created outside this repo has to be recorded in THIS table, not only in
 | `liquidity-hq-qa` | `srv-d9p42ke1egvs73f8car0` | free | Singapore | `qa` | `liquidity-hq-qa.onrender.com` | **Dev's integration site, not QA's.** Serves `qa`, which dev promotes into freely; it exists so dev can confirm a promotion before QA sees it. `autoDeploy: no` — whoever merges `dev` → `qa` triggers the deploy. Uses the **dev** Supabase project (free plan caps the account at 2 active projects, so neither non-prod service has one of its own). Free plan, sleeps when idle. |
 | `n8n-workflows` | `srv-d6e4fkq4d50c73b8dpk0` | starter | Singapore | n/a (Docker image `n8nio/n8n:latest`) | `n8n-workflows-6ig6.onrender.com` | Self-hosted n8n instance, 5GB persistent disk. Shared across projects, not LHQ-exclusive. |
 
-All three LHQ services have `autoDeploy: no` — pushing to `main`/`dev` does **not** auto-deploy. Deploys are triggered manually (via Render dashboard, the `mcp__render__trigger_deploy` tool, or `git push` if that ever changes).
+**All four LHQ services have `autoDeploy: no`. No service in this project auto-deploys.** Pushing to any branch deploys nothing; every deploy is triggered by a person (Render dashboard, or the `mcp__render__trigger_deploy` tool).
 
-`liquidity-hq-qa` is the same: `autoDeploy: no`. **No service in this project auto-deploys.** Whoever merges `dev` → `qa` triggers the qa deploy — normally dev, as part of handing the build to QA. Promoting `qa` → `staging` deploys nothing, because `staging` has no service; it only fixes what the release contains, and only QA can change it. CI runs on `qa` as well (`.github/workflows/ci.yml`), so a merge is checked even though it does not ship by itself.
+That applies to each hop, and the person differs:
+
+| Promotion | Who deploys | Which service |
+|---|---|---|
+| `dev` → `qa` | dev, as part of handing the build over | `liquidity-hq-qa` |
+| `qa` → `staging` | **QA** | `liquidity-hq-staging` |
+| `staging` → `main` | **QA** | `liquidity-hq-prod` |
+
+**A promotion into `qa` or `staging` fires no CI at all**, and that is deliberate — `.github/workflows/ci.yml` lists `push` branches as `[dev, main]` only. Both promotions are fast-forward, so the commit landing is bit-identical to one already tested on `dev`, and re-running would bill a second full suite for the same tree. Do not read a quiet Actions tab after a promotion as a failure to run.
+
+### The URL is fixed at creation and a rename cannot change it
+
+**Render derives a service's hostname from its slug when the service is created, and renaming the service afterwards does not move the URL.** A renamed service keeps serving on its original hostname indefinitely.
+
+This is recorded because acting on the opposite belief cost real time on 2026-08-07: `liquidity-hq-qa` was renamed rather than replaced, the rename was assumed to have moved the hostname with it, and `NEXT_PUBLIC_APP_URL` was pointed at a host that returned 404. The fix was a new service — `liquidity-hq-staging`, created 2026-08-07 12:06 — because that is the only way to get a different hostname.
+
+So when a hostname and a service name disagree, **the hostname is the older fact.** Read the URL column of the table above, never the service name, and never infer either from the branch.
 
 `render.yaml` in this repo has **no cron job definitions** — Render's own Cron Jobs feature is not used anywhere for this project (it has no free tier, unlike the alternatives below).
 

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -41,6 +41,28 @@ That applies to each hop, and the person differs:
 
 **A promotion into `qa` or `staging` fires no CI at all**, and that is deliberate — `.github/workflows/ci.yml` lists `push` branches as `[dev, main]` only. Both promotions are fast-forward, so the commit landing is bit-identical to one already tested on `dev`, and re-running would bill a second full suite for the same tree. Do not read a quiet Actions tab after a promotion as a failure to run.
 
+### Credentials with an expiry date
+
+| Secret | Purpose | **Expires** |
+|---|---|---|
+| `RELEASE_PAT` | Lets `release-signals.yml` open the `staging` → `main` release PR | **2027-08-09** |
+
+**Why a PAT rather than the built-in token.** GitHub does not trigger workflows
+on events created by `GITHUB_TOKEN` — a deliberate loop-breaker. A release PR
+opened by the bot therefore never fires `pull_request`, so `CI Gate` is **absent
+rather than failing**, and `main` requires it. The PR sits unmergeable with
+nothing red to explain why. Diagnosed on 2026-08-08 (issue #126) after a
+promotion looked entirely successful and the checks never queued.
+
+**What happens when it expires.** The release PR stops opening. `.github/workflows/release-signals.yml`
+falls back rather than failing hard, so the run raises an issue carrying the
+release body it had already built — but **the symptom is "the release PR did not
+appear", and this table is the only place that connects that to a date.**
+
+Fine-grained, scoped to this repository only: contents read, pull requests
+read+write, issues read+write. Issues write is load-bearing — it is what lets the
+fallback announce itself.
+
 ### The URL is fixed at creation and a rename cannot change it
 
 **Render derives a service's hostname from its slug when the service is created, and renaming the service afterwards does not move the URL.** A renamed service keeps serving on its original hostname indefinitely.

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -54,10 +54,16 @@ rather than failing**, and `main` requires it. The PR sits unmergeable with
 nothing red to explain why. Diagnosed on 2026-08-08 (issue #126) after a
 promotion looked entirely successful and the checks never queued.
 
-**What happens when it expires.** The release PR stops opening. `.github/workflows/release-signals.yml`
-falls back rather than failing hard, so the run raises an issue carrying the
-release body it had already built — but **the symptom is "the release PR did not
-appear", and this table is the only place that connects that to a date.**
+**What happens when it expires.** The release PR stops opening. The step **fails
+rather than falling back** — `release-pr-failed` then opens an issue carrying the
+release body it had already built, on a **different credential** (`github.token`)
+so one expiry cannot silence the primary and the announcement together. That
+separation is deliberate and load-bearing; see the comment on that job before
+"tidying" the PAT up to a workflow-level `env:`.
+
+Loud, and non-blocking: QA opens the PR by hand from that issue while the token is
+rotated. But **the symptom is "the release PR did not appear", and this table is
+the only place that connects that to a date.**
 
 Fine-grained, scoped to this repository only: contents read, pull requests
 read+write, issues read+write. Issues write is load-bearing — it is what lets the


### PR DESCRIPTION
**QA Team** → **Dev Team**

## Rewritten. Everything it originally said is superseded — one thing in it was not.

You asked me to rebase this and keep the Render-slug paragraph. I tried the
rebase and **abandoned it**: the old content is not stale, it is now false.

It said *"Four branches, three services"*, *"`qa` branch — nothing serves it"*
and *"`liquidity-hq-qa.onrender.com` serves `staging`"*. All true when written on
2026-08-07, all wrong since you created `liquidity-hq-staging`. My #95 and your
#87 already landed the correct versions. Rebasing would have re-introduced the
error this PR existed to fix.

So the diff is now one file and none of the original text.

## What changed

**`docs/INFRASTRUCTURE.md` §1 — the prose under the service table contradicted
the table.** #87 fixed the table; the two paragraphs beneath it were not touched:

| Line | Said | Reality |
|---|---|---|
| 32 | "**All three** LHQ services have `autoDeploy: no`" | four |
| 34 | "Promoting `qa` → `staging` deploys nothing, **because `staging` has no service**" | `srv-d9qskniju40c73brtqgg`, listed two rows above in the same table |

Replaced with a per-hop table naming who triggers which deploy — the fact
someone actually needs at that point in the file.

**A CI claim in the same paragraph was also wrong, and it was mine to catch
because I nearly repeated it.** The old text said a merge is checked because CI
runs on `qa`. `ci.yml` lists `push: branches: [dev, main]` — `qa` and `staging`
are absent, deliberately, because both promotions are fast-forward and the tree
is bit-identical to one already tested on `dev`. I wrote "CI runs on `qa` and
`staging` as well" into this very commit before checking the workflow, which
would have been a false claim shipped inside a PR fixing false claims. The
section now says a quiet Actions tab after a promotion is expected, not a
failure.

**Your Render-slug paragraph, kept — and it was recorded nowhere.** I grepped
`INFRASTRUCTURE.md`, `CONTRIBUTING.md` and `qa/` for it before writing: the fact
that Render fixes a hostname at creation and a rename cannot move it does not
appear in the repo at all. Given that believing the opposite pointed
`NEXT_PUBLIC_APP_URL` at a 404 host, it is now its own subsection, with the
incident as the reason rather than a rule stated flatly.

## Why

§1 is the table people look at, which is the argument you made yourself — and it
is why the half-correction was worse than none. The table said four services and
the sentence below it said three, so the file disagreed with itself in the same
screenful, and it stayed that way after the PR that was supposed to fix it.

## How to test (QA)

Docs only. No code paths, no deploy, nothing to check on a running site.

1. Open `docs/INFRASTRUCTURE.md` §1. The service count in the prose should match
   the four LHQ rows in the table above it.
2. No sentence should claim `staging` has no service.
3. The CI statement should match `.github/workflows/ci.yml` —
   `push: branches: [dev, main]`.

## Risk level

**Low.** Documentation only.

`docs/` is yours by convention and this is QA writing into it, so the review
matters more than usual — particularly the deploy-ownership table, which
restates §6 of `CONTRIBUTING.md` from memory of the flow rather than from your
Render dashboard. Correct it if any row is wrong.

## Screenshots

n/a — no UI change.
