### PR TITLE
fix(journal): mask session replay by container, not by class list

### DIFF
--- a/__tests__/sessionRecordingMask.test.mts
+++ b/__tests__/sessionRecordingMask.test.mts
@@ -1,0 +1,114 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import {
+  maskText,
+  MASK_TEXT_SELECTOR,
+  UNMASK_TEXT_SELECTOR,
+  SESSION_RECORDING,
+} from '../lib/sessionRecording.ts';
+
+/* Session replay is on in production and records real users. The masking it
+   replaced was a list of five class names, which had already leaked once - a
+   trade's notes, thesis and P&L captured in the clear - and would leak again on
+   the next field added to TradeJournal, silently, with no error and no failing
+   test.
+
+   These tests exist because that failure has no symptom. The output is a video
+   in PostHog nobody watches, so the only place it can be caught is here. */
+
+/* rrweb hands maskTextFn the text node's PARENT element, and only for text it
+   has already decided to mask. The one thing the function does is ask whether
+   that element sits inside an opted-in subtree, so a fake with closest() is a
+   faithful stand-in - no DOM needed. */
+const el = (optedIn: boolean) =>
+  ({ closest: (sel: string) => (optedIn && sel === UNMASK_TEXT_SELECTOR ? {} : null) }) as unknown as HTMLElement;
+
+test('session replay masking', async (t) => {
+  await t.test('private text is masked', () => {
+    assert.equal(maskText('BTC long, thesis: liquidity sweep', el(false)),
+                          '*** ***** ******* ********* *****');
+    assert.equal(maskText('-$1,240.55', el(false)), '**********');
+  });
+
+  /* Word shape and whitespace survive so a masked recording still shows layout.
+     Matches rrweb's own default replacement, /[\S]/g -> '*'. */
+  await t.test('whitespace is preserved, everything else is not', () => {
+    const masked = maskText('a b  c', el(false));
+    assert.equal(masked, '* *  *');
+    assert.ok(!/[a-z0-9]/i.test(masked));
+  });
+
+  await t.test('an explicitly opted-in subtree is returned verbatim', () => {
+    assert.equal(maskText('Take Profit', el(true)), 'Take Profit');
+  });
+
+  /* The important direction. Every unrecognised case must mask, because the
+     cases we did not think of are exactly the ones this replaced. */
+  await t.test('fails closed on a missing or unusable element', () => {
+    assert.equal(maskText('secret', undefined), '******');
+    assert.equal(maskText('secret', null), '******');
+    assert.equal(maskText('secret', {} as unknown as HTMLElement), '******');
+  });
+
+  await t.test('config keys posthog.init() depends on are all present', () => {
+    assert.equal(SESSION_RECORDING.maskAllInputs, true);
+    assert.equal(SESSION_RECORDING.maskTextSelector, MASK_TEXT_SELECTOR);
+    assert.ok(MASK_TEXT_SELECTOR.length > 0);
+    // Dropping maskTextFn fails closed rather than open, so it is not dangerous
+    // - but it silently removes the exception mechanism entirely.
+    assert.equal(typeof SESSION_RECORDING.maskTextFn, 'function');
+  });
+
+  /* QA's assertion, and the one that survives longest. After the inversion the
+     danger is no longer a forgotten mask - it is someone widening the exception
+     to make a recording readable, which looks like a small helpful change.
+
+     The exception is an ATTRIBUTE for this reason: opting an element in is a
+     visible edit to that element. Anything class-shaped appearing here means
+     the allow-list has started growing. */
+  await t.test('the exception list cannot be widened into a class list', () => {
+    assert.equal(UNMASK_TEXT_SELECTOR, '[data-ph-safe]');
+    assert.ok(!UNMASK_TEXT_SELECTOR.includes('.'), 'no class selector may appear in the unmask list');
+  });
+});
+
+/* The mask is a container class, so removing that class from a component
+   unmasks everything in it - the same silent failure in a new place. #108
+   fixed only the classes a failing test named and missed two more, so this
+   enumerates the surfaces rather than sampling them.
+
+   Every component here renders the user's own financial data as TEXT.
+   maskAllInputs covers what is typed; it does not cover a computed result
+   rendered back out, which is why the calculators are in this list. */
+const PRIVATE_SURFACES = [
+  'components/TradeJournal.tsx',      // notes, thesis, P&L, R, prices
+  'components/HypothesisTracker.tsx', // the user's own written hypotheses
+  'components/PnLCalc.tsx',           // computed P&L
+  'components/PositionSizer.tsx',     // account size, risk, position size
+  'components/DcaCalc.tsx',           // entered ladder and averages
+];
+
+test('every private surface still declares the mask container', async (t) => {
+  for (const file of PRIVATE_SURFACES) {
+    await t.test(file, () => {
+      const src = readFileSync(new URL('../' + file, import.meta.url), 'utf8');
+      assert.ok(
+        src.includes('className="lhq-private"'),
+        `${file} renders user-private text but no longer carries lhq-private - ` +
+        `session replay would capture it in the clear`,
+      );
+    });
+  }
+});
+
+/* Guards the deletion this replaced. The old deny-list is gone; if it comes
+   back it means someone re-anchored masking to class names, which is the
+   fail-open shape the whole change exists to remove. */
+test('masking is not re-anchored to TradeJournal class names', () => {
+  const src = readFileSync(new URL('../components/PostHogProvider.tsx', import.meta.url), 'utf8');
+  assert.ok(!/maskTextSelector\s*:/.test(src),
+    'PostHogProvider should take the config from lib/sessionRecording.ts, not spell it out');
+  assert.ok(!src.includes('.tj-'),
+    'a per-class mask list has reappeared - it fails open on the next field added');
+});

--- a/components/DcaCalc.tsx
+++ b/components/DcaCalc.tsx
@@ -65,7 +65,9 @@ export default function DcaCalc({ coin }: { coin: CoinId | '' }) {
   }
 
   return (
-    <div>
+    // lhq-private: the entered ladder and its averages are the user's position.
+    // Rendered as text, so maskAllInputs does not reach it.
+    <div className="lhq-private">
       <div style={{ padding: '1rem 0 0.75rem' }}>
         <h2 style={{ fontSize: 'var(--fs-section)', fontWeight: 700, color: 'var(--txt)', marginBottom: 2 }}>{t('CALC_DCA_TITLE')}</h2>
         <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)' }}>{t('CALC_DCA_SUBTITLE')}</div>

--- a/components/HypothesisTracker.tsx
+++ b/components/HypothesisTracker.tsx
@@ -229,7 +229,9 @@ export default function HypothesisTracker() {
   }
 
   return (
-    <div>
+    // lhq-private: the user's own written hypotheses - same class of content as
+    // a trade's notes. Masked in session replay, see lib/sessionRecording.ts.
+    <div className="lhq-private">
       {/* Header */}
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 14 }}>
         <div>

--- a/components/PnLCalc.tsx
+++ b/components/PnLCalc.tsx
@@ -63,7 +63,9 @@ export default function PnLCalc({ coin }: { coin: CoinId | '' }) {
   const isProfit = result ? result.pnl >= 0 : null;
 
   return (
-    <div>
+    // lhq-private: maskAllInputs covers what is typed in; the computed P&L is
+    // rendered TEXT and was never covered. See lib/sessionRecording.ts.
+    <div className="lhq-private">
       <div style={{ padding: '1rem 0 0.75rem' }}>
         <h2 style={{ fontSize: 'var(--fs-section)', fontWeight: 700, color: 'var(--txt)', marginBottom: 2 }}>{t('CALC_PNL_TITLE')}</h2>
         <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)' }}>{t('CALC_PNL_SUBTITLE')}</div>

--- a/components/PositionSizer.tsx
+++ b/components/PositionSizer.tsx
@@ -146,7 +146,9 @@ export default function PositionSizer({ coin }: { coin: CoinId | '' }) {
   };
 
   return (
-    <div>
+    // lhq-private: account size and risk are entered, but the sizing result is
+    // rendered text. Masked in session replay, see lib/sessionRecording.ts.
+    <div className="lhq-private">
       {/* Header */}
       <div style={{ padding: '1rem 0 0.75rem' }}>
         <h2 style={{ fontSize: 'var(--fs-section)', fontWeight: 700, color: 'var(--txt)', marginBottom: 2 }}>{t('CALC_SIZER_TITLE')}</h2>

--- a/components/PostHogProvider.tsx
+++ b/components/PostHogProvider.tsx
@@ -4,6 +4,7 @@ import { usePathname, useSearchParams } from 'next/navigation';
 import { useEffect, useRef, useState, Suspense } from 'react';
 import { readConsent, onConsentChange, type ConsentState } from '@/lib/consent';
 import { analyticsKey } from '@/lib/analytics';
+import { SESSION_RECORDING } from '@/lib/sessionRecording';
 
 // analyticsKey() also returns '' on any non-production environment, so a
 // dev/qa/staging build cannot write into production's single PostHog project
@@ -109,19 +110,12 @@ export default function PostHogProvider({ children }: { children: React.ReactNod
           capture_pageview:   false,
           capture_pageleave:  true,
           persistence:        'localStorage+cookie',
-          session_recording: {
-            maskAllInputs: true,
-            // maskAllInputs only covers form inputs. Rendered TEXT - a saved
-            // trade's notes, its thesis, and every dollar/R figure in
-            // TradeJournal - was captured in the clear, so a user's trade
-            // history and P&L landed in PostHog's recordings unmasked even
-            // though nothing was ever typed into a masked field during that
-            // capture. These are the only classes covered - PostHog masks
-            // exactly the matched elements' text, not the whole page, so
-            // anything added to TradeJournal later needs one of these classes
-            // (or a new one added here) to be covered too.
-            maskTextSelector: '.tj-trade-notes, .tj-tp-val, .tj-stat-val, .tj-breakdown-pnl, .tj-thesis-text',
-          },
+          // Deliberately not spelled out here. This used to be a list of five
+          // class names, which meant a field added to TradeJournal defaulted to
+          // captured in the clear. It is now a container mask with an opt-in
+          // exception - see lib/sessionRecording.ts for why, and for the one
+          // gap (PostHog's remote config) that no test here can catch.
+          session_recording: SESSION_RECORDING,
         });
         inited.current = true;
       } else {

--- a/components/TradeJournal.tsx
+++ b/components/TradeJournal.tsx
@@ -802,7 +802,9 @@ function Inner() {
   );
 
   return (
-    <div>
+    // lhq-private: every rendered figure below is this user's own trading data.
+    // Masked wholesale in session replay - see lib/sessionRecording.ts.
+    <div className="lhq-private">
       {/* Header */}
       <div style={{ padding: '1rem 0 0.75rem' }}>
         <h1 style={{ fontSize: 'var(--fs-section)', fontWeight: 700, color: 'var(--txt)', marginBottom: 2 }}>{t('TRADE_JOURNAL_PAGE_TITLE')}</h1>
@@ -1783,7 +1785,8 @@ function Inner() {
                     )}
                   </div>
 
-                  {/* Thesis text - tj-thesis-text is masked in session replay, see PostHogProvider.tsx */}
+                  {/* Thesis text - masked because it is inside lhq-private, not
+                      because of its own class. See lib/sessionRecording.ts. */}
                   <div className="tj-thesis-text" style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt2)', lineHeight: 1.5, marginBottom: 8 }}>{thesis.thesisText}</div>
 
                   {/* Assumptions */}

--- a/lib/sessionRecording.ts
+++ b/lib/sessionRecording.ts
@@ -1,0 +1,83 @@
+/* PostHog session-replay masking.
+ *
+ * Session replay is ON in production - posthog-recorder.js loads and records
+ * real users. `maskAllInputs: true` covers what a user TYPES. It does not cover
+ * what the app RENDERS, and rendered text is where this app keeps the sensitive
+ * material: a trade's notes and thesis, every P&L figure, every position size.
+ *
+ * That leaked once already and was fixed by hand, with a list of the five class
+ * names that happened to be dangerous at the time:
+ *
+ *   maskTextSelector: '.tj-trade-notes, .tj-tp-val, .tj-stat-val, ...'
+ *
+ * A deny-list fails OPEN. A field added to TradeJournal defaults to captured in
+ * the clear, a rename silently stops masking, and neither produces an error, a
+ * warning or a failing test - the only artifact is a video in PostHog that
+ * nobody on this side watches.
+ *
+ * So this is inverted. `.lhq-private` marks a subtree as private and everything
+ * inside it is masked; a new field there is masked because it is inside, not
+ * because someone remembered. The exception is opt-in and deliberate.
+ *
+ * HOW rrweb ACTUALLY DECIDES, because both halves depend on it:
+ *
+ *   1. masking is ancestor-aware - `el.closest(maskTextSelector)`, verified in
+ *      the bundled rrweb - so ONE class on a container covers every descendant.
+ *   2. `maskTextFn` is called ONLY for text rrweb has already decided to mask,
+ *      and is handed the text node's parent element:
+ *        maskTextFn ? maskTextFn(text, parentElement(n)) : text.replace(/[\S]/g, '*')
+ *      which is what makes an un-mask possible at all.
+ *
+ * There is no `unmaskTextSelector` in posthog-js 1.404.1 - checked the types and
+ * the bundle. `maskTextFn` is the only hook, and it is a better one: the
+ * exception cannot be widened by editing a class list, only by adding an
+ * attribute to an element, in a diff, where it is visible.
+ *
+ * KNOWN GAP, and no test in this repo can close it: PostHog's REMOTE config can
+ * override masking -
+ *   masking?: Pick<SessionRecordingOptions, 'maskAllInputs' | 'maskTextSelector' | 'blockSelector'>
+ * so a change in the PostHog project settings can switch the container mask off
+ * with nothing here changing, and every assertion below would still pass.
+ * `maskTextFn` is not in that Pick and survives - but it never fires if nothing
+ * is being masked to begin with.
+ */
+
+/** Marks a subtree whose rendered text is user-private. Everything inside is
+ *  masked in session replay. Applied to the component roots that render a
+ *  user's own financial data - see the test for the enforced list. */
+export const MASK_TEXT_SELECTOR = '.lhq-private';
+
+/** The only exception, and deliberately an ATTRIBUTE rather than a class list.
+ *  Ships with zero usages. Widening it means touching an element in a diff, not
+ *  appending to a string that looks like configuration.
+ *
+ *  Anything carrying this is captured in the clear. Nothing user-specific may. */
+export const UNMASK_TEXT_SELECTOR = '[data-ph-safe]';
+
+/**
+ * Called by rrweb for text it is about to mask. Returns the text unchanged only
+ * for an explicitly opted-in subtree; everything else is masked.
+ *
+ * Fails closed by construction - a missing element, a detached node, or any
+ * unrecognised case falls through to masking.
+ *
+ * The replacement matches rrweb's own default (`/[\S]/g` -> '*') so a masked
+ * recording looks the same as it did before this change, preserving word shape
+ * and whitespace for layout.
+ */
+export function maskText(text: string, element?: HTMLElement | null): string {
+  // closest() searches the element itself and its ancestors, so opting in a
+  // container opts in everything under it - same semantics as the mask side.
+  if (element && typeof element.closest === 'function' && element.closest(UNMASK_TEXT_SELECTOR)) {
+    return text;
+  }
+  return text.replace(/\S/g, '*');
+}
+
+/** The `session_recording` block passed to posthog.init(). Exported rather than
+ *  built inline in PostHogProvider so it can be asserted without a browser. */
+export const SESSION_RECORDING = {
+  maskAllInputs:    true,
+  maskTextSelector: MASK_TEXT_SELECTOR,
+  maskTextFn:       maskText,
+};


### PR DESCRIPTION
**Dev Team** → **QA Team**

Closes #103. The contract you asked for on the issue is in `lib/sessionRecording.ts`
and is what this PR is built around.

## Summary

Session-replay masking was a deny-list of five class names. It is now a
container mask with an opt-in exception, applied to five components rather than
one.

## What changed

| File | Change |
|---|---|
| `lib/sessionRecording.ts` | **new** — the whole config, exported |
| `components/PostHogProvider.tsx` | takes the config instead of spelling it out |
| `TradeJournal` `HypothesisTracker` `PnLCalc` `PositionSizer` `DcaCalc` | `className="lhq-private"` on the root |
| `__tests__/sessionRecordingMask.test.mts` | **new** — 11 assertions |

```ts
export const MASK_TEXT_SELECTOR   = '.lhq-private';
export const UNMASK_TEXT_SELECTOR = '[data-ph-safe]';   // zero usages today
export function maskText(text, element?): string;
export const SESSION_RECORDING = { maskAllInputs, maskTextSelector, maskTextFn };
```

## Why

Production records real user sessions. `maskAllInputs: true` covers what a user
**types**; it never covered what the app **renders**, and rendered text is where
this app keeps the sensitive material.

The old list had already leaked once — notes, thesis and P&L captured in the
clear — and was fixed by naming the five classes that were dangerous **that
day**. A new field defaults to unmasked, a rename stops masking, and neither
produces an error, a warning or a failing test. The only artifact is a video in
PostHog nobody watches.

Now a field is masked because of where it **is**, not because someone remembered.

## `unmaskTextSelector` does not exist — this uses a different hook

Full detail on #103. Short version: it is not in posthog-js 1.404.1, in the
types or the bundle. `maskTextFn` is, and rrweb calls it **only for text it has
already decided to mask**, handing it the parent element:

```js
maskTextFn ? maskTextFn(text, parentElement(n)) : text.replace(/[\S]/g, "*")
```

Which is a better hook for the failure you named. The exception cannot be
widened by appending a class to a config string — only by putting an attribute
on an element, in a diff.

## The sweep found four more surfaces

TradeJournal was the named one, not the only one:

| Component | Exposed as rendered text |
|---|---|
| `HypothesisTracker` | the user's own written hypotheses |
| `PnLCalc` | computed P&L |
| `PositionSizer` | account size, risk, position size |
| `DcaCalc` | entered ladder and averages |

The calculators are easy to miss for a specific reason: **none of them render
the answer into an input**, so `maskAllInputs` never reached it.

## How to test (QA)

On `qa` once promoted. **The masking itself cannot be observed outside
production** — see Risk — so these check the half that is observable.

1. `/journal`, `/calc`, `/research` — each page's main content sits inside an
   element with `class="lhq-private"`. Inspect the DOM, or
   `document.querySelectorAll('.lhq-private').length` in the console.
2. Nothing on those pages carries `data-ph-safe` — it should return **0**:
   `document.querySelectorAll('[data-ph-safe]').length`
3. Pages look and behave exactly as before. This adds a class and changes no
   styles; `.lhq-private` has no CSS rule anywhere.
4. `npm test` — 139 pass.

Your spec should cover more than `/journal`. That is the part of this I would
most like a second pair of eyes on.

## 🔴 Risk level — **Medium**, and the reason is what I could NOT verify

**Low in code**: one class per component, no style, no behaviour, all four gates
green (lint 0 errors, tsc clean, 139 tests, build), and both `lhq-private` and
`data-ph-safe` verified present in the built client bundle rather than only in
source.

**Medium because the fix cannot be exercised anywhere I can reach.** PostHog is
switched off in every non-production build by the #93 gate — `analyticsKey()`
returns `''` unless `NEXT_PUBLIC_APP_ENV === 'prod'`. So no recorder runs on
dev, qa or staging, and **no environment available to either of us can produce a
recording to inspect.** The config is only live in production.

What I verified instead: rrweb's masking and `maskTextFn` semantics read out of
the bundled source rather than assumed; the config compiles into the shipped
bundle; and the suite fails on both mutations — making `maskText` a no-op fails
4 assertions, removing the container class from one surface fails 2.

What remains unverified: **that a real recording is actually masked.** Stating
it rather than leaving it to be discovered.

## 🔴 One gap no test in this repository can close

PostHog's **remote** config can override masking:

```ts
masking?: Pick<SessionRecordingOptions, 'maskAllInputs' | 'maskTextSelector' | 'blockSelector'>
```

A change in the PostHog project settings can switch the container mask off with
nothing here changing, and every assertion in this PR would still pass.
`maskTextFn` is not in that `Pick` and survives — but it never fires if nothing
is being masked to begin with.

Flagged to the owner too. "The config is right in the code" is a weaker
statement than it looks.

## Environment variables

None added.
