### PR TITLE
test(settings): add data-testid hooks for the a11y specs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,6 +207,29 @@ Commit messages are exempt: the `type(scope):` prefix already carries intent and
 the bodies are detailed enough to place. Say "QA" in the body anyway when a
 commit *is* a handoff or a request rather than just work.
 
+**One account also means no PR here can ever be approved.** GitHub refuses:
+
+```
+Review Can not approve your own pull request
+```
+
+The author is always the reviewer, so the button is unavailable on every PR —
+dev's, QA's, and the release PR. Review still happens; it lands as a comment.
+
+> **Do not add an approval requirement to any ruleset while dev and QA share one
+> GitHub account.** It cannot be satisfied by anyone, and it fails as an absent
+> check rather than a failing one.
+
+That is written as a prohibition because requiring an approval on `main` is the
+most obvious hardening anyone would reach for on a production branch, and it
+reads as unambiguously good practice. It would deadlock every release
+permanently, and the release PR would sit unmergeable with **nothing red to
+explain why**.
+
+Same signature as the bot-PR problem: automation blocked by a permission that
+reports nothing. Both were found by trying the thing, not by reading the config —
+which is the general lesson, and the reason neither was predicted.
+
 ---
 
 ### 3b. QA also tracks the project, and that pulls against being the gate

--- a/__tests__/testIdParity.test.mts
+++ b/__tests__/testIdParity.test.mts
@@ -1,0 +1,95 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/* #52 — QA's a11y specs select by CSS class, which nobody owes them stability
+ * on. These `data-testid` attributes are the stable hook.
+ *
+ * The reason this file exists is what happens NEXT. The attributes are only
+ * useful while they stay attached to every element carrying the class, and the
+ * specs that use them do not fail when one is missing - they measure LESS:
+ *
+ *   expect(pairs.length, 'no .tj-field label/control pairs found').toBeGreaterThan(0)
+ *
+ * Four fields today. Add a fifth without the attribute and that assertion still
+ * passes on the other four, having silently stopped covering the new one. Same
+ * shape as #108, where a fix addressed only the classes a failing test named.
+ *
+ * So this asserts PARITY: as many elements carry the class as carry the testid.
+ *
+ * WHAT THIS DOES NOT CHECK, stated rather than implied: that the two sit on the
+ * SAME element. Verifying that means parsing JSX opening tags, and `onClick={()
+ * => ...}` puts a `>` inside the tag, so a regex either truncates or needs a
+ * parser. Counting catches the case that actually happens - an element added
+ * without the attribute - and cannot fail spuriously. The pairing is a review
+ * concern, once, at the point the attribute is added. */
+
+const PAIRS: Array<{ cls: string; testId: string }> = [
+  { cls: 'login-error',  testId: 'login-error'   },
+  { cls: 'st-page',      testId: 'settings-page' },
+  { cls: 'tj-field',     testId: 'tj-field'      },
+  { cls: 'tj-edit-form', testId: 'tj-edit-form'  },
+  { cls: 'gchat-panel',  testId: 'grok-panel'    },
+  { cls: 'gchat-msgs',   testId: 'grok-messages' },
+];
+
+/** Every .tsx under app/ and components/ - not a fixed file list, so a NEW file
+ *  introducing one of these classes is covered without anyone updating this. */
+function sources(dir: string, out: string[] = []): string[] {
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    if (e.isDirectory()) sources(`${dir}/${e.name}`, out);
+    else if (e.name.endsWith('.tsx')) out.push(`${dir}/${e.name}`);
+  }
+  return out;
+}
+
+const files = [
+  ...sources(fileURLToPath(new URL('../app', import.meta.url))),
+  ...sources(fileURLToPath(new URL('../components', import.meta.url))),
+].map(f => stripComments(readFileSync(f, 'utf8')));
+
+/* Comments come out first. `app/login/page.tsx` documents the bug it fixed by
+   quoting the markup - `<div className="login-error">` - inside a comment, and
+   a scanner counts that as a seventh element. It did, on the first run.
+
+   Second time today a source-scanning test has read prose as code. Worth doing
+   this by default in anything that greps source for structure. */
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+}
+
+/* Reads the class list out of className="a b" and className={`a${...} b`}, so a
+   class is counted as a class rather than as a substring - '.tj-field' must not
+   match a comment mentioning it, and 'st-page' must not match 'st-page-header'. */
+const CLASS_ATTR = /className=(?:"([^"]*)"|\{`([^`]*)`)/g;
+
+function countClass(src: string, cls: string): number {
+  let n = 0;
+  for (const [, quoted, templated] of src.matchAll(CLASS_ATTR)) {
+    const raw = quoted ?? templated ?? '';
+    // Template literals interpolate: `gchat-panel${open ? ' gchat-open' : ''}`.
+    // Splitting on ${...} leaves the literal class names either side.
+    const names = raw.replace(/\$\{[^}]*\}/g, ' ').split(/\s+/).filter(Boolean);
+    if (names.includes(cls)) n++;
+  }
+  return n;
+}
+
+test('every element carrying a spec-selected class carries its data-testid', async (t) => {
+  for (const { cls, testId } of PAIRS) {
+    await t.test(`.${cls} -> [data-testid="${testId}"]`, () => {
+      const withClass = files.reduce((n, src) => n + countClass(src, cls), 0);
+      const withTestId = files.reduce(
+        (n, src) => n + (src.match(new RegExp(`data-testid="${testId}"`, 'g'))?.length ?? 0), 0);
+
+      assert.ok(withClass > 0, `.${cls} is gone from the source - QA's spec selects it`);
+      assert.equal(
+        withTestId, withClass,
+        `${withClass} element(s) carry .${cls} but ${withTestId} carry ` +
+        `data-testid="${testId}". An element was added or removed without its ` +
+        `test hook; the a11y spec will measure less rather than fail.`,
+      );
+    });
+  }
+});

--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -51,7 +51,7 @@ function CallbackInner() {
       <div className="login-wrap">
         <div className="login-card">
           <div className="login-logo">Liquidity<span>HQ</span></div>
-          <div className="login-error" style={{ marginTop: 24, textAlign: 'left' }}>
+          <div className="login-error" data-testid="login-error" style={{ marginTop: 24, textAlign: 'left' }}>
             Sign-in failed: {errMsg}
           </div>
           {/*

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -105,7 +105,7 @@ export default function ForgotPasswordPage() {
                 region exists before the text arrives. WCAG 2.2 SC 4.1.3.
                 The original claim in the audit named /login only; this page
                 does the same thing and has no live region either. */}
-            <div className="login-error" role="alert">{error}</div>
+            <div className="login-error" data-testid="login-error" role="alert">{error}</div>
 
             {/* No display override here - .login-back-btn centres its own text
                 via inline-flex, and `display: block` would defeat that. */}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -307,7 +307,7 @@ function LoginInner() {
                   `.login-error:empty` collapses it visually without
                   `display: none`, which would remove it from the accessibility
                   tree and reintroduce the bug. */}
-              <div className="login-error" role="alert">{error}</div>
+              <div className="login-error" data-testid="login-error" role="alert">{error}</div>
 
               <button
                 className="login-back-btn"
@@ -412,7 +412,7 @@ function LoginInner() {
 
               {/* Same as the magic-link form above - always present, empty
                   until it has something to say. See that comment. */}
-              <div className="login-error" role="alert">{pwError}</div>
+              <div className="login-error" data-testid="login-error" role="alert">{pwError}</div>
 
               <button
                 className="login-back-btn"

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -82,7 +82,7 @@ export default function ResetPasswordPage() {
       <div className="login-wrap">
         <div className="login-card">
           <div className="login-logo">Liquidity<span>HQ</span></div>
-          <div className="login-error" style={{ marginTop: 16 }}>{t('RESET_PASSWORD_INVALID_LINK')}</div>
+          <div className="login-error" data-testid="login-error" style={{ marginTop: 16 }}>{t('RESET_PASSWORD_INVALID_LINK')}</div>
           <Link href="/forgot-password" className="login-back-btn" style={{ display: 'block', marginTop: 14 }}>
             {t('RESET_PASSWORD_REQUEST_NEW_LINK')}
           </Link>
@@ -131,7 +131,7 @@ export default function ResetPasswordPage() {
               </button>
             </div>
 
-            {error && <div className="login-error">{error}</div>}
+            {error && <div className="login-error" data-testid="login-error">{error}</div>}
           </>
         )}
       </div>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -226,7 +226,7 @@ export default function SettingsPage() {
       t('SETTINGS_SECTION_TELEGRAM'),
     ];
     return (
-      <div className="st-page">
+      <div className="st-page" data-testid="settings-page">
         <div className="st-header"><h1 className="st-header-title">{t('SETTINGS_PAGE_TITLE')}</h1></div>
 
         <Section title={t('SETTINGS_SECTION_APPEARANCE')}>
@@ -282,7 +282,7 @@ export default function SettingsPage() {
   };
 
   return (
-    <div className="st-page">
+    <div className="st-page" data-testid="settings-page">
 
       <SaveToast status={saveStatus} />
 
@@ -324,7 +324,7 @@ export default function SettingsPage() {
           >
             {pwLoading ? <span className="login-spinner" /> : t('SETTINGS_PASSWORD_SAVE_BUTTON')}
           </button>
-          {pwError && <div className="login-error">{pwError}</div>}
+          {pwError && <div className="login-error" data-testid="login-error">{pwError}</div>}
           {pwSaved && <div className="login-success-desc">{t('SETTINGS_PASSWORD_SAVED')}</div>}
         </div>
 

--- a/components/GrokChat.tsx
+++ b/components/GrokChat.tsx
@@ -620,6 +620,7 @@ export default function GrokChat() {
           which is exactly the semantics opacity:0 was being asked to imply. */}
       <div
         className={`gchat-panel${open ? ' gchat-open' : ''}${expanded ? ' gchat-expanded' : ''}`}
+        data-testid="grok-panel"
         inert={!open}
         aria-hidden={!open}
       >
@@ -812,6 +813,7 @@ export default function GrokChat() {
                 everything again" once a thread is a few messages long. */}
             <div
               className="gchat-msgs"
+              data-testid="grok-messages"
               ref={msgsRef}
               role="log"
               aria-live="polite"

--- a/components/TradeJournal.tsx
+++ b/components/TradeJournal.tsx
@@ -873,25 +873,25 @@ function Inner() {
           <div className="tj-card">
             <div className="tj-card-lbl">{t('TRADE_JOURNAL_LOG_PRICE_LEVELS_LABEL')}</div>
             <div className="tj-price-grid">
-              <div className="tj-field">
+              <div className="tj-field" data-testid="tj-field">
                 <label className="tj-lbl">{t('TRADE_JOURNAL_LOG_ENTRY_LABEL')}</label>
                 <div className="tj-irow"><span className="tj-affix">$</span>
                   <input className="tj-inp" aria-label={t('TRADE_JOURNAL_LOG_ENTRY_ARIA')} type="number" placeholder="0.00" value={entry} onChange={e => setEntry(e.target.value)} />
                 </div>
               </div>
-              <div className="tj-field">
+              <div className="tj-field" data-testid="tj-field">
                 <label className="tj-lbl">{t('TRADE_JOURNAL_LOG_STOP_LOSS_LABEL')}</label>
                 <div className="tj-irow"><span className="tj-affix">$</span>
                   <input className="tj-inp tj-inp-stop" aria-label={t('TRADE_JOURNAL_LOG_STOP_LOSS_ARIA')} type="number" placeholder="0.00" value={stopLoss} onChange={e => setStopLoss(e.target.value)} />
                 </div>
               </div>
-              <div className="tj-field">
+              <div className="tj-field" data-testid="tj-field">
                 <label className="tj-lbl">{t('TRADE_JOURNAL_LOG_TAKE_PROFIT_LABEL')}</label>
                 <div className="tj-irow"><span className="tj-affix">$</span>
                   <input className="tj-inp tj-inp-tp" aria-label={t('TRADE_JOURNAL_LOG_TAKE_PROFIT_LABEL')} type="number" placeholder="0.00" value={tpPrice} onChange={e => setTpPrice(e.target.value)} />
                 </div>
               </div>
-              <div className="tj-field">
+              <div className="tj-field" data-testid="tj-field">
                 <label className="tj-lbl">{t('TRADE_JOURNAL_LOG_POSITION_SIZE_LABEL')}</label>
                 <div className="tj-irow"><span className="tj-affix">$</span>
                   <input className="tj-inp" aria-label={t('TRADE_JOURNAL_LOG_POSITION_SIZE_ARIA')} type="number" placeholder={t('TRADE_JOURNAL_LOG_POSITION_SIZE_PLACEHOLDER')} value={posUSD} onChange={e => setPosUSD(e.target.value)} />
@@ -1165,7 +1165,7 @@ function Inner() {
 
               {/* Inline edit form */}
               {editingId === trade.id && (
-                <div className="tj-edit-form">
+                <div className="tj-edit-form" data-testid="tj-edit-form">
                   {/* WCAG 2.2 SC 4.1.2 Name, Role, Value (Level A), issue #48.
                       The visible labels were already here - they just named
                       nothing: no htmlFor, wrapping no control. A screen reader


### PR DESCRIPTION
**Dev Team** → **QA Team**

Closes #52. Attributes only — **no spec touched**, per the split you confirmed.
`qa/e2e/` is untouched and yours.

## Two corrections to what I told you

**It is not six attributes, it is 16.** Six *selectors*, but they sit on 16
elements:

| selector | testid | elements |
|---|---|---|
| `.login-error` | `login-error` | **7**, across 5 files |
| `.st-page` | `settings-page` | **2** |
| `.tj-field` | `tj-field` | **4** |
| `.tj-edit-form` | `tj-edit-form` | 1 |
| `.gchat-panel` | `grok-panel` | 1 |
| `.gchat-msgs` | `grok-messages` | 1 |

**And it is not `components/` only.** Five of the seven files are under `app/` —
`login`, `forgot-password`, `reset-password`, `auth/callback`, `settings`. I said
`components/*.tsx` when I named my boundary; that was wrong and I am correcting
it rather than quietly widening. You said your RTL work is a new spec plus
`_shared.ts`, so it still does not collide — but the boundary I claimed was not
the boundary I needed.

Testid names mirror the class names so your rename is mechanical, except
`.st-page` → `settings-page` and the two `gchat-` → `grok-`, where the class
abbreviation would have made a worse public name.

## The part worth more than the attributes

Your specs do not fail when an element is missing. They measure less:

```ts
expect(pairs.length, 'no .tj-field label/control pairs found').toBeGreaterThan(0)
```

Four fields today. A fifth added without the attribute still passes on the other
four, having silently stopped covering the new one. That is #108 exactly — a fix
that addressed only the classes a failing test named.

So there is a parity test: **as many elements carry each class as carry its
testid**, scanned across every `.tsx` in `app/` and `components/` — not a fixed
file list, so a new file introducing `.login-error` is covered without anyone
remembering this PR.

Mutation verified: removing one attribute fails 2 assertions.

**What it does not check, said plainly:** that the class and the testid sit on
the *same* element. Proving that means parsing JSX opening tags, and
`onClick={() => ...}` puts a `>` inside the tag, so a regex either truncates or
needs a real parser. Counting catches the case that actually happens — an
element added without its hook — and cannot fail spuriously. The pairing is a
review concern, once, at the point the attribute is added. Which is now, and is
the thing to look at in this diff.

## It caught something on its first run

It reported 8 elements with `.login-error` against 7 testids. The eighth was
`app/login/page.tsx` quoting `<div className="login-error">` **inside a comment**
that documents an old bug.

Second time today a source-scanning test has read my own prose as code — the
telegram one did it too. The fix is the same both times and is now in both
files: strip comments before scanning. Worth knowing if you write one.

## CONTRIBUTING — done, and your premise was wrong

You said put it next to the #126 note. **There is no #126 note in
`CONTRIBUTING.md`** — that discussion only ever lived on the issue. So this is a
new paragraph, in **§3a**, which is already the section about one account meaning
two roles. The approval limit is another consequence of the same fact, so it
belongs with it rather than in a CI section.

Your sentence is in verbatim as a block quote. I added why it is phrased as a
prohibition, and that both instances were found by trying the thing rather than
reading the config.

## How to test (QA)

1. `npm test` — 156 pass, including 7 new parity assertions.
2. Any page in the table renders identically. These are inert attributes; no
   style, no behaviour, no handler.
3. When you do the selector swap: `[data-testid="login-error"]` returns the same
   7 elements `.login-error` does. If it does not, the parity test missed a
   pairing and I want to know.

## Risk level

**Low.** Inert attributes and one docs paragraph. All four gates green (lint 0
errors, tsc, 156 tests, build).

**Unverified:** that the testids select the same elements in a *browser*. The
parity test counts source occurrences; only your spec swap proves the selectors
resolve. That is step 3 and it is yours.
