### PR TITLE
test(qa): prove the PII scrubber runs inside the real SDK

### DIFF
--- a/__tests__/monitoringPipeline.test.mts
+++ b/__tests__/monitoringPipeline.test.mts
@@ -37,6 +37,8 @@ function stubTransport(captured: Captured) {
 
 const EMAIL = 'victim@example.test';
 const TOKEN = 'sb-abcdef-auth-token';
+const JWT = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVP';
+const ORDINARY = 'retrying in 5 seconds after upstream timeout';
 
 test('the scrubber runs inside the real SDK pipeline', async (t) => {
   const savedDsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
@@ -56,7 +58,18 @@ test('the scrubber runs inside the real SDK pipeline', async (t) => {
   scope.setClient(client);
 
   scope.setUser({ id: 'u1', email: EMAIL, ip_address: '203.0.113.9', username: 'victim' });
-  scope.captureException(new Error(`checkout failed for ${EMAIL} with ${TOKEN}`));
+
+  /* An implicit-flow OAuth callback, the real shape. This app reverted PKCE on
+   * 2026-07-20, so Supabase returns the session in the URL FRAGMENT - and the
+   * browser SDK reports `window.location.href`, fragment included.
+   *
+   * A fragment never reaches a server, so no API-side test can see this. The
+   * envelope captured at the transport is the only place it is observable. */
+  scope.addBreadcrumb({
+    category: 'navigation',
+    data: { to: `https://liquidity-hq.com/auth/callback#access_token=${JWT}&refresh_token=v1.MRq8` },
+  });
+  scope.captureException(new Error(`checkout failed for ${EMAIL} with ${TOKEN} - ${ORDINARY}`));
   await client.flush(2000);
 
   const event = captured.event;
@@ -82,25 +95,35 @@ test('the scrubber runs inside the real SDK pipeline', async (t) => {
     assert.doesNotMatch(serialised, /victim/, 'username survived the pipeline');
   });
 
-  /* RECORDS TODAY'S BEHAVIOUR, WHICH IS WRONG - see #72.
+  /* INVERTED 2026-08-08 after #143 landed. This assertion previously recorded
+   * that the token SURVIVED, and its failure message said
+   * `#72 has been fixed, invert this assertion` - which is what happened. A
+   * characterisation test that cannot tell you it has become obsolete rots into
+   * a wrong assertion nobody questions. */
+  await t.test('an auth token in an error message is redacted', () => {
+    assert.doesNotMatch(JSON.stringify(event), /sb-abcdef-auth-token/, 'an auth token survived inside the error message');
+  });
+
+  /* THE ONE ONLY THIS TEST CAN PROVE.
    *
-   * `scrubText` is `text.replace(UUID, ':id').replace(EMAIL, ':email')`. There
-   * is no token pattern, so a Supabase session token, a bearer token or an API
-   * key inside an error message reaches GlitchTip verbatim. Error messages are
-   * exactly where those end up, because a failing request tends to include what
-   * it was authenticating with.
+   * `scrubUrl` dropping the fragment is verifiable in isolation by a unit test.
+   * That it is WIRED - that a real breadcrumb built by the SDK passes through
+   * it before the envelope leaves - is only observable here, at the transport. */
+  await t.test('an OAuth callback fragment never reaches the envelope', () => {
+    const serialised = JSON.stringify(event);
+    assert.doesNotMatch(serialised, /eyJhbGciOi/, 'an access token survived in a breadcrumb URL fragment');
+    assert.doesNotMatch(serialised, /refresh_token/, 'a refresh token survived in a breadcrumb URL fragment');
+    assert.match(serialised, /auth\/callback/, 'the path was destroyed too - the breadcrumb is now useless for debugging');
+  });
+
+  /* OVER-REDACTION IS THE REAL COST OF #143, and unit tests cannot rule it out.
    *
-   * Asserting the leak keeps it visible instead of letting it read as intended.
-   * When #72 is fixed this test FAILS, and the name tells the next person the
-   * fix arrived rather than that they broke something.
-   *
-   * Named after dev's pattern on #135. I told them on #72 that I was holding
-   * this rather than encoding the bug, and called it the same decision they
-   * made - it was the opposite one. An untracked failing test on my disk
-   * protects nobody; this at least fails loudly the day it stops being true. */
-  await t.test('an auth token in an error message SURVIVES - this is the defect, see #72', () => {
-    assert.match(JSON.stringify(event), /sb-abcdef-auth-token/,
-      'a token no longer survives - #72 has been fixed, invert this assertion');
+   * A pattern broad enough to catch every credential also catches version
+   * strings, hashes and ids. If this fails, the fix is a one-line narrowing -
+   * not a wider allowlist. */
+  await t.test('ordinary prose is left alone', () => {
+    assert.match(JSON.stringify(event), /retrying in 5 seconds after upstream timeout/,
+      'ordinary text was redacted - a credential pattern is too broad');
   });
 
   if (savedDsn === undefined) delete process.env.NEXT_PUBLIC_SENTRY_DSN;

--- a/__tests__/monitoringPipeline.test.mts
+++ b/__tests__/monitoringPipeline.test.mts
@@ -1,0 +1,110 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as Sentry from '@sentry/node';
+import { monitoringOptions } from '../lib/monitoring.ts';
+
+/* Does the scrubber actually run on a real event, inside the real SDK?
+ *
+ * `monitoringScrub.test.mts` calls `scrubEvent()` directly — 15 tests, all
+ * passing, and none of them prove the function is WIRED. Issue #72 is precisely
+ * that gap: the scrubber has never been observed running on an event the SDK
+ * built and was about to send.
+ *
+ * It was recorded as "blocked by the GlitchTip quota" for days. That was wrong,
+ * and it was my mistake: `beforeSend` runs client-side, before transmission, so
+ * a 429 rejects the DELIVERY and says nothing about whether scrubbing happened.
+ * Nothing was ever blocked.
+ *
+ * A stub transport captures the envelope at the same point the network would,
+ * so this needs no DSN that resolves, no quota, and no browser. */
+
+type Captured = { event?: Record<string, unknown> };
+
+/** Stands in for the HTTP transport. Returns the envelope instead of sending. */
+function stubTransport(captured: Captured) {
+  return () => ({
+    send: async (envelope: unknown) => {
+      // envelope = [headers, [[itemHeader, payload], ...]]
+      const items = (envelope as [unknown, [unknown, Record<string, unknown>][]])[1] ?? [];
+      for (const [, payload] of items) {
+        if (payload && typeof payload === 'object') captured.event = payload;
+      }
+      return {};
+    },
+    flush: async () => true,
+  });
+}
+
+const EMAIL = 'victim@example.test';
+const TOKEN = 'sb-abcdef-auth-token';
+
+test('the scrubber runs inside the real SDK pipeline', async (t) => {
+  const savedDsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+  const savedApp = process.env.NEXT_PUBLIC_APP_ENV;
+  process.env.NEXT_PUBLIC_SENTRY_DSN = 'https://key@example.invalid/1';
+  process.env.NEXT_PUBLIC_APP_ENV = 'prod';
+
+  const captured: Captured = {};
+  const client = new Sentry.NodeClient({
+    ...monitoringOptions(),
+    dsn: 'https://key@example.invalid/1',
+    transport: stubTransport(captured),
+    stackParser: Sentry.defaultStackParser,
+    integrations: [],
+  });
+  const scope = new Sentry.Scope();
+  scope.setClient(client);
+
+  scope.setUser({ id: 'u1', email: EMAIL, ip_address: '203.0.113.9', username: 'victim' });
+  scope.captureException(new Error(`checkout failed for ${EMAIL} with ${TOKEN}`));
+  await client.flush(2000);
+
+  const event = captured.event;
+
+  /* POSITIVE CONTROL FIRST. Every assertion below is about something being
+   * ABSENT, and absence is also what a transport that captured nothing looks
+   * like. Without this, a broken stub reports a perfectly clean scrub. */
+  await t.test('an event was actually captured (guards against a vacuous pass)', () => {
+    assert.ok(event, 'the stub transport captured nothing - every assertion below would pass trivially');
+    assert.ok(JSON.stringify(event).length > 100, 'captured something, but it is not a real event payload');
+  });
+
+  await t.test('the error still arrives - a scrubber that removes everything is useless', () => {
+    const serialised = JSON.stringify(event);
+    assert.match(serialised, /checkout failed/, 'the message was destroyed, not scrubbed');
+    assert.ok((event as { exception?: unknown }).exception, 'the exception itself was dropped');
+  });
+
+  await t.test('the user email and ip never leave the process', () => {
+    const serialised = JSON.stringify(event);
+    assert.doesNotMatch(serialised, new RegExp(EMAIL.replace('.', '\\.')), 'user email survived the pipeline');
+    assert.doesNotMatch(serialised, /203\.0\.113\.9/, 'ip address survived the pipeline');
+    assert.doesNotMatch(serialised, /victim/, 'username survived the pipeline');
+  });
+
+  /* RECORDS TODAY'S BEHAVIOUR, WHICH IS WRONG - see #72.
+   *
+   * `scrubText` is `text.replace(UUID, ':id').replace(EMAIL, ':email')`. There
+   * is no token pattern, so a Supabase session token, a bearer token or an API
+   * key inside an error message reaches GlitchTip verbatim. Error messages are
+   * exactly where those end up, because a failing request tends to include what
+   * it was authenticating with.
+   *
+   * Asserting the leak keeps it visible instead of letting it read as intended.
+   * When #72 is fixed this test FAILS, and the name tells the next person the
+   * fix arrived rather than that they broke something.
+   *
+   * Named after dev's pattern on #135. I told them on #72 that I was holding
+   * this rather than encoding the bug, and called it the same decision they
+   * made - it was the opposite one. An untracked failing test on my disk
+   * protects nobody; this at least fails loudly the day it stops being true. */
+  await t.test('an auth token in an error message SURVIVES - this is the defect, see #72', () => {
+    assert.match(JSON.stringify(event), /sb-abcdef-auth-token/,
+      'a token no longer survives - #72 has been fixed, invert this assertion');
+  });
+
+  if (savedDsn === undefined) delete process.env.NEXT_PUBLIC_SENTRY_DSN;
+  else process.env.NEXT_PUBLIC_SENTRY_DSN = savedDsn;
+  if (savedApp === undefined) delete process.env.NEXT_PUBLIC_APP_ENV;
+  else process.env.NEXT_PUBLIC_APP_ENV = savedApp;
+});


### PR DESCRIPTION
**QA Team** → **Dev Team**

## Summary

`__tests__/monitoringPipeline.test.mts` — drives the real Sentry client with a stub transport and asserts on the envelope at the point the network would have sent it. **180 tests pass, 0 fail.**

## Why

`monitoringScrub.test.mts` calls `scrubEvent()` directly: 15 tests, all green, **none of which prove the function is wired**. #72 is exactly that gap.

I also recorded #72 as *"blocked by the GlitchTip quota"* for days. That was wrong — `beforeSend` runs client-side, before transmission, so a 429 rejects the **delivery** and says nothing about whether scrubbing happened. Nothing was ever blocked.

## What it proves

- user email, ip and username never leave the process
- **the error message and stack survive** — a scrubber that removes everything passes a naive assertion while making the tool useless
- a positive control first: an event was actually captured, because every other assertion is about absence and a broken stub looks identical to a clean scrub

## What it records rather than proves

```
an auth token in an error message SURVIVES - this is the defect, see #72
```

`scrubText` is `replace(UUID).replace(EMAIL)`. **No token pattern.** A Supabase session token, bearer token or API key inside an error message reaches GlitchTip verbatim — and error messages are where those land, because a failing request tends to include what it authenticated with.

Named as the defect, so when you add the patterns this test **fails** and the name tells you the fix arrived rather than that you broke something. Your pattern from #135.

## A correction

I told you on #72 I was *holding this rather than encoding the bug*, and called it the same decision you made on #135. **It was the opposite decision.** Yours recorded current behaviour with a name that made it safe; mine sat untracked on my disk, where one `git checkout` would have lost it — and nearly did.

Merged and failing-loudly-later beats correct and absent.

## How to test (QA)

```
npm test
```

180 pass. No DSN that resolves, no quota, no browser, no fixtures.

## Risk level

**Low.** One new test file, no app code.

**#72 does not close on this.** It closes when a token in an error message does not reach the envelope — which needs two patterns in `scrubText`, and that is app code.

## Screenshots

n/a