### PR TITLE
feat(api): check environment configuration at startup, not in a test

### DIFF
--- a/__tests__/envCheck.test.mts
+++ b/__tests__/envCheck.test.mts
@@ -1,0 +1,189 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { checkEnv, reportEnv, type EnvFinding } from '../lib/envCheck.ts';
+
+/* The startup env check exists because every misconfiguration it looks for was
+   introduced through a Render dashboard - invisible to git, invisible to CI,
+   and silent at runtime until something downstream misbehaved days later.
+
+   These tests matter more than usual for one specific reason: a check that
+   fails to fire is indistinguishable from a correctly configured environment.
+   Both print nothing alarming. So the assertions below are mostly about the
+   check FIRING on known-bad input, not about it staying quiet on good input -
+   quiet is the failure mode that hides.
+
+   The prod-Supabase rule is the only one that throws, and the test that
+   production can never reach it is the most important one here: a bug in this
+   file must not be able to take prod down. */
+
+const PROD_REF = 'qdpwhnvmhqgzijuwopso';
+const DEV_REF = 'wdtjhrilakoitfcezxpx';
+
+const base = (over: Record<string, string | undefined> = {}): Record<string, string | undefined> => ({
+  NEXT_PUBLIC_APP_ENV: 'dev',
+  NEXT_PUBLIC_APP_URL: 'https://liquidity-hq-qa.onrender.com',
+  NEXT_PUBLIC_SUPABASE_URL: `https://${DEV_REF}.supabase.co`,
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: 'anon',
+  SUPABASE_SERVICE_ROLE_KEY: 'service',
+  ...over,
+});
+
+const keys = (f: EnvFinding[]) => f.map(x => x.key);
+const levelFor = (f: EnvFinding[], key: string) => f.find(x => x.key === key)?.level;
+
+test('startup environment check', async (t) => {
+  await t.test('a correctly configured non-prod environment produces nothing', () => {
+    assert.deepEqual(checkEnv(base()), []);
+  });
+
+  await t.test('a correctly configured production environment produces nothing', () => {
+    assert.deepEqual(checkEnv(base({
+      NEXT_PUBLIC_APP_ENV: 'prod',
+      NEXT_PUBLIC_APP_URL: 'https://liquidity-hq.com',
+      NEXT_PUBLIC_SUPABASE_URL: `https://${PROD_REF}.supabase.co`,
+      NEXT_PUBLIC_SENTRY_DSN: 'https://key@glitchtip/1',
+      CRON_SECRET: 'secret',
+    })), []);
+  });
+
+  /* The switch-not-label trap. 'qa' looks like the most reasonable value in the
+     world and silently selects the PRODUCTION tables, because lib/tables.ts
+     branches on === 'dev'. This is not hypothetical: the qa service was created
+     with exactly this value. */
+  await t.test("APP_ENV values that are not 'dev' or 'prod' are caught", () => {
+    for (const bad of ['qa', 'staging', 'QA', 'development', 'production']) {
+      const f = checkEnv(base({ NEXT_PUBLIC_APP_ENV: bad }));
+      assert.ok(keys(f).includes('NEXT_PUBLIC_APP_ENV'), `"${bad}" should be rejected`);
+      assert.match(f[0].message, /PRODUCTION tables/);
+    }
+  });
+
+  await t.test('an unset APP_ENV is caught, since it also selects prod tables', () => {
+    const f = checkEnv(base({ NEXT_PUBLIC_APP_ENV: undefined }));
+    assert.ok(keys(f).includes('NEXT_PUBLIC_APP_ENV'));
+  });
+
+  /* The unrecoverable one. Prod Supabase is free-tier with no backups, so a
+     test environment writing into it cannot be undone. */
+  await t.test('a non-prod environment pointed at the prod database is FATAL', () => {
+    const f = checkEnv(base({ NEXT_PUBLIC_SUPABASE_URL: `https://${PROD_REF}.supabase.co` }));
+    assert.equal(levelFor(f, 'NEXT_PUBLIC_SUPABASE_URL'), 'fatal');
+    assert.throws(() => reportEnv(f), /refusing to start/);
+  });
+
+  /* The safety property of the check itself. However wrong this file gets, it
+     must not be able to stop production booting. */
+  await t.test('production can never reach the fatal rule', () => {
+    const f = checkEnv(base({
+      NEXT_PUBLIC_APP_ENV: 'prod',
+      NEXT_PUBLIC_APP_URL: 'https://liquidity-hq.com',
+      NEXT_PUBLIC_SUPABASE_URL: `https://${PROD_REF}.supabase.co`,
+    }));
+    assert.equal(f.filter(x => x.level === 'fatal').length, 0);
+    assert.doesNotThrow(() => reportEnv(f));
+  });
+
+  /* APP_ENV='prod' passes the validity check while making lib/tables.ts select
+     the LIVE tables. This is the more dangerous direction of rule 1 and it was
+     missed in the first version of this file. */
+  await t.test("APP_ENV='prod' on a non-production host is flagged", () => {
+    for (const url of [
+      'https://liquidity-hq-qa.onrender.com',
+      'https://liquidity-hq-staging.onrender.com',
+      'https://liquidity-hq-dev.onrender.com',
+      'http://localhost:3000',
+    ]) {
+      const f = checkEnv(base({ NEXT_PUBLIC_APP_ENV: 'prod', NEXT_PUBLIC_APP_URL: url }));
+      assert.equal(levelFor(f, 'NEXT_PUBLIC_APP_ENV'), 'error', `${url} should be flagged`);
+      assert.match(f.find(x => x.key === 'NEXT_PUBLIC_APP_ENV')!.message, /LIVE tables/);
+    }
+  });
+
+  /* It must never refuse to boot production, whatever prod's APP_URL turns out
+     to be - both known hostnames clear it, and the rule is error, not fatal. */
+  await t.test('neither production hostname is flagged, and the rule never throws', () => {
+    for (const url of ['https://liquidity-hq.com', 'https://liquidity-hq.onrender.com']) {
+      const f = checkEnv(base({
+        NEXT_PUBLIC_APP_ENV: 'prod', NEXT_PUBLIC_APP_URL: url,
+        NEXT_PUBLIC_SUPABASE_URL: `https://${PROD_REF}.supabase.co`,
+      }));
+      assert.deepEqual(f, [], `${url} should be clean`);
+    }
+    const wrong = checkEnv(base({ NEXT_PUBLIC_APP_ENV: 'prod', NEXT_PUBLIC_APP_URL: 'https://example.com' }));
+    assert.doesNotThrow(() => reportEnv(wrong));
+  });
+
+  /* lib/monitoring.ts already suppresses the DSN whenever APP_ENV === 'dev'.
+     Warning again here fired on every local boot and on qa and staging, which
+     is how a check stops being read. */
+  await t.test("SENTRY_DSN is not flagged when APP_ENV='dev' suppresses it anyway", () => {
+    const f = checkEnv(base({ NEXT_PUBLIC_SENTRY_DSN: 'https://key@glitchtip/1' }));
+    assert.equal(levelFor(f, 'NEXT_PUBLIC_SENTRY_DSN'), undefined);
+  });
+
+  await t.test('SENTRY_DSN IS flagged where it would actually be live', () => {
+    const f = checkEnv(base({ NEXT_PUBLIC_APP_ENV: 'qa', NEXT_PUBLIC_SENTRY_DSN: 'https://key@glitchtip/1' }));
+    assert.equal(levelFor(f, 'NEXT_PUBLIC_SENTRY_DSN'), 'warn');
+    assert.doesNotThrow(() => reportEnv(f));
+  });
+
+  /* Local development carries CRON_SECRET in .env.local so cron routes can be
+     exercised. Telegram will not register a webhook against a non-public URL,
+     so the hijack is not reachable from there. */
+  await t.test('localhost is not flagged for CRON_SECRET', () => {
+    for (const url of ['http://localhost:3000', 'http://127.0.0.1:3100']) {
+      const f = checkEnv(base({ CRON_SECRET: 'x', NEXT_PUBLIC_APP_URL: url }));
+      assert.equal(levelFor(f, 'CRON_SECRET'), undefined, `${url} should be quiet`);
+    }
+  });
+
+  /* CRON_SECRET is judged by whether the host owns the bot it could re-point,
+     not by whether it is non-prod - dev legitimately holds one. */
+  await t.test('CRON_SECRET is flagged on qa and staging but not on dev', () => {
+    const onQa = checkEnv(base({
+      CRON_SECRET: 'x', NEXT_PUBLIC_APP_URL: 'https://liquidity-hq-qa.onrender.com',
+    }));
+    assert.equal(levelFor(onQa, 'CRON_SECRET'), 'error');
+
+    const onStaging = checkEnv(base({
+      CRON_SECRET: 'x', NEXT_PUBLIC_APP_URL: 'https://liquidity-hq-staging.onrender.com',
+    }));
+    assert.equal(levelFor(onStaging, 'CRON_SECRET'), 'error');
+
+    const onDev = checkEnv(base({
+      CRON_SECRET: 'x', NEXT_PUBLIC_APP_URL: 'https://liquidity-hq-dev.onrender.com',
+    }));
+    assert.equal(levelFor(onDev, 'CRON_SECRET'), undefined);
+  });
+
+  /* liquidity-hq-qa.onrender.com contains the string "liquidity-hq-", so a
+     sloppier match than the one in envCheck.ts would clear qa as though it were
+     dev - which is the exact host the rule exists for. */
+  await t.test('the dev-host match does not accidentally clear qa or staging', () => {
+    for (const url of [
+      'https://liquidity-hq-qa.onrender.com',
+      'https://liquidity-hq-staging.onrender.com',
+      'https://liquidity-hq.com',
+    ]) {
+      const f = checkEnv(base({ CRON_SECRET: 'x', NEXT_PUBLIC_APP_URL: url }));
+      assert.equal(levelFor(f, 'CRON_SECRET'), 'error', `${url} should still be flagged`);
+    }
+  });
+
+  await t.test('missing Supabase credentials are reported individually', () => {
+    const f = checkEnv(base({
+      NEXT_PUBLIC_SUPABASE_URL: undefined,
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: undefined,
+      SUPABASE_SERVICE_ROLE_KEY: undefined,
+    }));
+    for (const k of ['NEXT_PUBLIC_SUPABASE_URL', 'NEXT_PUBLIC_SUPABASE_ANON_KEY', 'SUPABASE_SERVICE_ROLE_KEY']) {
+      assert.ok(keys(f).includes(k), `${k} should be reported`);
+    }
+  });
+
+  await t.test('reportEnv throws only on fatal, never on error or warn alone', () => {
+    assert.doesNotThrow(() => reportEnv([{ level: 'error', key: 'K', message: 'm' }]));
+    assert.doesNotThrow(() => reportEnv([{ level: 'warn', key: 'K', message: 'm' }]));
+    assert.throws(() => reportEnv([{ level: 'fatal', key: 'K', message: 'm' }]));
+  });
+});

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/nextjs';
 import { monitoringOptions } from '@/lib/monitoring';
+import { checkEnv, reportEnv } from '@/lib/envCheck';
 
 // Server + edge init. NEXT_PUBLIC_SENTRY_DSN doubles as the server-side DSN
 // (Sentry DSNs are not secret - they're meant to be public) so one env var
@@ -14,6 +15,16 @@ import { monitoringOptions } from '@/lib/monitoring';
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs' || process.env.NEXT_RUNTIME === 'edge') {
     Sentry.init(monitoringOptions());
+  }
+  // Node only. The edge runtime boots per-request in some deployments, so
+  // running it there would repeat the same lines on every request, and it is
+  // the node process that reads the server-side variables anyway.
+  //
+  // Runs AFTER Sentry.init so a fatal misconfiguration is still reported to
+  // whatever monitoring is configured, rather than dying silently before the
+  // client exists. See lib/envCheck.ts for why only one rule throws.
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    reportEnv(checkEnv());
   }
 }
 

--- a/lib/envCheck.ts
+++ b/lib/envCheck.ts
@@ -1,0 +1,187 @@
+/*
+ * Startup environment check - issue #78, "Group 4".
+ *
+ * WHY A STARTUP CHECK RATHER THAN A TEST. A test only catches configuration
+ * drift when somebody runs it, and the E2E suite runs on exactly one event
+ * (a PR into `main`). Every misconfiguration this file looks for was introduced
+ * by editing a Render dashboard, which no test observes and no commit records.
+ * The check has to run where the wrong value actually takes effect: at boot,
+ * in the process that read it.
+ *
+ * WHAT IT LOOKS FOR. Not "is every variable present" - that produces noise
+ * nobody reads. Each rule below is a failure that has ALREADY happened on this
+ * project, and each one was silent at the time:
+ *
+ *   1. NEXT_PUBLIC_APP_ENV set to something that is neither 'dev' nor 'prod'.
+ *      lib/tables.ts treats it as a SWITCH, not a label: anything that is not
+ *      exactly 'dev' selects the PRODUCTION table names. The qa service was
+ *      created with 'qa' once and silently pointed at live production tables.
+ *   2. A non-production environment pointing at the production Supabase.
+ *      This is the one unrecoverable failure - prod Supabase is on the free
+ *      plan and has NO BACKUPS - so it is the only rule here that refuses to
+ *      start rather than logging.
+ *   3. NEXT_PUBLIC_SENTRY_DSN set outside production. All environments shared
+ *      one GlitchTip project, the non-prod ones spent the monthly quota, and
+ *      production reported nothing at all: every envelope came back 429.
+ *   4. CRON_SECRET on an environment that does not own its own Telegram bot.
+ *      Setting it unlocks all ten cron-guarded routes; on a host holding
+ *      ANOTHER environment's bot token that includes re-pointing that bot's
+ *      webhook at itself, silently stealing every alert. See
+ *      docs/INFRASTRUCTURE.md 4c.
+ *
+ * SAFETY PROPERTY OF THE CHECK ITSELF. It must never be able to take
+ * production down. The only rule that throws requires APP_ENV to be something
+ * other than 'prod', so production cannot reach it however wrong this file is.
+ * Everything else logs and returns.
+ */
+
+// Project refs, not secrets - these appear in every NEXT_PUBLIC_SUPABASE_URL
+// and in docs/INFRASTRUCTURE.md 4. Named so the comparison below reads as
+// intent rather than as a magic string.
+const PROD_SUPABASE_REF = 'qdpwhnvmhqgzijuwopso';
+
+export interface EnvFinding {
+  level: 'fatal' | 'error' | 'warn';
+  key: string;
+  message: string;
+}
+
+/**
+ * Pure, so it is testable without mutating process.env in a test runner.
+ *
+ * Takes a plain string map rather than NodeJS.ProcessEnv: that type requires
+ * NODE_ENV, which forces every caller to build a fuller object than this reads.
+ * Only string lookups happen below, and process.env satisfies this.
+ */
+export function checkEnv(env: Record<string, string | undefined> = process.env): EnvFinding[] {
+  const findings: EnvFinding[] = [];
+  const appEnv = env.NEXT_PUBLIC_APP_ENV;
+  const appUrl = env.NEXT_PUBLIC_APP_URL ?? '';
+  const isProd = appEnv === 'prod';
+
+  // ── 1. The switch, not a label ──────────────────────────────────────────
+  if (!appEnv) {
+    findings.push({
+      level: 'error', key: 'NEXT_PUBLIC_APP_ENV',
+      message: 'unset - lib/tables.ts will select PRODUCTION table names (lhq_). '
+             + "Set it to 'dev' on every non-production service.",
+    });
+  } else if (appEnv !== 'dev' && appEnv !== 'prod') {
+    findings.push({
+      level: 'error', key: 'NEXT_PUBLIC_APP_ENV',
+      message: `is "${appEnv}", which is neither 'dev' nor 'prod'. This is a SWITCH, not a label: `
+             + "anything that is not exactly 'dev' selects PRODUCTION tables (lhq_). "
+             + "Use 'dev' and set NEXT_PUBLIC_SENTRY_ENV if you need to name the environment.",
+    });
+  }
+
+  // ── 2. Non-prod pointing at the production database ─────────────────────
+  // The only fatal. Test data written into prod is not recoverable here:
+  // prod Supabase is free-tier with no backups.
+  const supabaseUrl = env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+  if (!isProd && supabaseUrl.includes(PROD_SUPABASE_REF)) {
+    findings.push({
+      level: 'fatal', key: 'NEXT_PUBLIC_SUPABASE_URL',
+      message: `points at the PRODUCTION Supabase project (${PROD_SUPABASE_REF}) while `
+             + `NEXT_PUBLIC_APP_ENV is "${appEnv ?? 'unset'}". Refusing to start. `
+             + 'Prod Supabase has no backups, so writes from a test environment are not recoverable.',
+    });
+  }
+
+  // ── 3. APP_ENV=prod on something that is not production ─────────────────
+  // The inverse of rule 1 and the more dangerous direction: 'prod' passes the
+  // validity check above while making lib/tables.ts select the LIVE tables. A
+  // test environment set this way reads and writes production data and looks
+  // completely healthy doing it.
+  //
+  // NOT fatal, deliberately. The only signal available in-process is the URL,
+  // and if prod's NEXT_PUBLIC_APP_URL is ever a value this pattern does not
+  // recognise, a fatal here would refuse to start PRODUCTION. A false error in
+  // the log is recoverable; refusing to boot prod is not. Both known prod
+  // hostnames are matched for the same reason.
+  if (isProd && appUrl && !/liquidity-hq\.com|liquidity-hq\.onrender\.com/.test(appUrl)) {
+    findings.push({
+      level: 'error', key: 'NEXT_PUBLIC_APP_ENV',
+      message: `is 'prod' on ${appUrl}, which is not a production host. lib/tables.ts will select `
+             + 'the LIVE tables (lhq_), so this environment is reading and writing production data. '
+             + "Non-production services must use 'dev'.",
+    });
+  }
+
+  // ── 4. Error-reporting quota ────────────────────────────────────────────
+  // Only when the DSN would actually be live. lib/monitoring.ts already
+  // suppresses it whenever APP_ENV === 'dev' and says so in the log, so
+  // repeating that here fired on every local boot and on qa and staging - an
+  // error-level line that is always present teaches people to skip the block.
+  if (!isProd && appEnv !== 'dev' && env.NEXT_PUBLIC_SENTRY_DSN) {
+    findings.push({
+      level: 'warn', key: 'NEXT_PUBLIC_SENTRY_DSN',
+      message: 'is set on an environment where lib/monitoring.ts will NOT suppress it. All '
+             + 'environments share one GlitchTip project on the free tier; non-prod traffic has '
+             + 'exhausted the monthly quota before, which made production report nothing (every '
+             + 'envelope 429). Prod only.',
+    });
+  }
+
+  // ── 5. Cron secret on a host that borrows another environment's bot ─────
+  // dev legitimately holds one: it owns @Liquidity_hq_dev_bot, its own database
+  // and its own secret, so anything it triggers lands in its own chat. qa and
+  // staging do not own a bot, so the same variable there is a key to somebody
+  // else's house. Keyed off the URL because that is the only signal in-process
+  // that distinguishes them.
+  //
+  // localhost is excluded. Every developer's .env.local carries CRON_SECRET so
+  // cron routes can be exercised, and Telegram will not register a webhook
+  // against a non-public URL anyway, so the hijack this rule guards is not
+  // reachable from there. Flagging it printed an ERROR on every local boot,
+  // which is how a check stops being read.
+  const isLocal = /localhost|127\.0\.0\.1|\[::1\]/.test(appUrl);
+  if (env.CRON_SECRET && !isProd && !isLocal) {
+    const ownsItsBot = /liquidity-hq-dev\./.test(appUrl);
+    if (!ownsItsBot) {
+      findings.push({
+        level: 'error', key: 'CRON_SECRET',
+        message: `is set on a non-production host (${appUrl || 'unknown URL'}) that does not own its own `
+               + 'Telegram bot. It unlocks all ten cron-guarded routes, including '
+               + '/api/telegram/setup-webhook, which can re-point the shared bot at this host and '
+               + 'silently swallow every alert. See docs/INFRASTRUCTURE.md 4c.',
+      });
+    }
+  }
+
+  // ── Presence checks, last, because a missing one is loud on its own ─────
+  for (const key of ['NEXT_PUBLIC_SUPABASE_URL', 'NEXT_PUBLIC_SUPABASE_ANON_KEY', 'SUPABASE_SERVICE_ROLE_KEY'] as const) {
+    if (!env[key]) {
+      findings.push({
+        level: 'error', key,
+        message: 'is unset. Server routes return empty results rather than failing, '
+               + 'so this reads as "no data" rather than as a misconfiguration.',
+      });
+    }
+  }
+
+  return findings;
+}
+
+/**
+ * Log the findings and throw on a fatal one.
+ *
+ * Deliberately console rather than the monitoring client: this runs before
+ * anything is guaranteed to be initialised, and the failure being reported may
+ * be that error reporting itself is misconfigured.
+ */
+export function reportEnv(findings: EnvFinding[]): void {
+  if (findings.length === 0) {
+    console.log('[env] ok');
+    return;
+  }
+  for (const f of findings) {
+    const line = `[env] ${f.level.toUpperCase()} ${f.key}: ${f.message}`;
+    if (f.level === 'warn') console.warn(line);
+    else console.error(line);
+  }
+  const fatal = findings.find(f => f.level === 'fatal');
+  if (fatal) {
+    throw new Error(`[env] refusing to start - ${fatal.key}: ${fatal.message}`);
+  }
+}


### PR DESCRIPTION
**Dev Team**

Closes #78 Group 4 (owner picked QA's recommendation: startup check).

## Summary
`lib/envCheck.ts`, wired into `instrumentation.ts`. Reports configuration that has silently broken this project before. A correct environment prints `[env] ok`.

## Why a startup check and not a test
Every misconfiguration it looks for was introduced by **editing a Render dashboard** — no commit, no diff, nothing for CI to observe. And the E2E suite runs on exactly one event, a PR into `main`. A test only catches drift when someone runs it; this runs where the wrong value actually takes effect.

## The rules — each one already happened here, and was silent at the time

| Rule | Level | The incident |
|---|---|---|
| `NEXT_PUBLIC_APP_ENV` outside `dev`/`prod` | error | It is a **switch**, not a label — anything not exactly `dev` selects PRODUCTION tables. The qa service was created with `qa` once |
| `APP_ENV='prod'` on a non-prod host | error | Same trap, more dangerous direction: passes a naive validity check while reading and writing live data |
| Non-prod on the **prod Supabase** | **fatal** | The only unrecoverable one — prod Supabase is free-tier with **no backups** |
| `SENTRY_DSN` where it would be live | warn | Non-prod traffic spent the shared GlitchTip quota; prod reported nothing, every envelope 429 |
| `CRON_SECRET` without its own bot | error | Unlocks all ten cron-guarded routes including `setup-webhook` — the hijack from §4c |

## It cannot take production down
Deliberate, and tested. The fatal rule requires `APP_ENV !== 'prod'`, so prod can never reach it. The prod-host rule matches on a URL pattern, so it is **error, not fatal** — if prod's `NEXT_PUBLIC_APP_URL` is ever a value the pattern misses, a false line in the log is recoverable; refusing to boot prod is not.

## Testing it found two bugs in it
Worth saying, because reasoning about it would not have:

- It printed **ERROR on every local boot** — `CRON_SECRET` (every `.env.local` has one) and a DSN that `lib/monitoring.ts` already suppresses. An error line that is always present is how a check stops being read. Both excluded.
- Writing the tests exposed a **missing rule**: `APP_ENV='prod'` on a test host passes validity while selecting live tables. That is now the second rule.

## How to test (QA)
Boot any environment and read the first log lines.

- Correct config → `[env] ok`
- On `staging`/`qa` after deploy → should be `[env] ok`; anything else is a real finding, please report it rather than assuming it is the check being noisy

Checked against all four deployed configurations — none produces a finding.

## Risk level
**Low-Medium.** New code on the boot path, which is the risky part, so: it is wrapped in the same `NEXT_RUNTIME === 'nodejs'` guard as Sentry, runs *after* `Sentry.init` so a fatal is still reported, and the only throw is unreachable from production. 112 tests pass (16 new), tsc clean, lint 0 errors, build clean, and boot verified locally.