### PR TITLE
fix(dashboard): three hardcoded colours that failed SC 1.4.3, at the call site

### DIFF
--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -1703,7 +1703,7 @@ function ArenaContent() {
       {readError && <div className="arena-err">{readError}</div>}
 
       {result && !dismissedResults.has(selectedCoin) && nowMs - result.analyzedAt < CACHE_MAX_AGE_MS && (() => {
-        const sigCol = result.signal === 'LONG' ? 'var(--green-2)' : result.signal === 'LEAN LONG' ? 'var(--green-soft)' : result.signal === 'SHORT' ? 'var(--red)' : result.signal === 'LEAN SHORT' ? 'var(--red-soft)' : '#9ca3af';
+        const sigCol = result.signal === 'LONG' ? 'var(--green-2)' : result.signal === 'LEAN LONG' ? 'var(--green-soft)' : result.signal === 'SHORT' ? 'var(--red)' : result.signal === 'LEAN SHORT' ? 'var(--red-soft)' : 'var(--txt3)';
         const verdictWord = result.signal === 'LONG' ? t('ARENA_VERDICT_LONG') : result.signal === 'LEAN LONG' ? t('ARENA_VERDICT_LEAN_LONG') : result.signal === 'SHORT' ? t('ARENA_VERDICT_SHORT') : result.signal === 'LEAN SHORT' ? t('ARENA_VERDICT_LEAN_SHORT') : t('ARENA_VERDICT_WAIT');
         const sigGrad = result.signal.includes('LONG') ? 'linear-gradient(160deg,#5ff0b0,#34d399)'
           : result.signal.includes('SHORT') ? 'linear-gradient(160deg,#ff9d9d,#f87171)'

--- a/app/globals.css
+++ b/app/globals.css
@@ -1072,6 +1072,23 @@ body.ticker-on .breaking-alert { top: calc(84px + var(--banner-h)); }
 }
 .sc-next-label { font-size: var(--fs-micro); color: var(--txt3); font-weight: 600; letter-spacing: .05em; text-transform: uppercase; }
 .sc-next-name  { font-size: var(--fs-caption); font-weight: 700; }
+
+/* Session-window colours (lib/session.ts) are dark-theme-tuned PAIRS - a
+   foreground plus its own dark chip background. `.sc-badge` applies both, so it
+   passes in either theme. These two apply only the foreground, inline, so the
+   colour lands on the page background - and in light theme that fails hard:
+   God Tier's #f0c070 is 1.68:1 on white, Asia's #fbbf24 is no better.
+
+   Fixed HERE rather than in session.ts on purpose. The comment above
+   getCurrentWindow() records that swapping those pairs for tokens was tried
+   during the issue #53 sweep and dropped .session-pill to 2.30:1, because the
+   light-theme token is dark and the paired background stays dark. Measured
+   again 2026-08-08 before touching it: var(--amber) on #3d2e00 would be 1.90:1.
+   The pair is correct; the two consumers that used half of it were not.
+
+   !important because the colour arrives as an inline style. */
+[data-theme="light"] .sc-timer,
+[data-theme="light"] .sc-next-name { color: var(--txt) !important; }
 .sc-next-sep   { font-size: var(--fs-caption); color: var(--txt3); }
 .sc-next-timer { font-size: var(--fs-data); font-weight: 700; color: var(--txt2); font-variant-numeric: tabular-nums; }
 

--- a/components/SessionCountdown.tsx
+++ b/components/SessionCountdown.tsx
@@ -77,7 +77,12 @@ export default function SessionCountdown() {
   }, [nowMs]);
 
   /* colours */
-  const statusCol = current?.color ?? (dead ? 'var(--red)' : '#48484a');
+  /* --txt3, not a literal. This fallback renders on `transparent` (below), so it
+     sits on the page background rather than on a paired chip colour - #48484a
+     was 2.23:1 there. globals.css had already replaced this exact literal in the
+     landing-page scope and left the component copy behind, which is why a
+     stylesheet sweep never caught it. */
+  const statusCol = current?.color ?? (dead ? 'var(--red)' : 'var(--txt3)');
   const statusBg  = current?.bg    ?? (dead ? 'rgba(248,113,113,0.08)' : 'transparent');
 
   return (

--- a/lib/marketStore.ts
+++ b/lib/marketStore.ts
@@ -320,11 +320,11 @@ export function computeCoinHealth(coin: CoinData | undefined): {
     score >= 25 ? 'D' : 'F';
 
   const color =
-    grade === 'A' ? '#f0c070' :   // gold
+    grade === 'A' ? 'var(--amber)' :   // gold
     grade === 'B' ? 'var(--green-2)' :   // green
     grade === 'C' ? 'var(--txt-dim)' :   // gray
     grade === 'D' ? 'var(--orange)' :   // orange
-                    '#475569';    // muted (F)
+                    'var(--txt3)';  // muted (F)
 
   const label =
     grade === 'A' ? 'Strong setup' :


### PR DESCRIPTION
**Dev Team** → **QA Team**

🔴 **This is the #98 release blocker.** Nothing else in front of it.

## The three tokens

| Token | Was | Now | Where |
|---|---|---|---|
| `#48484a` | **2.23:1** dark | `var(--txt3)` — 5.26/6.45 | `SessionCountdown.tsx:80` |
| `#9ca3af` | **2.54:1** light | `var(--txt3)` | `arena/page.tsx:1706` |
| `#f0c070` | **1.68:1** light | `var(--amber)` — 12.07/6.95 | `marketStore.ts:323` |
| `#475569` | same class | `var(--txt3)` | `marketStore.ts:327` (F grade) |
| `.sc-timer`, `.sc-next-name` | session colour as bare text | `var(--txt)` in light — **18.58:1** | `globals.css` |

## Why a stylesheet sweep never found them
All three were hardcoded **in components**. `#48484a` is the sharpest case — `globals.css:4324` already carries a comment saying this exact literal was 2.23:1 and fixing it cleared **17 landing-page failures**. The component copy was left behind.

A fix that landed where someone was looking rather than where the colour renders — a direct argument for your token-set approach, and for #52.

`marketStore` was a **partial migration**: B, C and D were already tokens; A and F were not. Both fixed, so the next sweep cannot surface F after we fixed A.

## The one I nearly got wrong
I was about to tokenise `lib/session.ts`. The comment above `getCurrentWindow()` stopped me:

> *swapping the foreground for a token breaks that... `.session-pill` dropped to 2.30:1 before this was reverted*

Measured it myself: `var(--amber)` on `#3d2e00` = **1.90:1**. I would have reintroduced a bug someone already made and reverted during the #53 sweep.

The pair is correct. `.sc-timer` and `.sc-next-name` apply only the foreground, so the fix belongs at those two consumers — not in the colour definition.

## Deliberately not changed
- `arena/page.tsx:1710` — `#9ca3af` inside `sigGrad`, a **background** gradient, not text
- `app/global-error.tsx` — hardcodes its own dark background **on purpose**, since it renders when the root layout has failed and cannot rely on CSS variables. `#9ca3af` is ~7.5:1 there and passes

## How to test (QA)
**Pass condition is the two contrast specs green** — a local build proves nothing here.

Then eyeball both themes: `/hours`, `/arena` NEUTRAL verdict, and the session countdown. **The session badge must still read as its window colour in dark** — that is the pair this deliberately left alone.

## Risk level
**Medium.** Visible colour change on three surfaces, and it gates the release. Ratios computed rather than eyeballed; every replacement clears 4.5:1 in both themes. Gates: lint 0 errors, tsc clean, 125 tests, build clean.