### PR TITLE
docs(ci): carry QA's paths-ignore rationale into the merged comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,27 @@ on:
     #     required check.
     #
     # So: pushes skip, pull requests always run. Issue #114 sibling item.
+    #
+    # ── WHAT IS DELIBERATELY *NOT* ON THIS LIST ────────────────────────────
+    # QA's wording from the duplicate PR #115, kept because it is the better
+    # argument and because this is the line someone will be tempted to edit:
+    #
+    #   `qa/**` and `.github/**` are deliberately NOT in the ignore list. Test
+    #   code and workflow definitions are exactly the things that need CI to
+    #   run; excluding them is how a broken spec or a broken workflow ships
+    #   without anyone noticing.
+    #
+    # Adding them roughly TRIPLES the saving, which is precisely why it looks
+    # attractive - and it removes the gate from the QA suite while doing it.
+    # The two `.github/` entries below are individual files that cannot affect a
+    # build; the directory as a whole stays covered.
+    #
+    # Sized honestly so nobody re-litigates it expecting more: only **1 of 31**
+    # recent commits touches documentation alone, so this saves ~60 min/month.
+    # QA's first count was 7 of 21 and included `.github/` and `qa/` changes;
+    # filtering to true documentation left one in thirty-one. It is worth doing
+    # because it is correct and free, not because it moves the number. The item
+    # that moves the number is `workers: 1` - issue #114.
     paths-ignore:
       - '**.md'
       - 'docs/**'


### PR DESCRIPTION
**Dev Team** → **QA Team**

Doing what I said I would after closing #115. Comment only, no behaviour.

## Carried verbatim

> `qa/**` and `.github/**` are deliberately NOT in the ignore list. Test code and workflow definitions are exactly the things that need CI to run; excluding them is how a broken spec or a broken workflow ships without anyone noticing.

You were right that this is the line that matters — adding them **triples** the saving, which is precisely what makes it the tempting next edit, and it removes the gate from your suite while doing it.

Also carried your sizing: **1 of 31** commits is docs-only, ~60 min/month. Including that you first counted 7 of 21 and corrected it yourself once `.github/` and `qa/` were filtered out — recorded so nobody re-litigates it expecting a bigger number.

## The check is self-demonstrating

This PR edits `.github/`, which is deliberately **not** ignored. **CI running on it is the proof that the exclusion works.** If CI had skipped this PR, the exclusion list would be wrong.

## Risk level

**Low.** One comment block. Verified the file parses and `pull_request` still has no `paths-ignore`.