### PR TITLE
fix(qa): skip the signed webhook tests without admin env, loudly

### DIFF
--- a/qa/e2e/payments-webhook.spec.ts
+++ b/qa/e2e/payments-webhook.spec.ts
@@ -129,6 +129,33 @@ test.describe('LemonSqueezy webhook', () => {
       'LEMONSQUEEZY_WEBHOOK_SECRET is not set, so no correctly-signed payload can be built. ' +
       'Skipping rather than passing: a signed-payload test that never signs anything proves nothing.');
 
+    /* AND the handler needs SUPABASE_SERVICE_ROLE_KEY, which CI does not have.
+     *
+     * Both branches these tests target run through `getSupabaseAdmin()`:
+     * the replay guard inserts into `ls_webhook_events`, and the ownership check
+     * calls `sb.auth.admin.getUserById`. Without the admin client the route
+     * errors before reaching either, so the test fails on the environment rather
+     * than on the behaviour.
+     *
+     * This is the SAME wall that keeps `/api/push/test` out of
+     * `entitlements.spec.ts`, documented there hours before this spec was
+     * written - and I walked into it anyway, because I reasoned about which
+     * branch answers first and never checked what it needed to get there.
+     *
+     * `ci.yml`'s header argues deliberately against putting developer env in
+     * CI: building without it has caught two real defects. So this is a real
+     * trade, not an oversight to fix quietly - and the honest position is that
+     * **the ownership check and replay guard are verified by nothing in CI.**
+     *
+     * Skipping loudly rather than asserting something weaker. A test that
+     * passes by lowering its own standard is worse than one that says it did
+     * not run. */
+    test.skip(!process.env.SUPABASE_SERVICE_ROLE_KEY,
+      'SUPABASE_SERVICE_ROLE_KEY is absent, so the handler cannot reach the replay guard or the ' +
+      'ownership check - it errors first. Same limitation as /api/push/test. These two assertions ' +
+      'are therefore verified by NOTHING in CI; covering them needs the admin key, which ci.yml ' +
+      'deliberately withholds. Owner decision, tracked on #78.');
+
     /* THE BOLA OF PAYMENTS, and it has never run.
      *
      * `user_id` arrives in `custom_data`, which `lib/checkout.ts` writes into a


### PR DESCRIPTION
**QA Team** → **Dev Team** · **unblocks #141's gate**

## What failed

The two `with a valid signature` tests executed for the first time — #140 gave them the secret — and both failed:

```
✘ a payer cannot grant Pro to an account they do not own
✘ a replayed payload is recognised and not re-applied
   [WebServer] ⨯ Error: Missing Supabase admin env vars
```

**Not a product defect.** The handler runs both branches they target through `getSupabaseAdmin()` — the replay guard inserts into `ls_webhook_events`, the ownership check calls `sb.auth.admin.getUserById`. Without the admin client the route errors before reaching either.

## This is my mistake, and the second of its kind today

**Same wall that keeps `/api/push/test` out of `entitlements.spec.ts`** — which I documented there *hours before* writing this spec, then walked into anyway.

Both times I traced which branch answers *first* and never checked what it needed to *get* there. The other instance was the replay guard killing these same two tests on their second run, which you caught on review.

## What I am NOT doing

Lowering the assertion so it passes. A test that passes by dropping its own standard is worse than one that says it did not run.

## The honest consequence, stated not hidden

**The ownership check and the replay guard are verified by nothing in CI.**

That is the BOLA of payments — `user_id` comes from `custom_data`, which `lib/checkout.ts` writes into a client-side URL, so the payer chooses it. It is the assertion I called the most valuable in the file, and it cannot run where it matters.

Covering it needs `SUPABASE_SERVICE_ROLE_KEY` in CI, which `ci.yml` deliberately withholds — building without developer env has caught two real defects. **A real trade, and the owner's call.** Tracked on #78 alongside the same question for `push/test`.

## What still runs

The three unsigned tests, covering the property that matters most: a forged signature is rejected, an absent one is rejected, and a malformed one returns 401 rather than crashing the route.

## How to test (QA)

```
npx playwright test qa/e2e/payments-webhook.spec.ts --project=desktop
```

**3 passed, 2 skipped**, each skip naming its reason and its consequence.

## Risk level

**Low** for the change. **Medium** for what it documents — this is the second untested Pro-gate surface parked behind the same missing credential.

## Screenshots

n/a