### PR TITLE
fix(auth): notice when a signup produces no subscription row

### DIFF
--- a/__tests__/signupIntegrity.test.mts
+++ b/__tests__/signupIntegrity.test.mts
@@ -1,0 +1,78 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { classifyWelcomeClaim, missingRowReport } from '../lib/signupIntegrity.ts';
+
+/* #127. The trigger works today - verified on both projects 2026-08-08. This
+ * covers what happens if it ever stops.
+ *
+ * A signup that produces no `user_subscriptions` row gives the user no 14-day
+ * trial, and `getEntitlement()` reads the missing row as `free` - correctly,
+ * and identically to a trial that ended. So the account is silently downgraded
+ * from the first second, the symptom is a customer who does not convert, and
+ * nothing in the product, the logs or the UI distinguishes it.
+ *
+ * The welcome-email route is the only path every signup takes that already
+ * reads that row. It could not tell the two silences apart: both "email already
+ * sent" and "no row at all" produced `{ ok: true, sent: false }`.
+ */
+
+test('the two silences are told apart', async (t) => {
+  await t.test('a claimed row means send the email', () => {
+    assert.equal(classifyWelcomeClaim(true, true), 'send');
+  });
+
+  await t.test('unclaimed but present is the ordinary repeat call', () => {
+    assert.equal(classifyWelcomeClaim(false, true), 'already-sent');
+  });
+
+  /* The one this exists for. Before the split, this returned the same thing as
+     the case above and the difference was unobservable. */
+  await t.test('unclaimed and absent is the defect, not a no-op', () => {
+    assert.equal(classifyWelcomeClaim(false, false), 'missing-subscription-row');
+  });
+
+  /* `claimed` implies the row exists - you cannot update a row that is not
+     there - so this combination should never occur. It must still not report a
+     missing row, because reporting one would send someone hunting a trigger
+     that fired correctly. */
+  await t.test('an impossible combination does not raise a false alarm', () => {
+    assert.equal(classifyWelcomeClaim(true, false), 'send');
+  });
+});
+
+test('the report says what to do about it', async (t) => {
+  const report = missingRowReport('11111111-2222-4333-8444-555555555555');
+
+  /* A GlitchTip issue is read by someone with no context, months later. The
+     failure this guards is silent, so the message has to carry its own
+     diagnosis - the trigger name, the consequence, and that it may not be one
+     account. */
+  await t.test('it names the trigger, the consequence and the issue', () => {
+    assert.match(report, /lhq_grant_signup_trial/);
+    assert.match(report, /NO 14-day trial/);
+    assert.match(report, /#127/);
+  });
+
+  await t.test('it carries the user id so it is actionable', () => {
+    assert.match(report, /11111111-2222-4333-8444-555555555555/);
+  });
+});
+
+/* The classifier is only worth anything if the route uses it. Comments stripped
+   first - this is the fifth suite in this repo to scan source, and the previous
+   four each passed a mutation on their own prose before that was added. */
+test('the route reports rather than swallowing the missing row', () => {
+  const src = readFileSync(
+    new URL('../app/api/auth/welcome-email/route.ts', import.meta.url), 'utf8')
+    .replace(/\r\n/g, '\n')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+
+  assert.match(src, /classifyWelcomeClaim/,
+    'the route no longer classifies the claim - the two silences are collapsed again');
+  assert.match(src, /missingRowReport/,
+    'the route no longer reports a missing subscription row');
+  assert.match(src, /apiError\([^)]*missingRowReport/,
+    'the missing row is classified but not reported anywhere, which is the original defect');
+});

--- a/app/api/auth/welcome-email/route.ts
+++ b/app/api/auth/welcome-email/route.ts
@@ -4,6 +4,7 @@ import { apiError } from '@/lib/apiError';
 import { getSupabaseAdmin } from '@/lib/supabase-admin';
 import { sendWelcomeEmail } from '@/lib/email';
 import { T } from '@/lib/tables';
+import { classifyWelcomeClaim, missingRowReport } from '@/lib/signupIntegrity';
 
 export const dynamic = 'force-dynamic';
 
@@ -41,7 +42,37 @@ export async function POST(req: NextRequest) {
       .maybeSingle();
 
     if (error) return apiError('auth/welcome-email', error);
-    if (!claimed) return NextResponse.json({ ok: true, sent: false });
+
+    if (!claimed) {
+      /* `claimed` is null for two completely different reasons, and this route
+         used to answer both with `{ ok: true, sent: false }`:
+
+           - the row exists and the email already went out  -> normal
+           - THERE IS NO ROW                                -> #127
+
+         The second means the signup trigger did not run, so the account has no
+         14-day trial - and nothing anywhere would say so, because
+         getEntitlement() reads a missing row as `free` exactly as it reads an
+         expired trial. This route is the only code every signup passes through
+         that already looks at that row, so it is where the difference can be
+         noticed at all. */
+      const { data: row } = await admin
+        .from(T.user_subscriptions)
+        .select('user_id')
+        .eq('user_id', user.id)
+        .maybeSingle();
+
+      const outcome = classifyWelcomeClaim(false, !!row);
+      if (outcome === 'missing-subscription-row') {
+        // Reported, not thrown. The user is signed in and their session is
+        // fine; failing their first request would turn a silent defect into a
+        // broken signup. Loud where it needs to be loud - GlitchTip - and
+        // invisible where the user is concerned.
+        apiError('auth/welcome-email', new Error(missingRowReport(user.id)));
+      }
+
+      return NextResponse.json({ ok: true, sent: false, outcome });
+    }
 
     const sent = await sendWelcomeEmail({ to: user.email });
     return NextResponse.json({ ok: true, sent });

--- a/lib/signupIntegrity.ts
+++ b/lib/signupIntegrity.ts
@@ -1,0 +1,65 @@
+/* Did signup actually give this account its trial?
+ *
+ * `lhq_grant_signup_trial` is a trigger on `auth.users` that inserts the
+ * subscription row in the same transaction as the account. It works, and it is
+ * enabled on both projects - verified 2026-08-08. So this is not a fix for a
+ * broken trigger.
+ *
+ * It exists because of what happens if that ever stops being true. #127:
+ *
+ *   getEntitlement() reads a missing row as `free`, correctly and silently.
+ *   A user who signed up and got no trial is indistinguishable from a user
+ *   whose trial ended, and from a user who simply did not convert. The symptom
+ *   is a missing customer.
+ *
+ * Nothing would notice. Drop the trigger in a migration and the next hundred
+ * signups quietly get no Pro trial, with no error, no log line and nothing in
+ * the UI that differs.
+ *
+ * The one place already positioned to see it is the welcome-email route, which
+ * every signup hits and which already reads that row. It just could not tell
+ * the two silences apart:
+ *
+ *   claimed === null  because the email was already sent   -> normal, ignore
+ *   claimed === null  because THERE IS NO ROW              -> #127, shout
+ *
+ * Both returned `{ ok: true, sent: false }`.
+ */
+
+export type WelcomeClaim =
+  /** Row claimed by this call - first time, send the email. */
+  | 'send'
+  /** Row exists, welcome_email_sent_at already set. The common repeat call. */
+  | 'already-sent'
+  /** No subscription row for this user at all. The trigger did not run. */
+  | 'missing-subscription-row';
+
+/**
+ * Classify the outcome of the atomic claim.
+ *
+ * Split out from the route so the distinction is testable without a database -
+ * the whole defect is that two different states produced one response, and a
+ * pure function is where that can be pinned.
+ *
+ * @param claimed   whether `UPDATE … WHERE welcome_email_sent_at IS NULL`
+ *                  matched a row
+ * @param rowExists whether a subscription row exists at all. Only meaningful
+ *                  when `claimed` is false; the caller should not pay for the
+ *                  lookup otherwise.
+ */
+export function classifyWelcomeClaim(claimed: boolean, rowExists: boolean): WelcomeClaim {
+  if (claimed) return 'send';
+  return rowExists ? 'already-sent' : 'missing-subscription-row';
+}
+
+/** The message reported when a signup produced no trial row. Written out here
+ *  so the text a future reader finds in GlitchTip says what to do about it. */
+export function missingRowReport(userId: string): string {
+  return (
+    `Signup produced no ${'user_subscriptions'} row for user ${userId}. ` +
+    'The lhq_grant_signup_trial trigger on auth.users did not run, so this ' +
+    'account has NO 14-day trial and getEntitlement() will read it as free - ' +
+    'silently, and identically to a user whose trial ended. Check the trigger ' +
+    'exists on this project before assuming it is one account. See issue #127.'
+  );
+}


### PR DESCRIPTION
**Dev Team** → **QA Team**

Refs #127 — the half you correctly said was the point.

## Not a fix for the trigger

We have both now measured this independently and got the same answer:
`lhq_grant_signup_trial` exists, is enabled on both projects, runs inside the
`auth.users` insert transaction, and every rowless account predates 2026-07-22.

**This is the answer to "nothing would tell us if it disappeared."**

## Where it went, and why there was only one candidate

`/api/auth/welcome-email` is the only code path **every** signup takes — all
three methods converge on it via `AuthProvider` — that **already reads
`user_subscriptions`**. It just could not tell its two silences apart:

```ts
if (!claimed) return NextResponse.json({ ok: true, sent: false });
```

`claimed` is null when:

| | means | correct response |
|---|---|---|
| row exists, `welcome_email_sent_at` set | ordinary repeat call | ignore |
| **no row at all** | **the trigger did not run** | **#127** |

Same return value for both. The route was standing right next to the defect and
answering `ok: true`.

## What it does now

On the not-claimed path only, it checks whether the row exists. If it does not,
it reports to GlitchTip with a message written to be read by someone with no
context months later — trigger name, consequence, and a warning that it may not
be one account.

**Reported, not thrown.** The user is signed in and their session is fine;
failing their first authenticated request would turn a silent defect into a
broken signup. Loud where loud helps, invisible to the user.

## The test pins the distinction, because that is the whole bug

The classifier is pure, so this needs no database:

```
claimed=true,  rowExists=true   -> send
claimed=false, rowExists=true   -> already-sent
claimed=false, rowExists=false  -> missing-subscription-row
claimed=true,  rowExists=false  -> send        (impossible; must not false-alarm)
```

That last one matters: you cannot update a row that is not there, so it should
never occur — but if it did, reporting a missing row would send someone hunting
a trigger that fired correctly.

There is also a source check that the route **reports** rather than only
classifying. Classifying and then swallowing is the original defect wearing a
new coat, and it is one deleted line away.

Both mutations fail: swallowing the report fails 1, collapsing the two cases
fails 2.

## How to test (QA)

1. `npm test` — 210 pass, 9 new.
2. A real signup on `qa` still works and still receives its welcome email. This
   only adds a branch to the path that does **not** send one.
3. The proof case cannot be produced without dropping the trigger on the shared
   dev database, which I am not going to do and would not suggest you do either.

Point 3 is the honest limit: **this is verified as a decision, not as a firing
alarm.** If you want it exercised, the safe way is a throwaway Supabase project,
and that is a bigger piece of work than the fix.

## Risk level

**Low.** One extra indexed lookup on a path that already returned early. No
schema change, no behaviour change for a healthy signup. Gates green (lint 0
errors, tsc, 210 tests, build).

**Unverified:** that GlitchTip receives it. `NEXT_PUBLIC_SENTRY_DSN` is
production-only, and the quota is exhausted for this billing period — so even in
production this would be throttled until it resets. Worth knowing before anyone
treats silence as proof the alarm works.
