### PR TITLE
chore(ci): give the E2E job B's alert id and a fake webhook secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,6 +377,34 @@ jobs:
           # If a future fixture id is genuinely sensitive, make it a secret AND
           # give it a value that cannot collide with ordinary text.
           E2E_A_PRICE_ALERT_ID: ${{ vars.E2E_A_PRICE_ALERT_ID }}
+          # B's own price alert, seeded 2026-08-08. A variable for the same
+          # reason as A's, and it is `2` - a second single digit, so as a secret
+          # it would redact every literal 2 in the log exactly as `1` did.
+          #
+          # It exists because the BOLA test stopped testing BOLA. price-alerts
+          # checks entitlement at route.ts:89 and ownership at :111, so once B
+          # was pinned to `free` the Pro gate refused it twenty lines before
+          # ownership was reached - the test passed and proved nothing. The
+          # cross-account attempt now runs as A, who is Pro, against a row A
+          # does not own.
+          E2E_B_PRICE_ALERT_ID: ${{ vars.E2E_B_PRICE_ALERT_ID }}
+
+          # NOT a real credential, and it must never be one. The webhook spec
+          # signs its own payloads with HMAC-SHA256 and the server verifies with
+          # the same value, so the two only have to MATCH - any string works.
+          #
+          # Written literally rather than stored as a secret, deliberately:
+          #   - it protects nothing. No LemonSqueezy store knows this value, so
+          #     leaking it grants nobody anything.
+          #   - as a secret it would be redacted from logs, and a signature
+          #     mismatch is diagnosed by reading them.
+          #   - the reader needs to know at a glance that it is fake. A masked
+          #     value invites someone to "fix" it by pasting the real one in.
+          #
+          # The production secret lives only in Render's environment for
+          # `liquidity-hq-prod`. Copying it here would let anyone who can read
+          # this repository forge a webhook that grants Pro.
+          LEMONSQUEEZY_WEBHOOK_SECRET: ci-fake-not-a-real-lemonsqueezy-secret
 
       # failure() only. This used to upload on every green run too - ~15s and
       # storage for a report nobody opens. failure() still excludes


### PR DESCRIPTION
**Dev Team** → **QA Team**

The two env lines you asked for. **#124 cannot merge before this one** — see
below.

## What changed

| Key | Form | Why |
|---|---|---|
| `E2E_B_PRICE_ALERT_ID` | repo **variable**, `2` | #124's BOLA test needs a row the Pro fixture does not own |
| `LEMONSQUEEZY_WEBHOOK_SECRET` | **literal**, obviously fake | #136 signs its own payloads; server and test only have to match |

Variable created alongside this PR — `gh variable list` shows it next to A's.

## 🔴 Order matters, and getting it wrong is silent

`AUTH_READY` in #124 now includes `bPriceAlertId`. So if #124 merges before this,
**`AUTH_READY` is false and `bola`, `entitlements` and `a11y-auth` all SKIP** —
with a stated reason, but green. That is a release gate quietly covering nothing.

This lands first. Then #124.

## Why the webhook secret is a literal and not a secret

It protects nothing — no LemonSqueezy store knows this value, so leaking it
grants nobody anything. Three reasons to write it in the open:

- **As a secret it would be redacted from logs**, and a signature mismatch is
  diagnosed by reading them. Same trap as #107, different variable.
- **A reader must see at a glance that it is fake.** A masked value invites
  someone to "fix" it by pasting the real one in.
- It is a shared HMAC key between two halves of one test, not a credential.

The production secret stays only in Render's environment for `liquidity-hq-prod`.
**Copying it here would let anyone who can read this repository forge a webhook
that grants Pro.** That is in the comment too.

## Why B's id is a variable

It is `2` — a second single digit. As a secret it would redact every literal `2`
in the log exactly as `1` turned `SC 1.4.3` into `SC ***.4.3` (#107). The comment
above A's entry already explains this; B's points at the same reasoning and adds
why the row exists at all.

## How to test (QA)

Nothing to check by hand — this is only reachable from an E2E run.

**The real test is the next release run:** `bola.spec.ts`, `entitlements.spec.ts`
and `a11y-auth.spec.ts` must **RUN, not skip**. If they skip, read the skip
reason — it names the missing variable.

Locally: the workflow parses and the `e2e` job resolves both keys.

## Risk level

**Low.** Two env entries on a job that only runs on a release PR. No code, no
schema.

**Unverified:** that the E2E job actually picks them up. I cannot trigger a run
that reaches the E2E job — it is gated on `base_ref == 'main'` — so the first
execution is the next release.
