### PR TITLE
test(qa): hold the Pro boundary closed on all 15 gated routes

### DIFF
--- a/qa/e2e/entitlements.spec.ts
+++ b/qa/e2e/entitlements.spec.ts
@@ -1,0 +1,152 @@
+import { test, expect } from '@playwright/test';
+import { AUTH_READY, AUTH_SKIP_REASON, FIXTURES, SUPABASE_URL, SUPABASE_ANON, signIn } from './_auth';
+
+/* The Pro boundary — 15 routes, HTTP level.
+ *
+ * WHY THIS EXISTS. `lib/limits.ts` records that until 2026-08-07 only 6 of the
+ * 11 ExtraTool routes actually called `hasProFeatures()`, so a free account
+ * could run the other 5. Every one of them is sold on /upgrade. That was found
+ * by a person reading a file, closed in code, and nothing has held it closed
+ * since — there is no test anywhere that a free account is refused.
+ *
+ * This is the revenue boundary. It is also the cheapest thing on
+ * `qa/TEST_GAPS.md` to test: pure HTTP, no market data, no UI, no LemonSqueezy,
+ * so it is immune to §1 and can gate a release.
+ *
+ * WHY IT DERIVES THE EXPECTATION INSTEAD OF ASSUMING IT. A new account gets a
+ * 14-day trial, and `getEntitlement()` grants Pro FEATURES for its duration
+ * (`proFeatures = role === 'pro' || trialActive`). So a seeded fixture inside
+ * its trial window legitimately passes every gate below. Hardcoding "expect
+ * 403" would make this spec fail for a correct product, and hardcoding "expect
+ * 200" would make it pass for a broken one.
+ *
+ * So it reads the account's own subscription row first (RLS-scoped — a token
+ * can only see its own) and asserts whichever direction that row implies. The
+ * test knows which case it is in and says so.
+ */
+
+const P = process.env.NEXT_PUBLIC_APP_ENV === 'dev' ? 'lhq_dev_' : 'lhq_';
+
+/** The gated surface. Method matters: a GET against a POST-only handler returns
+ *  405 and would look like a failure that has nothing to do with entitlement.
+ *
+ *  `price-alerts` appears twice on purpose — its GET is deliberately NOT gated
+ *  (a free user may read alerts, not create them), so only POST and PATCH are
+ *  listed. Asserting 403 on the GET would be asserting a bug. */
+const GATED: Array<{ method: 'GET' | 'POST' | 'PATCH'; path: string }> = [
+  { method: 'POST',  path: '/api/alerts/preview' },
+  { method: 'POST',  path: '/api/behavioral-bias' },
+  { method: 'GET',   path: '/api/dry-powder' },
+  { method: 'GET',   path: '/api/macro-context' },
+  { method: 'GET',   path: '/api/onchain' },
+  { method: 'POST',  path: '/api/pine-script' },
+  { method: 'POST',  path: '/api/price-alerts' },
+  { method: 'PATCH', path: '/api/price-alerts' },
+  { method: 'POST',  path: '/api/push/test' },
+  { method: 'POST',  path: '/api/shadow-account' },
+  { method: 'POST',  path: '/api/smc-snapshot' },
+  { method: 'POST',  path: '/api/strategy-research' },
+  { method: 'GET',   path: '/api/telegram/test' },
+  { method: 'POST',  path: '/api/thesis-check' },
+  { method: 'POST',  path: '/api/token-unlock' },
+];
+
+test.describe('Pro entitlement boundary', () => {
+  test.skip(!AUTH_READY, AUTH_SKIP_REASON);
+  // HTTP level — running both viewport projects would just double the requests.
+  test.beforeEach(({}, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop', 'HTTP-level, viewport irrelevant');
+  });
+
+  let token = '';
+  let expectPro = false;
+  let why = '';
+
+  test.beforeAll(async () => {
+    token = await signIn(FIXTURES.aEmail, FIXTURES.aPassword);
+
+    // The account's own row. RLS restricts this to the caller's user_id, which
+    // is the same read `getEntitlement()` performs server-side.
+    const res = await fetch(
+      `${SUPABASE_URL}/rest/v1/${P}user_subscriptions?user_id=eq.${FIXTURES.aId}&select=role,trial_ends_at`,
+      { headers: { apikey: SUPABASE_ANON, Authorization: `Bearer ${token}` } },
+    );
+    if (!res.ok) {
+      throw new Error(
+        `could not read ${P}user_subscriptions for the fixture (HTTP ${res.status}). ` +
+        'Refusing to continue: without the row this spec cannot know which direction ' +
+        'to assert, and would be guessing.',
+      );
+    }
+    const rows = (await res.json()) as Array<{ role?: string; trial_ends_at?: string }>;
+    const row = rows[0];
+    const role = row?.role === 'pro' ? 'pro' : 'free';
+    const trialEnds = row?.trial_ends_at ? new Date(row.trial_ends_at).getTime() : 0;
+    const trialActive = role !== 'pro' && trialEnds > Date.now();
+
+    expectPro = role === 'pro' || trialActive;
+    why = `role=${role} trialActive=${trialActive} (trial_ends_at=${row?.trial_ends_at ?? 'null'})`;
+    console.log(`[entitlements] fixture A: ${why} -> expect Pro access: ${expectPro}`);
+  });
+
+  /* Guard against a vacuous pass. If the token were rejected, every route below
+   * would return 401 and a naive "not 200" assertion would read as a clean run.
+   * The ungated GET proves the token authenticates before anything else is
+   * concluded from a status code. */
+  test('the fixture token actually authenticates (guards against a vacuous pass)', async ({ request }) => {
+    const r = await request.get('/api/price-alerts', {
+      headers: { Authorization: `Bearer ${token}` },
+      failOnStatusCode: false,
+    });
+    expect(r.status(), 'GET /api/price-alerts is not Pro-gated, so a valid token must be accepted').toBe(200);
+  });
+
+  for (const { method, path } of GATED) {
+    test(`${method} ${path} respects the Pro boundary`, async ({ request }) => {
+      const opts = {
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        data: {},
+        failOnStatusCode: false,
+      };
+      const r = method === 'GET'    ? await request.get(path, opts)
+              : method === 'PATCH'  ? await request.patch(path, opts)
+              :                       await request.post(path, opts);
+
+      const status = r.status();
+      const body = await r.text();
+
+      /* 405 or 404 means this entry names the wrong method or path, not that the
+       * product is wrong. Fail loudly rather than let it read as "refused". */
+      expect(status, `${method} ${path} returned ${status} — this spec has the wrong method/path, not a finding`)
+        .not.toBe(405);
+      expect(status, `${method} ${path} returned 404 — route moved or renamed`).not.toBe(404);
+      expect(status, `${method} ${path} returned 401 — the token stopped working mid-run`).not.toBe(401);
+
+      if (expectPro) {
+        // Trial or paid: the gate must NOT refuse. Anything else about the
+        // response (400 for an empty body, 500 from an upstream) is not this
+        // test's business — only that it was not refused for entitlement.
+        expect(status, `${path} refused a Pro-entitled account (${why})`).not.toBe(403);
+      } else {
+        expect(status, `${path} did NOT refuse a free account (${why}) — Pro feature reachable without Pro`).toBe(403);
+        expect(body, `${path} returned 403 without PRO_REQUIRED — refused for some other reason`).toContain('PRO_REQUIRED');
+      }
+    });
+  }
+
+  /* An unauthenticated caller must be turned away as unauthenticated. A 403 with
+   * no token would mean the route evaluated entitlement for nobody, which is a
+   * different and worse bug than a missing gate. */
+  test('no token is 401, never 403', async ({ request }) => {
+    const failures: string[] = [];
+    for (const { method, path } of GATED) {
+      const opts = { headers: { 'Content-Type': 'application/json' }, data: {}, failOnStatusCode: false };
+      const r = method === 'GET'   ? await request.get(path, opts)
+              : method === 'PATCH' ? await request.patch(path, opts)
+              :                      await request.post(path, opts);
+      if (r.status() === 403) failures.push(`${method} ${path} -> 403 with no token`);
+      if (r.status() === 200) failures.push(`${method} ${path} -> 200 with no token`);
+    }
+    expect(failures, failures.join('\n')).toEqual([]);
+  });
+});


### PR DESCRIPTION
**QA Team** → **Dev Team**

## Summary

`qa/e2e/entitlements.spec.ts` — all **15 Pro-gated routes**, HTTP level, plus an
unauthenticated pass. The revenue boundary has never had a test.

## Why

From your own note in `lib/limits.ts`:

> Until 2026-08-07 only 6 of the 11 enforced it, so a free account really could
> run the other 5 — that gap is closed.

Closed in code, found by a person reading a file, and **nothing has held it
closed since**. Every one of those five is sold on `/upgrade`.

This is also the cheapest thing on `TEST_GAPS.md` to cover: pure HTTP, no market
data, no UI, no LemonSqueezy — so it is immune to §1 and can gate a release.

## What changed

One new spec. No changes to shared files, config or existing tests.

**It derives its expectation rather than assuming one.** A new account gets a
14-day trial and `getEntitlement()` grants Pro *features* for its duration, so a
seeded fixture inside its trial window legitimately passes every gate. Hardcoding
`expect 403` would fail against a correct product; hardcoding `expect 200` would
pass against a broken one. The spec reads the account's own subscription row
(RLS-scoped, same read the server does) and asserts whichever direction that row
implies, logging which case it is in.

Three things I got wrong first and checked before writing:

- **`price-alerts` GET is deliberately ungated** — a free user may read alerts,
  not create them. Only POST and PATCH are listed. Asserting 403 on the GET
  would have been asserting a bug into place.
- **The Pro check runs before body parsing** (`thesis-check:67` vs `:82`), so an
  empty POST body still reaches the gate and returns 403 rather than 400.
- **Method matters.** A GET against a POST-only handler returns 405, which would
  read as "refused" to a naive assertion. 404/405/401 are explicitly failed with
  a message saying *this spec* is wrong, not the product.

It also carries the vacuous-pass guard the other auth specs use: an ungated
authenticated GET must return 200 first, because if the token were rejected every
route below would return 401 and a "not 200" assertion would read as a clean run.

## How to test (QA)

CI runs it on a PR into `main`, where the E2E job already supplies the
`E2E_USER_A_*` secrets.

1. `npx playwright test qa/e2e/entitlements.spec.ts --list` — **34 tests**.
2. With `E2E_USER_A_*` set, run it; the output logs
   `[entitlements] fixture A: role=… trialActive=… -> expect Pro access: …` so
   which direction it asserted is visible rather than inferred.
3. Without those vars it **skips**, and says why.

## Risk level

**Medium**, and the reason is about this PR rather than the product.

**The spec has never been executed.** The auth fixtures are not set in my
environment, so it skips locally — it typechecks, lints, and lists 34 tests, and
that is the whole of what I have verified. It runs for the first time in CI on
the next PR into `main`.

Stating it plainly because a spec that skips everywhere is green everywhere, and
that is the exact failure this file exists to catch elsewhere. **If its first CI
run skips rather than runs, treat that as a failure of this PR, not a pass.**

Two outcomes I cannot predict:

- If fixture A is **inside its trial window**, the spec asserts the not-403
  direction and proves less than the free-account case does. Still correct, but
  the stronger assertion needs a free fixture — which is the seeded-account
  question from #78. Your permanent-account suggestion covers it.
- If any route returns **400 before 403**, the gate sits behind body validation.
  Still a gate, but worth knowing, and this spec will surface it as a failure
  with the status in the message.

## Screenshots

n/a — no UI change.
