### PR TITLE
fix(api): actually stop session envelopes - the previous fix was a no-op

### DIFF
--- a/__tests__/monitoringScrub.test.mts
+++ b/__tests__/monitoringScrub.test.mts
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { getDefaultIntegrations } from '@sentry/browser';
 import { scrubUrl, scrubText, scrubEvent, monitoringEnvironment, monitoringDsn, monitoringOptions } from '../lib/monitoring.ts';
 
 /* The PII scrubber runs on every event leaving the app for GlitchTip. It is the
@@ -263,8 +264,33 @@ test('monitoring quota settings', async (t) => {
   process.env.NEXT_PUBLIC_SENTRY_DSN = 'https://key@glitchtip.example/1';
   process.env.NEXT_PUBLIC_APP_ENV = 'prod';
 
-  await t.test('session tracking is OFF - it consumed the whole free-tier quota', () => {
-    assert.equal(monitoringOptions().autoSessionTracking, false);
+  /* Asserted against the SDK's OWN default integration list, not against our
+     options object. The previous version of this test read
+     `monitoringOptions().autoSessionTracking === false` - which passed because
+     we had just set that property, and proved nothing: `autoSessionTracking`
+     was removed in SDK v10 and setting it does nothing at all. The fix shipped
+     green and changed no behaviour.
+
+     The positive control below is the part that matters. If Sentry renames
+     BrowserSession, the filter silently stops matching and sessions come back -
+     and a test that only checked "not present in the output" would still pass,
+     because the name it is looking for would be absent for the wrong reason. */
+  await t.test('BrowserSession is in the SDK defaults - the control this test needs', () => {
+    const names = getDefaultIntegrations({}).map(i => i.name);
+    assert.ok(
+      names.includes('BrowserSession'),
+      `BrowserSession is no longer a default integration (got: ${names.join(', ')}). ` +
+      'Either the SDK renamed it - in which case the filter in monitoringOptions() ' +
+      'is now a no-op and sessions are being sent again - or it stopped being a ' +
+      'default. Check before changing this assertion.',
+    );
+  });
+
+  await t.test('the integrations filter removes BrowserSession', () => {
+    const filter = monitoringOptions().integrations as (d: { name: string }[]) => { name: string }[];
+    const kept = filter(getDefaultIntegrations({})).map(i => i.name);
+    assert.ok(!kept.includes('BrowserSession'), 'session tracking would still be on');
+    assert.ok(kept.includes('InboundFilters'), 'the filter removed more than it should have');
   });
 
   await t.test('transaction sampling stays at 0', () => {

--- a/lib/monitoring.ts
+++ b/lib/monitoring.ts
@@ -296,8 +296,7 @@ export function monitoringOptions() {
     tracesSampleRate: 0,
     /* THE SAME QUOTA DECISION, and the one that was actually spending it.
        `tracesSampleRate: 0` stopped transactions. Sessions were never in scope,
-       and `autoSessionTracking` defaults to TRUE - so Release Health quietly
-       became the entire consumption.
+       so Release Health quietly became the entire consumption.
 
        Measured on production 2026-08-08, six routes, signed out, no interaction:
        14 envelopes across 6 pageviews and ZERO of them an error. Every single
@@ -306,16 +305,27 @@ export function monitoringOptions() {
        firing in a loop.
 
        That is why hunting for a noisy error never found the source (issue #73):
-       there was no noisy error. It also means error reporting was not merely
-       degraded, it was DEAD - every error envelope came back 429 because
-       sessions had already spent the month.
+       there was no noisy error. Error reporting was not merely degraded, it was
+       DEAD - every error envelope came back 429 because sessions had already
+       spent the month.
 
-       What is given up: crash-free-session rate. Worth being explicit that it
-       is not a real loss today - the metric was being rejected at the door
-       along with everything else, so nobody could read it either. If the tier
-       is ever paid for, turn this back on deliberately rather than by removing
-       a line. */
-    autoSessionTracking: false,
+       WHY AN INTEGRATION FILTER AND NOT `autoSessionTracking: false`. That
+       option was removed in SDK v10; this project is on 10.67.0. Setting it does
+       NOTHING - and nothing complains, because these options are passed to
+       Sentry.init() as a plain object literal, so TypeScript's excess-property
+       check never runs on them. The first attempt at this fix set that option,
+       shipped green, and changed no behaviour whatsoever. Sessions come from the
+       `BrowserSession` integration, which IS in getDefaultIntegrations().
+
+       Harmless on server and edge, where BrowserSession is not in the defaults
+       and the filter simply matches nothing.
+
+       What is given up: crash-free-session rate. Not a real loss today - the
+       metric was being rejected at the door with everything else, so nobody
+       could read it either. If the tier is ever paid for, drop this filter
+       deliberately rather than by accident. */
+    integrations: (defaults: { name: string }[]) =>
+      defaults.filter(i => i.name !== 'BrowserSession'),
     sendDefaultPii: false,
     /* Passed by reference rather than wrapped in an arrow. `scrubEvent` is
        generic in its argument, so it satisfies both hook signatures without


### PR DESCRIPTION
**Dev Team** → **QA Team**

You were right. #100 changed nothing. Fix-forward per the owner's call — this does **not** go near #98.

## Why #100 did nothing
`autoSessionTracking` was **removed in SDK v10**. This project is on **10.67.0**.

And nothing complained, for a reason worth keeping: these options are returned as a plain object literal and passed to `Sentry.init()`, so **TypeScript's excess-property check never runs on them**. It shipped green, merged, deployed, and changed no behaviour.

## The actual fix
```ts
integrations: (defaults) => defaults.filter(i => i.name !== 'BrowserSession'),
```
Confirmed `BrowserSession` is in `getDefaultIntegrations()` on this version. Harmless on server/edge where it is not a default.

**One meaningful difference from last time:** `integrations` is a *declared* property in the options type, not an excess one — so its type genuinely is checked at the call site. The previous property was invisible to tsc by construction.

## The old test was worthless and I wrote it
It asserted `monitoringOptions().autoSessionTracking === false` — that our own object literal carried a property we had just set. **It could never fail.** It passed while the behaviour was unchanged.

Same vacuous shape this project has been catching all week, written by the person who kept flagging it.

## The new test, built to your spec
Asserts against the **SDK's own** default integration list, with a **positive control**:

1. `BrowserSession` **is** in the defaults — fails loudly if Sentry renames it
2. the filter removes it
3. the filter does not remove anything else

Without (1), a rename makes the filter silently stop matching while "not present in output" still passes — absent for the wrong reason.

**Verified by mutation, not by going green:** replacing the filter with an identity function makes the test **fail** (`session tracking would still be on`); restoring it passes.

## How to test (QA)
The unit test is not the pass condition. After this deploys, re-run your probe — six routes, `page.on('request')` counter, read each envelope body's `type`.

- **Reproduce first:** 14 envelopes / 6 pageviews, 0 errors, 100% `type=session`
- **Pass:** zero `type=session` envelopes measured

## Risk level
**Low-Medium.** Touches SDK init, so a mistake affects error reporting rather than the app. Mitigated by the mutation check and the positive control. 125 tests, tsc clean, lint 0 errors.

Noted #103 (session-replay masking is five hardcoded class names, no test) — not touching it in this PR.