### PR TITLE
docs(workflow): staging has its own service, in the files people actually read

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,8 +68,9 @@ the merge, then the deploy, then re-checks the test steps against production.
 
 **Flow is `dev` → `qa` → `staging` → `main`.**
 
-Four branches, three deployed sites. `staging` is a branch, not a place — it
-holds the release candidate and has no service of its own.
+Four branches, four deployed sites, one each. Since 2026-08-07 the hostname
+tells you the branch. This file said "three deployed sites — `staging` is a
+branch, not a place" until 2026-08-08, which was true for about six hours.
 
 | Branch | Who promotes into it | What it is for |
 |---|---|---|
@@ -99,11 +100,14 @@ permission needed. **Deploying the `liquidity-hq-dev` service is different —
 ask first**, it has a ~500 build-hour/month cap prod does not. Verify locally
 by default.
 
-`qa` branch → liquidity-hq-qa.onrender.com, the QA test environment. This is
-the only deployed non-production site; `staging` has no service of its own.
-QA tests **Does not auto-deploy** — merge `dev` → `qa`, then trigger the deploy
-manually, and say you have done it. Whoever merges also deploys. Free plan, so
-it sleeps when idle and the first request after that is slow. Uses the
+`qa` branch → liquidity-hq-qa.onrender.com — **dev's** integration site, where
+dev confirms a promotion before QA sees it. **Does not auto-deploy** — merge
+`dev` → `qa`, then trigger the deploy manually, and say you have done it.
+Whoever merges also deploys.
+
+`staging` branch → liquidity-hq-staging.onrender.com — **the site QA tests and
+signs off on.** QA promotes `qa` → `staging` and deploys it. Also manual. Free
+plan, so it sleeps when idle and the first request after that is slow. Uses the
 **dev** Supabase (`wdtjhrilakoitfcezxpx`) — a known compromise, since Supabase's
 free plan caps the account at two active projects and dev + prod already take
 both. **It must never point at prod Supabase (`qdpwhnvmhqgzijuwopso`) — hard

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -506,15 +506,18 @@ When in doubt: would a QA person need to look at this? If yes, write the body.
 
 The flow is `dev` → `qa` → `staging` → `main`.
 
-**Four branches, three deployed sites.** `staging` is a branch, not a place: it
-holds the release candidate and has no service of its own.
+**Four branches, four deployed sites — one each.** Since 2026-08-07 the hostname
+tells you the branch, so there is no longer a name to memorise. This section said
+"three deployed sites: `staging` is a branch, not a place" until 2026-08-08; that
+was true for roughly six hours on the 7th, and reading it afterwards put the
+wrong host in front of a test plan.
 
 | Branch | Environment | Who promotes into it | Deploys automatically? |
 |---|---|---|---|
 | `<type>/<description>` | none | dev | n/a |
 | `dev` | liquidity-hq-dev.onrender.com | dev | **no** — trigger manually |
 | `qa` | **liquidity-hq-qa.onrender.com** | **dev** merges `dev` → `qa` | **no** — trigger manually |
-| `staging` | none — a branch, not a place | **QA** merges `qa` → `staging` | n/a |
+| `staging` | **liquidity-hq-staging.onrender.com** | **QA** merges `qa` → `staging` | **no** — trigger manually |
 | `main` | liquidity-hq.com (production) | **QA** merges `staging` → `main` | **no** — trigger manually |
 
 ### Why `staging` exists
@@ -566,10 +569,18 @@ broken in practice.
   `main`, not here. Merging a feature branch into `dev` needs no permission
   and no QA pass.
 
-### The `qa` test environment
+### The `qa` and `staging` environments
 
-This is the only deployed non-production site. `staging` has no environment of
-its own — QA tests here, then parks approved work on `staging`.
+**`staging` is where QA tests** — liquidity-hq-staging.onrender.com, serving the
+`staging` branch, so what QA signs off IS the release candidate rather than a
+branch dev keeps advancing.
+
+**`qa` is dev's** — liquidity-hq-qa.onrender.com, serving `qa`, so dev can
+confirm a promotion before QA sees it.
+
+Both are free-plan and both are `autoDeploy: no`. Everything below about the
+branch moving and the environment moving being two separate acts applies to
+each.
 
 Merging `dev` → `qa` does **not** deploy. Like prod and dev, this service is
 `autoDeploy: no`, so the branch moving and the environment moving are two

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -8,13 +8,25 @@ This file exists because the codebase alone doesn't tell the whole story. `docs/
 
 ## 1. Hosting — Render
 
-Four services, one Render account, org workspace shared with unrelated projects (`n8n workflows` is also used by other automations, not exclusive to LHQ).
+Five services, one Render account, org workspace shared with unrelated projects (`n8n workflows` is also used by other automations, not exclusive to LHQ).
+
+**Four branches, four LHQ services, and since 2026-08-07 the hostname finally
+tells you the branch** — `dev`, `qa`, `staging` and `main` each have their own.
+This table said the opposite until 2026-08-08: it claimed `staging` was "a
+release-candidate branch with no environment of its own" and called
+`liquidity-hq-qa` "the QA test environment". Both were true for about six hours
+on 2026-08-07 and were corrected in `render.yaml` the same day but not here — so
+this table, which is where people actually look, kept asserting it. QA wrote a
+doc from it on 2026-08-08 and put the wrong host in front of the test plan.
+Anything created outside this repo has to be recorded in THIS table, not only in
+`render.yaml`.
 
 | Service | Render ID | Plan | Region | Branch | URL | Purpose |
 |---|---|---|---|---|---|---|
 | `liquidity-hq-prod` | `srv-d8aluf6l51nc73e1ijp0` | starter | Singapore | `main` | `liquidity-hq.onrender.com` | Production. `npm install; npm run build` → `npm start`. |
 | `liquidity-hq-dev` | `srv-d8prs6po3t8c739aepdg` | free | Singapore | `dev` | `liquidity-hq-dev.onrender.com` | Dev integration. Free plan — spins down after inactivity, first request after idle is slow/can fail. |
-| `liquidity-hq-qa` | `srv-d9p42ke1egvs73f8car0` | free | Singapore | `qa` | `liquidity-hq-qa.onrender.com` | **The QA test environment.** Note the branch flow gained a fourth branch on 2026-08-07 (`dev` → `qa` → `staging` → `main`) but NOT a fourth service: `staging` is a release-candidate branch with no environment of its own, so this stays the only deployed non-production site. `autoDeploy: no`, like the other two: merging `dev` → `qa` moves the branch, not the environment. Uses the **dev** Supabase project (free plan caps the account at 2 active projects, so it has none of its own). Free plan, so it sleeps when idle. |
+| `liquidity-hq-staging` | `srv-d9qskniju40c73brtqgg` | free | Singapore | `staging` | `liquidity-hq-staging.onrender.com` | **The environment QA tests and signs off on.** Created 2026-08-07 12:06. Serves the release candidate, so what QA tests IS the release rather than a branch dev keeps advancing. `autoDeploy: no` — QA promotes `qa` → `staging` and triggers the deploy. Uses the **dev** Supabase project. Free plan, sleeps when idle. |
+| `liquidity-hq-qa` | `srv-d9p42ke1egvs73f8car0` | free | Singapore | `qa` | `liquidity-hq-qa.onrender.com` | **Dev's integration site, not QA's.** Serves `qa`, which dev promotes into freely; it exists so dev can confirm a promotion before QA sees it. `autoDeploy: no` — whoever merges `dev` → `qa` triggers the deploy. Uses the **dev** Supabase project (free plan caps the account at 2 active projects, so neither non-prod service has one of its own). Free plan, sleeps when idle. |
 | `n8n-workflows` | `srv-d6e4fkq4d50c73b8dpk0` | starter | Singapore | n/a (Docker image `n8nio/n8n:latest`) | `n8n-workflows-6ig6.onrender.com` | Self-hosted n8n instance, 5GB persistent disk. Shared across projects, not LHQ-exclusive. |
 
 All three LHQ services have `autoDeploy: no` — pushing to `main`/`dev` does **not** auto-deploy. Deploys are triggered manually (via Render dashboard, the `mcp__render__trigger_deploy` tool, or `git push` if that ever changes).


### PR DESCRIPTION
**Dev Team**

Unblocks QA's #84. Related to #78.

## Summary
`liquidity-hq-staging` was created 2026-08-07 12:06 and recorded in `render.yaml`. **Four other files kept saying it did not exist** — including `CLAUDE.md`, which loads into every session's context.

## What was wrong

| File | Said |
|---|---|
| `docs/INFRASTRUCTURE.md` §1 | "the branch flow gained a fourth branch **but NOT a fourth service**: `staging` is a release-candidate branch with no environment of its own" — and called `liquidity-hq-qa` "**The QA test environment**" |
| `CONTRIBUTING.md` §6 | "Four branches, three deployed sites"; table row `staging → none — a branch, not a place" |
| `CONTRIBUTING.md` §6 | "This is the only deployed non-production site" |
| `CLAUDE.md` | "Four branches, three deployed sites" and "`staging` has no service of its own" |

## Verified live before changing anything

```
liquidity-hq-qa.onrender.com        HTTP 200    Render API branch: qa
liquidity-hq-staging.onrender.com   HTTP 200    Render API branch: staging   created 08-07 12:06
```

## Why this matters beyond the typo
QA opened #84 on 2026-08-08 documenting that `staging` has no environment and that they test on the qa host. **They were reading these files.** Their PR was correct against the docs and wrong against reality — and it would have pointed the test plan at dev's integration site.

The failure is not a forgotten doc update. The change happened in a **dashboard**, was written into one file, and four others contradicted it for a day with nothing able to notice the disagreement. `INFRASTRUCTURE.md` §1 now says explicitly that anything created outside the repo belongs in that table, not only in `render.yaml`.

## Which host is whose, now stated once

- **`staging` → liquidity-hq-staging.onrender.com** — what QA tests and signs off
- **`qa` → liquidity-hq-qa.onrender.com** — dev's integration site, for confirming a promotion before QA sees it

## How to test (QA)
Docs only. Read `INFRASTRUCTURE.md` §1 against the Render dashboard: five services, four LHQ, hostname matches branch in every case. Then `CONTRIBUTING.md` §6 — every branch except a feature branch names a host.

Once this is on `dev`, #84 can be rewritten against it. The Render-slug paragraph in #84 is correct and worth keeping.

## Risk level
**Low.** Three markdown files, no code. Note `CLAUDE.md` changes what future sessions are told, which is the point — it was the source of the wrong belief.