### PR TITLE
fix(ci): open the release PR with a PAT so it triggers its own CI

### DIFF
--- a/.github/workflows/release-signals.yml
+++ b/.github/workflows/release-signals.yml
@@ -44,9 +44,31 @@ jobs:
         with:
           fetch-depth: 0
 
+      # WHY A PAT AND NOT github.token, because the next person will assume it
+      # is unnecessary and remove it:
+      #
+      # GitHub does not trigger workflows on events created by GITHUB_TOKEN.
+      # It is deliberate anti-recursion, and it has no opt-out. So a release PR
+      # opened by this job never fired `pull_request`, CI never ran, and the
+      # required `CI Gate` check was ABSENT rather than failing - a PR blocked
+      # forever with nothing red to explain why. That is #126, and it was caused
+      # by the automation added in #99.
+      #
+      # A PAT is a different actor, so the PR it opens triggers CI normally.
+      #
+      # RELEASE_PAT is fine-grained, this repo only, contents:read +
+      # pull-requests:write + issues:write. Expiry is recorded in
+      # docs/INFRASTRUCTURE.md §1 - when it lapses the release PR simply stops
+      # appearing, and the symptom carries no hint of the cause.
+      #
+      # NO FALLBACK TO github.token, on purpose. A fallback would mean an absent
+      # or expired secret quietly restores exactly the bug above. Instead the
+      # step fails, the job fails, and `release-pr-failed` below opens an issue
+      # carrying the release body - loud, and the release is not even blocked
+      # while someone rotates the token.
       - name: Open the staging -> main release PR if there is not one
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -244,6 +266,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      # THIS MUST KEEP github.token. Do not "tidy" RELEASE_PAT up to a
+      # workflow-level env: - the whole reason the PAT is safe to adopt is that
+      # this job runs on a DIFFERENT credential. Share one and an expired token
+      # kills the fallback and the primary together, which is the silence both
+      # were built to remove.
+      #
+      # Issues do not need to trigger workflows, so github.token's anti-recursion
+      # rule costs nothing here. It is the release PR that needed a real actor.
       - name: Open an issue carrying the release list
         env:
           GH_TOKEN: ${{ github.token }}

--- a/__tests__/releaseSignalsTokens.test.mts
+++ b/__tests__/releaseSignalsTokens.test.mts
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+/* #126 — the release PR opens itself, and for its whole life it never ran CI.
+ *
+ * GitHub does not trigger workflows on events created by GITHUB_TOKEN. It is
+ * deliberate anti-recursion with no opt-out, so a bot-opened PR fired no
+ * `pull_request` event, the required `CI Gate` check was ABSENT rather than
+ * failing, and the PR was unmergeable with nothing red to explain why.
+ *
+ * The fix is a PAT on the release-PR step. What makes the PAT safe to adopt is
+ * that its failure mode is LOUD: an expired token fails `gh pr create`, and
+ * `release-pr-failed` opens an issue carrying the release body.
+ *
+ * THAT ARGUMENT HOLDS ONLY WHILE THE TWO JOBS USE DIFFERENT CREDENTIALS.
+ * Hoisting RELEASE_PAT to a workflow-level `env:` looks like tidying and reads
+ * as harmless. It would make one expiry kill the primary and the fallback
+ * together - restoring the exact silence both were built to remove.
+ *
+ * Nothing else can catch that. There is no environment where a lapsed PAT can
+ * be rehearsed, and the symptom is a release PR that stops appearing.
+ *
+ * Text, not YAML: `js-yaml` resolves here but is NOT a declared dependency -
+ * it arrives transitively, so a dependency bump could remove it and take this
+ * test with it. The file's job blocks are unambiguous at four-space indent. */
+
+/* Line endings normalised first. Git checks this out CRLF on Windows and LF on
+   the CI runner, so a pattern anchored on `:\n` matches in CI and not on a
+   developer's machine - green where nobody looks, red where they do. Found by
+   this test failing locally while the workflow was correct. */
+const SRC = readFileSync(
+  new URL('../.github/workflows/release-signals.yml', import.meta.url), 'utf8',
+).replace(/\r\n/g, '\n');
+
+/** The lines belonging to one job, from its `  name:` header to the next one,
+ *  with full-line comments removed.
+ *
+ *  The comments have to go, and this is the third time today a source-scanning
+ *  test has read prose as code. The comment on `release-pr-failed` says "do not
+ *  tidy RELEASE_PAT up to a workflow-level env:" - so a check for the ABSENCE of
+ *  RELEASE_PAT in that job failed on the sentence warning against it.
+ *
+ *  Only whole-line comments are stripped, not `#` to end of line: the run blocks
+ *  contain shell strings with `#` in them (issue references, colour literals),
+ *  and a naive strip would silently truncate the very lines being checked. */
+function job(name: string): string {
+  const start = SRC.indexOf(`\n  ${name}:\n`);
+  assert.ok(start > 0, `job "${name}" is gone from release-signals.yml`);
+  const rest = SRC.slice(start + 1);
+  const next = rest.search(/\n {2}[a-z][a-z0-9-]*:\n/);
+  const block = next === -1 ? rest : rest.slice(0, next);
+  return block.split('\n').filter(l => !/^\s*#/.test(l)).join('\n');
+}
+
+test('release-signals token separation', async (t) => {
+  await t.test('the release PR is opened by the PAT, not the bot', () => {
+    const j = job('release-pr');
+    assert.match(j, /GH_TOKEN:\s*\$\{\{\s*secrets\.RELEASE_PAT\s*\}\}/,
+      'release-pr must use RELEASE_PAT - with github.token the PR it opens ' +
+      'never triggers CI, and CI Gate is absent rather than failing (#126)');
+  });
+
+  /* The invariant everything else rests on. */
+  await t.test('the fallback runs on a different credential', () => {
+    const j = job('release-pr-failed');
+    assert.doesNotMatch(j, /RELEASE_PAT/,
+      'release-pr-failed must NOT use RELEASE_PAT. It exists to report the ' +
+      'primary failing; sharing the credential means one expiry silences both.');
+    assert.match(j, /GH_TOKEN:\s*\$\{\{\s*github\.token\s*\}\}/,
+      'release-pr-failed must keep github.token');
+  });
+
+  /* A workflow-level env: would leak the PAT into every job including the
+     fallback, which is the tidy-up the test above cannot see on its own -
+     the fallback would still not MENTION RELEASE_PAT while using it. */
+  await t.test('no workflow-level env hands the PAT to every job', () => {
+    const header = SRC.slice(0, SRC.indexOf('\njobs:'));
+    assert.doesNotMatch(header, /GH_TOKEN/,
+      'GH_TOKEN is set at workflow level - every job now shares one credential, ' +
+      'including the fallback that exists to survive that credential failing');
+  });
+
+  /* Not a token concern, but the same file and the same failure shape: this
+     job reads production and must never be the thing that writes to it. */
+  await t.test('the drift check still runs on the default token', () => {
+    assert.match(job('prod-drift'), /GH_TOKEN:\s*\$\{\{\s*github\.token\s*\}\}/);
+  });
+});


### PR DESCRIPTION
**Dev Team** → **QA Team**

Closes #126. One token swap, one invariant, one test that exists because nothing
else can catch this.

## What changed

| Job | Token | Why |
|---|---|---|
| `release-pr` | **`secrets.RELEASE_PAT`** | a PAT is a different actor, so the PR it opens triggers CI |
| `release-pr-failed` | `github.token` — **unchanged, load-bearing** | must survive the credential that killed the primary |
| `prod-drift` | `github.token` — unchanged | reads production, triggers nothing |

## Where I differed from your spec, and why

Your point 1 asked for two different things in one sentence:

> If `RELEASE_PAT` is empty the step should behave **as it does today** — try,
> **fail**, and let #123 raise the issue.

Those are opposite outcomes. **Today it succeeds silently** — the PR opens, CI
never runs, nothing is red. That is the bug.

So there is **no `|| github.token` fallback**. An absent or expired secret fails
`gh pr create`, fails the job, and #123 opens an issue carrying the release body.
I read that as your actual intent — the second half of the sentence, not the
first. If you meant the literal first half, say so and I will change it, but I
think a fallback would quietly reintroduce exactly what we are closing.

## The invariant your own argument depends on

The PAT is safe to adopt **only because the fallback runs on a different
credential**. Share one and a single expiry silences both — the primary stops
opening the PR, and the thing built to announce that failure dies with it.

Nothing in the YAML says so, and hoisting `RELEASE_PAT` to a workflow-level
`env:` looks like tidying. It is now a comment on the job **and** an assertion:

- `release-pr` uses the PAT
- `release-pr-failed` does **not**
- no workflow-level `env:` sets `GH_TOKEN` — the tidy-up neither of the first two
  would see on its own, since the fallback would still not *mention* the PAT
  while using it

Both mutations fail it: reverting the PAT fails 2, sharing it with the fallback
fails 2.

**This is the only place that failure can be caught.** A lapsed PAT cannot be
rehearsed in any environment, and its symptom is a release PR that stops
appearing.

## Three things I got wrong writing the test, since two are portable

1. **CRLF.** Git checks this file out CRLF locally and LF on the runner, so a
   pattern anchored on `:\n` would have passed in CI and failed on a developer's
   machine. Normalised on read.
2. **It read my own comment as code.** The `doesNotMatch(/RELEASE_PAT/)` check on
   the fallback failed on the comment *warning against* putting `RELEASE_PAT`
   there. **Third time today** — the telegram and testid suites both did it too.
   Whole-line comments only, so shell strings containing `#` survive.
3. **`js-yaml` is not a declared dependency.** It resolves here transitively, so
   a test importing it could vanish on a dependency bump. Text scanning instead.

## How to test (QA)

Cannot be verified before it runs. That is the nature of it.

**The real test is the next `qa` → `staging` promotion after the halt lifts:**
the release PR opens **and its `CI Gate` check queues within a minute or two,
unattended.** The PR appearing is not the test — it appeared last time and the
checks never came.

Locally: `npm test` — 154 pass, 5 new.

Keep #126 open until a check queues on a PR nobody touched. Agreed with your
framing entirely.

## Risk level

**Medium**, and only because of when it fails.

Low in content — one `env:` value, no logic. But the first execution is a real
release, and if `RELEASE_PAT` is wrong in any way (scope, expiry, name) that run
is when we find out. The failure is loud and non-blocking by design: #123 raises
an issue with the release body, and you open the PR by hand as you did for #98.

**Unverified:** that the PAT has the permissions the owner intended. I cannot
read a secret and would not. `gh pr create` needs `pull_requests: write` and
`contents: read` on this repo — if it 403s on the first run, that is the thing to
check.

## Environment variables

`RELEASE_PAT` — repository **secret**, already created by the owner. Expires
**2027-08-09**, recorded on #84.
