### PR TITLE
perf(ci): skip docs-only pushes, on push only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,34 @@ on:
     # open for the whole cycle, so each ff-push to its base ALSO fired
     # `synchronize` on it - one promotion used to bill three full runs.
     branches: [dev, main]
+    # Docs-only pushes do not need a build. Every path here is either not
+    # compiled or not shipped, so a run over them proves nothing that the
+    # PR-side run had not already proved.
+    #
+    # DELIBERATELY ON `push` ONLY, not on `pull_request`, and the reason matters
+    # more than the saving:
+    #
+    #   - `main` is the only branch with a required status check (`CI Gate`).
+    #     Required checks are evaluated on the PULL REQUEST. A required check
+    #     that never runs never reports, and GitHub treats "never reported" as
+    #     pending forever - so a docs-only release PR would be unmergeable with
+    #     no way to force it short of an admin override. That is a worse failure
+    #     than the minutes are worth.
+    #   - The alternative - keep the workflow running and skip the expensive
+    #     jobs with an `if:` - is worse still. The `gate` job below rests on
+    #     "build carries no `if:`, so anything other than success is real".
+    #     Teaching it to accept `skipped` reopens the hole it was hardened to
+    #     close after release PR #38, where a skipped job read as a green
+    #     required check.
+    #
+    # So: pushes skip, pull requests always run. Issue #114 sibling item.
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'pendings/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/pull_request_template.md'
+      - 'LICENSE'
 
   # For running the browser suite on demand: re-checking after a flake, or
   # proving a fix without opening a release PR first.


### PR DESCRIPTION
**Dev Team** → **QA Team**

The small sibling from #114. **Not #114 itself** — see the last section, the `workers: 1` pin still cannot move.

## What changed

`paths-ignore` on the **`push`** trigger for `**.md`, `docs/**`, `pendings/**` and issue templates.

`pull_request` deliberately untouched.

## Why only push, and this is the whole design decision

`main` is the only branch carrying a required status check (`CI Gate`) — I checked the rulesets rather than assuming:

```
dev / qa / staging  ->  no required checks
main                ->  requires "CI Gate"
```

**Required checks are evaluated on the pull request.** A required check that never runs never reports, and GitHub treats "never reported" as pending forever. So `paths-ignore` on `pull_request` would make a **docs-only release PR unmergeable**, with no recourse short of an admin override — surfacing at exactly the moment someone needs to ship.

## Why I did not take the cleaner-looking option

Keeping the workflow running and skipping the expensive jobs with an `if:` saves more. It is also worse.

Your `gate` job rests on one line:

> `# build carries no `if:`, so anything other than success is real.`

It fails on any build result that is not `success` — **`skipped` included**. Teaching it to accept `skipped` reopens precisely the hole it was hardened to close after release PR #38, where a skipped job published a green required check and a release looked mergeable while its own suite was still running.

Weakening the one control in front of production to save ~60 minutes a month is a bad trade. I would rather bank half the saving than touch that job.

## 🔴 #114 itself is still blocked, and by more than the issue states

I checked before going near `workers`:

```
market-scenarios.spec.ts    USES fixtures
a11y-auth  a11y  bola  contrast  offline
perf  responsive  security  seo  smoke      hits LIVE apis
```

**One spec of eleven.** Unpinning now gives four workers times ten live specs — your "current problem multiplied by four".

Worth amending #114 to say so: the blocker is not "fixtures exist", it is **"every spec that touches market data installs them"**. Eight endpoints of 27 is enough for `market-scenarios`; it is not enough for `contrast`, which sweeps 32 routes.

## How to test (QA)

1. Push a docs-only commit to `dev` — **no CI run should appear**
2. Open a PR touching only markdown — **CI should still run**

(2) is the important one. A PR that stops running checks is the failure this avoids rather than causes.

## Risk level

**Low.** One trigger key. Verified: file parses, `pull_request` has no `paths-ignore`, and `build` still carries no `if:` — the invariant your gate depends on.
