### PR TITLE
chore(ci): skip the build on documentation-only pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,17 @@ on:
     # open for the whole cycle, so each ff-push to its base ALSO fired
     # `synchronize` on it - one promotion used to bill three full runs.
     branches: [dev, main]
+    # Documentation cannot change what a build produces, so it should not spend
+    # a build. Measured before adding: only 1 of 31 recent commits qualifies, so
+    # this is worth ~60 min/month - correct rather than significant.
+    #
+    # `qa/**` and `.github/**` are deliberately NOT here. Test code and workflow
+    # definitions are precisely the things that need CI to run; excluding them is
+    # how a broken spec or a broken workflow ships without anyone noticing.
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'pendings/**'
 
   # For running the browser suite on demand: re-checking after a flake, or
   # proving a fix without opening a release PR first.


### PR DESCRIPTION
**QA Team** → **Dev Team**

## Summary

Third and smallest item from the CI minutes audit. `paths-ignore` on the `push`
trigger so a documentation commit does not spend a build.

## What changed

```diff
   push:
     branches: [dev, main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'pendings/**'
```

Plus a comment recording why `qa/**` and `.github/**` are *not* on that list.

## Why

The owner is close to exhausting a 3,000 min/month allowance. Measured over the
1.9 days to 2026-08-08: **~7,419 min/30d projected, 99% of it CI**.

**Sized honestly: this saves ~60 min/month.** Only **1 of 31** recent commits
touches documentation alone. I originally expected this to be the headline
finding, counted "7 of 21", then realised that count included `.github/` and
`qa/` changes — workflow edits and test code, both of which *should* run CI.
Filtering only true documentation leaves one commit in thirty-one.

It is worth doing because it is correct and free, not because it moves the
number. The two that move the number:

| | Item | Saving | Status |
|---|---|---|---|
| 1 | Unpin `workers: 1` | ~2,200 min | **#114**, blocked on fixtures (#101) |
| 2 | Lint rule | ~400–800 min | **#110**, your PR #113 |
| 3 | This | ~60 min | here |

## The deliberate exclusion

`qa/**` and `.github/**` stay out of the ignore list. Test code and workflow
definitions are precisely the things that need CI to run — excluding them is how
a broken spec or a broken workflow ships without anyone noticing. Worth stating
because adding them would roughly triple the saving and quietly remove the gate
from the QA suite.

## How to test (QA)

1. Push a commit touching only a `.md` file to `dev` — **no CI run appears** in
   the Actions tab.
2. Push a commit touching any `.ts` / `.tsx` / `qa/` / `.github/` file — CI runs
   as before.
3. Open any PR — unchanged. The `pull_request` trigger is untouched, so every PR
   is still gated regardless of what it contains.

## Risk level

**Low**, with one thing worth naming: `paths-ignore` on `push` means a
docs-only commit landing on `main` produces no CI run, so nothing reports a
status for that commit. Branch protection applies to PRs rather than direct
pushes, and direct pushes to `main` are already prohibited by `CONTRIBUTING.md`
§7, so nothing depends on it.

YAML validated with a parser rather than by eye.

## Screenshots

n/a — no UI change.
