### PR TITLE
feat(ci): a failed announcement now opens an issue instead of failing silently

### DIFF
--- a/.github/workflows/ready-for-qa.yml
+++ b/.github/workflows/ready-for-qa.yml
@@ -169,3 +169,71 @@ jobs:
             gh issue close "$N" --repo "$REPO" \
               --comment "\`staging\` has moved — QA has taken this work. Closing automatically. The next promotion to \`qa\` opens a fresh one."
           done
+
+  # ── If the announcement itself fails, say so LOUDLY ────────────────────────
+  #
+  # The whole point of this workflow is that a promotion cannot go unannounced.
+  # Without this job, a failure in `announce` leaves `qa` moved and NOTHING
+  # telling QA - which is the exact failure it exists to prevent, one level up.
+  #
+  # That is not hypothetical. `release-signals.yml` failed on its first real run
+  # (issue #99): the promotion succeeded, the ready-for-QA issue closed
+  # correctly, and no release PR appeared. Nothing announced the failure. QA
+  # found it by going to look for a PR that was not there.
+  #
+  # WHY THIS CANNOT FAIL THE SAME WAY. The primary path calls `gh issue
+  # create`/`edit`, which needs `issues: write` - declared at the top of this
+  # file and exercised on every run since. The thing that broke release-signals
+  # was `gh pr create`, which needs a REPO SETTING ("Allow GitHub Actions to
+  # create and approve pull requests") that was off for the entire life of that
+  # workflow. This job opens an issue, so it depends only on a permission the
+  # workflow already holds and has already used.
+  #
+  # `if: failure()` runs when a needed job failed. It does not run if the
+  # workflow never starts at all - a YAML parse error or a runner outage is
+  # still silent, and nothing inside a workflow can cover that case.
+  announce-failed:
+    needs: announce
+    if: failure() && github.ref == 'refs/heads/qa'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Open an issue saying the promotion was not announced
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -uo pipefail
+          BASE=origin/staging
+          git rev-parse --verify --quiet "$BASE" >/dev/null || BASE=origin/main
+
+          {
+            echo "**Automated** - the Ready-for-QA announcement failed, so this promotion"
+            echo "was not announced by the usual route."
+            echo
+            echo "\`qa\` is at \`$(git rev-parse --short=7 origin/qa)\` and has moved."
+            echo "**Treat this as the notification** and check the range by hand."
+            echo
+            echo "Failed run: $RUN"
+            echo
+            echo "## What is on \`qa\` and not on \`staging\`"
+            echo
+            echo '```'
+            git log --format='%h %s' "$BASE..origin/qa" 2>/dev/null | head -40 || echo "(range unavailable)"
+            echo '```'
+            echo
+            echo "This issue is a fallback, so it is deliberately cruder than the real one -"
+            echo "no per-PR \"How to test\" sections. Fix the workflow, then re-push \`qa\` to"
+            echo "regenerate the proper list."
+          } > /tmp/fail.md
+
+          gh label create announcement-failed --repo "$REPO" --color D93F0B \
+            --description "A promotion happened but the automated announcement did not" 2>/dev/null || true
+
+          gh issue create --repo "$REPO" --label announcement-failed \
+            --title "Promotion to \`qa\` was NOT announced - ready-for-qa.yml failed" \
+            --body-file /tmp/fail.md

--- a/.github/workflows/release-signals.yml
+++ b/.github/workflows/release-signals.yml
@@ -214,3 +214,69 @@ jobs:
             gh issue create --repo "$REPO" --label release-drift \
               --title "Production is not running \`main\`" --body-file /tmp/drift.md
           fi
+
+  # ── If the release PR could not be opened, do not fail into silence ────────
+  #
+  # This is the job that should have existed on 2026-08-08. `release-pr` failed
+  # on its first real run - the repo setting "Allow GitHub Actions to create and
+  # approve pull requests" was off - and the promotion looked completely normal:
+  # `qa` moved, the Ready-for-QA issue closed itself correctly, and no release PR
+  # appeared. Nothing said why. QA found it by going to look for a PR that was
+  # not there. Issue #99.
+  #
+  # QA's phrasing, kept because it is the requirement: "a workflow that exists to
+  # remove a manual step failed silently at the one moment it was needed".
+  #
+  # WHY THIS CANNOT FAIL THE SAME WAY: the primary needs `gh pr create`, gated by
+  # a REPO SETTING. This needs `gh issue create`, gated by `issues: write` -
+  # declared at the top of this file and already exercised. Different permission,
+  # and one the workflow has always held.
+  #
+  # The body the primary had already built is gone with its runner, so this
+  # rebuilds a cruder version rather than pretending to recover it. Everything
+  # up to the final API call had succeeded, which is why this stays useful.
+  release-pr-failed:
+    needs: release-pr
+    if: failure() && github.ref == 'refs/heads/staging'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Open an issue carrying the release list
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -uo pipefail
+          {
+            echo "**Automated** - \`staging\` moved but the release PR could NOT be opened."
+            echo
+            echo "**Open it by hand:** \`staging\` -> \`main\`. The contents are below."
+            echo
+            echo "Failed run: $RUN"
+            echo
+            echo "First thing to check: Settings -> Actions -> General -> Workflow"
+            echo "permissions -> \"Allow GitHub Actions to create and approve pull"
+            echo "requests\". That was the cause on 2026-08-08 (#99), and the Save button"
+            echo "under that section is separate from the checkbox."
+            echo
+            echo "## In this release (\`main..staging\`)"
+            echo
+            echo '```'
+            git log --format='%h %s' origin/main..origin/staging 2>/dev/null | head -50 || echo "(range unavailable)"
+            echo '```'
+            echo
+            echo "Per-PR \"How to test\" sections are not aggregated here - open the PRs"
+            echo "listed above for those. Fix the workflow and re-push \`staging\` to get the"
+            echo "full body."
+          } > /tmp/relfail.md
+
+          gh label create announcement-failed --repo "$REPO" --color D93F0B \
+            --description "A promotion happened but the automated announcement did not" 2>/dev/null || true
+
+          gh issue create --repo "$REPO" --label announcement-failed \
+            --title "Release PR was NOT opened - release-signals.yml failed" \
+            --body-file /tmp/relfail.md


### PR DESCRIPTION
**Dev Team** → **QA Team**

Closes the other half of #99 — the one you named and I had queued.

## The hole

Both workflows exist so a promotion cannot go unannounced. Until now, a failure
*inside* one produced exactly the thing they prevent.

Not hypothetical. On 2026-08-08 `release-signals.yml` failed on its first real
run and from outside it looked completely normal: `qa` moved, the Ready-for-QA
issue closed itself correctly, no release PR appeared, **nothing said why.** You
found it by going to look for a PR that was not there.

Your phrasing is the requirement, and it is in the file now:

> a workflow that exists to remove a manual step failed silently at the one
> moment it was needed

## What changed

| Workflow | New job | Fires when |
|---|---|---|
| `ready-for-qa.yml` | `announce-failed` | `announce` fails on a push to `qa` |
| `release-signals.yml` | `release-pr-failed` | `release-pr` fails on a push to `staging` |

Both open an issue labelled `announcement-failed` carrying the branch range the
primary would have listed. The release one also names the exact setting to check
first — that was the cause once, and the Save button under it is separate from
the checkbox.

## Why it cannot fail the same way — your argument, not mine

You made this point on #78 and it is stronger than defence-in-depth:

- the release-PR path needs `gh pr create`, gated by a **repo setting** that was
  off for that workflow's entire life
- the fallback needs `gh issue create`, gated by **`issues: write`** — declared
  in both files and exercised on every run since they were added

Different permission, and one already proven in production by #89, #102 and #116.

## The limit, stated rather than left to be discovered

`if: failure()` covers a job that **ran and failed**. It does not cover a
workflow that never starts — a YAML parse error or a runner outage is still
silent, and nothing inside a workflow can cover that case. It is in the comment.

## The fallback issues are deliberately worse than the real ones

A commit list, no per-PR "How to test" aggregation. The primary's assembled body
dies with its runner, so this rebuilds what it can rather than pretending to
recover it. Fix the workflow and re-push to get the proper list.

## How to test (QA)

**I could not exercise this** without breaking a workflow on purpose, which would
have announced a fake failure to you. Verified statically instead:

- both files parse
- all 8 embedded shell steps pass `bash -n`
- each fallback is scoped to the same branch condition as the job it follows, so
  it cannot fire on the wrong event

The real test is the next genuine failure. The point is that there will be
something to read when it happens.

If you would rather see it proven, I can break one deliberately on a branch and
show you the issue it produces — say the word, since that fires a real
notification.

## Risk level

**Low.** Two new jobs, both `if: failure()`, neither on the success path. Worst
case is a spurious issue; they cannot block a promotion or a merge.
