### PR TITLE
feat(ci): announce promotions to QA automatically instead of relying on memory

### DIFF
--- a/.github/workflows/ready-for-qa.yml
+++ b/.github/workflows/ready-for-qa.yml
@@ -1,0 +1,171 @@
+# Tells QA there is work waiting, without anyone having to remember to say so.
+#
+# THE GAP THIS CLOSES. Dev promotes `dev` -> `qa`. Nothing announced it.
+# CONTRIBUTING said "ask QA before promoting", which is a courtesy BEFORE the
+# fact; the feature PRs carrying "How to test (QA)" are all closed by then; and
+# the release PR that aggregates them is opened by QA themselves, after they
+# have already decided to look. So the only thing telling QA work was waiting
+# was a human remembering to mention it.
+#
+# HOW THE SIGNAL IS COMPUTED. From `staging..qa`, not from the push event.
+# That range is the definition of the thing we want - commits on qa that QA has
+# not yet taken into staging - so it is correct after a force-push, a re-run, a
+# revert, or several promotions in a row with no one looking in between. Push
+# events describe one hop and would silently under-report all of those.
+#
+# THE LOOP CLOSES ITSELF. A push to `staging` means QA has taken the work, so
+# the issue closes. Nothing to tidy up by hand, and the next promotion opens a
+# fresh one rather than appending to a stale thread.
+name: Ready for QA
+
+on:
+  push:
+    branches: [qa, staging]
+
+# A promotion is often two pushes seconds apart. Without this they race and
+# both try to create the issue. Never cancel in progress: the second push is
+# the one with the complete range, so losing it would under-report.
+concurrency:
+  group: ready-for-qa
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  announce:
+    if: github.ref == 'refs/heads/qa'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Work out what is on qa but not yet on staging
+        id: pending
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # staging may not exist on a fresh clone of this workflow; main is the
+          # honest fallback since it is the only other branch QA has signed off.
+          BASE=origin/staging
+          git rev-parse --verify --quiet "$BASE" >/dev/null || BASE=origin/main
+          echo "base=$BASE" >> "$GITHUB_OUTPUT"
+
+          git log --format=%s "$BASE..origin/qa" > /tmp/subjects.txt || true
+          COUNT=$(wc -l < /tmp/subjects.txt | tr -d ' ')
+          echo "commits=$COUNT" >> "$GITHUB_OUTPUT"
+
+          grep -oE 'Merge pull request #[0-9]+' /tmp/subjects.txt \
+            | grep -oE '[0-9]+' | sort -u > /tmp/prs.txt || true
+          echo "prs=$(wc -l < /tmp/prs.txt | tr -d ' ')" >> "$GITHUB_OUTPUT"
+
+      - name: Build the issue body
+        if: steps.pending.outputs.commits != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          {
+            echo "**Dev Team** -> **QA Team** (posted automatically on every promotion to \`qa\`)"
+            echo
+            echo "\`qa\` has moved. These are on \`qa\` and **not yet on \`staging\`** - so they are"
+            echo "waiting for you to promote and test."
+            echo
+            echo "Promote with \`git checkout staging && git merge --ff-only qa\`, deploy"
+            echo "\`liquidity-hq-staging\`, then open the \`staging\` -> \`main\` release PR."
+            echo "**This issue closes itself** when \`staging\` moves."
+            echo
+          } > /tmp/body.md
+
+          if [ -s /tmp/prs.txt ]; then
+            echo "## What is waiting" >> /tmp/body.md
+            echo >> /tmp/body.md
+            while read -r N; do
+              [ -n "$N" ] || continue
+              TITLE=$(gh pr view "$N" --repo "$REPO" --json title --jq .title 2>/dev/null || echo "(could not read PR)")
+              echo "### #$N — $TITLE" >> /tmp/body.md
+              echo >> /tmp/body.md
+              # Pull the PR's own "How to test (QA)" section through verbatim.
+              # That section is the dev->QA handoff and it is otherwise buried in
+              # a closed PR by the time the work reaches you.
+              gh pr view "$N" --repo "$REPO" --json body --jq .body 2>/dev/null \
+                | awk '/^#+ *How to test/{f=1; next} /^#+ /{if(f) exit} f' \
+                | sed '/^[[:space:]]*$/d' > /tmp/howto.md || true
+              if [ -s /tmp/howto.md ]; then
+                cat /tmp/howto.md >> /tmp/body.md
+              else
+                echo "_No \"How to test (QA)\" section in that PR — ask dev before testing it._" >> /tmp/body.md
+              fi
+              echo >> /tmp/body.md
+            done < /tmp/prs.txt
+          fi
+
+          # Commits that arrived without a PR are the ones most worth surfacing:
+          # nothing else records them anywhere QA would look.
+          if ! [ -s /tmp/prs.txt ]; then
+            echo "## Commits on \`qa\` (no merge commits found — direct pushes?)" >> /tmp/body.md
+            echo >> /tmp/body.md
+            sed 's/^/- /' /tmp/subjects.txt >> /tmp/body.md
+            echo >> /tmp/body.md
+          fi
+
+          {
+            echo "---"
+            echo
+            echo "Range: \`${{ steps.pending.outputs.base }}..origin/qa\` — "
+            echo "${{ steps.pending.outputs.commits }} commit(s), ${{ steps.pending.outputs.prs }} PR(s)."
+            echo "Computed from the branch range rather than the push event, so it stays"
+            echo "correct across force-pushes, re-runs and several promotions in a row."
+          } >> /tmp/body.md
+
+      - name: Open or update the Ready-for-QA issue
+        if: steps.pending.outputs.commits != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh label create ready-for-qa --repo "$REPO" --color 0E8A16 \
+            --description "Work is on qa and waiting for QA to promote and test" 2>/dev/null || true
+
+          TITLE="Ready for QA: ${{ steps.pending.outputs.prs }} PR(s) on \`qa\` awaiting promotion"
+          EXISTING=$(gh issue list --repo "$REPO" --label ready-for-qa --state open \
+            --json number --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING" ]; then
+            # Edit rather than comment: the issue should always show the CURRENT
+            # pending set, not a pile of superseded snapshots.
+            gh issue edit "$EXISTING" --repo "$REPO" --title "$TITLE" --body-file /tmp/body.md
+            gh issue comment "$EXISTING" --repo "$REPO" \
+              --body "\`qa\` moved again — the list above now reflects everything still waiting."
+            echo "updated #$EXISTING"
+          else
+            gh issue create --repo "$REPO" --title "$TITLE" --body-file /tmp/body.md --label ready-for-qa
+          fi
+
+  close:
+    # staging moving means QA has taken the work.
+    if: github.ref == 'refs/heads/staging'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close the Ready-for-QA issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Tolerate the label not existing yet: `gh issue list --label` errors
+          # on an unknown label, and staging can legitimately move before the
+          # first promotion ever created one. Nothing to close in that case.
+          OPEN=$(gh issue list --repo "$REPO" --label ready-for-qa --state open \
+                   --json number --jq '.[].number' 2>/dev/null || true)
+          for N in $OPEN; do
+            gh issue close "$N" --repo "$REPO" \
+              --comment "\`staging\` has moved — QA has taken this work. Closing automatically. The next promotion to \`qa\` opens a fresh one."
+          done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,10 +133,17 @@ tester. "Ok to push?" / "hold" or "go". No answer means go; it is a courtesy,
 not a lock. QA is not reviewing the code — nothing dev writes is independently
 reviewed until QA tests the build on the qa environment.
 
+**Announcing the promotion afterwards is automatic — do not rely on remembering
+it.** Pushing to `qa` opens or updates a **"Ready for QA" issue**
+(`.github/workflows/ready-for-qa.yml`) listing every PR on `qa` but not yet on
+`staging`, with each one's "How to test (QA)" section pulled through verbatim.
+Pushing to `staging` closes it. Computed from the `staging..qa` range rather
+than the push event, so it survives force-pushes, re-runs and several
+promotions in a row.
+
 **Open the `staging` → `main` release PR immediately after promoting to
-`staging`.** QA does this, since QA owns that promotion. It is the
-only thing that tells QA there is anything to test — every feature PR is already
-closed by then. It aggregates the "How to test" steps for the whole release,
+`staging`.** QA does this, since QA owns that promotion. It aggregates the
+"How to test" steps for the whole release,
 ends with merge/deploy/re-check/tag, and collects every "could not verify
 locally" caveat in Risk level. Promoting without it is deploying into silence.
 Keep it open while QA works; failures are reported as comments on it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -804,9 +804,32 @@ thing", it was not ready.
 
 ### Two PRs, and who opens which
 
-**Dev, immediately after promoting `dev` → `qa`: open a `dev` → `qa` PR**, or
-say so on the release thread. That PR is the only thing that tells QA anything
-is waiting. Not later, not when the release feels big enough.
+**Nobody has to remember to announce a promotion.** Pushing to `qa` opens or
+updates a **"Ready for QA" issue** automatically —
+`.github/workflows/ready-for-qa.yml`. It lists every PR that is on `qa` and not
+yet on `staging`, and pulls each one's **"How to test (QA)" section through
+verbatim**, which is otherwise buried in a PR that closed days earlier. Pushing
+to `staging` closes it, because QA taking the work is the signal that it is no
+longer waiting.
+
+This replaced a rule that told dev to open a `dev` → `qa` PR "immediately after
+promoting". That rule was the only thing telling QA anything was waiting, and it
+depended entirely on a human remembering — which is not a mechanism. It was
+missed, and #78 existed partly to paper over the result.
+
+Two properties worth knowing, because they decide whether you can trust it:
+
+- **It is computed from the branch range `staging..qa`, not from the push
+  event.** That range *is* the definition of "work QA has not taken yet", so the
+  issue stays correct after a force-push, a re-run, a revert, or three
+  promotions in a row that nobody looked at. A push-event version would report
+  one hop and silently under-report all of those.
+- **It edits the existing issue rather than piling on comments**, so the issue
+  always shows the current pending set rather than a stack of superseded
+  snapshots. A short comment marks each update so the thread still shows movement.
+
+Dev still asks before promoting (below). That is a *timing* check — it stops a
+promotion landing mid-test-run. The announcement afterwards is now automatic.
 
 **QA, when a batch is approved and ready to park: promote `qa` → `staging` and
 open the `staging` → `main` release PR.** Dev does not open this one and does


### PR DESCRIPTION
**Dev Team**

Related to #78.

## Summary
Nothing told QA that work was waiting on `qa`. Now a push to `qa` opens a **"Ready for QA" issue** automatically; a push to `staging` closes it.

## The gap
Trace it: dev promotes `dev` → `qa`. CONTRIBUTING said *"ask QA before promoting"* — a courtesy **before** the fact. Every feature PR carrying "How to test (QA)" is **closed** by then. The release PR that aggregates them is opened by **QA themselves**, after they have already decided to look.

The one instruction covering it — *"open a `dev` → `qa` PR immediately after promoting"* — depended on a human remembering. That is not a mechanism. It was missed, and #78 exists partly to paper over the result.

## What the issue contains
Every PR on `qa` but not yet on `staging`, each with its **"How to test (QA)" section pulled through verbatim** — otherwise buried in a PR that closed days earlier, which is exactly the handoff that was going missing.

## Two design decisions worth reviewing

**Computed from the range `staging..qa`, not the push event.** That range *is* "work QA has not taken yet", so it survives force-pushes, re-runs, reverts, and several promotions in a row that nobody looked at. A push-event version describes one hop and silently under-reports all of those — and silent under-reporting is the failure mode this whole thing exists to remove.

**Edits the issue rather than commenting.** It should always show the *current* pending set, not a stack of superseded snapshots. A one-line comment marks each update so the thread still shows movement.

## Verified against real data before committing
Not reasoned about — run:

- Range resolves to **27 commits, 10 PRs** (74, 76, 77, 79, 80, 81, 83, 85, 86, 87) against `origin/staging` today.
- The awk extractor pulls **#86's** "How to test" section cleanly and **stops at the next heading** rather than swallowing "Risk level".
- YAML parses; all four embedded shell steps pass `bash -n`.
- Fixed one hole found while checking: `gh issue list --label` **errors on an unknown label**, so the close job would have failed on a `staging` push that happened before any promotion. Now tolerated.

## How to test (QA)
**This PR tests itself on arrival.** When it reaches `qa`, a "Ready for QA" issue should appear listing the PRs above with their test steps. Then:

1. Promote `qa` → `staging` and push — the issue should **close itself** with a comment.
2. Next promotion to `qa` should open a **fresh** one, not reopen the old.

If the issue lists the wrong set, say so — the range logic is the part worth distrusting.

## Risk level
**Low.** New workflow file, no existing job touched, no application code. Worst case it posts a wrong list; it cannot fail a build or block a merge. `concurrency` is set with `cancel-in-progress: false` because a promotion is often two pushes seconds apart and the *second* carries the complete range.