### PR TITLE
fix(ci): E2E_A_PRICE_ALERT_ID is a variable, not a secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,7 +310,24 @@ jobs:
           E2E_USER_B_ID: ${{ secrets.E2E_USER_B_ID }}
           E2E_A_TRADE_ID: ${{ secrets.E2E_A_TRADE_ID }}
           E2E_A_HYPOTHESIS_ID: ${{ secrets.E2E_A_HYPOTHESIS_ID }}
-          E2E_A_PRICE_ALERT_ID: ${{ secrets.E2E_A_PRICE_ALERT_ID }}
+          # A VARIABLE, not a secret, and deliberately. lhq_dev_price_alerts
+          # uses an integer primary key where trades and hypotheses use UUIDs,
+          # and this fixture is the only row in the table - so the value is the
+          # literal string "1".
+          #
+          # GitHub redacts every occurrence of a secret's value anywhere in a
+          # log. As a secret, this one turned EVERY literal 1 in CI output into
+          # ***: "SC 1.4.3" printed as "SC ***.4.3" and a "2.20:1" contrast
+          # ratio as "2.20:***". QA lost time reading a contrast failure through
+          # that on 2026-08-08 (issue #107).
+          #
+          # It was never sensitive - it is a row id in the dev database, created
+          # alongside genuinely secret things and classified with them by
+          # proximity rather than by need. As a variable it prints normally.
+          #
+          # If a future fixture id is genuinely sensitive, make it a secret AND
+          # give it a value that cannot collide with ordinary text.
+          E2E_A_PRICE_ALERT_ID: ${{ vars.E2E_A_PRICE_ALERT_ID }}
 
       # failure() only. This used to upload on every green run too - ~15s and
       # storage for a report nobody opens. failure() still excludes


### PR DESCRIPTION
**Dev Team** → **QA Team**

Closes #107 — the secret that was mangling your CI logs.

## Root cause, measured

`lhq_dev_price_alerts` has **exactly one row in the entire table** — the E2E
fixture — and its id is `1`. That table uses an integer primary key where
`trades` and `hypotheses` use UUIDs, so it was the only fixture short enough to
collide with ordinary text.

GitHub redacts a secret's value **everywhere** it appears in a log, so every
literal `1` became `***`. That is why you read `SC ***.4.3` and `2.20:***` while
diagnosing a release blocker.

## Fix: reclassify, do not work around

It is a row id in a dev database. It was never sensitive — it was created
alongside genuinely secret things (passwords, service-role key) and classified
with them **by proximity rather than by need**.

- Repo **variable** `E2E_A_PRICE_ALERT_ID` = `1` — created
- `ci.yml` reads `vars.` instead of `secrets.`
- Value unchanged, so `bola.spec.ts:103` still asserts the alerts response
  contains it

## Why not change the row id

That was the other option and I rejected it: it needs a write to the shared dev
database, and it fixes this instance rather than the classification. **The next
single-digit fixture would do exactly the same thing.**

## 🔴 One step left, and it is the owner's

**Delete the SECRET named `E2E_A_PRICE_ALERT_ID`.** While both exist, `ci.yml`
reads the variable — but the secret's value is still registered for redaction,
so **logs stay mangled until it is gone.** Flagged to them.

## How to test (QA)

Next E2E run. Contrast ratios should print `2.20:1` rather than `2.20:***`, and
`SC 1.4.3` should be intact. Nothing about the test changes.

If they still read `***` after the secret is deleted, tell me — that would mean
something else holds the value `1` and my diagnosis was incomplete.

## Risk level

**Low.** One workflow line. If the variable were missing the E2E fixture guard
in `_auth.ts:53` fails closed, so the failure mode is a skipped test rather than
a silently wrong one.

---

Separately, noted #114 — `workers: 1`. That pin is why
`test.describe.configure({ mode: 'parallel' })` did nothing when it was tried on
the contrast spec, and why today cost three ~40-minute cycles. It is
`playwright.config.ts`, so yours to write and mine to review whenever you
sequence it.
