### PR TITLE
fix(settings): keep non-production analytics out of the production PostHog project

### DIFF
--- a/__tests__/analyticsKey.test.mts
+++ b/__tests__/analyticsKey.test.mts
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { analyticsKey } from '../lib/analytics.ts';
+
+/* One PostHog project on the free plan, and every environment holding the key
+   writes into it. Measured 2026-08-08: dev and prod served the SAME phc_ key,
+   so anyone accepting cookies on dev landed events in production's analytics.
+
+   qa and staging avoided this only by never being given the variable, which is
+   configuration, not a guarantee - dev was overlooked for exactly that reason.
+   These tests cover the gate that makes it a property of the build instead. */
+
+const KEY = 'phc_rLooCMA4a4ShFKiJutRMkywFBVkAa6R3WQxbLf9BBMgy';
+
+test('analytics key gating', async (t) => {
+  await t.test('production gets the key', () => {
+    assert.equal(
+      analyticsKey({ NEXT_PUBLIC_POSTHOG_KEY: KEY, NEXT_PUBLIC_APP_ENV: 'prod' }),
+      KEY,
+    );
+  });
+
+  /* NEXT_PUBLIC_APP_ENV is 'dev' on dev, qa AND staging - it is the same switch
+     lib/tables.ts reads - so one condition covers every non-production
+     environment, including any created later. */
+  await t.test('every non-production environment gets nothing, even holding the key', () => {
+    assert.equal(
+      analyticsKey({ NEXT_PUBLIC_POSTHOG_KEY: KEY, NEXT_PUBLIC_APP_ENV: 'dev' }),
+      '',
+    );
+  });
+
+  await t.test('no key configured returns empty rather than undefined', () => {
+    assert.equal(analyticsKey({ NEXT_PUBLIC_APP_ENV: 'prod' }), '');
+    assert.equal(analyticsKey({}), '');
+  });
+
+  /* An empty string is what PostHogProvider treats as "do not init at all", so
+     the return type must stay a string - returning undefined would still be
+     falsy but changes what `PH_KEY` is, and posthog.init(undefined) is not the
+     same no-op as never calling it. */
+  await t.test('the return is always a string', () => {
+    for (const env of [
+      { NEXT_PUBLIC_POSTHOG_KEY: KEY, NEXT_PUBLIC_APP_ENV: 'dev' },
+      { NEXT_PUBLIC_POSTHOG_KEY: KEY, NEXT_PUBLIC_APP_ENV: 'prod' },
+      {},
+    ]) {
+      assert.equal(typeof analyticsKey(env), 'string');
+    }
+  });
+
+  /* Guards the failure this exists to prevent: an unrecognised APP_ENV must not
+     silently behave like production. It does here - anything that is not 'dev'
+     passes the key through - which matches lib/tables.ts, where anything not
+     'dev' selects the production tables. Both are wrong in the same direction
+     on purpose: lib/envCheck.ts flags such a value at startup rather than each
+     call site inventing its own fallback. */
+  await t.test('an unrecognised APP_ENV behaves like production, and envCheck is what catches it', () => {
+    assert.equal(
+      analyticsKey({ NEXT_PUBLIC_POSTHOG_KEY: KEY, NEXT_PUBLIC_APP_ENV: 'qa' }),
+      KEY,
+    );
+  });
+});

--- a/components/PostHogProvider.tsx
+++ b/components/PostHogProvider.tsx
@@ -3,8 +3,27 @@ import posthog from 'posthog-js';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { useEffect, useRef, useState, Suspense } from 'react';
 import { readConsent, onConsentChange, type ConsentState } from '@/lib/consent';
+import { analyticsKey } from '@/lib/analytics';
 
-const PH_KEY  = process.env.NEXT_PUBLIC_POSTHOG_KEY  ?? '';
+// analyticsKey() also returns '' on any non-production environment, so a
+// dev/qa/staging build cannot write into production's single PostHog project
+// even if it is handed the key. See lib/analytics.ts.
+//
+// THE TWO VALUES MUST BE SPELLED OUT AS STATIC `process.env.NEXT_PUBLIC_*`
+// MEMBER ACCESSES, exactly as below. Next.js inlines only that literal form at
+// build time; passing `process.env` as an object and reading properties off it
+// inside the function is a runtime lookup, and `process.env` is empty in the
+// browser - so the key came back '' in EVERY environment, production included.
+// That is how the first version of this shipped-in-thirty-seconds change would
+// have silently switched analytics off for real users. Caught by building twice
+// and checking the key was present in a prod build, not only absent in a dev one.
+//
+// NEXT_PUBLIC_* are inlined at build time, so this is resolved per build - a
+// service that changes NEXT_PUBLIC_APP_ENV needs a rebuild, not a restart.
+const PH_KEY  = analyticsKey({
+  NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY,
+  NEXT_PUBLIC_APP_ENV:     process.env.NEXT_PUBLIC_APP_ENV,
+});
 const PH_HOST = process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com';
 
 function PageViewTracker() {

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -4,6 +4,42 @@
  */
 import posthog from 'posthog-js';
 
+/**
+ * The PostHog key, but only where analytics SHOULD run.
+ *
+ * There is one PostHog project on the free plan and every environment that
+ * holds the key writes into it. Measured 2026-08-08: dev and prod were serving
+ * the SAME `phc_...` key, so anyone who accepted cookies on dev was landing
+ * events in production's analytics. qa and staging were already excluded by
+ * simply never being given the variable - dev was overlooked, which is the
+ * problem with enforcing this through configuration alone.
+ *
+ * So the environment gate lives here instead, mirroring `monitoringDsn()` in
+ * lib/monitoring.ts, which solved exactly this for the GlitchTip DSN after
+ * non-prod traffic exhausted that quota. Removing the key from a dashboard
+ * fixes today; this fixes the next service someone copies an environment into.
+ *
+ * Returns '' rather than throwing: PostHogProvider already treats an empty key
+ * as "do not init at all", which is the behaviour we want and is trivially
+ * checkable in devtools - no PostHog request, no PostHog cookie.
+ *
+ * CALLERS MUST PASS THE VALUES IN as literal `process.env.NEXT_PUBLIC_*` member
+ * accesses. There is deliberately no `= process.env` default: Next.js inlines
+ * only that literal form into the client bundle, so reading properties off a
+ * `process.env` object passed in as a whole resolves to nothing in the browser
+ * and this returns '' everywhere - switching analytics off in production too.
+ * A default parameter here made that mistake easy and invisible, so it is gone.
+ */
+export function analyticsKey(env: Record<string, string | undefined>): string {
+  const key = env.NEXT_PUBLIC_POSTHOG_KEY ?? '';
+  if (!key) return '';
+  // Same switch lib/tables.ts reads: 'dev' means every non-production
+  // environment, so this covers dev, qa and staging in one condition and any
+  // future one automatically.
+  if (env.NEXT_PUBLIC_APP_ENV === 'dev') return '';
+  return key;
+}
+
 function capture(event: string, props?: Record<string, unknown>) {
   if (typeof window === 'undefined') return;
   try { posthog.capture(event, props); } catch { /* PostHog not initialised yet */ }


### PR DESCRIPTION
**Dev Team**

## Summary
dev and prod were serving the **same** PostHog key. Anyone accepting cookies on dev landed events in **production's** analytics.

## The finding
Verified by fetching both sites' bundles — identical `phc_...` key on `liquidity-hq.com` and `liquidity-hq-dev.onrender.com`. One PostHog project on the free plan, so every environment holding the key writes into it.

The only gate on `posthog.init()` was **cookie consent**. No environment check — unlike `monitoringDsn()`, which solved exactly this for the GlitchTip DSN after non-prod traffic exhausted that quota.

qa and staging escaped only by never being given the variable. That is configuration, not a guarantee — dev was overlooked for that reason, and the next service someone copies an environment into inherits it.

## The bug I nearly shipped
The first version **passed** the dev build and was still broken.

`analyticsKey` took `= process.env` as a default parameter. Next.js inlines only literal `process.env.NEXT_PUBLIC_*` member accesses — reading properties off a `process.env` object passed in whole is a runtime lookup, and `process.env` is **empty in the browser**. It returned `''` in every environment, **production included**, silently switching analytics off for real users.

Only building the **prod** case exposed it. Checking that the key was absent from a dev build proved nothing on its own — absence is what a broken gate and a working one both look like. The default parameter is removed so it cannot happen silently again.

## Verified end to end
Dev bundle call site, after the fix:
```js
analyticsKey({NEXT_PUBLIC_POSTHOG_KEY:"phc_...",NEXT_PUBLIC_APP_ENV:"dev"})
```
Both literals inlined; returns `''` for dev, the key for prod.

The key literal stays in the non-prod bundle as an unused argument. It is a public client-side write key and is never passed to `posthog.init()`.

## How to test (QA)
On staging or qa, accept cookies, then check devtools Network — **no request to posthog.com** and no `ph_` cookie. On production the opposite should hold.

## Risk level
**Medium.** Touches whether production analytics records anything at all — that is why both builds were checked rather than one. Gates: 119 tests, tsc clean, lint 0 errors, build clean.

Still worth removing `NEXT_PUBLIC_POSTHOG_KEY` from dev in Render — this makes it harmless, not tidy.