### PR TITLE
feat(settings): lint rule - no bare hex as a text colour, at warn

### DIFF
--- a/eslint-rules/no-bare-hex-colour.mjs
+++ b/eslint-rules/no-bare-hex-colour.mjs
@@ -1,0 +1,113 @@
+/**
+ * Flag a bare hex literal used as a TEXT colour.
+ *
+ * WHY THIS EXISTS. Three hardcoded colours (#48484a, #9ca3af, #f0c070) failed
+ * WCAG SC 1.4.3 and cost the 2026-08-08 release three ~40-minute CI cycles. All
+ * three were in components rather than stylesheets, so every sweep of
+ * globals.css missed them, and two of the three sat in `neutral` branches that
+ * only render when the market is neither bullish nor bearish.
+ *
+ * That is the argument for a lint rule over a test: the contrast sweep can only
+ * see a colour when a route happens to render the state containing it, so it
+ * finds these when the market cooperates. This finds them when the line is
+ * typed. Issue #110.
+ *
+ * SCOPE IS DELIBERATELY TEXT ONLY. `background`, `border`, `fill` and `stroke`
+ * are not flagged - a hardcoded background is a design choice, while a
+ * hardcoded text colour is the thing that fails in one theme and passes in the
+ * other. Widening this would add ~34 sites and no accessibility value.
+ *
+ * Gradients need no special case: `linear-gradient(160deg,#d8dee9,#9ca3af)` is
+ * not a bare hex literal, so the pattern below never matches it.
+ */
+
+/** A whole-string hex colour. Anchored, so `linear-gradient(...#abc...)` is out. */
+const BARE_HEX = /^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+
+/**
+ * `sigCol`, `leanColor`, `statusCol`, `biasCol`, or the bare word `color`.
+ *
+ * The camelCase boundary is load-bearing. A plain /col(our|or)?$/i also matches
+ * `protocol`, which ends in "col" and is not a colour - caught while testing
+ * this rule rather than after it started warning about someone's URL handling.
+ * So: an uppercase C preceded by a lowercase character, or the whole identifier
+ * being the word itself.
+ */
+const COLOUR_IDENTIFIER = /(?:[a-z0-9_]Col(?:our|or)?|^col(?:our|or)?)$/;
+
+/** Object keys that put a value on TEXT. `borderColor` is a border, not text. */
+const TEXT_COLOUR_KEYS = new Set(['color', 'textColor', 'colour']);
+
+function keyNameOf(property) {
+  if (!property || property.type !== 'Property') return null;
+  if (property.key.type === 'Identifier') return property.key.name;
+  if (property.key.type === 'Literal') return String(property.key.value);
+  return null;
+}
+
+/**
+ * Is this literal being used as a text colour?
+ *
+ * Two shapes, both taken from real failures in this repo:
+ *   { color: '#9ca3af' }                    - inline style / style object
+ *   const leanColor = cond ? tok : '#9ca3af' - a colour-named binding
+ *
+ * The second walks up through ConditionalExpression and LogicalExpression
+ * because that is how every one of these was actually written - the token
+ * branches were already migrated and the fallback was left behind.
+ */
+function textColourContext(node) {
+  let current = node;
+  let parent = current.parent;
+
+  while (parent) {
+    if (parent.type === 'Property' && parent.value === current) {
+      return TEXT_COLOUR_KEYS.has(keyNameOf(parent)) ? 'property' : null;
+    }
+    if (parent.type === 'VariableDeclarator' && parent.init === current) {
+      return parent.id.type === 'Identifier' && COLOUR_IDENTIFIER.test(parent.id.name)
+        ? 'binding' : null;
+    }
+    if (parent.type === 'AssignmentExpression' && parent.right === current) {
+      return parent.left.type === 'Identifier' && COLOUR_IDENTIFIER.test(parent.left.name)
+        ? 'binding' : null;
+    }
+    // Keep climbing only through the shapes a colour choice is written in.
+    // Anything else (a call argument, an array, a return) is not something this
+    // rule claims to understand, so it stops rather than guessing.
+    if (parent.type === 'ConditionalExpression' || parent.type === 'LogicalExpression') {
+      current = parent;
+      parent = parent.parent;
+      continue;
+    }
+    return null;
+  }
+  return null;
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Use a theme token instead of a bare hex literal for text colour, so the value adapts to light and dark',
+    },
+    schema: [],
+    messages: {
+      bareHex:
+        "Bare hex '{{hex}}' as a text colour. Hardcoded colours do not adapt to theme - this is how #9ca3af " +
+        'shipped at 2.54:1 in light mode. Use a token such as var(--txt), var(--txt2), var(--txt3) or ' +
+        'var(--amber). If the colour genuinely cannot be a token, disable this line with a comment saying why.',
+    },
+  },
+
+  create(context) {
+    return {
+      Literal(node) {
+        if (typeof node.value !== 'string' || !BARE_HEX.test(node.value)) return;
+        if (!textColourContext(node)) return;
+        context.report({ node, messageId: 'bareHex', data: { hex: node.value } });
+      },
+    };
+  },
+};

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,8 @@
 import { defineConfig, globalIgnores } from 'eslint/config';
 import nextVitals from 'eslint-config-next/core-web-vitals';
+import noBareHexColour from './eslint-rules/no-bare-hex-colour.mjs';
+
+const local = { rules: { 'no-bare-hex-colour': noBareHexColour } };
 
 // Next 16 removed `next lint`, and `next build` no longer runs linting at all,
 // so nothing in this repo was linted until this file existed. Lint now runs
@@ -59,6 +62,50 @@ const eslintConfig = defineConfig([
       'react-hooks/preserve-manual-memoization': 'warn',
       'react-hooks/use-memo': 'warn',
     },
+  },
+
+  {
+    // ── No bare hex as a TEXT colour (issue #110) ──────────────────────────
+    // WARN, not error, and deliberately so: ~56 sites already violate this and
+    // making it an error fails the build immediately, so the four gates in
+    // CONTRIBUTING.md §7 stop being passable. As a warning it ships today and
+    // every NEW violation prints in CI from the first run - which is the whole
+    // point. Flip to 'error' once the backlog is burned down; that is issue
+    // #110 step 3 and blocks nothing.
+    //
+    // Scope is text colour only. See eslint-rules/no-bare-hex-colour.mjs for
+    // why background/border/fill/stroke are out.
+    plugins: { local },
+    rules: { 'local/no-bare-hex-colour': 'warn' },
+  },
+
+  {
+    // Genuine exceptions, allow-listed rather than argued with each time.
+    files: [
+      // Chart library config object, not DOM styling - these colours are passed
+      // to KLineCharts, which has no access to CSS variables.
+      'components/KLineProChart.tsx',
+      // Renders when the root layout has already failed, so it cannot rely on
+      // CSS variables existing. It carries its own #0d0d0d background and its
+      // text is 7.66:1 against it - verified 2026-08-08.
+      'app/global-error.tsx',
+      // Native shell config. No CSS, no variables.
+      'capacitor.config.ts',
+      // THE IMPORTANT ONE. session.ts returns foreground/background PAIRS
+      // ({ color: '#f0c070', bg: '#3d2e00' }) tuned for dark, and consumers
+      // apply both together. Tokenising the foreground was tried during the
+      // issue #53 sweep and dropped .session-pill to 2.30:1, because the light
+      // token is dark and the paired background stays dark; re-measured
+      // 2026-08-08 as var(--amber) on #3d2e00 = 1.90:1.
+      //
+      // Left warning, this rule would have told someone to make exactly that
+      // change - it would have caused the defect it exists to prevent. The
+      // colours here are correct; the failure mode is a CONSUMER applying the
+      // foreground without its background, which is a different bug and lives
+      // in the [data-theme="light"] block in globals.css.
+      'lib/session.ts',
+    ],
+    rules: { 'local/no-bare-hex-colour': 'off' },
   },
 
   globalIgnores([


### PR DESCRIPTION
**Dev Team** → **QA Team**

Closes #110 step 2. Your scoping, your sequencing — built after #109 landed, as a separate PR, at `warn`.

## Numbers

| | |
|---|---|
| Violations | **46** across 22 files |
| Errors | **0** — build passes |
| Total lint output | 140 warnings (94 pre-existing + 46) |

You estimated ~56 for a rule covering `color:` plus `*Col`/`*Color` bindings. 46 after the allow-list below — close enough that your measurement was doing real work.

## What it flags

A bare hex literal used as **text** colour: a `color:` key, or assignment to a `*Col` / `*Color` binding, including through `?:` and `||` — which is how every one of these was written, with the token branches already migrated and the fallback left behind.

Not flagged: `background`, `border`, `fill`, `stroke`, and gradients. The pattern is anchored, so `linear-gradient(160deg,#d8dee9,#9ca3af)` never matches — no special case needed.

## Two things testing the rule found that shipping it would not

**1. `/col(our|or)?$/i` also matches `protocol`.** Ends in "col". Tightened to require a camelCase boundary, so nobody gets warned that their URL variable is a colour.

**2. `lib/session.ts` was the single largest violator — 7 — and every one is correct.**

This is the one worth your attention. Left warning, the rule would have told someone to tokenise those foreground/background pairs. That change was tried during the #53 sweep, dropped `.session-pill` to 2.30:1, and was reverted. I re-measured it on #108: `var(--amber)` on `#3d2e00` is **1.90:1**.

**The rule would have caused the defect it exists to prevent.** Allow-listed, with the measurement in the config so the next person reads it before "fixing" the file.

The real failure mode there is a *consumer* applying the foreground without its background — a different bug, and it lives in the `[data-theme="light"]` block we just extended.

## Also allow-listed

- `KLineProChart.tsx` — chart library config, no CSS variables reachable
- `app/global-error.tsx` — renders when the root layout has failed, carries its own `#0d0d0d` at 7.66:1
- `capacitor.config.ts` — native shell

## How to test (QA)

Nothing user-facing. `npm run lint` — **0 errors**, 46 of the warnings are this rule.

Fires: add `const testCol = '#123456';` to any component, re-run.
Does not over-fire: `style={{ background: '#123456' }}` and a `linear-gradient(...)` string stay silent.

## Risk level

**Low.** Lint config only, no application code, no behaviour. Cannot fail a build at `warn`.

Step 3 — burning down the 46 and flipping to `error` — is yours to sequence. It blocks nothing and the top files are `WhaleTradesFeed` (6), `TradeJournal` (5), `upgrade` (4).
