### PR TITLE
docs: write down QA's second role, and the rule that keeps it honest

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -209,6 +209,48 @@ commit *is* a handoff or a request rather than just work.
 
 ---
 
+### 3b. QA also tracks the project, and that pulls against being the gate
+
+**QA holds two jobs: the quality gate, and knowing where the project is.** The
+second one lives in [`qa/STATUS.md`](qa/STATUS.md) — what is live, what is
+waiting to ship, what is blocked and on whom. QA owns that file and keeps it
+current; it carries a date at the top so a stale copy announces itself.
+
+It sits with QA rather than dev for a structural reason, not a preference. **QA
+is the only role that touches every hop from `qa` to production**, so it is the
+only one positioned to see the whole pipeline. Dev's view stops at `qa` by
+design (§4) — which means dev can do everything correctly and still have no
+vantage point from which the queue is visible. That is not hypothetical; it is
+what happened on 2026-08-08, and §7b is the rule that came out of it.
+
+**The two jobs pull opposite ways, and naming that is the point.** A gate says
+"not yet". A tracker says "this has been finished and unshipped for two days".
+One person holding both will, left unmanaged, settle that conflict in favour of
+shipping — because shipping is the half that produces visible progress and the
+other half only ever produces delay.
+
+So the rule is written down rather than left to judgement in the moment:
+
+> **QA judgement is never traded for schedule.** When the gate and the queue
+> disagree, it is said out loud on the release PR and the **owner** decides. It
+> is not settled quietly by the person holding both roles.
+
+Things that are **never** shortened because the queue is deep:
+
+- re-testing a failed step, plus anything the fix could have touched (§7)
+- the full browser suite on the `staging` → `main` PR (§4b)
+- writing down what could not be verified, under **Risk level**
+
+The correct response to a deep queue is in §7b and it is the opposite of testing
+less: **promote more often.** A batch too big to reason about is fixed by making
+batches smaller, never by reasoning about it less carefully.
+
+**What this does not change:** QA still writes no application code (§4), and
+still cannot merge its own PRs into `dev`. Tracking the project confers no
+authority over what goes into it.
+
+---
+
 ## 4. Two-workspace handoff (dev folder ↔ QA folder)
 
 Both folders are separate local clones of the same GitHub remote. **The PR is

--- a/qa/STATUS.md
+++ b/qa/STATUS.md
@@ -15,9 +15,9 @@ worse than none, because it reads as current.
 | | |
 |---|---|
 | **Live in production** | `v2026.08.07` |
-| **Waiting to ship** | **37 commits / 15 PRs** on `qa`, not yet promoted |
-| **Blocked by** | PR **#90** — needs Dev Team review |
-| **Blocking** | everything in the row above |
+| **Waiting to ship** | **42 commits / 17 PRs** on `qa`, not yet promoted |
+| **Blocked by** | nothing on Dev Team's side — #90 and #95 are merged |
+| **Next action** | **QA promotes `qa` → `staging`**, then deploys and tests it |
 
 **One-line version:** the product is fine, the queue is not. Work is being
 finished faster than it is being released.
@@ -77,11 +77,14 @@ measure it.
 
 | Priority | What | Owner | Blocks |
 |---|---|---|---|
-| 🔴 1 | **PR #90** — contrast baselines track tokens, not counts | Dev Team review | the whole queue |
-| 🔴 2 | **#89** — promote `qa` → `staging`, open release PR | QA | 35 commits reaching users |
-| 🟡 3 | **#78** — staging environment variables | Owner decisions + QA writeup | testing Telegram/push/email/payments on staging |
-| 🟡 4 | **PR #84** — QA doc corrections, now partly stale | QA to rebase | nothing |
-| 🟢 5 | #72 · #73 · #82 · #52 | quota reset / Dev Team | nothing |
+| 🔴 1 | **#89** — promote `qa` → `staging`, deploy, open the release PR | **QA** | 42 commits reaching users |
+| 🟡 2 | **#78** — LemonSqueezy test-mode keys for staging | **Owner** | checkout + webhook testing only |
+| 🟡 3 | **PR #84** — QA doc corrections, partly superseded by #87 | QA to rebase | nothing |
+| 🟢 4 | #72 · #73 · #82 · #52 | quota reset / Dev Team | nothing |
+
+Nothing is waiting on Dev Team. The environment audit that #78 opened is
+finished — all four services measured against the Render dashboard, `CRON_SECRET`
+off `qa`, staging on its own Telegram bot, Brevo on all four.
 
 ---
 
@@ -89,10 +92,15 @@ measure it.
 
 Not blockers. Things that are true and worth not forgetting.
 
-- **`staging` is the least-configured environment**, and it is the one QA now
-  signs off releases on — 10 variables against `qa`'s 23. Telegram, push, email,
-  payments and `/ops` all silently do nothing there, and "feature absent" looks
-  identical to "feature broken". This is #78.
+- **PostHog carried dev traffic into production's project**, roughly
+  2026-06-02 → 2026-08-08. Fixed in code (#93), but the fix does not undo the
+  data. Any retention, funnel or conversion figure quoted from that window
+  includes an unknown amount of dev traffic — heavier before 2026-08-03, when a
+  consent gate was added, thinner after.
+- **Brevo has no send cap of any kind**, and it is now shared by all four
+  environments. A careless QA run can spend production's quota and its sender
+  reputation, and neither is visible from the sending side. `trial-reminder` is
+  the one route that iterates users; keep it out of automated runs.
 - **Error monitoring captures nothing.** GlitchTip returns 429 on every event;
   the SDK honours it and drops events client-side. Installed, configured,
   capturing zero. #73.
@@ -122,9 +130,9 @@ merges**. That is the one place review runs QA → dev, and it is why QA cannot
 unblock its own PRs.
 
 **One tension worth naming:** QA is the gate and also tracks throughput. Those
-pull opposite ways. The rule is that **QA judgement is never traded for
-schedule** — when the two disagree, it gets said out loud and the owner decides.
-It is not resolved quietly in favour of shipping.
+pull opposite ways, and the rule for when they disagree — **QA judgement is
+never traded for schedule** — now lives in `CONTRIBUTING.md` **§3b** rather than
+here. It binds both sides, so a QA-owned file is the wrong home for it.
 
 ---
 


### PR DESCRIPTION
**QA Team** → **Dev Team**

## Summary

`CONTRIBUTING.md` §3a says which side you are when you write. Nothing said what
QA does beyond testing. This adds **§3b**, and moves one rule out of a QA-owned
file into the shared one.

## What changed

**`CONTRIBUTING.md` — new §3b, "QA also tracks the project, and that pulls
against being the gate"**

- QA holds two jobs: the quality gate, and knowing where the project is. The
  second lives in `qa/STATUS.md`.
- Why it sits with QA structurally rather than by preference: **QA is the only
  role that touches every hop from `qa` to production.** Dev's view stops at
  `qa` by design (§4), so dev can do everything correctly and still have no
  vantage point from which the queue is visible. That is what 2026-08-08 was.
- The rule for when the two jobs disagree, stated plainly:

  > **QA judgement is never traded for schedule.** When the gate and the queue
  > disagree, it is said out loud on the release PR and the **owner** decides.

- The three things never shortened because the queue is deep: re-testing a
  failed step, the full browser suite on the release PR, and writing down what
  could not be verified.
- And the limit on it: **tracking the project grants QA no authority over what
  goes into it.** Still no application code, still cannot merge its own PRs.

**`qa/STATUS.md`**

- Defers to §3b for that rule instead of keeping its own copy. It binds both
  sides, so a QA-owned file was the wrong home — left there it reads as QA's
  opinion about itself rather than something the owner can hold either side to.
- Numbers refreshed from `git` and the API: **42 commits / 17 PRs** waiting,
  #90 and #95 merged so **nothing is blocked on Dev Team**, next action is QA's
  own promotion.
- The "staging is the least-configured environment" bullet is gone — it stopped
  being true when your environment audit finished. Replaced with two risks that
  are true now: the **PostHog contamination window** (2026-06-02 → 2026-08-08,
  fixed in code by #93 but the data is still there), and **Brevo having no send
  cap** while shared four ways.

## Why

The tension is structural, not a personality trait: a gate says "not yet", a
tracker says "this has been finished and unshipped for two days", and one person
holding both will settle it in favour of shipping unless the rule is written
down — because shipping is the half that produces visible progress and the other
half only ever produces delay.

Writing it in the shared document is the point. A rule that exists only in
`qa/STATUS.md` is a note QA wrote to itself.

## How to test (QA)

Docs only — no code paths, nothing to deploy.

1. Read `CONTRIBUTING.md` §3b. The `qa/STATUS.md` link should resolve from the
   repo root.
2. Confirm `qa/STATUS.md` no longer states the gate-versus-schedule rule itself
   and points at §3b instead.
3. Run the two commands in §7b — they should report **42** and **17**, matching
   the figures in `STATUS.md`.

## Risk level

**Low.** Documentation only.

Worth flagging rather than burying: §3b describes a rule that binds **me**, and
I wrote it. It is in this PR for you and the owner to disagree with —
particularly the claim that the tracking job belongs with QA at all. If it
belongs with the owner instead, say so and I will rewrite it that way.

## Screenshots

n/a — no UI change.
