### PR TITLE
fix(telegram): give failing responses a real status instead of 200

### DIFF
--- a/__tests__/telegramStatusCodes.test.mts
+++ b/__tests__/telegramStatusCodes.test.mts
@@ -1,0 +1,75 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/* `ok: false` answered with an HTTP 200.
+ *
+ * Four of these sat in the telegram routes. The Pro branch in test/route.ts had
+ * already been fixed once, with the reason written directly above it -
+ *
+ *   "it used to answer 200 with an error body, so any caller checking res.ok
+ *    read the rejection as success"
+ *
+ * - and the same shape was left in place three lines further down, plus in
+ * bot-info. Fixing instances is what let that happen; this asserts the rule.
+ *
+ * Found by QA's entitlements spec on its first run, via the assertion they
+ * nearly did not write: an unauthenticated caller must be turned away AS
+ * unauthenticated. Production has TELEGRAM_BOT_TOKEN set so the worst one never
+ * fired there - it fired on CI and staging, the environments we test on. */
+
+const dir = fileURLToPath(new URL('../app/api/telegram/', import.meta.url));
+
+/* Matches a NextResponse.json(...) whose body object contains ok: false, and
+   captures everything after that body up to the closing paren - which is where
+   an options object carrying `status` would be. Bodies here are flat, no nested
+   braces, so the non-greedy character class is sufficient and stays readable.
+
+   No `s` flag - it is unavailable at this tsconfig target, and unnecessary:
+   every part that has to cross a line break is a character class, which matches
+   newlines already. Nothing here relies on `.`. */
+const RESPONSE = /NextResponse\.json\(\s*\{[^{}]*\bok:\s*false[^{}]*\}([^;]*?)\)/g;
+
+const routes = readdirSync(dir, { withFileTypes: true })
+  .filter(e => e.isDirectory())
+  .map(e => `${e.name}/route.ts`);
+
+test('a failing telegram response never answers 200', async (t) => {
+  assert.ok(routes.length > 0, 'no telegram routes found - has the directory moved?');
+
+  for (const route of routes) {
+    await t.test(route, () => {
+      const src = readFileSync(dir + route, 'utf8');
+      for (const [call, tail] of src.matchAll(RESPONSE)) {
+        assert.match(
+          tail, /status:\s*\d{3}/,
+          `${route} returns ok: false with no status, so it answers 200 and any ` +
+          `caller checking res.ok reads the failure as success:\n\n${call.trim()}\n`,
+        );
+      }
+    });
+  }
+});
+
+/* The one that was reachable without credentials. Everything above is about
+   honest status codes; this is about not answering an anonymous caller at all.
+   The server-config check must sit BELOW the auth check, or an unauthenticated
+   request learns whether this server has a bot configured. */
+test('telegram/test does not answer an unauthenticated caller', () => {
+  /* Comments are stripped first. The route explains this ordering in a comment
+     that necessarily names TELEGRAM_BOT_TOKEN above the auth check, and a naive
+     indexOf reads that prose as the check itself - which it did, and failed. */
+  const src  = readFileSync(dir + 'test/route.ts', 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+  const auth = src.indexOf("'Sign in required'");
+  const cfg  = src.indexOf('process.env.TELEGRAM_BOT_TOKEN');
+
+  assert.ok(auth > 0 && cfg > 0, 'route no longer has the checks this asserts about');
+  assert.ok(
+    cfg > auth,
+    'the TELEGRAM_BOT_TOKEN check has moved back above the auth check - an ' +
+    'anonymous caller can again learn whether the server has a bot configured',
+  );
+});

--- a/app/api/telegram/bot-info/route.ts
+++ b/app/api/telegram/bot-info/route.ts
@@ -8,8 +8,21 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ ok: false, error: 'Rate limit exceeded' }, { status: 429 });
   }
 
+  // Public on purpose - /alerts calls this before sign-in - so this stays
+  // unauthenticated. It only gains a status: `ok: false` with 200 read as
+  // success to anything checking res.ok.
+  //
+  // The BODY is deliberately unchanged, webhook_ok: true included. The UI
+  // surfaces webhook_ok: false as a warning banner, and an environment with no
+  // bot has no webhook to be wrong about - flipping it would raise a fault
+  // where there is none.
   const token = process.env.TELEGRAM_BOT_TOKEN;
-  if (!token) return NextResponse.json({ ok: false, username: null, first_name: null, webhook_ok: true });
+  if (!token) {
+    return NextResponse.json(
+      { ok: false, username: null, first_name: null, webhook_ok: true },
+      { status: 503 },
+    );
+  }
 
   const [meRes, webhookRes] = await Promise.all([
     fetch(`https://api.telegram.org/bot${token}/getMe`, { cache: 'no-store', signal: AbortSignal.timeout(7_000) }),

--- a/app/api/telegram/test/route.ts
+++ b/app/api/telegram/test/route.ts
@@ -15,8 +15,15 @@ function makeSb(token: string) {
 }
 
 export async function GET(req: NextRequest) {
-  const botToken = process.env.TELEGRAM_BOT_TOKEN;
-  if (!botToken) return NextResponse.json({ ok: false, error: 'Bot not configured on server' });
+  // The server-config check used to live HERE, above the auth check, and
+  // answered 200. So on any environment without TELEGRAM_BOT_TOKEN this route
+  // was both unauthenticated and successful-looking, and an anonymous caller
+  // could learn whether the server had a bot configured. It now sits below the
+  // entitlement gate - see there.
+  //
+  // Production has the variable set, so it never fired there. It fired on CI
+  // and on staging until 2026-08-08 - the environments we test on, behaving
+  // differently from the one we ship.
 
   // Previously an anonymous caller (no Authorization header at all) fell
   // through to the global TELEGRAM_CHAT_ID env var below with no auth check
@@ -48,6 +55,17 @@ export async function GET(req: NextRequest) {
     );
   }
 
+  // Entitlement outranks server state: a free user is told they are not
+  // entitled, not what this server does or does not have configured.
+  // 503 matches push/test:34, which does the same thing for missing VAPID keys.
+  const botToken = process.env.TELEGRAM_BOT_TOKEN;
+  if (!botToken) {
+    return NextResponse.json(
+      { ok: false, error: 'Bot not configured on server' },
+      { status: 503 },
+    );
+  }
+
   const { data: settingsData } = await sb
     .from(T.user_settings)
     .select('telegram_chat_id')
@@ -57,8 +75,14 @@ export async function GET(req: NextRequest) {
   // authenticated, rate-limited Pro user, not an anonymous caller.
   const chatId = settingsData?.telegram_chat_id?.trim() || process.env.TELEGRAM_CHAT_ID || null;
 
+  // 409, not 400: the request is well-formed and authorised. What is not ready
+  // is the caller's own account state - they have not connected Telegram yet -
+  // and 400 would tell them they sent something wrong when they did not.
   if (!chatId) {
-    return NextResponse.json({ ok: false, error: 'No Chat ID configured. Connect Telegram first.' });
+    return NextResponse.json(
+      { ok: false, error: 'No Chat ID configured. Connect Telegram first.' },
+      { status: 409 },
+    );
   }
 
   const now = new Date().toLocaleString('en-GB', {
@@ -84,6 +108,10 @@ export async function GET(req: NextRequest) {
   });
 
   const data = await res.json();
-  if (!data.ok) return NextResponse.json({ ok: false, error: data.description });
+  // 502: Telegram rejected the send. Nothing the caller did and nothing they
+  // can fix, so it must not read as success to anything checking the status.
+  if (!data.ok) {
+    return NextResponse.json({ ok: false, error: data.description }, { status: 502 });
+  }
   return NextResponse.json({ ok: true });
 }


### PR DESCRIPTION
**Dev Team** → **QA Team**

Closes #129. Your ordering was right and my default was wrong — this had to go
before #124, because #124 carries the spec that is red on it.

## What changed

| Route | Condition | Was | Now |
|---|---|---|---|
| `telegram/test` | bot not configured | **200, before auth** | **503**, below auth |
| `telegram/test` | no chat id | 200 | **409** |
| `telegram/test` | Telegram rejected the send | 200 | **502** |
| `telegram/bot-info` | no token | 200 | **503** |

`bot-info` stays public and unauthenticated — it is deliberately out of `GATED`
in your spec, `/alerts` calls it before sign-in. It gains a status, not a gate.

## Two placement decisions worth stating

**The 503 sits below the Pro gate, not just below auth.** Entitlement outranks
server state: a free user is told they are not entitled, rather than what this
server does or does not have configured.

**`bot-info`'s body is unchanged, `webhook_ok: true` included.** The UI raises a
warning banner on `webhook_ok: false`, and an environment with no bot has no
webhook to be wrong about. Flipping it would invent a fault. Only the status
moved.

## I took your 409

You said take mine and leaned 409 anyway. Your argument is better than my 400:
the request is well-formed and authorised, and it is the caller's own account
state that is not ready. 400 tells a user they sent something wrong when they
did not.

## The test asserts the rule, not the four instances

That distinction is the whole reason this issue exists. The Pro branch in this
file was fixed once, with the reason written directly above it —

> it used to answer 200 with an error body, so any caller checking `res.ok` read
> the rejection as success

— and three lines further down the same shape survived. **Fixing instances is
what let the rest live.**

So the suite scans **all 8 telegram routes** and fails on any `ok: false`
response without a status, plus asserts the config check stays below the auth
check. A fifth one added later fails without anyone remembering this issue.

Both mutations verified to fail it: removing the 409 fails 2, moving the config
read back above auth fails 1.

One thing I would flag about my own test — it is source-scanning, not
behavioural. It cannot tell you the route *returns* 503; it tells you the code
says 503. Yours is the one that exercises it.

## How to test (QA)

On `qa` once promoted. `qa` has no `TELEGRAM_BOT_TOKEN`, which is what makes
this checkable there at all.

1. `curl -i https://liquidity-hq-qa.onrender.com/api/telegram/test`
   → **401**, not 200. This is the assertion that was red.
2. `curl -i https://liquidity-hq-qa.onrender.com/api/telegram/bot-info`
   → **503**, body unchanged.
3. `/alerts` signed in — the Telegram test button behaves exactly as before,
   same error text. It reads `d.ok` from the body, not `res.ok`, so no status
   change reaches it.
4. `npm test` — 149 pass.

Step 3 is the one that would show a regression. 1 and 2 are the fix.

## Risk level

**Low.** Four status codes and one moved guard, no logic change, no new
dependency. All four gates green (lint 0 errors, tsc, 149 tests, build).

**Not verified:** the routes' actual runtime responses. I have no environment
without `TELEGRAM_BOT_TOKEN` that I can curl — local has it, prod has it, and
`qa` only gets this once promoted. Step 1 above is therefore the first real
execution of the fix, and it is yours.

## Environment variables

None added.
