### PR TITLE
feat(api): downgrade immediately when a renewal payment fails

### DIFF
--- a/__tests__/lemonsqueezyEvents.test.mts
+++ b/__tests__/lemonsqueezyEvents.test.mts
@@ -1,0 +1,103 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { patchForEvent } from '../lib/lemonsqueezy.ts';
+
+/* The webhook decides who is a paying customer, and per qa/QA_TEST_PLAN.md it
+ * has never processed a payload in any environment - payments are not live and
+ * no real payload exists to test with. Three weeks from launch that made it the
+ * least exercised thing in the product.
+ *
+ * These cover the DECISION. QA's signed-payload harness covers the route -
+ * signature, replay guard, ownership check, the write. Neither replaces the
+ * other, and only this half can run today. */
+
+const ACTIVE = { status: 'active', customer_id: 42, renews_at: '2026-09-08T00:00:00Z' };
+
+test('LemonSqueezy event -> subscription row', async (t) => {
+  await t.test('an active subscription grants Pro', () => {
+    const p = patchForEvent('subscription_created', ACTIVE, 'sub_1');
+    assert.equal(p?.role, 'pro');
+    assert.equal(p?.ls_subscription_id, 'sub_1');
+    assert.equal(p?.ls_customer_id, '42');
+    assert.equal(p?.current_period_end, '2026-09-08T00:00:00Z');
+  });
+
+  /* OWNER DECISION, 2026-08-08: immediate downgrade, no grace period.
+     LemonSqueezy retries a failed renewal for days, so a declined card ends Pro
+     on the FIRST failure and restores it if a retry succeeds. That flapping is
+     the accepted cost of the decision - if this test ever reads as wrong, the
+     decision changed, not the code. */
+  await t.test('a failed payment ends access immediately, no grace period', () => {
+    const p = patchForEvent('subscription_payment_failed', { status: 'failed' }, 'inv_9');
+    assert.equal(p?.role, 'free');
+  });
+
+  /* The invoice payload's data.id is an INVOICE id. Writing it into
+     ls_subscription_id would silently overwrite the link to the real
+     subscription, and nothing downstream would look wrong until someone tried
+     to reconcile a customer against LemonSqueezy. */
+  await t.test('an invoice id is never written as the subscription id', () => {
+    const p = patchForEvent('subscription_payment_failed', { status: 'failed' }, 'inv_9');
+    assert.equal(p?.ls_subscription_id, undefined);
+  });
+
+  await t.test('an order id is never written as the subscription id either', () => {
+    const p = patchForEvent('order_refunded', { status: 'refunded' }, 'order_7');
+    assert.equal(p?.ls_subscription_id, undefined);
+    assert.equal(p?.role, 'free');
+  });
+
+  /* ASSUMPTION, NOT A DECISION - the owner answered failed payments only.
+     Refunding means the money went back, so the customer is not one. If that is
+     wrong, this test is where it is written down and the fix is one line in
+     ENDS_ACCESS. */
+  await t.test('a refund ends access (stated assumption, not an owner decision)', () => {
+    assert.equal(patchForEvent('subscription_payment_refunded', { status: 'refunded' })?.role, 'free');
+  });
+
+  /* past_due is what LemonSqueezy sets the SUBSCRIPTION to when a renewal
+     fails, and it fires subscription_updated for it. So the downgrade has two
+     independent routes. They agree, which is what makes it safe - if
+     custom_data does not survive onto invoice events (unverified, payments are
+     not live), this path still ends access. */
+  await t.test('past_due via subscription_updated downgrades too', () => {
+    assert.equal(patchForEvent('subscription_updated', { status: 'past_due' })?.role, 'free');
+  });
+
+  await t.test('expiry ends access', () => {
+    assert.equal(patchForEvent('subscription_expired', { status: 'expired' })?.role, 'free');
+  });
+
+  /* Records today's behaviour, which issue #134 says is wrong: LemonSqueezy
+     "cancelled" means auto-renew off, and the user keeps access until ends_at.
+     Asserting it keeps the defect visible instead of letting it read as
+     intended. When #134 is decided this test changes with the code. */
+  await t.test('cancellation downgrades immediately - see #134, this is the defect', () => {
+    assert.equal(patchForEvent('subscription_cancelled', { status: 'cancelled' })?.role, 'free');
+  });
+
+  /* null, not an empty patch. The caller skips the database write entirely on
+     null; a patch would mean "write these columns", and an event we do not
+     understand must not touch the row. */
+  await t.test('an unknown event returns null so nothing is written', () => {
+    assert.equal(patchForEvent('order_created', { status: 'paid' }, 'order_1'), null);
+    assert.equal(patchForEvent('', {}), null);
+  });
+
+  await t.test('a missing status never becomes the string "undefined"', () => {
+    assert.equal(patchForEvent('subscription_created', {}, 'sub_2')?.ls_status, '');
+    // Falls back to the event name, which records WHY the row changed.
+    assert.equal(patchForEvent('subscription_payment_failed', {})?.ls_status, 'payment_failed');
+  });
+
+  await t.test('a missing renewal date is null, not undefined', () => {
+    assert.equal(patchForEvent('subscription_created', { status: 'active' }, 's')?.current_period_end, null);
+  });
+
+  /* ends_at is the fallback for a subscription with no renewal date - one that
+     is cancelled but still running. Order matters: renews_at wins. */
+  await t.test('ends_at is used when there is no renews_at', () => {
+    const p = patchForEvent('subscription_updated', { status: 'active', ends_at: '2026-10-01T00:00:00Z' }, 's');
+    assert.equal(p?.current_period_end, '2026-10-01T00:00:00Z');
+  });
+});

--- a/app/api/lemonsqueezy/webhook/route.ts
+++ b/app/api/lemonsqueezy/webhook/route.ts
@@ -3,6 +3,7 @@ import crypto from 'crypto';
 import { apiError } from '@/lib/apiError';
 import { getSupabaseAdmin } from '@/lib/supabase-admin';
 import { T } from '@/lib/tables';
+import { patchForEvent } from '@/lib/lemonsqueezy';
 
 const SECRET = process.env.LEMONSQUEEZY_WEBHOOK_SECRET ?? '';
 
@@ -81,34 +82,18 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ received: true, ignored: 'email_mismatch' });
   }
 
-  const isActive = attrs.status === 'active';
+  // The decision lives in lib/lemonsqueezy.ts so it can be tested without a
+  // database, a signature or a LemonSqueezy account - see the comment there.
+  // null means an event we do not act on, which must stay distinguishable from
+  // "act, and the result is no change".
+  const patch = patchForEvent(eventName, attrs, String(event.data?.id ?? ''));
+  if (!patch) return NextResponse.json({ received: true, ignored: 'unhandled_event' });
 
-  switch (eventName) {
-    case 'subscription_created':
-    case 'subscription_updated':
-    case 'subscription_payment_success': {
-      await sb.from(T.user_subscriptions).upsert({
-        user_id:            userId,
-        role:               isActive ? 'pro' : 'free',
-        ls_subscription_id: String(event.data?.id ?? ''),
-        ls_customer_id:     String(attrs.customer_id ?? ''),
-        ls_status:          attrs.status ?? '',
-        current_period_end: attrs.renews_at ?? attrs.ends_at ?? null,
-        updated_at:         new Date().toISOString(),
-      }, { onConflict: 'user_id' });
-      break;
-    }
-    case 'subscription_cancelled':
-    case 'subscription_expired': {
-      await sb.from(T.user_subscriptions).upsert({
-        user_id:    userId,
-        role:       'free',
-        ls_status:  attrs.status ?? eventName.replace('subscription_', ''),
-        updated_at: new Date().toISOString(),
-      }, { onConflict: 'user_id' });
-      break;
-    }
-  }
+  await sb.from(T.user_subscriptions).upsert({
+    user_id:    userId,
+    ...patch,
+    updated_at: new Date().toISOString(),
+  }, { onConflict: 'user_id' });
 
   return NextResponse.json({ received: true });
 }

--- a/lib/lemonsqueezy.ts
+++ b/lib/lemonsqueezy.ts
@@ -1,0 +1,117 @@
+/* What a LemonSqueezy webhook event means for a user's subscription row.
+ *
+ * Pulled out of the route handler because of the reason this file exists at all:
+ * per qa/QA_TEST_PLAN.md the webhook "has never been tested, payments aren't
+ * live, no real webhook payload exists to test with". The 114 lines that decide
+ * who is a paying customer had never run against a payload in ANY environment.
+ *
+ * A pure function can be tested today, with no database, no signature, and no
+ * LemonSqueezy account. That does not replace QA's signed-payload harness - the
+ * harness proves the route verifies, dedupes and writes; this proves the
+ * decision itself. Different halves.
+ */
+
+export type SubscriptionRole = 'pro' | 'free';
+
+/** The columns an event implies. `user_id` and `updated_at` are the caller's. */
+export interface SubscriptionPatch {
+  role: SubscriptionRole;
+  ls_status: string;
+  ls_subscription_id?: string;
+  ls_customer_id?: string;
+  current_period_end?: string | null;
+}
+
+/** The subset of a payload's `data.attributes` this decision reads. */
+export interface EventAttributes {
+  status?: unknown;
+  customer_id?: unknown;
+  renews_at?: unknown;
+  ends_at?: unknown;
+}
+
+/* Events whose payload `data` IS the subscription, so its id is the
+   subscription id and `status` is the subscription's status. */
+const SUBSCRIPTION_EVENTS = new Set([
+  'subscription_created',
+  'subscription_updated',
+  'subscription_payment_success',
+]);
+
+/* Events that end access immediately.
+ *
+ * `subscription_payment_failed` is here by an owner decision on 2026-08-08:
+ * immediate downgrade, no grace period. LemonSqueezy retries a failed renewal
+ * for several days before giving up, so a user whose card declines loses Pro on
+ * the first failure and regains it if a retry succeeds. That flapping is the
+ * accepted cost of the decision, not an oversight.
+ *
+ * The refund events are here under a STATED ASSUMPTION rather than a decision:
+ * the money has been returned, so the customer is not one. Reverse this if the
+ * owner disagrees - it is one line and the tests name it explicitly.
+ *
+ * `subscription_expired` is the genuine end of a paid period.
+ *
+ * `subscription_cancelled` is NOT here and its presence in the same branch as
+ * `expired` in the route is a defect - see issue #134. Cancellation means
+ * auto-renew off, not access ended, and downgrading on it takes back a period
+ * the user has already paid for. Left alone deliberately: fixing it needs
+ * getEntitlement() to end access at current_period_end, which is not this
+ * change. */
+const ENDS_ACCESS = new Set([
+  'subscription_payment_failed',
+  'subscription_payment_refunded',
+  'order_refunded',
+  'subscription_cancelled',
+  'subscription_expired',
+]);
+
+/**
+ * The row change an event implies, or `null` for an event we do not act on.
+ *
+ * Returning null rather than a no-op patch matters: the caller must be able to
+ * tell "this event means nothing to us" from "this event means stay as you
+ * are", because only the first should skip the write entirely.
+ *
+ * @param dataId `event.data.id`. Only written as `ls_subscription_id` for the
+ *   events whose data IS a subscription. On `subscription_payment_failed` the
+ *   payload is a subscription INVOICE and on `order_refunded` it is an ORDER,
+ *   so `data.id` is an invoice/order id - writing it into `ls_subscription_id`
+ *   would silently corrupt the link to the real subscription.
+ */
+export function patchForEvent(
+  eventName: string,
+  attrs: EventAttributes = {},
+  dataId?: string,
+): SubscriptionPatch | null {
+  const status = typeof attrs.status === 'string' ? attrs.status : '';
+
+  if (SUBSCRIPTION_EVENTS.has(eventName)) {
+    return {
+      // Any status other than 'active' means no Pro. LemonSqueezy uses
+      // 'past_due' the moment a renewal fails, so this path can downgrade too -
+      // which is consistent with the decision, not a second opinion on it.
+      role:               status === 'active' ? 'pro' : 'free',
+      ls_status:          status,
+      ls_subscription_id: dataId ?? '',
+      ls_customer_id:     attrs.customer_id == null ? '' : String(attrs.customer_id),
+      current_period_end: pickDate(attrs.renews_at) ?? pickDate(attrs.ends_at) ?? null,
+    };
+  }
+
+  if (ENDS_ACCESS.has(eventName)) {
+    return {
+      role: 'free',
+      // An invoice/order payload's `status` describes the invoice ('failed',
+      // 'refunded'), not the subscription - so fall back to the event name,
+      // which is the more truthful record of why the row changed.
+      ls_status: status || eventName.replace('subscription_', ''),
+    };
+  }
+
+  return null;
+}
+
+function pickDate(v: unknown): string | null {
+  return typeof v === 'string' && v.length > 0 ? v : null;
+}


### PR DESCRIPTION
**Dev Team** → **QA Team**

The owner's dunning decision, implemented. **Immediate downgrade on a failed
payment, no grace period.**

## What changed

| Event | Before | Now |
|---|---|---|
| `subscription_payment_failed` | **ignored entirely** | `role: 'free'` |
| `subscription_payment_refunded` | **ignored entirely** | `role: 'free'` |
| `order_refunded` | **ignored entirely** | `role: 'free'` |
| everything else | unchanged | unchanged |

A declined renewal previously did **nothing**. The user kept full Pro through
LemonSqueezy's multi-day retry window, then lost it abruptly when the
subscription finally expired — no signal at any point, to them or to us. A
refunded user kept `role='pro'` until some other event happened to move them.

## Two things that are decisions, not code

**Flapping is accepted.** LemonSqueezy retries a failed renewal for days. Under
this rule a declined card ends Pro on the *first* failure and restores it if a
retry succeeds. That is the owner's call, stated in the test so that if it ever
reads as wrong, it is the decision that changed.

**Refunds are a stated assumption, not a decision.** The owner answered failed
payments only. I applied the same rule — money returned means not a customer —
and it is one line in `ENDS_ACCESS` to reverse. Named in the test rather than
buried.

## The extraction is as much the point as the handlers

Your test plan says it plainly: the webhook *"has never been tested, payments
aren't live, no real webhook payload exists to test with"*. So the code deciding
who is a paying customer had no test of any kind, and adding two branches to it
would have been adding untested code to untested code.

`patchForEvent()` in `lib/lemonsqueezy.ts` is pure — **no database, no
signature, no LemonSqueezy account.** 13 cases run today.

This does **not** replace your harness. Yours proves the route verifies,
dedupes, checks ownership and writes. Mine proves the decision. Only one of them
can run before keys exist.

## 🔴 Two things I could not verify, both real

**1. Does `custom_data.user_id` survive onto invoice events?** The route returns
early at `:40` without it. `subscription_payment_failed` carries a subscription
**invoice**, not a subscription, and I have no way to confirm LemonSqueezy
propagates custom data onto it. **If it does not, this handler never runs.**

There is a second path that saves it: LemonSqueezy sets the subscription to
`past_due` on failure and fires `subscription_updated`, which already downgrades
anything not `active`. Both routes agree, which is why I am comfortable — but
your harness should settle which one actually fires.

**2. That the route still behaves identically for existing events.** The switch
became one call plus one upsert. Verified by reading and by tests, not by
running a payload.

## Not fixed here — #134

`subscription_cancelled` shares a branch with `expired` and downgrades a user who
has already paid for the rest of the period. Opposite direction, needs its own
decision, filed separately.

There is a test asserting today's (wrong) behaviour, so the defect stays visible
instead of reading as intended. It changes with the code when #134 is decided.

## How to test (QA)

1. `npm test` — 174 pass, 13 new.
2. When the harness exists: post a signed `subscription_payment_failed` for a
   `pro` fixture and assert the row goes `free`. **That is the first real
   execution of this.**
3. Same for `order_refunded`.
4. Confirm `custom_data.user_id` is present on the invoice payload. If it is
   absent, item 1 above is real and I want to know.

## Risk level

**Medium**, and only because nothing here has ever run against a payload.

Low in content: one pure function, one call site, no schema change, no new
dependency. All four gates green (lint 0 errors, tsc, 174 tests, build). Both
mutations fail the suite — removing `payment_failed` from `ENDS_ACCESS` fails 3,
letting an invoice id reach `ls_subscription_id` fails 4.

**Unverified:** every statement about what LemonSqueezy actually sends. This is
written from their event names and payload shapes, not from observed traffic.

## Environment variables

None added.
