### PR TITLE
fix(api): stop session tracking spending the entire GlitchTip quota

### DIFF
--- a/__tests__/monitoringScrub.test.mts
+++ b/__tests__/monitoringScrub.test.mts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { scrubUrl, scrubText, scrubEvent, monitoringEnvironment, monitoringDsn } from '../lib/monitoring.ts';
+import { scrubUrl, scrubText, scrubEvent, monitoringEnvironment, monitoringDsn, monitoringOptions } from '../lib/monitoring.ts';
 
 /* The PII scrubber runs on every event leaving the app for GlitchTip. It is the
    last thing between a user's id or email and a third-party dashboard, and it
@@ -243,4 +243,49 @@ test('reporting is restricted to production', async (t) => {
   });
 
   set(savedDsn, savedApp);
+});
+
+/* The quota settings, guarded because both are one line and neither has a
+   visible symptom when removed.
+
+   `autoSessionTracking: false` was added 2026-08-08 after a production probe
+   found 14 envelopes across 6 pageviews and ZERO of them an error - every item
+   was type=session. Release Health was spending the entire free-tier month, so
+   every real error came back 429. Deleting that line does not break a test, does
+   not warn, and does not fail a build; it just silently stops error reporting
+   again a few hundred pageviews later.
+
+   `tracesSampleRate: 0` is the same shape of decision and was already load
+   bearing, so it is asserted here too rather than left to the file comment. */
+test('monitoring quota settings', async (t) => {
+  const savedDsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+  const savedApp = process.env.NEXT_PUBLIC_APP_ENV;
+  process.env.NEXT_PUBLIC_SENTRY_DSN = 'https://key@glitchtip.example/1';
+  process.env.NEXT_PUBLIC_APP_ENV = 'prod';
+
+  await t.test('session tracking is OFF - it consumed the whole free-tier quota', () => {
+    assert.equal(monitoringOptions().autoSessionTracking, false);
+  });
+
+  await t.test('transaction sampling stays at 0', () => {
+    assert.equal(monitoringOptions().tracesSampleRate, 0);
+  });
+
+  await t.test('PII is not sent by default', () => {
+    assert.equal(monitoringOptions().sendDefaultPii, false);
+  });
+
+  /* Both scrub hooks must stay wired. beforeSend is what makes PII scrubbing
+     verifiable client-side at all (issue #72) - it runs before transmission, so
+     a 429 rejects delivery without affecting whether scrubbing happened. */
+  await t.test('both scrub hooks are wired', () => {
+    const o = monitoringOptions();
+    assert.equal(typeof o.beforeSend, 'function');
+    assert.equal(typeof o.beforeSendTransaction, 'function');
+  });
+
+  if (savedDsn === undefined) delete process.env.NEXT_PUBLIC_SENTRY_DSN;
+  else process.env.NEXT_PUBLIC_SENTRY_DSN = savedDsn;
+  if (savedApp === undefined) delete process.env.NEXT_PUBLIC_APP_ENV;
+  else process.env.NEXT_PUBLIC_APP_ENV = savedApp;
 });

--- a/lib/monitoring.ts
+++ b/lib/monitoring.ts
@@ -294,6 +294,28 @@ export function monitoringOptions() {
     release: monitoringRelease(),
     // See the file header - this is a quota decision, not an oversight.
     tracesSampleRate: 0,
+    /* THE SAME QUOTA DECISION, and the one that was actually spending it.
+       `tracesSampleRate: 0` stopped transactions. Sessions were never in scope,
+       and `autoSessionTracking` defaults to TRUE - so Release Health quietly
+       became the entire consumption.
+
+       Measured on production 2026-08-08, six routes, signed out, no interaction:
+       14 envelopes across 6 pageviews and ZERO of them an error. Every single
+       item was `type=session`. At ~2.3 envelopes per pageview a 1,000-event
+       month is gone in roughly 430 pageviews - ordinary browsing, not a bug
+       firing in a loop.
+
+       That is why hunting for a noisy error never found the source (issue #73):
+       there was no noisy error. It also means error reporting was not merely
+       degraded, it was DEAD - every error envelope came back 429 because
+       sessions had already spent the month.
+
+       What is given up: crash-free-session rate. Worth being explicit that it
+       is not a real loss today - the metric was being rejected at the door
+       along with everything else, so nobody could read it either. If the tier
+       is ever paid for, turn this back on deliberately rather than by removing
+       a line. */
+    autoSessionTracking: false,
     sendDefaultPii: false,
     /* Passed by reference rather than wrapped in an arrow. `scrubEvent` is
        generic in its argument, so it satisfies both hook signatures without


### PR DESCRIPTION
**Dev Team**

Closes #73. Unblocks #72.

## Summary
Error reporting in production was not degraded — it was **dead**. The cause was not an error.

## What QA measured
Six routes on production, signed out, no interaction:

| | |
|---|---|
| Envelopes across 6 pageviews | **14** |
| Of those that were errors | **0** |
| Every item's type | `session` |

`tracesSampleRate: 0` stopped transactions. Sessions were never in scope, and **`autoSessionTracking` defaults to `true`** — so Release Health became the entire consumption. ~2.3 envelopes/pageview burns a 1,000-event month in **~430 pageviews**. Ordinary browsing, not a bug in a loop.

That is why #73 was never solved by hunting for a noisy error: **there was no noisy error.** Every real error came back 429 because sessions had already spent the month.

## What we give up
Crash-free-session rate — and it is not a real loss today. The metric was being rejected at the door along with everything else, so nobody could read it either. If the tier is ever paid for, turn it back on deliberately rather than by deleting a line.

## Tests, because this is exactly the shape that regresses silently
`monitoringOptions()` had **no coverage at all**. Deleting `autoSessionTracking` breaks no build, emits no warning, and silently stops error reporting again a few hundred pageviews later.

Now asserted: `autoSessionTracking`, `tracesSampleRate`, `sendDefaultPii`, and both scrub hooks — `beforeSend` especially, since it is what makes PII scrubbing verifiable client-side (#72).

## How to test (QA)
After this reaches **production**, trigger a deliberate error and read the envelope response. It should **not** be 429 — which has not been true for weeks.

Before then, on staging: the envelope count per pageview should drop to roughly zero when nothing errors, where it was ~2.3.

## Risk level
**Low.** One SDK option plus tests. No app behaviour changes. 124 tests pass (5 new), tsc clean, lint 0 errors.

Note this does **not** ship in #98 — it lands after, so the first production check is the release following it.