### PR TITLE
feat(ci): automate the last three release signals that relied on memory

### DIFF
--- a/.github/workflows/release-signals.yml
+++ b/.github/workflows/release-signals.yml
@@ -1,0 +1,216 @@
+# The three release-stage signals that still depended on somebody remembering.
+#
+# `ready-for-qa.yml` closed the dev -> qa hop. These are the rest of the chain:
+#
+#   qa -> staging      the release PR was opened BY HAND, and it is the only
+#                      thing that tells QA what a release contains. Same
+#                      "remember to" wording that had already failed once.
+#   staging -> main    merging is NOT the deploy. Every Render service is
+#                      autoDeploy: no, so main can move and production keeps
+#                      serving the old build indefinitely with nothing to say so.
+#   after deploying    CONTRIBUTING says tag main. Nothing checked, so "what is
+#                      in production?" stayed answerable only from a dashboard.
+#
+# The last two fail SILENTLY AFTER a release looks finished, which is why they
+# are on a schedule as well as on push: nobody is watching a workflow run at
+# that point.
+name: Release signals
+
+on:
+  push:
+    branches: [staging, main]
+  schedule:
+    # 08:00 Asia/Manila. Catches "merged on Friday, never deployed" without
+    # anyone having to look.
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: release-signals
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  # ── qa -> staging: open the release PR, do not wait to be asked ───────────
+  release-pr:
+    if: github.ref == 'refs/heads/staging'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Open the staging -> main release PR if there is not one
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$(git log --format=%H origin/main..origin/staging)" ]; then
+            echo "staging has nothing main does not - no release PR needed"
+            exit 0
+          fi
+
+          EXISTING=$(gh pr list --repo "$REPO" --base main --head staging --state open \
+            --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            # Do NOT rewrite the body. QA works in that PR and reports failures
+            # as comments; replacing it under them would destroy their notes.
+            gh pr comment "$EXISTING" --repo "$REPO" \
+              --body "\`staging\` moved again — this release now contains more than it did. Re-check anything already signed off."
+            echo "commented on existing #$EXISTING"
+            exit 0
+          fi
+
+          git log --format=%s origin/main..origin/staging > /tmp/subjects.txt
+          grep -oE 'Merge pull request #[0-9]+' /tmp/subjects.txt \
+            | grep -oE '[0-9]+' | sort -u > /tmp/prs.txt || true
+
+          {
+            echo "**QA Team** — opened automatically when \`staging\` moved."
+            echo
+            echo "## Summary"
+            echo
+            echo "Release candidate. Everything below is on \`staging\` and not yet in production."
+            echo
+            echo "## How to test (QA)"
+            echo
+            echo "Test on **liquidity-hq-staging.onrender.com**, which serves \`staging\`."
+            echo "Each section below is the PR author's own steps, carried through verbatim."
+            echo
+          } > /tmp/body.md
+
+          while read -r N; do
+            [ -n "$N" ] || continue
+            TITLE=$(gh pr view "$N" --repo "$REPO" --json title --jq .title 2>/dev/null || echo "(unreadable)")
+            echo "### #$N — $TITLE" >> /tmp/body.md
+            echo >> /tmp/body.md
+            gh pr view "$N" --repo "$REPO" --json body --jq .body 2>/dev/null \
+              | awk '/^#+ *How to test/{f=1; next} /^#+ /{if(f) exit} f' \
+              | sed '/^[[:space:]]*$/d' > /tmp/howto.md || true
+            if [ -s /tmp/howto.md ]; then cat /tmp/howto.md >> /tmp/body.md
+            else echo "_No \"How to test (QA)\" section — ask dev before signing this off._" >> /tmp/body.md; fi
+            echo >> /tmp/body.md
+          done < /tmp/prs.txt
+
+          # Risk level is collected the same way: the caveats a PR author flagged
+          # are exactly what a release reviewer needs and never sees otherwise.
+          {
+            echo "## Risk level"
+            echo
+            echo "Per-PR risk, verbatim:"
+            echo
+          } >> /tmp/body.md
+          while read -r N; do
+            [ -n "$N" ] || continue
+            gh pr view "$N" --repo "$REPO" --json body --jq .body 2>/dev/null \
+              | awk '/^#+ *Risk level/{f=1; next} /^#+ /{if(f) exit} f' \
+              | sed '/^[[:space:]]*$/d' | sed "s/^/- #$N: /" >> /tmp/body.md || true
+          done < /tmp/prs.txt
+
+          {
+            echo
+            echo "## Release steps — QA owns all four"
+            echo
+            echo "1. Test every section above on staging."
+            echo "2. Merge this PR."
+            echo "3. **Deploy production manually.** Merging is not the deploy —"
+            echo "   \`liquidity-hq-prod\` is \`autoDeploy: no\`. A drift check raises an"
+            echo "   issue if main moves and production does not follow."
+            echo "4. Re-check the steps against production, then tag:"
+            echo "   \`git tag -a v\$(date +%Y.%m.%d) -m \"...\" && git push --tags\`"
+          } >> /tmp/body.md
+
+          gh pr create --repo "$REPO" --base main --head staging \
+            --title "Release $(date +%Y-%m-%d): $(wc -l < /tmp/prs.txt | tr -d ' ') PR(s)" \
+            --body-file /tmp/body.md
+
+  # ── main merged but production still serving the old build ───────────────
+  prod-drift:
+    if: github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compare production against main, and check main is tagged
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          MAIN=$(git rev-parse origin/main)
+          MAIN_SHORT=${MAIN:0:7}
+
+          # A cold free-tier host can take a while; prod is on starter, but be
+          # generous rather than raise a false alarm on a slow response.
+          LIVE=$(curl -s --max-time 60 https://liquidity-hq.com/api/version | jq -r '.commit // "unreachable"' || echo unreachable)
+          TAG=$(git tag --points-at origin/main | head -1)
+
+          echo "main=$MAIN_SHORT live=$LIVE tag=${TAG:-none}"
+
+          # Accumulated in a file rather than a shell variable: a multi-line
+          # string assignment inside a YAML block scalar has to close at column
+          # 0, which dedents out of the block and breaks the workflow parse.
+          : > /tmp/problems.md
+
+          if [ "$LIVE" = "unreachable" ] || [ "$LIVE" = "unknown" ]; then
+            # Deliberately NOT treated as drift. An unreachable endpoint means
+            # the check could not measure, and reporting that as "production is
+            # behind" would be a confident claim from a failed measurement.
+            echo "could not read production version - reporting nothing rather than guessing"
+            exit 0
+          fi
+
+          if [ "$LIVE" != "$MAIN_SHORT" ]; then
+            printf -- '- **Production is serving `%s`, but `main` is `%s`.** Merging is not the deploy: `liquidity-hq-prod` is `autoDeploy: no`. Render dashboard -> liquidity-hq-prod -> Manual Deploy.\n' \
+              "$LIVE" "$MAIN_SHORT" >> /tmp/problems.md
+          fi
+          if [ -z "$TAG" ] && [ "$LIVE" = "$MAIN_SHORT" ]; then
+            printf -- '- **Production matches `main` but `main` carries no tag.** Without one, "what is in production?" is only answerable from the Render dashboard. Tag it with `git tag -a vYYYY.MM.DD -m "..." && git push --tags`.\n' \
+              >> /tmp/problems.md
+          fi
+
+          gh label create release-drift --repo "$REPO" --color B60205 \
+            --description "main and production disagree, or a release is untagged" 2>/dev/null || true
+          OPEN=$(gh issue list --repo "$REPO" --label release-drift --state open \
+                   --json number --jq '.[0].number // empty' 2>/dev/null || true)
+
+          if [ ! -s /tmp/problems.md ]; then
+            if [ -n "$OPEN" ]; then
+              gh issue close "$OPEN" --repo "$REPO" \
+                --comment "Production now matches \`main\` (\`$MAIN_SHORT\`) and the commit is tagged. Closing automatically."
+            fi
+            echo "production is current and tagged"
+            exit 0
+          fi
+
+          {
+            echo "**Automated check** — production and \`main\` disagree."
+            echo
+            cat /tmp/problems.md
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| \`main\` | \`$MAIN_SHORT\` |"
+            echo "| production is serving | \`$LIVE\` |"
+            echo "| tag on \`main\` | ${TAG:-**none**} |"
+            echo
+            echo "Read from https://liquidity-hq.com/api/version, so it reflects what is"
+            echo "actually running rather than what was merged."
+            echo
+            echo "Closes itself once production matches \`main\` and the commit is tagged."
+          } > /tmp/drift.md
+
+          if [ -n "$OPEN" ]; then
+            gh issue edit "$OPEN" --repo "$REPO" --body-file /tmp/drift.md
+          else
+            gh issue create --repo "$REPO" --label release-drift \
+              --title "Production is not running \`main\`" --body-file /tmp/drift.md
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,8 +141,10 @@ Pushing to `staging` closes it. Computed from the `staging..qa` range rather
 than the push event, so it survives force-pushes, re-runs and several
 promotions in a row.
 
-**Open the `staging` → `main` release PR immediately after promoting to
-`staging`.** QA does this, since QA owns that promotion. It aggregates the
+**The `staging` → `main` release PR opens itself** on any push to `staging`
+(`.github/workflows/release-signals.yml`) — QA no longer has to remember. If one
+is already open it is commented on, never rewritten, since QA reports failures
+in that thread. It aggregates the
 "How to test" steps for the whole release,
 ends with merge/deploy/re-check/tag, and collects every "could not verify
 locally" caveat in Risk level. Promoting without it is deploying into silence.
@@ -187,6 +189,13 @@ path** — prod Supabase is on the free plan and has no backups.
 **Tag `main` after a successful prod deploy** — `git tag -a v2026.08.05 -m "..."`.
 Date-based. Without it, "what is in production?" is only answerable from the
 Render dashboard.
+
+**A drift check enforces both halves of that** — on every push to `main`, daily
+on a schedule, and on demand. It reads `/api/version` on liquidity-hq.com, so it
+compares what production is *serving* against `main`, not what was merged, and
+opens a `release-drift` issue if they differ or if the deployed commit is
+untagged. It closes itself when both are right. If the endpoint is unreachable
+it reports **nothing** — a failed measurement is not evidence of drift.
 
 **Low ceremony** — small internal chores (dep bumps, formatting, comments) may
 skip the commit body and screenshots. Branch naming and the `type(scope):`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -831,17 +831,48 @@ Two properties worth knowing, because they decide whether you can trust it:
 Dev still asks before promoting (below). That is a *timing* check — it stops a
 promotion landing mid-test-run. The announcement afterwards is now automatic.
 
-**QA, when a batch is approved and ready to park: promote `qa` → `staging` and
-open the `staging` → `main` release PR.** Dev does not open this one and does
-not promote into `staging` — that is the whole point of the branch. If dev can
-move the release candidate, the guarantee is gone.
+**QA, when a batch is approved and ready to park: promote `qa` → `staging`.**
+Dev does not promote into `staging` — that is the whole point of the branch. If
+dev can move the release candidate, the guarantee is gone.
+
+**The `staging` → `main` release PR now opens itself**
+(`.github/workflows/release-signals.yml`), aggregating each PR's "How to test
+(QA)" *and* "Risk level" sections verbatim from `main..staging`. If one is
+already open it is **commented on, never rewritten** — QA reports failures in
+that thread and replacing the body underneath them would destroy the record.
 
 This was missing and it silently broke the handoff. Five changes sat on the
 `qa` site — including the worst Core Web Vital in the product and a bug that
 was getting users' IPs banned — with nothing anywhere saying so. Every
-individual PR had already been merged and closed, `qa` had moved, the qa service had
-been redeployed, and QA had no way to know. Promoting without opening this PR is
-deploying into silence.
+individual PR had already been merged and closed, `qa` had moved, the qa service
+had been redeployed, and QA had no way to know.
+
+That is why none of these three signals is an instruction any more. Each one was
+written down as a rule, each rule was followed most of the time, and the times
+it was not are the only times it mattered.
+
+### Merging to `main` is not the deploy, and something now checks
+
+Every Render service is `autoDeploy: no`. `main` can move and production keeps
+serving the previous build indefinitely, with a green PR and a closed release
+thread saying otherwise.
+
+A drift check runs on every push to `main`, **daily on a schedule**, and on
+demand. It reads `https://liquidity-hq.com/api/version` — what production is
+actually serving, not what was merged — and raises a `release-drift` issue when:
+
+- production's commit does not match `main`, or
+- production matches `main` but the commit carries **no tag**, which is what
+  makes "what is in production?" answerable without opening a dashboard.
+
+It closes itself once both hold. The schedule matters more than the push
+trigger: this class of failure happens *after* everyone has stopped watching, so
+"merged Friday, never deployed" is exactly what it is for.
+
+**If it cannot read the version endpoint it reports nothing at all.** An
+unreachable host means the check could not measure, and calling that "production
+is behind" would be a confident claim built on a failed measurement — the
+specific mistake this whole set of signals exists to stop.
 
 The release PR is different from a feature PR in three ways:
 

--- a/app/api/version/route.ts
+++ b/app/api/version/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+/*
+ * What build is this host actually serving?
+ *
+ * Two things needed this and neither could answer it:
+ *
+ *   1. "Merging to main is not the deploy." Every service is autoDeploy: no, so
+ *      main can move and production keeps serving the old build indefinitely.
+ *      Nothing detected that. `.github/workflows/release-signals.yml` compares
+ *      this against origin/main and raises an issue when they diverge.
+ *   2. QA repeatedly needed to know which build a host was serving, and the
+ *      only answer was the Render dashboard - which QA reads far less often
+ *      than the site itself.
+ *
+ * RENDER_GIT_COMMIT and RENDER_GIT_BRANCH are injected by Render at build time.
+ * Locally they are absent, so this reports 'unknown' rather than pretending.
+ *
+ * PUBLIC ON PURPOSE, and only this much. A short commit SHA and a branch name
+ * are not credentials and reveal nothing without access to a private repo -
+ * they are the minimum a drift check can run on without handing CI a Render API
+ * token. Nothing environment-shaped goes in here: no variable names, no
+ * versions, no dependency list. If that ever needs to grow, gate it behind
+ * checkCronAuth rather than widening what is open.
+ */
+export async function GET() {
+  const commit = process.env.RENDER_GIT_COMMIT ?? '';
+  return NextResponse.json(
+    {
+      commit: commit ? commit.slice(0, 7) : 'unknown',
+      branch: process.env.RENDER_GIT_BRANCH ?? 'unknown',
+      // Which table set this host is reading - the switch that has silently
+      // pointed a test environment at production data before now.
+      appEnv: process.env.NEXT_PUBLIC_APP_ENV ?? 'unset',
+    },
+    // Must never be cached: a stale answer here would report the previous
+    // build as current, which is precisely the failure it exists to catch.
+    { headers: { 'Cache-Control': 'no-store, max-age=0' } },
+  );
+}


### PR DESCRIPTION
**Dev Team**

Follows #88, which closed the `dev` → `qa` hop. These are the rest of the chain.

## The three gaps

| Hop | Was | Now |
|---|---|---|
| `qa` → `staging` | release PR opened **by hand** — the only thing telling QA what a release contains | opens itself on push to `staging` |
| `staging` → `main` | merging is **not** the deploy (`autoDeploy: no`) — nothing noticed | drift check on push, **daily**, and on demand |
| after deploying | "tag `main`" was an instruction nobody verified | same check flags an untagged deployed commit |

All three were instructions, not mechanisms. Each was followed most of the time; the times it was not are the only times it mattered.

## Why a schedule and not just push
The last two fail **after** a release looks finished. Nobody is watching a workflow run at that point, so "merged Friday, never deployed" is exactly the case the daily run exists for.

## `/api/version`
Minimal new route: short commit SHA, branch, `NEXT_PUBLIC_APP_ENV`. Nothing else.

- It is what lets the drift check compare what production is **serving** against `main` — rather than what was merged — **without handing CI a Render API token**.
- It also answers a question QA has repeatedly opened the Render dashboard for: *which build is this host serving?*
- `Cache-Control: no-store`, because a cached answer would report the previous build as current — the exact failure it exists to catch.
- Public deliberately, and only this much. A short SHA and a branch name are not credentials. If it ever needs to grow, gate it behind `checkCronAuth` rather than widening what is open.

## The behaviour I most want reviewed
**An unreachable endpoint reports nothing at all.** Not "production is behind" — that would be a confident claim built on a failed measurement, which is the specific mistake this whole set of signals exists to remove. I have made that mistake twice this week and would rather the check stay silent than be wrong loudly.

## Verified against the real repo, not reasoned about
- `main` is `0e4c85f` and **tagged `v2026.08.07`** — so the tag rule does not false-fire today.
- All three branches simulated: unreachable → silent; matching + tagged → closes the issue; mismatched → reports drift.
- Endpoint exercised on a real server: `{"commit":"unknown","branch":"unknown","appEnv":"dev"}` locally where Render's vars are absent, with the `no-store` header set.
- YAML parses, both shell steps pass `bash -n`. The first draft **failed to parse** — a multi-line shell assignment must close at column 0, which dedents out of a YAML block scalar. Problems now accumulate in a file.

## How to test (QA)
1. **On your next `qa` → `staging` promotion**: a release PR should appear on its own, with every PR's test steps and risk notes already in it. Nothing to open by hand.
2. **After the next production deploy**: if you deploy and tag, no issue appears. If you merge `main` and do **not** deploy, a `release-drift` issue should appear within a day naming both commits.
3. Visit `https://liquidity-hq-staging.onrender.com/api/version` — it should report the commit staging is serving. Useful on its own for confirming which build you are testing.

Distrust the drift check first if something looks wrong; it is the piece with the most moving parts.

## Risk level
**Low.** One new workflow, one new read-only route. No existing job or route touched, nothing can fail a build or block a merge. Gates: lint 0 errors, tsc clean, 112 tests, build clean.