### PR TITLE
fix(api): staging owns its own Telegram bot, so CRON_SECRET is allowed there

### DIFF
--- a/__tests__/envCheck.test.mts
+++ b/__tests__/envCheck.test.mts
@@ -137,33 +137,35 @@ test('startup environment check', async (t) => {
     }
   });
 
-  /* CRON_SECRET is judged by whether the host owns the bot it could re-point,
-     not by whether it is non-prod - dev legitimately holds one. */
-  await t.test('CRON_SECRET is flagged on qa and staging but not on dev', () => {
-    const onQa = checkEnv(base({
-      CRON_SECRET: 'x', NEXT_PUBLIC_APP_URL: 'https://liquidity-hq-qa.onrender.com',
-    }));
-    assert.equal(levelFor(onQa, 'CRON_SECRET'), 'error');
-
-    const onStaging = checkEnv(base({
-      CRON_SECRET: 'x', NEXT_PUBLIC_APP_URL: 'https://liquidity-hq-staging.onrender.com',
-    }));
-    assert.equal(levelFor(onStaging, 'CRON_SECRET'), 'error');
-
-    const onDev = checkEnv(base({
-      CRON_SECRET: 'x', NEXT_PUBLIC_APP_URL: 'https://liquidity-hq-dev.onrender.com',
-    }));
-    assert.equal(levelFor(onDev, 'CRON_SECRET'), undefined);
+  /* The rule is bot OWNERSHIP, not environment. A host that owns its bot can
+     only re-point its own webhook, which is a no-op. dev has owned one since
+     2026-08-04; staging got its own on 2026-08-08. qa still holds dev's token,
+     which is why CRON_SECRET was removed from it. */
+  await t.test('CRON_SECRET is allowed on hosts that own their bot', () => {
+    for (const url of [
+      'https://liquidity-hq-dev.onrender.com',
+      'https://liquidity-hq-staging.onrender.com',
+    ]) {
+      const f = checkEnv(base({ CRON_SECRET: 'x', NEXT_PUBLIC_APP_URL: url }));
+      assert.equal(levelFor(f, 'CRON_SECRET'), undefined, `${url} owns its bot — should be quiet`);
+    }
   });
 
-  /* liquidity-hq-qa.onrender.com contains the string "liquidity-hq-", so a
-     sloppier match than the one in envCheck.ts would clear qa as though it were
-     dev - which is the exact host the rule exists for. */
-  await t.test('the dev-host match does not accidentally clear qa or staging', () => {
+  await t.test('CRON_SECRET is still flagged on qa, which holds dev\'s token', () => {
+    const f = checkEnv(base({
+      CRON_SECRET: 'x', NEXT_PUBLIC_APP_URL: 'https://liquidity-hq-qa.onrender.com',
+    }));
+    assert.equal(levelFor(f, 'CRON_SECRET'), 'error');
+  });
+
+  /* The trailing dot in the pattern is load-bearing. Without it, a host whose
+     name merely STARTS with an owning environment's name would be cleared -
+     and `liquidity-hq-qa` is the one host that must never be. */
+  await t.test('lookalike hostnames are not cleared by the owner match', () => {
     for (const url of [
       'https://liquidity-hq-qa.onrender.com',
-      'https://liquidity-hq-staging.onrender.com',
-      'https://liquidity-hq.com',
+      'https://liquidity-hq-staging-old.onrender.com',
+      'https://liquidity-hq-devious.example.com',
     ]) {
       const f = checkEnv(base({ CRON_SECRET: 'x', NEXT_PUBLIC_APP_URL: url }));
       assert.equal(levelFor(f, 'CRON_SECRET'), 'error', `${url} should still be flagged`);

--- a/lib/envCheck.ts
+++ b/lib/envCheck.ts
@@ -124,11 +124,22 @@ export function checkEnv(env: Record<string, string | undefined> = process.env):
   }
 
   // ── 5. Cron secret on a host that borrows another environment's bot ─────
-  // dev legitimately holds one: it owns @Liquidity_hq_dev_bot, its own database
-  // and its own secret, so anything it triggers lands in its own chat. qa and
-  // staging do not own a bot, so the same variable there is a key to somebody
-  // else's house. Keyed off the URL because that is the only signal in-process
-  // that distinguishes them.
+  // The rule is ownership, not environment. A host that owns its bot can only
+  // ever re-point its own webhook - a no-op. A host holding SOMEONE ELSE'S
+  // token can re-point that bot at itself and silently swallow every alert.
+  //
+  // dev owns @Liquidity_hq_dev_bot; staging got its own bot on 2026-08-08.
+  // Both therefore qualify. qa does not - it still holds dev's token - which is
+  // why CRON_SECRET was removed from it the same day.
+  //
+  // Keyed off the URL because that is the only signal available in-process.
+  // The trailing `\.` matters: without it, `liquidity-hq-staging` would also
+  // match a prefix check against `liquidity-hq-stagingsomething`, and more to
+  // the point `liquidity-hq-qa.` must never match either alternative here.
+  //
+  // WHEN THIS NEEDS EDITING AGAIN: the moment any environment is given its own
+  // bot, or has one taken away. There is no way to detect bot ownership from
+  // inside the process, so this list is the fact - keep it next to the reason.
   //
   // localhost is excluded. Every developer's .env.local carries CRON_SECRET so
   // cron routes can be exercised, and Telegram will not register a webhook
@@ -137,7 +148,7 @@ export function checkEnv(env: Record<string, string | undefined> = process.env):
   // which is how a check stops being read.
   const isLocal = /localhost|127\.0\.0\.1|\[::1\]/.test(appUrl);
   if (env.CRON_SECRET && !isProd && !isLocal) {
-    const ownsItsBot = /liquidity-hq-dev\./.test(appUrl);
+    const ownsItsBot = /liquidity-hq-(dev|staging)\./.test(appUrl);
     if (!ownsItsBot) {
       findings.push({
         level: 'error', key: 'CRON_SECRET',


### PR DESCRIPTION
**Dev Team**

## Summary
The startup check's `CRON_SECRET` rule now clears `liquidity-hq-staging` as well as `liquidity-hq-dev`.

## Why
The rule is **bot ownership**, not environment:

| Host | Owns its bot? | `CRON_SECRET` |
|---|---|---|
| dev | yes, since 2026-08-04 | allowed |
| **staging** | **yes, since 2026-08-08** | **now allowed** |
| qa | no — holds **dev's** token | still flagged |

A host that owns its bot can only re-point its own webhook — a no-op. A host holding someone else's token can re-point that bot at itself and swallow every alert.

Left unfixed, this would have flagged a **correct** configuration the moment staging got a `CRON_SECRET`. A check that cries wolf stops being read, which is the exact failure this file was written to avoid.

## How to test (QA)
Boot staging after `CRON_SECRET` is set there — logs should read `[env] ok`, not an error about the cron secret. qa should still be flagged if one is ever set on it again.

## Risk level
**Low.** One regex, plus tests. 113 pass, tsc clean, lint 0 errors. Added a lookalike-hostname case — the trailing dot is load-bearing and `liquidity-hq-qa` must never be cleared by a prefix match.