### PR TITLE
docs: a written queue-depth limit, and one link for "where are we"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,12 @@ check.** Everything below exists to serve that. Where a rule would slow down
 solo work without helping QA, it is explicitly relaxed — see
 [Solo / low-ceremony work](#solo--low-ceremony-work).
 
+**This file is the rules. It is not the current state.** For what is live, what
+is waiting to ship, and what is blocked on whom, read
+[`qa/STATUS.md`](qa/STATUS.md) — one page, kept current by QA, dated at the top.
+Picking work back up after a break starts there; this file is where you come
+back for how to move it.
+
 ---
 
 ## 1. Branch naming
@@ -725,6 +731,36 @@ Two things follow from this, and both are the point rather than side effects:
   waits. Shipping a feature mid-week to production, outside the batch, is a
   decision someone makes deliberately — not something that happens because a PR
   merged.
+
+### 7b. The queue has a depth limit
+
+Batching to a weekly release and letting the queue grow without limit are not
+the same thing. **Target: fewer than ~5 PRs waiting on `qa` at any time.**
+
+Measure it rather than estimating it:
+
+```bash
+git fetch origin
+git rev-list --count origin/staging..origin/qa              # commits waiting
+git log origin/staging..origin/qa --format=%s \
+  | grep -c "^Merge pull request"                           # PRs waiting
+```
+
+A batch of fifteen PRs is not one release. It is fifteen changes whose
+interactions nobody has reasoned about, arriving at the gate together — and if a
+regression shows up there, the bisect surface is the whole batch rather than one
+change.
+
+This is not hypothetical. On **2026-08-08 the queue reached 37 commits / 15
+PRs**, finished and unshipped, and nothing surfaced it until someone asked where
+the project was. Depth is invisible unless something measures it, which is why
+the number lives in [`qa/STATUS.md`](qa/STATUS.md) and is updated rather than
+remembered.
+
+**Over the limit, promoting takes priority over merging more into `dev`.** That
+is the only lever — `dev` merging continuously is otherwise correct and stays
+that way. The thing to watch is not how fast work is finished; it is how long
+finished work waits.
 
 ### Before `dev` → `qa`
 

--- a/qa/README.md
+++ b/qa/README.md
@@ -7,10 +7,33 @@ Testing and quality-assurance workspace for LiquidityHQ.
 > does *not* cover. "187 tests passed" reads like "the product works", and it
 > does not.
 
+> **Lost track of where things are? Read [`STATUS.md`](STATUS.md).** One page:
+> what is live, what is waiting, what is blocked and on whom.
+
+## Where QA tests
+
+**Four branches, four services, one each.** Nothing auto-deploys — moving a
+branch does not move an environment.
+
+| Branch | Deployed at | Who promotes into it |
+|---|---|---|
+| `dev` | `liquidity-hq-dev.onrender.com` | Dev Team |
+| `qa` | `liquidity-hq-qa.onrender.com` | Dev Team |
+| `staging` | **`liquidity-hq-staging.onrender.com`** | **QA** — this is the freeze |
+| `main` | `liquidity-hq.com` | **QA** |
+
+**QA signs off on `staging`.** `qa` is dev's integration site; `staging` is the
+release candidate and stops moving once QA promotes into it. See
+`CONTRIBUTING.md` §6 and issue #78.
+
+Say **"verified on `staging`"** and name the branch. "Verified on qa" was
+ambiguous for most of 2026-08-07 and should not be written.
+
 ## What lives where
 
 | File | What it is | Status |
 |---|---|---|
+| [`STATUS.md`](STATUS.md) | **Where the project is** — live version, what is waiting, blockers and owners. Updated by QA; check the date before trusting it. | Living |
 | [`TEST_GAPS.md`](TEST_GAPS.md) | **What a green suite does not mean** — every known coverage gap, ranked by value per unit of effort, with what closing each would take. The answer to "what is still untested?" | Living list, updated as gaps close |
 | [`QA_TEST_PLAN.md`](QA_TEST_PLAN.md) | Manual test approach + rigor tiers, plus the RLS deny-all gotcha. Pre-existing — **moved here from `docs/` on 2026-08-04**, so `HANDOVER.md` §4's doc table still points at the old path. | Plan, largely unexecuted |
 | [`../pendings/QA_AUDIT_2026-08-04.md`](../pendings/QA_AUDIT_2026-08-04.md) | Full automated sweep, 2026-08-04 — build gates, 65-route API security, responsiveness at 1440/375, a11y, SEO, CWV, tech debt | Executed, findings unfixed |

--- a/qa/STATUS.md
+++ b/qa/STATUS.md
@@ -1,0 +1,134 @@
+# Where the project is
+
+**One page. If you only read one thing, read this.**
+
+Kept current by QA. Last updated **2026-08-08**.
+
+If a date at the top of this file is more than a day old, treat every number
+below as stale and check the branches yourself — a status doc nobody updates is
+worse than none, because it reads as current.
+
+---
+
+## Right now
+
+| | |
+|---|---|
+| **Live in production** | `v2026.08.07` |
+| **Waiting to ship** | **35 commits / 14 PRs** on `qa`, not yet promoted |
+| **Blocked by** | PR **#90** — needs Dev Team review |
+| **Blocking** | everything in the row above |
+
+**One-line version:** the product is fine, the queue is not. Work is being
+finished faster than it is being released.
+
+---
+
+## The pipeline, and where things get stuck
+
+```
+dev  ──►  qa  ──►  staging  ──►  main ──► users
+ │         │         │            │
+ dev       dev       QA           QA
+ merges    promotes  promotes     merges + deploys + tags
+                     (the freeze)
+```
+
+| Branch | Deployed at | Who moves it into here |
+|---|---|---|
+| `dev` | `liquidity-hq-dev.onrender.com` | Dev Team |
+| `qa` | `liquidity-hq-qa.onrender.com` | Dev Team |
+| `staging` | `liquidity-hq-staging.onrender.com` | **QA** |
+| `main` | `liquidity-hq.com` | **QA** |
+
+**Nothing auto-deploys.** Moving a branch does not move an environment; a human
+triggers every deploy. So "merged" is three manual steps away from "live", and
+each of those steps is somewhere work can sit unnoticed.
+
+`staging` exists so a release QA has signed off stops changing. Before it, every
+`dev` → `qa` promotion silently grew an open release — three times on 2026-08-06,
+once after a completed manual pass.
+
+---
+
+## The number that actually matters
+
+Not commits. **Cycle time: merged → live.**
+
+1,491 commits in 75 days is not the problem and never was. The current batch has
+sat finished for **2 days**, and nothing surfaced that until someone asked.
+
+| | |
+|---|---|
+| Releases before 2026-08-05 | **0 tagged** — code reached production with no record of what shipped |
+| Releases since | 7, all in 3 days |
+
+So the release process is **three days old**. It is being debugged in public, and
+that is what the last two days of work mostly were.
+
+**Target: keep the promotion queue under ~5 PRs.** A 14-PR batch is not one
+release, it is fourteen changes whose interactions nobody has reasoned about.
+
+---
+
+## Open blockers
+
+| Priority | What | Owner | Blocks |
+|---|---|---|---|
+| 🔴 1 | **PR #90** — contrast baselines track tokens, not counts | Dev Team review | the whole queue |
+| 🔴 2 | **#89** — promote `qa` → `staging`, open release PR | QA | 35 commits reaching users |
+| 🟡 3 | **#78** — staging environment variables | Owner decisions + QA writeup | testing Telegram/push/email/payments on staging |
+| 🟡 4 | **PR #84** — QA doc corrections, now partly stale | QA to rebase | nothing |
+| 🟢 5 | #72 · #73 · #82 · #52 | quota reset / Dev Team | nothing |
+
+---
+
+## Standing risks
+
+Not blockers. Things that are true and worth not forgetting.
+
+- **`staging` is the least-configured environment**, and it is the one QA now
+  signs off releases on — 10 variables against `qa`'s 23. Telegram, push, email,
+  payments and `/ops` all silently do nothing there, and "feature absent" looks
+  identical to "feature broken". This is #78.
+- **Error monitoring captures nothing.** GlitchTip returns 429 on every event;
+  the SDK honours it and drops events client-side. Installed, configured,
+  capturing zero. #73.
+- **The PII scrubber has never run on a real event** — 15/15 unit tests, zero
+  real events, because of the above. #72.
+- **`qa` and `dev` share one Supabase project.** A clean QA run is not proof the
+  data path is clean.
+- Everything in [`TEST_GAPS.md`](TEST_GAPS.md) — what a green suite does *not*
+  mean.
+
+---
+
+## Who does what
+
+| | Dev Team | QA |
+|---|---|---|
+| Writes app code | ✅ | ❌ never |
+| Writes tests + CI | reviews | ✅ owns `qa/` |
+| `dev` → `qa` | ✅ | |
+| `qa` → `staging` | | ✅ the freeze |
+| `staging` → `main` | | ✅ |
+| Deploys production | ❌ | ✅ |
+| Render dashboard, secrets | ❌ | ❌ — **owner only** |
+
+QA-authored code goes through a PR into `dev` that **Dev Team reviews and
+merges**. That is the one place review runs QA → dev, and it is why QA cannot
+unblock its own PRs.
+
+**One tension worth naming:** QA is the gate and also tracks throughput. Those
+pull opposite ways. The rule is that **QA judgement is never traded for
+schedule** — when the two disagree, it gets said out loud and the owner decides.
+It is not resolved quietly in favour of shipping.
+
+---
+
+## Keeping this honest
+
+- Update the date at the top on every change. A stale status doc is a liability.
+- Numbers here come from `git` and the GitHub API, not memory.
+- When a blocker clears, move it out the same day. A list that only grows stops
+  being read.

--- a/qa/STATUS.md
+++ b/qa/STATUS.md
@@ -15,7 +15,7 @@ worse than none, because it reads as current.
 | | |
 |---|---|
 | **Live in production** | `v2026.08.07` |
-| **Waiting to ship** | **35 commits / 14 PRs** on `qa`, not yet promoted |
+| **Waiting to ship** | **37 commits / 15 PRs** on `qa`, not yet promoted |
 | **Blocked by** | PR **#90** — needs Dev Team review |
 | **Blocking** | everything in the row above |
 
@@ -66,8 +66,10 @@ sat finished for **2 days**, and nothing surfaced that until someone asked.
 So the release process is **three days old**. It is being debugged in public, and
 that is what the last two days of work mostly were.
 
-**Target: keep the promotion queue under ~5 PRs.** A 14-PR batch is not one
-release, it is fourteen changes whose interactions nobody has reasoned about.
+**Target: keep the promotion queue under ~5 PRs.** A 15-PR batch is not one
+release, it is fifteen changes whose interactions nobody has reasoned about.
+This is now a written rule — `CONTRIBUTING.md` §7b, with the commands to
+measure it.
 
 ---
 

--- a/qa/TEST_GAPS.md
+++ b/qa/TEST_GAPS.md
@@ -1,6 +1,6 @@
 # What a green suite does not mean
 
-**Owner: QA. Last measured 2026-08-06.**
+**Owner: QA. Last measured 2026-08-08.** Status and blockers live in [`STATUS.md`](STATUS.md); this file is only about coverage.
 
 This file exists because "187 tests passed" reads like "the product works", and it
 does not. It is the standing list of what is **not** covered, why it matters, and
@@ -190,7 +190,7 @@ offline: whether cached routes serve, whether the offline page appears, whether
 queued actions replay on reconnect, or whether a stale service worker serves an
 old build after a deploy.
 
-That last one bites in production and is invisible in staging.
+That last one bites in production and is invisible on the qa and staging test environments.
 
 **To close:** `context.setOffline(true)` plus service-worker lifecycle
 assertions. Playwright supports both.
@@ -236,7 +236,7 @@ The real finding is worse than the gap that was imagined:
 POST https://app.glitchtip.com/api/25983/envelope/   ->  429 Too Many Requests
 ```
 
-Measured on staging across four page loads — **every request, no exceptions**.
+Measured on the qa test environment across four page loads — **every request, no exceptions**.
 The event quota is exhausted, so every error the app reports is rejected and
 dropped.
 


### PR DESCRIPTION
**QA Team**

## Summary

Two gaps, one cause. Nothing recorded where the project currently *is*, and
nothing said how large the release queue was allowed to get. So it grew to **37
commits / 15 PRs** finished-and-unshipped, and that only surfaced because
someone asked.

## What changed

**`CONTRIBUTING.md` — new §7b, "The queue has a depth limit"**

§7a already said features batch to a weekly release. It did not say how big a
batch may get, and those are different rules. §7b adds:

- a target of **fewer than ~5 PRs** waiting on `qa`
- the two `git` commands that measure the depth, so it is checked rather than
  guessed
- the rule that **over the limit, promoting takes priority over merging more
  into `dev`** — that is the only lever, and continuous merging into `dev` is
  otherwise correct

**`CONTRIBUTING.md` — intro** now says plainly that this file is the *rules* and
not the *state*, and points at `qa/STATUS.md` for the latter.

**`qa/STATUS.md`** — new. One page: what is live, what is waiting, what is
blocked and on whom, and the branch → host table. Numbers come from `git` and
the GitHub API, not memory, and the file is dated at the top so a stale copy
announces itself.

**`qa/README.md`** — links `STATUS.md`, adds the four branch → host rows.

**`qa/TEST_GAPS.md`** — two lines still called the `qa` *site* "staging", which
became ambiguous when `staging` turned into a branch. Now names the branch.

## Why

The measured number is the argument. A 15-PR batch is not one release — it is
fifteen changes whose interactions nobody has reasoned about, arriving at the
gate together. If a regression appears there, the bisect surface is the whole
batch instead of one change.

And the depth was invisible. Nothing computed it, nothing displayed it, so it
was only ever noticed by accident. A rule with no measurement attached is a
preference; §7b ships both.

## How to test (QA)

Docs only — no code paths touched, nothing to deploy.

1. From the repo root, run the two commands in `CONTRIBUTING.md` §7b. They
   should report **37** and **15** against `origin/staging..origin/qa` as of
   2026-08-08, matching the figures quoted in the section and in `STATUS.md`.
2. Click the `qa/STATUS.md` links in the CONTRIBUTING intro and in §7b — both
   resolve from the repo root.
3. `grep -rn "staging" qa/*.md` — every remaining hit should name the *branch*
   or `liquidity-hq-staging.onrender.com`, never the `qa` site.

## Risk level

**Low.** Documentation only.

One caveat worth stating: `STATUS.md` is only useful if it is updated, and
nothing enforces that. It carries a date and an instruction to distrust it when
the date is old, which is the honest version of the problem rather than a fix
for it.

## Screenshots

n/a — no UI change.
