### PR TITLE
fix(alerts): emit PRO_REQUIRED from alerts/preview like every other gate

### DIFF
--- a/__tests__/telegramStatusCodes.test.mts
+++ b/__tests__/telegramStatusCodes.test.mts
@@ -73,3 +73,50 @@ test('telegram/test does not answer an unauthenticated caller', () => {
     'anonymous caller can again learn whether the server has a bot configured',
   );
 });
+
+/* Every Pro-gated route must emit the SAME error code, because `PRO_REQUIRED`
+ * is a contract three components branch on:
+ *
+ *   components/DryPowder.tsx:90        if (res.status === 403 && json.error === 'PRO_REQUIRED')
+ *   components/HypothesisTracker.tsx:214
+ *   components/TradeJournal.tsx:496,533
+ *
+ * `alerts/preview` returned 'Pro required' - gated correctly, labelled
+ * differently - so no client could recognise it and /alerts rendered the raw
+ * string to the user. Found by QA's entitlements.spec.ts on its first real run,
+ * which is the run #120 existed to wait for.
+ *
+ * The list comes from the spec's own GATED array rather than a copy, so a route
+ * added there is covered here without anyone remembering this file.
+ *
+ * COMMENTS ARE STRIPPED FIRST, and this test proved why. Written without it, it
+ * passed a mutation that reverted the route's label - because the comment ABOVE
+ * the fix, explaining the contract, contains the word it was searching for. It
+ * was asserting that the route talks about PRO_REQUIRED, not that it returns it.
+ * Fourth time in one session a source-scanning test has read prose as code. */
+test('every Pro gate speaks the same error code', () => {
+  const specSrc = readFileSync(
+    new URL('../qa/e2e/entitlements.spec.ts', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
+
+  const paths = [...specSrc.matchAll(/path:\s*'\/api\/([^']+)'/g)].map(m => m[1]);
+  assert.ok(paths.length > 5, `expected the GATED list, found ${paths.length} paths`);
+
+  const missing: string[] = [];
+  for (const p of new Set(paths)) {
+    const file = fileURLToPath(new URL(`../app/api/${p}/route.ts`, import.meta.url));
+    let src: string;
+    try {
+      src = readFileSync(file, 'utf8')
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/\/\/.*$/gm, '');
+    } catch { continue; } // dynamic segment
+    // Only routes that actually gate on entitlement - push/test verifies via the
+    // admin client and is excluded from the spec for that reason.
+    if (!/hasProFeatures/.test(src)) continue;
+    if (!/PRO_REQUIRED/.test(src)) missing.push(p);
+  }
+
+  assert.deepEqual(missing, [],
+    `these Pro-gated routes do not emit PRO_REQUIRED, so no client can detect the ` +
+    `lock and the raw error text reaches the user: ${missing.join(', ')}`);
+});

--- a/app/alerts/page.tsx
+++ b/app/alerts/page.tsx
@@ -468,6 +468,16 @@ export default function AlertsPage() {
       });
       if (!res.ok) {
         const d = await res.json().catch(() => ({}));
+        // Pro gate, not a failure. Without this the button reports the server's
+        // error code as if the request had broken - and fixing the route's
+        // label alone would have made that read "PRO_REQUIRED", which is worse
+        // than the "Pro required" it replaced. Same locked-state handling as
+        // DryPowder, HypothesisTracker and TradeJournal.
+        if (res.status === 403 && d.error === 'PRO_REQUIRED') {
+          setCheckState('idle');
+          setUpgradeGate(t('ALERTS_UPGRADE_GATE_FEATURE_LABEL'));
+          return;
+        }
         throw new Error(d.error ?? t('ALERTS_SERVER_ERROR', { status: res.status }));
       }
       setCheckResult(await res.json());

--- a/app/api/alerts/preview/route.ts
+++ b/app/api/alerts/preview/route.ts
@@ -75,8 +75,18 @@ export async function POST(req: NextRequest) {
 
   // Alerts are a Pro feature - same gate the delivery paths apply, so a free
   // account cannot use this to get the signal stream the alerts would carry.
+  //
+  // The error code is a CONTRACT, not a message. Every other gated route emits
+  // the same one, and three components branch on it to show a locked state
+  // rather than an error (DryPowder:90, HypothesisTracker:214,
+  // TradeJournal:496). This route used to answer 'Pro required' - correctly
+  // gated, wrong label - so no client could recognise it and /alerts rendered
+  // the raw string to the user. Found by entitlements.spec.ts on its first run.
   if (!(await hasProFeatures(token, userId))) {
-    return NextResponse.json({ error: 'Pro required' }, { status: 403 });
+    return NextResponse.json(
+      { error: 'PRO_REQUIRED', message: 'Alert preview is a Pro feature.' },
+      { status: 403 },
+    );
   }
 
   if (!rateLimit(`alerts-preview:${userId}`, RATE_LIMIT, RATE_WINDOW_MS)) {


### PR DESCRIPTION
**Dev Team** → **QA Team** · **read this before merging #145**

Your gate finding was right. **Do not widen the assertion — the route was
wrong, and it is fixed here.**

## Why widening is the wrong half of #145

Your contrast removal is correct and should still merge. The Pro-code half
should not.

`PRO_REQUIRED` is a **contract, not a message.** Three components branch on it:

```
components/DryPowder.tsx:90          if (res.status === 403 && json.error === 'PRO_REQUIRED')
components/HypothesisTracker.tsx:214
components/TradeJournal.tsx:496,533
```

Widening the spec to accept `Pro required` would make the test pass and leave
every client unable to detect the lock. Your own words on #107 apply exactly: a
value that must be recognised by a client is not a message, it is an interface.

## It is user-visible, which I did not expect either

`app/alerts/page.tsx:471` — the "Check Alerts Now" button:

```ts
if (!res.ok) {
  const d = await res.json().catch(() => ({}));
  throw new Error(d.error ?? …);   // <- renders the server's error code
}
```

So a free user pressing that button sees the bare string **"Pro required"** in a
red failure state, where every other Pro surface in the app shows an upgrade
prompt. Not a label mismatch — a broken lock.

**And fixing only the route would have made it worse.** The button would then
render `PRO_REQUIRED` at the user. So the caller changes too: it now opens the
upgrade gate, same as the other three. Both halves or neither.

## The test asserts the contract, not this instance

It reads the GATED list **out of your `entitlements.spec.ts`** rather than
copying it, so a route you add there is covered here without anyone remembering
this file exists. Routes that gate via the admin client (`push/test`) are skipped
by the same `hasProFeatures` check you used to exclude it.

## 🔴 The test was vacuous when I first wrote it, and mutation caught it

It passed a mutation that reverted the route's label. Cause: **the comment above
the fix explains the contract, and contains the word the test searched for.** It
was asserting the route *talks about* `PRO_REQUIRED`, not that it *returns* it.

Comments are now stripped before scanning. Post-fix the mutation fails with the
message you would want:

```
these Pro-gated routes do not emit PRO_REQUIRED, so no client can detect the lock
and the raw error text reaches the user: alerts/preview
```

**Fourth time in one session** a source-scanning test of mine has read prose as
code — the telegram, testid and release-token suites all did it. I am treating
that as a rule now rather than a coincidence: anything grepping source for
structure strips comments first.

## What I suggest for #145

Keep the contrast-assertion removal, drop the Pro-code widening, merge both. If
you would rather not respin it, merge #145 as-is and this PR makes its widened
assertion moot rather than wrong — but the strict version is the one worth
having.

## How to test (QA)

1. `npm test` — 185 pass.
2. Next release run: `POST /api/alerts/preview` as the free fixture returns 403
   **containing `PRO_REQUIRED`**, with the assertion unwidened.
3. On `qa`, signed in as a free account, press **Check Alerts Now** on `/alerts`
   — the upgrade gate opens. It must not show a red error containing any raw
   code.

Step 3 is the user-facing half and only you can see it.

## Risk level

**Low.** One route response, one client branch, no schema, gates green (lint 0
errors, tsc, 185 tests, build).

**Unverified:** step 3 in a browser. I changed the caller by reading the three
components that already do this correctly, not by clicking it.
