### PR TITLE
docs(api): record that Brevo is set on every environment, and why

### DIFF
--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -287,9 +287,39 @@ deliberate exceptions. Set as of 2026-08-05:
 
 | Variable | Why not |
 |---|---|
-| `NEXT_PUBLIC_POSTHOG_KEY` | QA test runs would land in product analytics and corrupt the numbers |
+| `NEXT_PUBLIC_POSTHOG_KEY` | QA test runs would land in product analytics and corrupt the numbers. **Also enforced in code since 2026-08-08** — `analyticsKey()` in `lib/analytics.ts` returns `''` whenever `NEXT_PUBLIC_APP_ENV` is `dev`, so a non-prod build cannot write into the single shared PostHog project even if someone sets the variable. dev and prod were found serving the *same* key that day |
+| `NEXT_PUBLIC_SENTRY_DSN` | Prod only. All environments share one GlitchTip project on the free tier; non-prod traffic exhausted the quota once and production reported nothing at all — every envelope came back 429 |
 | `LEMONSQUEEZY_WEBHOOK_SECRET` etc. | Payments. Staging has no business holding these |
 | `CRON_SECRET` | Cron routes fail **closed** without it (`lib/cronAuth.ts`), which is the desired state on any non-prod host. Was wrongly set on qa 2026-08-05 → 2026-08-08; removed, see below |
+
+### Brevo is set on EVERY environment, on purpose
+
+`BREVO_API_KEY` and `BREVO_SENDER_EMAIL` are on prod, dev, qa **and** staging.
+Decided 2026-08-08. That is a deliberate exception to the usual "non-prod holds
+as little as possible" rule, and the reason is worth keeping:
+
+**`lib/email.ts` fails silently.** Every sender returns `false` when the keys are
+missing rather than throwing, so an unconfigured environment is indistinguishable
+from "nobody was due". QA hit exactly this: the trial-reminder path could only be
+proven on a deployed environment, because local `.env.local` has no Brevo keys
+and the route reported success while sending nothing.
+
+So an environment without the keys cannot test email *and cannot tell that it is
+not testing email*. Dev needs them to verify its own work before promoting;
+staging needs them because that is where QA signs off. qa keeps them because
+removing them buys nothing once the other three have them.
+
+**What this costs, stated so it is not a surprise:** one Brevo account, one
+sending quota, one sender reputation, shared by all four. Test-run bounces would
+count against the reputation production depends on. If prod email ever starts
+landing in spam, check what non-prod has been sending before looking anywhere
+else.
+
+**What limits the blast radius:** of the six senders, four go to the owner or
+admins (`sendSpikeAlertEmail`, `sendHealthAlertEmail`, `sendAdminAddedEmail`, and
+`sendBanEmail` in practice). Only welcome, ban and trial-ending reach ordinary
+users — and on dev, qa and staging those tables are the **dev** Supabase project,
+so the recipients are test accounts rather than real customers.
 
 ### Telegram on QA — currently dev's bot, safe only by accident
 

--- a/render.yaml
+++ b/render.yaml
@@ -90,12 +90,29 @@ services:
       #                                     flow under test is not the one prod
       #                                     runs. Build-time - needs a rebuild.
       # CMC_API_KEY  FINNHUB_KEY  GROK_API_KEY
+      # ADMIN_EMAILS  VAPID_EMAIL  VAPID_PRIVATE_KEY  NEXT_PUBLIC_VAPID_PUBLIC_KEY
+      # BREVO_API_KEY  BREVO_SENDER_EMAIL
+      # NEXT_PUBLIC_SENTRY_ENV = "staging"   (not copied from qa, which says "qa")
       #
-      # DELIBERATELY UNSET: NEXT_PUBLIC_SENTRY_DSN (prod only), CRON_SECRET.
-      # Set CRON_SECRET only where BOTH hold: something on that host legitimately
-      # needs to call a cron-guarded route, AND the environment owns its own
-      # side-effect credentials (bot, database, mail sender). staging has
-      # neither. Full rule and the one exception: docs/INFRASTRUCTURE.md 4c.
+      # TELEGRAM_BOT_TOKEN / _CHAT_ID / _WEBHOOK_SECRET  <- staging's OWN bot,
+      #   created 2026-08-08. Do NOT copy qa's: those are dev's bot, and a host
+      #   holding another environment's token can re-point that bot at itself.
+      #
+      # CRON_SECRET is SET here, and legitimately. The rule is that BOTH must
+      # hold: something on the host needs to call a cron-guarded route (staging
+      # registers its own Telegram webhook), AND the environment owns its own
+      # side-effect credentials. Staging owns its bot, so both do. qa owns
+      # neither and must stay without one. Full rule: docs/INFRASTRUCTURE.md 4c.
+      #
+      # DELIBERATELY UNSET: NEXT_PUBLIC_SENTRY_DSN (prod only - shared GlitchTip
+      # quota), NEXT_PUBLIC_POSTHOG_KEY (prod only, and now also blocked in code
+      # by analyticsKey() in lib/analytics.ts), LEMONSQUEEZY_* (payments).
+      #
+      # Brevo IS set here even though it is a real external side effect - see
+      # docs/INFRASTRUCTURE.md 4c, "Brevo is set on EVERY environment". Short
+      # version: lib/email.ts returns false rather than throwing when the keys
+      # are absent, so an environment without them cannot test email AND cannot
+      # tell that it is not testing email.
       #
       # External settings that had to be updated for this hostname:
       #   Cloudflare Turnstile allowed domains
@@ -124,14 +141,21 @@ services:
       # 'qa' once and pointed at the live production tables.
       - key: NEXT_PUBLIC_APP_ENV
         value: dev
-      # Same dev Supabase project and the same deliberately-unset vars as
-      # staging. Set in the dashboard.
+      # Same dev Supabase project as staging. Set in the dashboard, including
+      # BREVO_API_KEY / BREVO_SENDER_EMAIL - Brevo is on every environment on
+      # purpose, see the staging block above and docs/INFRASTRUCTURE.md 4c.
       #
-      # CRON_SECRET was wrongly set here 2026-08-05 to 2026-08-08 while
+      # DIFFERENT FROM STAGING IN TWO WAYS:
+      #
+      # 1. TELEGRAM_* here are DEV's bot, not qa's own. qa does not have one.
+      # 2. CRON_SECRET must stay UNSET, precisely because of (1). Setting it
+      #    would let qa re-point dev's bot at itself and silently swallow every
+      #    alert. Staging may hold one only because it owns its bot.
+      #
+      # It was wrongly set here 2026-08-05 to 2026-08-08 while
       # docs/INFRASTRUCTURE.md 4c asserted it was unset and built a safety
-      # property on that. Removed. It matters more on qa than on dev because qa
-      # holds DEV's Telegram bot token - it does not own the bot it could
-      # re-point. Keep it unset until qa has its own bot.
+      # property on that claim. Removed 2026-08-08. Keep it unset until qa has
+      # its own bot. lib/envCheck.ts flags it at boot if it ever returns.
 
   # ── Dev integration - liquidity-hq-dev.onrender.com. MANUAL trigger. ────────
   # Carries a ~500 build-hour/month cap that prod does not, so deploying this


### PR DESCRIPTION
**Dev Team**

## Summary
Owner decided all four environments hold the Brevo keys. Recording it, because otherwise it reads like drift and someone removes it.

## Why Brevo is the exception
`lib/email.ts` returns `false` when the keys are missing rather than throwing. So an environment without them **cannot test email, and cannot tell that it is not testing email** — a misconfiguration looks identical to "nobody was due".

QA hit exactly this on the trial-reminder path: it could only be proven on a deployed environment, because local `.env.local` has no Brevo keys and the route reported success while sending nothing.

- **dev** needs it to verify its own work before promoting
- **staging** needs it because that is where QA signs off
- **qa** keeps it — removing it buys nothing once the other three have it

## The cost, stated not glossed
One Brevo account, one sending quota, one sender reputation, four environments. Test-run bounces count against the reputation prod depends on. **If prod email ever lands in spam, check what non-prod has been sending first.**

What limits it: 4 of the 6 senders go to the owner/admins. The 3 that reach users read the **dev** Supabase project on every non-prod host, so recipients are test accounts.

## Also corrected
`render.yaml`'s staging block still said staging had neither its own bot nor a `CRON_SECRET`. Both are now true and both are legitimate — staging owns the bot it could re-point, which is the condition qa fails. The qa block now spells out those two differences rather than saying "same as staging".

Plus the PostHog code gate (#93) and the Sentry DSN rule are now in the deliberately-unset table, where someone would actually look before setting one.

## How to test (QA)
Docs only. Read `INFRASTRUCTURE.md` §4c against the four Environment tabs:

| | prod | staging | qa | dev |
|---|---|---|---|---|
| Brevo | ✅ | ✅ | ✅ | ✅ |
| `CRON_SECRET` | ✅ | ✅ | ❌ | ✅ |
| PostHog key | ✅ | ❌ | ❌ | ❌ |

## Risk level
**Low.** Documentation and comments. `render.yaml` still parses and is not applied as a Blueprint.