### PR TITLE
fix(api): scrub credentials from error events, including OAuth URL fragments

### DIFF
--- a/__tests__/monitoringScrub.test.mts
+++ b/__tests__/monitoringScrub.test.mts
@@ -315,3 +315,67 @@ test('monitoring quota settings', async (t) => {
   if (savedApp === undefined) delete process.env.NEXT_PUBLIC_APP_ENV;
   else process.env.NEXT_PUBLIC_APP_ENV = savedApp;
 });
+
+/* CREDENTIALS. Added after QA's #72 pipeline test captured a real envelope with
+ * a session token in the clear - the email beside it was redacted, the token was
+ * not, because this file only knew about UUIDs and emails.
+ *
+ * The URL case is the one nothing would have found by reading: this app uses
+ * Supabase's IMPLICIT OAuth flow (PKCE was reverted 2026-07-20 for breaking
+ * mobile Google logins), which returns the session in the URL FRAGMENT. A
+ * fragment never reaches a server, so no API-side test could see it - but the
+ * browser SDK reports window.location.href, and scrubUrl split on `?` only.
+ */
+test('credentials never leave the process', async (t) => {
+  const JWT = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVP';
+
+  await t.test('a JWT in a message is redacted', () => {
+    const out = scrubText(`refresh failed with ${JWT}`);
+    assert.equal(out, 'refresh failed with :jwt');
+    assert.ok(!out.includes('eyJ'), 'a JWT survived scrubbing');
+  });
+
+  await t.test('the exact envelope QA captured is clean', () => {
+    const out = scrubText('checkout failed for a@b.com with sb-abcdef-auth-token');
+    assert.equal(out, 'checkout failed for :email with :supabase-token-key');
+  });
+
+  await t.test('a Bearer header quoted in prose is redacted', () => {
+    assert.equal(scrubText('sent Bearer abc123def456ghi'), 'sent Bearer :token');
+  });
+
+  await t.test("Supabase's non-JWT keys are redacted", () => {
+    assert.equal(scrubText('used sb_secret_abcd1234efgh'), 'used :supabase-key');
+    assert.equal(scrubText('used sb_publishable_abcd1234'), 'used :supabase-key');
+  });
+
+  /* THE ONE THAT WAS ACTUALLY BROKEN. Implicit-flow callback, real shape. */
+  await t.test('an OAuth callback fragment is dropped entirely', () => {
+    const out = scrubUrl(`https://liquidity-hq.com/auth/callback#access_token=${JWT}&refresh_token=v1.MRq8`);
+    assert.equal(out, 'https://liquidity-hq.com/auth/callback#<redacted>');
+    assert.ok(!out.includes('eyJ'), 'an access token survived in the URL fragment');
+    assert.ok(!out.includes('refresh_token'), 'a refresh token survived in the URL fragment');
+  });
+
+  await t.test('a URL with no fragment is unchanged in that respect', () => {
+    assert.equal(scrubUrl('https://liquidity-hq.com/dashboard'), 'https://liquidity-hq.com/dashboard');
+    assert.equal(scrubUrl('https://liquidity-hq.com/x#'), 'https://liquidity-hq.com/x');
+  });
+
+  /* Order matters. A token can contain a UUID-shaped substring; if UUID ran
+     first it would rewrite part of the token and leave the rest, producing
+     something that no longer matches JWT and survives as a partial credential. */
+  await t.test('a credential containing an id is redacted whole, not in part', () => {
+    const out = scrubText('Bearer 550e8400-e29b-41d4-a716-446655440000-extra');
+    assert.equal(out, 'Bearer :token');
+    assert.ok(!out.includes('550e8400'), 'part of a credential survived');
+  });
+
+  /* The scrubber must not mangle ordinary output, or the next person to read
+     through it weakens it. */
+  await t.test('ordinary text is left alone', () => {
+    const plain = 'TypeError: cannot read property length of undefined at getBars';
+    assert.equal(scrubText(plain), plain);
+    assert.equal(scrubText('BTC funding rate 0.0123 on binance'), 'BTC funding rate 0.0123 on binance');
+  });
+});

--- a/lib/monitoring.ts
+++ b/lib/monitoring.ts
@@ -124,6 +124,61 @@ export function monitoringRelease(): string | undefined {
 const UUID = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
 const EMAIL = /[^\s/?&=]+@[^\s/?&=]+\.[a-z]{2,}/gi;
 
+/* CREDENTIALS. Added 2026-08-08 after QA's pipeline test captured a real
+ * envelope carrying a session token in the clear (#72):
+ *
+ *   "checkout failed for :email with sb-abcdef-auth-token"
+ *
+ * The email was redacted. The token was not, because until now this file only
+ * knew about UUIDs and emails. Error messages are exactly where credentials
+ * land - a failing request tends to include what it authenticated with.
+ *
+ * These are deliberately SPECIFIC patterns rather than one "long random string"
+ * rule. A generic rule redacts ids, hashes and stack frames, and a scrubber
+ * that mangles ordinary output gets weakened by the next person who has to read
+ * through it.
+ */
+
+/* A JWT: three base64url segments, the first starting `eyJ` because that is
+   base64 for `{"`. Supabase access and refresh tokens are JWTs, and so is the
+   legacy anon/service-role key - so this one pattern covers the credential that
+   matters most and the one that must never appear at all. Nothing else in this
+   app's output has this shape. */
+const JWT = /eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]+/g;
+
+/* `Authorization: Bearer <token>` reproduced inside a message body. The header
+   itself is dropped by DROP_HEADERS; this catches the copy that ends up in
+   prose, which is the path DROP_HEADERS cannot see. */
+const BEARER = /\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/gi;
+
+/* Supabase's newer key format, which is not a JWT: sb_secret_… is the
+   service-role replacement and bypasses RLS entirely. sb_publishable_… is safe
+   by design, but a reader who finds one in a bug report cannot tell which kind
+   it is - the same reasoning `apikey` is in DROP_HEADERS. */
+const SB_KEY = /\bsb_(?:secret|publishable)_[A-Za-z0-9_-]{8,}/g;
+
+/* The browser's session storage key, `sb-<project-ref>-auth-token`. The NAME is
+   not a credential, but it carries the project ref, and its VALUE is a JSON
+   blob holding the tokens above - so a message quoting the key is usually a
+   message about to quote the value. */
+const SB_STORAGE_KEY = /\bsb-[a-z0-9-]{4,}-auth-token\b/gi;
+
+/**
+ * Credentials first, then identifiers.
+ *
+ * Order is load-bearing: a token can contain a UUID-shaped substring, and if
+ * UUID ran first it would rewrite part of the token to `:id` and leave the rest
+ * - producing something that no longer matches JWT and survives as a partial
+ * credential. Most specific to least, always.
+ */
+function scrubSecrets(text: string): string {
+  return text
+    .replace(JWT, ':jwt')
+    .replace(BEARER, 'Bearer :token')
+    .replace(SB_KEY, ':supabase-key')
+    .replace(SB_STORAGE_KEY, ':supabase-token-key');
+}
+
 /**
  * Header names dropped outright. Lowercased before comparison - Next normalises
  * incoming headers but `onRequestError` hands them through as received, so both
@@ -153,17 +208,38 @@ const DROP_HEADERS = new Set([
  */
 export function scrubUrl(url: string): string {
   if (!url) return url;
-  const [path, query] = url.split('?');
-  const cleanPath = path.replace(UUID, ':id').replace(EMAIL, ':email');
+
+  /* THE FRAGMENT GOES FIRST, and it is the reason this function was wrong.
+   *
+   * This app uses Supabase's IMPLICIT OAuth flow deliberately - PKCE was tried
+   * and reverted on 2026-07-20 because it broke real mobile Google logins. The
+   * implicit flow returns the session in the URL FRAGMENT:
+   *
+   *   /auth/callback#access_token=eyJ…&refresh_token=…
+   *
+   * A fragment is never sent to a server, so nothing on the API side could ever
+   * see it. But the browser SDK reports `window.location.href`, which has it -
+   * and this function split on `?` only, so a live access token passed through
+   * untouched. Verified before the fix by running the real function against a
+   * real-shaped callback URL.
+   *
+   * Dropped whole rather than scrubbed. A fragment on this app's URLs carries
+   * auth material or nothing worth keeping. */
+  const [beforeHash, hash] = url.split('#');
+  const hadFragment = hash !== undefined && hash.length > 0;
+
+  const [path, query] = beforeHash.split('?');
+  const cleanPath = scrubSecrets(path).replace(UUID, ':id').replace(EMAIL, ':email')
+    + (hadFragment ? '#<redacted>' : '');
   // The query string goes entirely. Nothing in this app puts anything in a query
   // parameter that is worth the risk of keeping - and "keep the safe ones" needs
   // an allowlist that some future route will forget to update.
   return query ? `${cleanPath}?<redacted>` : cleanPath;
 }
 
-/** Redact identifiers in free text - error messages, breadcrumb strings. */
+/** Redact credentials and identifiers in free text - error messages, breadcrumbs. */
 export function scrubText(text: string): string {
-  return text.replace(UUID, ':id').replace(EMAIL, ':email');
+  return scrubSecrets(text).replace(UUID, ':id').replace(EMAIL, ':email');
 }
 
 /** `Array.prototype.map` passes (value, index, array); scrubText's second


### PR DESCRIPTION
**Dev Team** → **QA Team**

Refs #72. Your capture was right, and looking for the rest of the class found a
worse one.

## The leak you found

```
"checkout failed for :email with sb-abcdef-auth-token"
```

Email redacted, token not. `scrubText` knew about UUIDs and emails and nothing
else. Fixed — that exact string is now a test.

## 🔴 The one nothing was looking for: the OAuth callback fragment

This app uses Supabase's **implicit** OAuth flow deliberately — PKCE was tried
and reverted on 2026-07-20 for breaking real mobile Google logins. The implicit
flow returns the session **in the URL fragment**:

```
/auth/callback#access_token=eyJ…&refresh_token=v1.MRq8
```

`scrubUrl` split on `?` only. I ran the real function against a real-shaped
callback URL before changing anything:

```
IN : https://liquidity-hq.com/auth/callback#access_token=eyJhbGci…&refresh_token=v1.MRq8
OUT: https://liquidity-hq.com/auth/callback#access_token=eyJhbGci…&refresh_token=v1.MRq8
```

**A live access token and refresh token, unchanged, on their way to GlitchTip.**

**Why no test on either side would have found it.** A fragment is never sent to
a server, so nothing API-side can observe one — your pipeline test included. It
only exists in `window.location.href`, which the browser SDK reports. It was
invisible from both of our angles, and visible from reading the flow.

The fragment is now dropped whole. On this app's URLs it carries auth material
or nothing worth keeping.

## Four patterns, deliberately specific

| Pattern | Catches |
|---|---|
| `JWT` | Supabase access + refresh tokens, and the legacy anon/service-role key |
| `BEARER` | `Bearer <token>` copied into prose — `DROP_HEADERS` only sees real headers |
| `SB_KEY` | `sb_secret_…` (service-role replacement, bypasses RLS) and `sb_publishable_…` |
| `SB_STORAGE_KEY` | `sb-<ref>-auth-token` — your capture |

You asked for two. Four, because each is a distinct shape and none overlaps.

**Not one generic "long random string" rule**, on purpose: that redacts ids,
hashes and stack frames, and a scrubber that mangles ordinary output is one
someone weakens later to read through it. There is a test asserting a plain
`TypeError` and a funding-rate message come through untouched.

## Order is load-bearing

Credentials scrub **before** identifiers. A token can contain a UUID-shaped
substring — with UUID first, part of it becomes `:id` and the rest survives as a
partial credential matching nothing. Asserted:

```ts
scrubText('Bearer 550e8400-e29b-41d4-a716-446655440000-extra') === 'Bearer :token'
```

## How to test (QA)

1. `npm test` — 184 pass, 8 new.
2. **Re-run your pipeline test.** Yours captures the real envelope at the
   transport; mine asserts the function. Yours is the one that proves the
   scrubber is actually wired into the path the SDK takes.
3. If you can drive a real OAuth sign-in with the SDK loaded, the callback URL
   in any captured event should read `…/auth/callback#<redacted>`.

Step 2 matters more than step 1 — my tests prove the function is right, not that
it runs.

## Risk level

**Low-Medium.** Pure functions, no call-site changes, gates green (lint 0
errors, tsc, 184 tests, build). Both mutations fail: disabling the fragment drop
fails 2, disabling the JWT pattern fails 2.

Medium for one reason: **over-redaction is a real cost and I cannot rule it out
from tests alone.** If GlitchTip issues start reading `:jwt` where something
useful used to be, tell me — that is a pattern too broad, and it is a one-line
narrowing.

**Unverified:** that these run in production. `NEXT_PUBLIC_SENTRY_DSN` is prod
only, so no non-prod environment sends events at all.
