### PR TITLE
docs(api): correct the cron-route count to nine, and a stale trial-limits comment

### DIFF
--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -329,11 +329,25 @@ qa service are copies of dev's.** That is not the intended end state.
 Registering a webhook goes through `/api/telegram/setup-webhook`, which is gated
 by `checkCronAuth`. That guard is **all-or-nothing**: `lib/cronAuth.ts` returns
 false when `CRON_SECRET` is unset, so the variable's presence unlocks **all
-ten** cron-guarded routes at once, not just this one —
-`telegram/{setup-webhook,webhook,alert}`, `alert-outcomes/resolve`,
+nine** `CRON_SECRET`-guarded routes at once, not just this one —
+`telegram/{setup-webhook,alert}`, `alert-outcomes/resolve`,
 `econ-calendar/ingest`, `macro-alert`, `news/ingest`, `ops/spike-alert`,
-`signals/track`, `trial-reminder`. Counted from the source
-(`grep -rl checkCronAuth app/api`), not from memory.
+`signals/track`, `trial-reminder`. Count it with
+`grep -rln "checkCronAuth(" app/api --include=route.ts` — **with the paren.**
+
+**`api/telegram/webhook` is guarded, but not by this secret.** It checks
+`TELEGRAM_WEBHOOK_SECRET` against the `x-telegram-bot-api-secret-token` header
+Telegram echoes back. Different secret, different rotation story: rotating an
+environment's `CRON_SECRET` changes what nine routes accept, rotating its
+`TELEGRAM_WEBHOOK_SECRET` changes one and only after `setup-webhook` is called
+again. Worth keeping straight now that staging has its own of both.
+
+**This number was wrong twice before it was right.** Eleven (counted from a
+too-loose grep), then ten. The ten came from `grep -rl checkCronAuth` without the
+paren, which matched a **comment** in `telegram/webhook/route.ts` reading "same
+as checkCronAuth". A grep that matches prose looks exactly like a grep that
+matches code — which is also how `api/version/route.ts` gets miscounted, since
+its comment mentions gating it behind `checkCronAuth` if it ever grows.
 
 `api/telegram/bot-info` is **not** in that set and should not be added to it. It
 is public and rate-limited, and deliberately **read-only** — it reports a webhook

--- a/lib/entitlements.ts
+++ b/lib/entitlements.ts
@@ -29,9 +29,21 @@ export interface Entitlement {
   trialActive: boolean; // inside the 14-day signup trial window
   // Whether Pro FEATURES are unlocked (paid Pro OR active trial). This is the
   // gate for feature access - fast timeframes, backtest, on-chain/macro, etc.
-  // The daily AI usage caps are deliberately NOT included: they key on `role`
-  // (via getUserRole), so a trial user keeps Free-tier AI limits - Pro tools,
-  // Free AI spend. See lib/tables.ts / the add_signup_trial migration.
+  //
+  // The daily AI usage caps are deliberately NOT keyed off this. They key off
+  // `usageTierOf()` below, which has THREE values - a trial user is billed
+  // against the `trial` row in AI_LIMITS, not the `free` one.
+  //
+  // This comment said "a trial user keeps Free-tier AI limits" until 2026-08-08.
+  // That was the behaviour before the trial row existed and it survived the fix
+  // that removed it, four lines above the function that disproves it. QA read it
+  // and was about to assert `limits === FREE_LIMITS` for a trial user - an
+  // assertion that passes only if the old bug comes back, so the test would have
+  // defended the regression instead of catching it.
+  //
+  // The rows differ where it counts: `free` has toolPool null and every extra
+  // tool at 0; `trial` has toolPool 8 and every extra tool at 8. Same headline
+  // quick/deep/chat numbers, which is what makes the two easy to confuse.
   proFeatures: boolean;
 }
 


### PR DESCRIPTION
**Dev Team**

Closes the last open item on #78. Both errors were caught by QA reading rather than accepting.

## Two corrections

**Nine `CRON_SECRET` routes, not ten.** The number was wrong twice — eleven from a loose grep, then ten from `grep -rl checkCronAuth` **without the paren**, which matched a *comment* in `telegram/webhook/route.ts` reading "same as checkCronAuth".

`telegram/webhook` is guarded, but by `TELEGRAM_WEBHOOK_SECRET` against the header Telegram echoes. Not pedantry now that staging has its own of both: rotating `CRON_SECRET` changes what **nine** routes accept; rotating `TELEGRAM_WEBHOOK_SECRET` changes **one**, and only after `setup-webhook` runs again.

**A stale comment in `lib/entitlements.ts`** claimed a trial user keeps Free-tier AI limits. True before the trial row existed; it survived the fix that removed it, sitting four lines above `usageTierOf()` which returns `'trial'` as its own value.

| | free | trial |
|---|---|---|
| `toolPool` | `null` | **8** |
| every extra tool | 0 | **8** |
| quick/deep/chat | 5/3/5 | 5/3/5 |

Identical headline numbers is what makes them easy to confuse.

## Why the comment one matters more than it looks
I read it and told QA the pre-fix behaviour **as fact**. They were about to write `expect(limits).toEqual(FREE_LIMITS)` for a trial user — an assertion that passes only if the old bug comes back. The test would have **defended the regression instead of catching it**.

A stale comment that outlives its bug is worse than no comment: it is confidently wrong in the one place someone checks before writing a test.

## How to test (QA)
Docs and comments only, no behaviour change. Verify the count with the command now in the doc — the paren is load-bearing:
```
grep -rln "checkCronAuth(" app/api --include=route.ts   # 9
```

## Risk level
**Low.** No code paths touched. 119 tests, tsc clean, lint 0 errors.