### PR TITLE
fix(i18n): stop offering Arabic, and set lang/dir from the route

### DIFF
--- a/__tests__/localeOffering.test.mts
+++ b/__tests__/localeOffering.test.mts
@@ -1,0 +1,78 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { SUPPORTED_LOCALES, isSupportedLocale, dirForLocale, getDictionary } from '../lib/i18n/dictionaries.ts';
+
+/* #138. Arabic shipped in the picker with RTL unimplemented: /ar served
+ * `<html lang="en">` with no `dir`, and `dirForLocale` reached one div inside
+ * LandingContent. An Arabic reader got Arabic text in a left-to-right layout.
+ *
+ * The decision was to withdraw the OFFER and keep the WORK. So these assert
+ * both halves - that `ar` is not offered anywhere, and that everything needed
+ * to offer it again is still here.
+ *
+ * Comments are stripped before scanning source. Written without that, the
+ * picker test passes on the comment that says العربية was removed - which has
+ * happened to four of these suites in one session, so it is now a habit.
+ */
+const strip = (s: string) =>
+  s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+
+const read = (p: string) =>
+  strip(readFileSync(new URL('../' + p, import.meta.url), 'utf8').replace(/\r\n/g, '\n'));
+
+test('Arabic is not offered', async (t) => {
+  await t.test('it is not a supported locale', () => {
+    assert.equal(isSupportedLocale('ar'), false);
+    assert.deepEqual([...SUPPORTED_LOCALES], ['ko', 'zh']);
+  });
+
+  /* The picker is the only place a user can choose one, so this is the
+     assertion that maps to "can somebody still pick Arabic". */
+  await t.test('it is not in the language picker', () => {
+    const src = read('components/LanguageSwitcher.tsx');
+    assert.doesNotMatch(src, /code:\s*'ar'/, 'Arabic is still selectable in the picker');
+    assert.doesNotMatch(src, /'\/ar'/, 'the picker still links to /ar');
+  });
+
+  /* generateStaticParams now derives from SUPPORTED_LOCALES. A literal list is
+     what let the two disagree in the first place. */
+  await t.test('no Arabic route is prerendered', () => {
+    const src = read('app/[locale]/page.tsx');
+    assert.doesNotMatch(src, /locale:\s*'ar'/, 'a literal ar entry is back in generateStaticParams');
+    assert.match(src, /SUPPORTED_LOCALES/, 'generateStaticParams no longer derives from SUPPORTED_LOCALES');
+  });
+
+  /* An unsupported locale must 404, not render English at /ar - a page that
+     silently serves the wrong language is the failure one layer down. */
+  await t.test('/ar is no longer a supported locale value', () => {
+    assert.equal(isSupportedLocale('ar'), false);
+    assert.equal(isSupportedLocale('ko'), true);
+    assert.equal(isSupportedLocale('zh'), true);
+  });
+});
+
+test('the Arabic work is preserved, not deleted', async (t) => {
+  /* The decision was "withdraw the offer", not "throw away the translation".
+     Deleting the dictionary is the tempting tidy-up and it destroys the only
+     part of this that was actually finished. */
+  await t.test('the translated dictionary still exists', () => {
+    const src = read('lib/i18n/dictionaries.ts');
+    assert.match(src, /export const ar: LandingDict/, 'the Arabic dictionary was deleted');
+  });
+
+  /* dirForLocale takes a string precisely so removing `ar` from the Locale type
+     could not turn `locale === 'ar'` into a compile error that someone "fixes"
+     by deleting the RTL branch. */
+  await t.test('dirForLocale still knows Arabic is right-to-left', () => {
+    assert.equal(dirForLocale('ar'), 'rtl');
+    assert.equal(dirForLocale('en'), 'ltr');
+    assert.equal(dirForLocale('ko'), 'ltr');
+  });
+
+  await t.test('an unknown locale falls back to English rather than throwing', () => {
+    assert.equal(getDictionary('ar').hero.sub, getDictionary('en').hero.sub,
+      'ar now resolves to the English dictionary, which is the intended fallback');
+    assert.ok(getDictionary('klingon'));
+  });
+});

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,12 +1,15 @@
 ﻿import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import LandingContent from '@/components/LandingContent';
-import { getDictionary, dirForLocale, isSupportedLocale } from '@/lib/i18n/dictionaries';
+import { getDictionary, dirForLocale, isSupportedLocale, SUPPORTED_LOCALES } from '@/lib/i18n/dictionaries';
 
 interface Params { locale: string }
 
+/* Derived from SUPPORTED_LOCALES rather than listed, so removing a locale
+   cannot leave a prerendered route behind. `ar` was in this literal and in that
+   array, and the two would have had to be edited together - see #138. */
 export function generateStaticParams() {
-  return [{ locale: 'ko' }, { locale: 'zh' }, { locale: 'ar' }];
+  return SUPPORTED_LOCALES.map(locale => ({ locale }));
 }
 
 export async function generateMetadata({ params }: { params: Promise<Params> }): Promise<Metadata> {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import localFont from 'next/font/local';
 import Script from 'next/script';
 import './globals.css';
 import AppShell from '@/components/AppShell';
+import HtmlLangSync from '@/components/HtmlLangSync';
 
 // Self-hosted, previously next/font/google.
 //
@@ -94,6 +95,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           and displaced it - which is how it got reported as "the FAB
           disappears". See body.consent-pending in globals.css. */}
       <body className="consent-pending">
+        {/* Corrects lang/dir on <html> once the route is known. The attribute
+            above is the server default and is wrong on /ko and /zh - see the
+            component for why this cannot be done server-side without making
+            every route dynamic. */}
+        <HtmlLangSync />
         {/* beforeInteractive - injected into the initial server HTML and
             runs before hydration, so data-theme is correct before first
             paint (no flash of the wrong theme). Mirrors lib/theme.ts's

--- a/components/HtmlLangSync.tsx
+++ b/components/HtmlLangSync.tsx
@@ -1,0 +1,54 @@
+'use client';
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+import { isSupportedLocale, dirForLocale } from '@/lib/i18n/dictionaries';
+
+/* `<html lang>` was hardcoded to "en" on every page, including /ko and /zh.
+ *
+ * WCAG 2.2 SC 3.1.1 (Level A). A screen reader picks its pronunciation from
+ * this attribute, so Korean read as English is not accented - it is
+ * unintelligible. Measured on production 2026-08-08: /ar and every other route
+ * served `<html lang="en">` with no `dir`.
+ *
+ * WHY THIS IS CLIENT-SIDE, WHICH IS NOT THE OBVIOUS CHOICE.
+ *
+ * Only the root layout may render <html>, and a root layout receives no route
+ * params. The server-side alternatives are:
+ *
+ *   - read headers() in the root layout -> makes EVERY route dynamic, and the
+ *     build currently prerenders 76 of them. A Level A fix that costs the whole
+ *     static build is the wrong trade.
+ *   - multiple root layouts via route groups -> restructures the entire app
+ *     three weeks before launch.
+ *
+ * So this sets the attribute on the live DOM instead.
+ *
+ * WHAT THAT DOES AND DOES NOT FIX, stated rather than left to be discovered:
+ *
+ *   fixed  - screen readers, which read the live DOM after hydration. That is
+ *            the actual accessibility failure and the actual user.
+ *   NOT    - the server-rendered HTML, which still says lang="en" until this
+ *            runs. A crawler reading only the initial response sees English.
+ *
+ * The second half needs the layout restructure above. It is a real remainder,
+ * not a rounding error, and it is on #138.
+ */
+export default function HtmlLangSync() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    // The locale is the first path segment, and only on the landing routes -
+    // /ko, /zh. Everything else is the English app.
+    const first = pathname?.split('/')[1] ?? '';
+    const locale = isSupportedLocale(first) ? first : 'en';
+
+    document.documentElement.lang = locale;
+
+    // Set together, never separately. A document whose language is Arabic but
+    // whose direction is ltr is the state #138 was filed about; keeping the two
+    // in one place is what stops them disagreeing again.
+    document.documentElement.dir = dirForLocale(locale);
+  }, [pathname]);
+
+  return null;
+}

--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -7,7 +7,10 @@ const OPTIONS: Array<{ code: Locale; label: string; href: string }> = [
   { code: 'en', label: 'English',  href: '/' },
   { code: 'ko', label: '한국어',    href: '/ko' },
   { code: 'zh', label: '中文',      href: '/zh' },
-  { code: 'ar', label: 'العربية',  href: '/ar' },
+  // العربية was here. Removed 2026-08-08 (#138): the translation is complete
+  // but the layout does not mirror, so choosing it produced Arabic text in a
+  // left-to-right layout. The dictionary is kept in lib/i18n/dictionaries.ts -
+  // see the comment there for what putting it back needs.
 ];
 
 export default function LanguageSwitcher({ locale }: { locale: Locale }) {

--- a/lib/i18n/dictionaries.ts
+++ b/lib/i18n/dictionaries.ts
@@ -1,15 +1,42 @@
 ﻿// Landing-page translation dictionaries. Only the landing page is localized
 // for now - the rest of the app (dashboard, Arena, etc.) stays English-only.
 
-export const SUPPORTED_LOCALES = ['ko', 'zh', 'ar'] as const;
+/* ARABIC WAS REMOVED 2026-08-08, and the dictionary below was deliberately kept.
+ *
+ * `ar` shipped in this list and in the picker, but RTL was never implemented.
+ * Measured on production: /ar served `<html lang="en">` with no `dir` at all,
+ * and `dirForLocale` reached exactly one div inside LandingContent - so an
+ * Arabic reader got Arabic text in a permanently left-to-right layout, with
+ * anything portalled to <body> (modals, toasts, the consent banner) outside
+ * even that one div.
+ *
+ * Implementing it properly is ~597 physical positioning sites (`left:`,
+ * `margin-left`, `text-align`, `border-left`) against ZERO logical properties
+ * in the codebase today. That is not a three-weeks-before-launch job, and
+ * offering a language that renders wrong reads as neglect rather than scope.
+ *
+ * So the OFFER is withdrawn and the WORK is preserved: `ar` is out of
+ * SUPPORTED_LOCALES, out of the picker and out of generateStaticParams, while
+ * the translated dictionary and `dirForLocale` stay exactly as they are. When
+ * the layout uses logical properties, putting it back is one entry in this
+ * array. Deleting the dictionary would have thrown away the only part that was
+ * finished. See issue #138.
+ */
+export const SUPPORTED_LOCALES = ['ko', 'zh'] as const;
 export type Locale = (typeof SUPPORTED_LOCALES)[number] | 'en';
 
 export function isSupportedLocale(v: string): v is (typeof SUPPORTED_LOCALES)[number] {
   return (SUPPORTED_LOCALES as readonly string[]).includes(v);
 }
 
-export function dirForLocale(locale: Locale): 'ltr' | 'rtl' {
-  return locale === 'ar' ? 'rtl' : 'ltr';
+/* Kept, and takes a plain string on purpose. `ar` is no longer in `Locale`, so
+   a typed parameter would make `locale === 'ar'` a compile error against a
+   non-overlapping type - and "fixing" that by deleting the branch would quietly
+   delete the RTL knowledge this function exists to hold. */
+const RTL_LOCALES = new Set(['ar', 'he', 'fa', 'ur']);
+
+export function dirForLocale(locale: string): 'ltr' | 'rtl' {
+  return RTL_LOCALES.has(locale) ? 'rtl' : 'ltr';
 }
 
 export interface LandingDict {
@@ -348,7 +375,11 @@ export const ar: LandingDict = {
   },
 };
 
-export const dictionaries: Record<Locale, LandingDict> = { en, ko, zh, ar };
+/* `ar` is deliberately absent, and the type is what enforces that: this is
+   keyed by `Locale`, so re-adding the translation here without also adding
+   'ar' back to SUPPORTED_LOCALES is a compile error rather than a half-restored
+   language. The dictionary itself is exported above and untouched - see #138. */
+export const dictionaries: Record<Locale, LandingDict> = { en, ko, zh };
 
 export function getDictionary(locale: string): LandingDict {
   return isSupportedLocale(locale) ? dictionaries[locale] : dictionaries.en;


### PR DESCRIPTION
**Dev Team** → **QA Team**

Closes #138, Option B. Owner confirmed the direction to me directly.

## What changed

| | |
|---|---|
| `SUPPORTED_LOCALES` | `['ko', 'zh', 'ar']` → `['ko', 'zh']` |
| Language picker | العربية removed |
| `generateStaticParams` | **derives from `SUPPORTED_LOCALES`** instead of a literal list |
| `dictionaries` map | `ar` removed |
| `<html lang>` / `dir` | now set from the route, was hardcoded `en` |

**Kept exactly as they were:** the translated `ar` dictionary and
`dirForLocale`. The offer is withdrawn; the work is not thrown away.

## Two things that make it hard to half-restore

**`generateStaticParams` no longer holds its own list.** That literal and
`SUPPORTED_LOCALES` had to be edited together, which is precisely how a locale
ends up prerendered but unsupported. Verified in the build output — `ko.html`
and `zh.html` exist, `ar.html` does not.

**The dictionaries map is typed by `Locale`.** So putting the Arabic dictionary
back there without also adding `'ar'` to `SUPPORTED_LOCALES` is a **compile
error**, not a half-restored language that renders LTR again.

`dirForLocale` now takes a `string` rather than a `Locale`, deliberately: with
`ar` out of the type, `locale === 'ar'` would be a comparison against a
non-overlapping type — and the obvious way to "fix" that error is to delete the
RTL branch, which is the only RTL knowledge in the codebase.

## 🔴 The `lang` fix is client-side, and that is a real limitation

`lang="en"` on `/ko` and `/zh` is **WCAG 2.2 SC 3.1.1, Level A** — a screen
reader applies English pronunciation to Korean, which is unintelligible rather
than accented.

Only a root layout may render `<html>`, and it receives no route params. The
server-side options were:

- **`headers()` in the root layout** — makes all **76 prerendered routes**
  dynamic. A Level A fix that costs the entire static build is the wrong trade.
- **multiple root layouts via route groups** — restructures the app, three weeks
  out.

So `HtmlLangSync` sets it on the live DOM.

| | |
|---|---|
| **Fixed** | screen readers, which read the live DOM after hydration — the actual failure, the actual user |
| **Not fixed** | the server-rendered HTML, which still says `lang="en"` until hydration. A crawler reading only the initial response sees English |

Stating the second half plainly rather than letting "closes #138" imply more
than it does. That remainder needs the layout restructure and stays on the
issue.

`lang` and `dir` are set in the same place on purpose — a document whose
language is Arabic and whose direction is `ltr` is exactly what #138 was about.

## How to test (QA)

1. `npm test` — 201 pass, 9 new.
2. On `qa`, `/ko` and `/zh` load; **`document.documentElement.lang`** reads `ko`
   / `zh`, and `en` everywhere else.
3. The language picker offers **English, 한국어, 中文** and nothing else.
4. `/ar` returns **404**, not an English page. A route that silently serves the
   wrong language is the failure one layer down.
5. View source on `/ko` — `lang="en"` in the initial HTML is **expected**, per
   the limitation above. Please do not file it.

Step 5 is the one I would otherwise expect back as a bug report.

## Risk level

**Low-Medium.** Low in content — one array, one picker entry, one client
component that only writes two attributes. Gates green (lint 0 errors, tsc, 201
tests, build).

Medium for one reason: **`/ar` was a live URL and is now a 404.** Anyone who
bookmarked or linked it gets nothing. No redirect, because Option B is that the
language is not offered — silently serving English at an Arabic URL is worse.
Flagging it as a deliberate break rather than an oversight.

**Unverified:** steps 2–4 in a browser. I changed the caller by reading the
route structure, and the build output confirms which pages prerender, but I have
not loaded `/ko` and inspected the DOM.
