### PR TITLE
fix(api): cancelling a subscription keeps access until the period ends

### DIFF
--- a/__tests__/lemonsqueezyEvents.test.mts
+++ b/__tests__/lemonsqueezyEvents.test.mts
@@ -68,12 +68,33 @@ test('LemonSqueezy event -> subscription row', async (t) => {
     assert.equal(patchForEvent('subscription_expired', { status: 'expired' })?.role, 'free');
   });
 
-  /* Records today's behaviour, which issue #134 says is wrong: LemonSqueezy
-     "cancelled" means auto-renew off, and the user keeps access until ends_at.
-     Asserting it keeps the defect visible instead of letting it read as
-     intended. When #134 is decided this test changes with the code. */
-  await t.test('cancellation downgrades immediately - see #134, this is the defect', () => {
-    assert.equal(patchForEvent('subscription_cancelled', { status: 'cancelled' })?.role, 'free');
+  /* #134. The two decisions are deliberately opposite and the branches look
+     interchangeable, which is how they came to share one in the first place:
+
+       payment_failed -> they did NOT pay -> end access now
+       cancelled      -> they DID pay     -> keep access until ends_at
+
+     `role` must be ABSENT, not 'pro'. Absent leaves the column out of the
+     upsert's update set, so the row keeps whatever it had. Writing 'pro' would
+     GRANT Pro to someone cancelling a subscription they never had - the
+     opposite bug, one line away. */
+  await t.test('cancellation does not touch entitlement (#134)', () => {
+    const p = patchForEvent('subscription_cancelled', {
+      status: 'cancelled', ends_at: '2026-09-08T00:00:00Z',
+    }, 'sub_1');
+    assert.ok(p, 'cancellation must still be recorded, not ignored');
+    assert.equal('role' in p, false, 'cancellation must not set role at all');
+    assert.equal(p.ls_status, 'cancelled');
+    assert.equal(p.current_period_end, '2026-09-08T00:00:00Z');
+  });
+
+  /* The event that DOES end a cancelled subscription. Verified against
+     LemonSqueezy's docs 2026-08-08: a cancelled subscription stays valid on a
+     grace period until ends_at, then expires and fires this. If that were not
+     true, removing cancellation from ENDS_ACCESS would strand users as `pro`
+     forever - which is the risk QA raised, and the fact this fix rests on. */
+  await t.test('expiry is what ends a cancelled subscription', () => {
+    assert.equal(patchForEvent('subscription_expired', { status: 'expired' })?.role, 'free');
   });
 
   /* null, not an empty patch. The caller skips the database write entirely on

--- a/lib/lemonsqueezy.ts
+++ b/lib/lemonsqueezy.ts
@@ -13,9 +13,15 @@
 
 export type SubscriptionRole = 'pro' | 'free';
 
-/** The columns an event implies. `user_id` and `updated_at` are the caller's. */
+/** The columns an event implies. `user_id` and `updated_at` are the caller's.
+ *
+ *  `role` is OPTIONAL, and its absence is meaningful: it means "record what
+ *  happened, do not change entitlement". Omitting a column from a Supabase
+ *  upsert leaves it out of the ON CONFLICT update set, so an existing row keeps
+ *  its role. (A row that does not exist gets the column default, `'free'` -
+ *  which is the right answer for someone with no subscription row anyway.) */
 export interface SubscriptionPatch {
-  role: SubscriptionRole;
+  role?: SubscriptionRole;
   ls_status: string;
   ls_subscription_id?: string;
   ls_customer_id?: string;
@@ -38,32 +44,52 @@ const SUBSCRIPTION_EVENTS = new Set([
   'subscription_payment_success',
 ]);
 
-/* Events that end access immediately.
+/* TWO OWNER DECISIONS, DELIBERATELY OPPOSITE. Both dated 2026-08-08.
  *
- * `subscription_payment_failed` is here by an owner decision on 2026-08-08:
- * immediate downgrade, no grace period. LemonSqueezy retries a failed renewal
- * for several days before giving up, so a user whose card declines loses Pro on
- * the first failure and regains it if a retry succeeds. That flapping is the
- * accepted cost of the decision, not an oversight.
+ *   subscription_payment_failed  -> they did NOT pay -> end access immediately
+ *   subscription_cancelled       -> they DID pay     -> keep access to ends_at
+ *
+ * The two branches look interchangeable and the second used to share a branch
+ * with `subscription_expired`, which is exactly how issue #134 happened. If you
+ * are about to merge them back together, this comment is why not.
+ *
+ * Events that end access immediately:
+ *
+ * `subscription_payment_failed` - LemonSqueezy retries a failed renewal for
+ * several days before giving up, so a declining card loses Pro on the FIRST
+ * failure and regains it if a retry succeeds. That flapping is the accepted
+ * cost of "no grace period", not an oversight.
  *
  * The refund events are here under a STATED ASSUMPTION rather than a decision:
- * the money has been returned, so the customer is not one. Reverse this if the
- * owner disagrees - it is one line and the tests name it explicitly.
+ * the money has been returned, so the customer is not one. One line to reverse,
+ * and the tests name it explicitly.
  *
- * `subscription_expired` is the genuine end of a paid period.
- *
- * `subscription_cancelled` is NOT here and its presence in the same branch as
- * `expired` in the route is a defect - see issue #134. Cancellation means
- * auto-renew off, not access ended, and downgrading on it takes back a period
- * the user has already paid for. Left alone deliberately: fixing it needs
- * getEntitlement() to end access at current_period_end, which is not this
- * change. */
+ * `subscription_expired` is the genuine end of a paid period - and it is the
+ * ONLY event that ends a cancelled subscription. Verified against LemonSqueezy's
+ * documentation 2026-08-08: a cancelled subscription stays valid on a grace
+ * period until `ends_at`, then expires and fires this event. So removing
+ * `subscription_cancelled` from this set does not strand anyone as `pro` -
+ * that was the risk QA raised on #134, and it is the fact the whole fix rests
+ * on. */
 const ENDS_ACCESS = new Set([
   'subscription_payment_failed',
   'subscription_payment_refunded',
   'order_refunded',
-  'subscription_cancelled',
   'subscription_expired',
+]);
+
+/* Events worth RECORDING that must not change entitlement.
+ *
+ * Cancellation in LemonSqueezy means auto-renew was turned off. The user has
+ * paid through `ends_at` and keeps access until then. Downgrading here took
+ * back a period they had already bought (#134).
+ *
+ * It is not simply ignored, because the row should carry `ls_status:
+ * 'cancelled'` and the date access actually ends - that is what support and
+ * `/ops` read, and dropping the event would leave a cancelled subscription
+ * indistinguishable from an active one until it expired. */
+const RECORD_ONLY = new Set([
+  'subscription_cancelled',
 ]);
 
 /**
@@ -106,6 +132,16 @@ export function patchForEvent(
       // 'refunded'), not the subscription - so fall back to the event name,
       // which is the more truthful record of why the row changed.
       ls_status: status || eventName.replace('subscription_', ''),
+    };
+  }
+
+  if (RECORD_ONLY.has(eventName)) {
+    // No `role`. The user keeps what they have until `subscription_expired`.
+    return {
+      ls_status: status || eventName.replace('subscription_', ''),
+      // ends_at is when access actually stops. renews_at is null on a cancelled
+      // subscription - there is no renewal - so this is the only date left.
+      current_period_end: pickDate(attrs.ends_at) ?? null,
     };
   }
 


### PR DESCRIPTION
**Dev Team** → **QA Team**

Closes #134. Owner confirmed the direction to me directly.

## ✅ The fact your fix rested on — checked before writing anything

You asked:

> **Does LemonSqueezy send `subscription_expired` for a subscription that was
> cancelled**, or only for one that lapsed on payment?

**It does.** From their documentation, two independent pages:

> a subscription has ended after being **previously cancelled**, or once dunning
> has been completed for `past_due` subscriptions

> When cancelled, the subscription is still technically active and valid (on a
> "grace period"), with `ends_at` showing when it is scheduled to expire

So the lifecycle is `cancelled` → grace period → `expired`, and `expired` is the
event that ends it. Removing the case does not strand anyone as `pro` — which
was the failure you named, and it was the right thing to name.

Their docs also state the rule directly, which is worth having on the record:

> The most important state transition mistake is deactivating access on
> `subscription_cancelled`. Only deactivate on `subscription_expired`.

We had made exactly that mistake.

## What changed

| Event | Before | Now |
|---|---|---|
| `subscription_cancelled` | `role: 'free'` — **immediate downgrade** | records `ls_status` + `current_period_end`, **`role` untouched** |
| `subscription_expired` | `role: 'free'` | unchanged — this is the real end |

## Where I differed from your diff

You proposed deleting the case. I kept it as **record-only** instead.

Deleting it means the write is skipped entirely, so the row keeps saying
`ls_status: 'active'` with a renewal date, and a cancelled subscription is
indistinguishable from a live one until it expires. `/ops` and support read that
column. Recording it costs nothing and keeps the state honest.

`role` is **omitted from the patch, not set**. Omitting leaves the column out of
the upsert's `ON CONFLICT` update set, so the existing row keeps its role. I
checked the schema rather than assuming: `role` is `NOT NULL DEFAULT 'free'`, so
even the theoretical insert path lands somewhere sane.

## The test asserts absence, and that is the interesting part

```ts
assert.equal('role' in p, false, 'cancellation must not set role at all');
```

Not `role === 'pro'`. Writing `'pro'` there would **grant** Pro to anyone
cancelling a subscription they never had — the opposite bug, one line away, and
it would look like a fix.

Both mutations fail: putting cancellation back in `ENDS_ACCESS` fails 2, making
it grant `pro` fails 2.

## Your point on #135 stands and this does not address it

> Nothing proves the route applies what the function decides.

Correct, and I am not going to paper over it with a source-scanning assertion —
I have written three of those today and every one had a bug in its first run.
Your phase 2 is the right owner for that half. This PR moves the decision, not
the write.

## How to test (QA)

1. `npm test` — 175 pass, 14 in this suite.
2. Phase 2, when it exists: post a signed `subscription_cancelled` for the `pro`
   fixture and assert the row still reads `pro`, with `ls_status: 'cancelled'`
   and `current_period_end` set. **That is the first real execution.**
3. Then `subscription_expired` for the same user and assert it flips to `free`.

Step 2 is the one that would have caught the original bug.

## Risk level

**Low-Medium.** One set membership and one branch, no schema change, gates green
(lint 0 errors, tsc, 175 tests, build).

Medium only because, like everything in this file, it has never run against a
real payload. But this change is strictly less destructive than what it replaces:
the failure mode of the old code was taking access away too early; the failure
mode of a mistake here is giving it away too long — and `subscription_expired`
still closes that.

**Unverified:** that LemonSqueezy's documented behaviour matches its actual
behaviour. Sourced from docs, not observed traffic.
