### PR TITLE
test(journal): finish the data-testid hooks and settle one naming convention

### DIFF
--- a/__tests__/signupIntegrity.test.mts
+++ b/__tests__/signupIntegrity.test.mts
@@ -1,0 +1,78 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { classifyWelcomeClaim, missingRowReport } from '../lib/signupIntegrity.ts';
+
+/* #127. The trigger works today - verified on both projects 2026-08-08. This
+ * covers what happens if it ever stops.
+ *
+ * A signup that produces no `user_subscriptions` row gives the user no 14-day
+ * trial, and `getEntitlement()` reads the missing row as `free` - correctly,
+ * and identically to a trial that ended. So the account is silently downgraded
+ * from the first second, the symptom is a customer who does not convert, and
+ * nothing in the product, the logs or the UI distinguishes it.
+ *
+ * The welcome-email route is the only path every signup takes that already
+ * reads that row. It could not tell the two silences apart: both "email already
+ * sent" and "no row at all" produced `{ ok: true, sent: false }`.
+ */
+
+test('the two silences are told apart', async (t) => {
+  await t.test('a claimed row means send the email', () => {
+    assert.equal(classifyWelcomeClaim(true, true), 'send');
+  });
+
+  await t.test('unclaimed but present is the ordinary repeat call', () => {
+    assert.equal(classifyWelcomeClaim(false, true), 'already-sent');
+  });
+
+  /* The one this exists for. Before the split, this returned the same thing as
+     the case above and the difference was unobservable. */
+  await t.test('unclaimed and absent is the defect, not a no-op', () => {
+    assert.equal(classifyWelcomeClaim(false, false), 'missing-subscription-row');
+  });
+
+  /* `claimed` implies the row exists - you cannot update a row that is not
+     there - so this combination should never occur. It must still not report a
+     missing row, because reporting one would send someone hunting a trigger
+     that fired correctly. */
+  await t.test('an impossible combination does not raise a false alarm', () => {
+    assert.equal(classifyWelcomeClaim(true, false), 'send');
+  });
+});
+
+test('the report says what to do about it', async (t) => {
+  const report = missingRowReport('11111111-2222-4333-8444-555555555555');
+
+  /* A GlitchTip issue is read by someone with no context, months later. The
+     failure this guards is silent, so the message has to carry its own
+     diagnosis - the trigger name, the consequence, and that it may not be one
+     account. */
+  await t.test('it names the trigger, the consequence and the issue', () => {
+    assert.match(report, /lhq_grant_signup_trial/);
+    assert.match(report, /NO 14-day trial/);
+    assert.match(report, /#127/);
+  });
+
+  await t.test('it carries the user id so it is actionable', () => {
+    assert.match(report, /11111111-2222-4333-8444-555555555555/);
+  });
+});
+
+/* The classifier is only worth anything if the route uses it. Comments stripped
+   first - this is the fifth suite in this repo to scan source, and the previous
+   four each passed a mutation on their own prose before that was added. */
+test('the route reports rather than swallowing the missing row', () => {
+  const src = readFileSync(
+    new URL('../app/api/auth/welcome-email/route.ts', import.meta.url), 'utf8')
+    .replace(/\r\n/g, '\n')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+
+  assert.match(src, /classifyWelcomeClaim/,
+    'the route no longer classifies the claim - the two silences are collapsed again');
+  assert.match(src, /missingRowReport/,
+    'the route no longer reports a missing subscription row');
+  assert.match(src, /apiError\([^)]*missingRowReport/,
+    'the missing row is classified but not reported anywhere, which is the original defect');
+});

--- a/__tests__/testIdParity.test.mts
+++ b/__tests__/testIdParity.test.mts
@@ -25,13 +25,43 @@ import { fileURLToPath } from 'node:url';
  * without the attribute - and cannot fail spuriously. The pairing is a review
  * concern, once, at the point the attribute is added. */
 
+/* One naming convention, settled 2026-08-09: expand the component's
+   abbreviation, keep the class untouched. #131 shipped `tj-field` next to
+   `grok-panel`, which is two conventions in one PR - renamed here while nothing
+   consumes them yet. */
 const PAIRS: Array<{ cls: string; testId: string }> = [
-  { cls: 'login-error',  testId: 'login-error'   },
-  { cls: 'st-page',      testId: 'settings-page' },
-  { cls: 'tj-field',     testId: 'tj-field'      },
-  { cls: 'tj-edit-form', testId: 'tj-edit-form'  },
-  { cls: 'gchat-panel',  testId: 'grok-panel'    },
-  { cls: 'gchat-msgs',   testId: 'grok-messages' },
+  { cls: 'login-error',   testId: 'login-error'        },
+  { cls: 'st-page',       testId: 'settings-page'      },
+  { cls: 'smod-panel',    testId: 'settings-modal'     },
+  { cls: 'tj-field',      testId: 'journal-field'      },
+  { cls: 'tj-edit-form',  testId: 'journal-edit-form'  },
+  { cls: 'tj-inp',        testId: 'journal-input'      },
+  { cls: 'tj-tab',        testId: 'journal-tab'        },
+  { cls: 'tj-edit-btn',   testId: 'journal-edit'       },
+  { cls: 'gchat-panel',   testId: 'grok-panel'         },
+  { cls: 'gchat-msgs',    testId: 'grok-messages'      },
+  { cls: 'gchat-fab',     testId: 'grok-launcher'      },
+  { cls: 'pb-star',       testId: 'playbook-star'      },
+];
+
+/* NOT in PAIRS, and the reason is the argument for this whole issue.
+ *
+ * These two classes are STYLING, reused by elements that mean different
+ * things - so a 1:1 count against the class would be asserting the wrong
+ * relationship, and attaching the testid everywhere the class appears would
+ * carry the ambiguity straight into the new attribute.
+ *
+ *   .login-email-input  - also on components/PasswordField.tsx. On /login in
+ *                         password mode, `input.login-email-input` therefore
+ *                         matches the email field AND the password field.
+ *   .st-toggle          - also on /alerts (page.tsx:1054), a different control
+ *                         that shares the look.
+ *
+ * The testid goes on the semantic element only, and the count is asserted
+ * directly. */
+const SEMANTIC_ONLY: Array<{ testId: string; count: number; absentFrom?: string }> = [
+  { testId: 'login-email',     count: 3, absentFrom: 'components/PasswordField.tsx' },
+  { testId: 'settings-toggle', count: 1, absentFrom: 'app/alerts/page.tsx' },
 ];
 
 /** Every .tsx under app/ and components/ - not a fixed file list, so a NEW file
@@ -91,5 +121,32 @@ test('every element carrying a spec-selected class carries its data-testid', asy
         `test hook; the a11y spec will measure less rather than fail.`,
       );
     });
+  }
+});
+
+/* The two selectors that are styling, not meaning. Asserted by count rather
+   than parity, plus an explicit absence: the point is that the testid lands on
+   the element the spec MEANS, and not on the unrelated element that happens to
+   share the class. */
+test('a shared styling class does not spread its test hook', async (t) => {
+  for (const { testId, count, absentFrom } of SEMANTIC_ONLY) {
+    await t.test(`[data-testid="${testId}"] appears exactly ${count}x`, () => {
+      const found = files.reduce(
+        (n, src) => n + (src.match(new RegExp(`data-testid="${testId}"`, 'g'))?.length ?? 0), 0);
+      assert.equal(found, count,
+        `expected ${count} element(s) with data-testid="${testId}", found ${found}. ` +
+        `Either a semantic element lost its hook, or the hook was copied onto one ` +
+        `that merely shares the styling class.`);
+    });
+
+    if (absentFrom) {
+      await t.test(`and never in ${absentFrom}`, () => {
+        const src = stripComments(
+          readFileSync(fileURLToPath(new URL('../' + absentFrom, import.meta.url)), 'utf8'));
+        assert.doesNotMatch(src, new RegExp(`data-testid="${testId}"`),
+          `${absentFrom} shares the styling class but is a different control - ` +
+          `giving it this hook reintroduces the ambiguity the hook exists to remove`);
+      });
+    }
   }
 });

--- a/app/api/auth/welcome-email/route.ts
+++ b/app/api/auth/welcome-email/route.ts
@@ -4,6 +4,7 @@ import { apiError } from '@/lib/apiError';
 import { getSupabaseAdmin } from '@/lib/supabase-admin';
 import { sendWelcomeEmail } from '@/lib/email';
 import { T } from '@/lib/tables';
+import { classifyWelcomeClaim, missingRowReport } from '@/lib/signupIntegrity';
 
 export const dynamic = 'force-dynamic';
 
@@ -41,7 +42,37 @@ export async function POST(req: NextRequest) {
       .maybeSingle();
 
     if (error) return apiError('auth/welcome-email', error);
-    if (!claimed) return NextResponse.json({ ok: true, sent: false });
+
+    if (!claimed) {
+      /* `claimed` is null for two completely different reasons, and this route
+         used to answer both with `{ ok: true, sent: false }`:
+
+           - the row exists and the email already went out  -> normal
+           - THERE IS NO ROW                                -> #127
+
+         The second means the signup trigger did not run, so the account has no
+         14-day trial - and nothing anywhere would say so, because
+         getEntitlement() reads a missing row as `free` exactly as it reads an
+         expired trial. This route is the only code every signup passes through
+         that already looks at that row, so it is where the difference can be
+         noticed at all. */
+      const { data: row } = await admin
+        .from(T.user_subscriptions)
+        .select('user_id')
+        .eq('user_id', user.id)
+        .maybeSingle();
+
+      const outcome = classifyWelcomeClaim(false, !!row);
+      if (outcome === 'missing-subscription-row') {
+        // Reported, not thrown. The user is signed in and their session is
+        // fine; failing their first request would turn a silent defect into a
+        // broken signup. Loud where it needs to be loud - GlitchTip - and
+        // invisible where the user is concerned.
+        apiError('auth/welcome-email', new Error(missingRowReport(user.id)));
+      }
+
+      return NextResponse.json({ ok: true, sent: false, outcome });
+    }
 
     const sent = await sendWelcomeEmail({ to: user.email });
     return NextResponse.json({ ok: true, sent });

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -71,7 +71,7 @@ export default function ForgotPasswordPage() {
                 <input
                   id="forgot-email"
                   type="email"
-                  className="login-email-input"
+                  className="login-email-input" data-testid="login-email"
                   placeholder={t('LOGIN_EMAIL_INPUT_PLACEHOLDER')}
                   value={email}
                   onChange={e => setEmail(e.target.value)}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -263,7 +263,7 @@ function LoginInner() {
                   <input
                     id="magic-email"
                     type="email"
-                    className="login-email-input"
+                    className="login-email-input" data-testid="login-email"
                     placeholder={t('LOGIN_EMAIL_INPUT_PLACEHOLDER')}
                     value={email}
                     onChange={e => setEmail(e.target.value)}
@@ -358,7 +358,7 @@ function LoginInner() {
                   <input
                     id="pw-email"
                     type="email"
-                    className="login-email-input"
+                    className="login-email-input" data-testid="login-email"
                     placeholder={t('LOGIN_EMAIL_INPUT_PLACEHOLDER')}
                     value={pwEmail}
                     onChange={e => setPwEmail(e.target.value)}

--- a/app/playbook/page.tsx
+++ b/app/playbook/page.tsx
@@ -73,6 +73,7 @@ export default function LiquidityPlaybook() {
                 <span className="s-num-right">
                   <span className={`cat-badge ${CAT_CLS[s.cat]}`}>{t(CAT_LABEL_KEYS[s.cat])}</span>
                   <button
+                    data-testid="playbook-star"
                     className={`pb-star${isFav ? ' on' : ''}`}
                     onClick={() => toggleFav(s.n)}
                     title={isFav ? t('PLAYBOOK_UNSAVE_TITLE') : t('PLAYBOOK_SAVE_TITLE')}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -56,6 +56,11 @@ function AnalyticsConsentToggle() {
         </div>
         <button
           className={`st-toggle${on ? ' on' : ''}`}
+          /* Only the settings toggle carries this. `.st-toggle` is also on
+             /alerts (page.tsx:1054), which is a different control that happens
+             to share the styling - so the class is not the thing the spec
+             means, and that ambiguity is what a testid removes. */
+          data-testid="settings-toggle"
           role="switch"
           aria-checked={on}
           aria-label={t('SETTINGS_ANALYTICS_TITLE')}

--- a/components/GrokChat.tsx
+++ b/components/GrokChat.tsx
@@ -596,6 +596,7 @@ export default function GrokChat() {
           for the mini-panel case, but the button is unclickable (and
           invisible) while open, so that path is effectively unreachable. */}
       <button
+        data-testid="grok-launcher"
         className={`gchat-fab${open ? ' gchat-fab-open' : ''}${!fabVisible ? ' gchat-fab-scrolling' : ''}`}
         onClick={() => { setOpen(v => !v); if (open) { setExpanded(false); setShowLoginModal(false); } }}
         title="Ask Grok"

--- a/components/TradeJournal.tsx
+++ b/components/TradeJournal.tsx
@@ -813,10 +813,10 @@ function Inner() {
 
       {/* Tabs */}
       <div className="tj-tabs">
-        <button className={`tj-tab${tab === 'log' ? ' on' : ''}`} onClick={() => setTab('log')}>{t('TRADE_JOURNAL_TAB_LOG')}</button>
-        <button className={`tj-tab${tab === 'history' ? ' on' : ''}`} onClick={() => setTab('history')}>{t('TRADE_JOURNAL_TAB_HISTORY', { count: trades.length })}</button>
-        <button className={`tj-tab${tab === 'stats' ? ' on' : ''}`} onClick={() => setTab('stats')}>{t('TRADE_JOURNAL_TAB_STATS')}</button>
-        <button className={`tj-tab${tab === 'rules' ? ' on' : ''}`} onClick={() => setTab('rules')} style={{ position: 'relative' }}>
+        <button data-testid="journal-tab" className={`tj-tab${tab === 'log' ? ' on' : ''}`} onClick={() => setTab('log')}>{t('TRADE_JOURNAL_TAB_LOG')}</button>
+        <button data-testid="journal-tab" className={`tj-tab${tab === 'history' ? ' on' : ''}`} onClick={() => setTab('history')}>{t('TRADE_JOURNAL_TAB_HISTORY', { count: trades.length })}</button>
+        <button data-testid="journal-tab" className={`tj-tab${tab === 'stats' ? ' on' : ''}`} onClick={() => setTab('stats')}>{t('TRADE_JOURNAL_TAB_STATS')}</button>
+        <button data-testid="journal-tab" className={`tj-tab${tab === 'rules' ? ' on' : ''}`} onClick={() => setTab('rules')} style={{ position: 'relative' }}>
           {t('TRADE_JOURNAL_TAB_RULES')}{rules.filter(r => r.enabled).length > 0 && (
             <span style={{
               marginLeft: 5, fontSize: 'var(--fs-caption)', fontWeight: 700,
@@ -825,9 +825,9 @@ function Inner() {
             }}>{rules.filter(r => r.enabled).length}</span>
           )}
         </button>
-        <button className={`tj-tab${tab === 'shadow' ? ' on' : ''}`} onClick={() => setTab('shadow')}>{t('TRADE_JOURNAL_TAB_SHADOW')}</button>
-        <button className={`tj-tab${tab === 'bias' ? ' on' : ''}`} onClick={() => setTab('bias')}>{t('TRADE_JOURNAL_TAB_BIAS')}</button>
-        <button className={`tj-tab${tab === 'thesis' ? ' on' : ''}`} onClick={() => setTab('thesis')} style={{ position: 'relative' }}>
+        <button data-testid="journal-tab" className={`tj-tab${tab === 'shadow' ? ' on' : ''}`} onClick={() => setTab('shadow')}>{t('TRADE_JOURNAL_TAB_SHADOW')}</button>
+        <button data-testid="journal-tab" className={`tj-tab${tab === 'bias' ? ' on' : ''}`} onClick={() => setTab('bias')}>{t('TRADE_JOURNAL_TAB_BIAS')}</button>
+        <button data-testid="journal-tab" className={`tj-tab${tab === 'thesis' ? ' on' : ''}`} onClick={() => setTab('thesis')} style={{ position: 'relative' }}>
           {t('TRADE_JOURNAL_TAB_THESIS')}{theses.length > 0 && (
             <span style={{ marginLeft: 5, fontSize: 'var(--fs-caption)', fontWeight: 700, background: 'var(--accent-solid)', color: '#fff', borderRadius: 10, padding: '1px 5px' }}>{theses.length}</span>
           )}
@@ -873,28 +873,28 @@ function Inner() {
           <div className="tj-card">
             <div className="tj-card-lbl">{t('TRADE_JOURNAL_LOG_PRICE_LEVELS_LABEL')}</div>
             <div className="tj-price-grid">
-              <div className="tj-field" data-testid="tj-field">
+              <div className="tj-field" data-testid="journal-field">
                 <label className="tj-lbl">{t('TRADE_JOURNAL_LOG_ENTRY_LABEL')}</label>
                 <div className="tj-irow"><span className="tj-affix">$</span>
-                  <input className="tj-inp" aria-label={t('TRADE_JOURNAL_LOG_ENTRY_ARIA')} type="number" placeholder="0.00" value={entry} onChange={e => setEntry(e.target.value)} />
+                  <input className="tj-inp" data-testid="journal-input" aria-label={t('TRADE_JOURNAL_LOG_ENTRY_ARIA')} type="number" placeholder="0.00" value={entry} onChange={e => setEntry(e.target.value)} />
                 </div>
               </div>
-              <div className="tj-field" data-testid="tj-field">
+              <div className="tj-field" data-testid="journal-field">
                 <label className="tj-lbl">{t('TRADE_JOURNAL_LOG_STOP_LOSS_LABEL')}</label>
                 <div className="tj-irow"><span className="tj-affix">$</span>
-                  <input className="tj-inp tj-inp-stop" aria-label={t('TRADE_JOURNAL_LOG_STOP_LOSS_ARIA')} type="number" placeholder="0.00" value={stopLoss} onChange={e => setStopLoss(e.target.value)} />
+                  <input className="tj-inp tj-inp-stop" data-testid="journal-input" aria-label={t('TRADE_JOURNAL_LOG_STOP_LOSS_ARIA')} type="number" placeholder="0.00" value={stopLoss} onChange={e => setStopLoss(e.target.value)} />
                 </div>
               </div>
-              <div className="tj-field" data-testid="tj-field">
+              <div className="tj-field" data-testid="journal-field">
                 <label className="tj-lbl">{t('TRADE_JOURNAL_LOG_TAKE_PROFIT_LABEL')}</label>
                 <div className="tj-irow"><span className="tj-affix">$</span>
-                  <input className="tj-inp tj-inp-tp" aria-label={t('TRADE_JOURNAL_LOG_TAKE_PROFIT_LABEL')} type="number" placeholder="0.00" value={tpPrice} onChange={e => setTpPrice(e.target.value)} />
+                  <input className="tj-inp tj-inp-tp" data-testid="journal-input" aria-label={t('TRADE_JOURNAL_LOG_TAKE_PROFIT_LABEL')} type="number" placeholder="0.00" value={tpPrice} onChange={e => setTpPrice(e.target.value)} />
                 </div>
               </div>
-              <div className="tj-field" data-testid="tj-field">
+              <div className="tj-field" data-testid="journal-field">
                 <label className="tj-lbl">{t('TRADE_JOURNAL_LOG_POSITION_SIZE_LABEL')}</label>
                 <div className="tj-irow"><span className="tj-affix">$</span>
-                  <input className="tj-inp" aria-label={t('TRADE_JOURNAL_LOG_POSITION_SIZE_ARIA')} type="number" placeholder={t('TRADE_JOURNAL_LOG_POSITION_SIZE_PLACEHOLDER')} value={posUSD} onChange={e => setPosUSD(e.target.value)} />
+                  <input className="tj-inp" data-testid="journal-input" aria-label={t('TRADE_JOURNAL_LOG_POSITION_SIZE_ARIA')} type="number" placeholder={t('TRADE_JOURNAL_LOG_POSITION_SIZE_PLACEHOLDER')} value={posUSD} onChange={e => setPosUSD(e.target.value)} />
                 </div>
               </div>
             </div>
@@ -1094,7 +1094,7 @@ function Inner() {
                       borderRadius: 4, padding: '2px 5px',
                     }}>{t('TRADE_JOURNAL_HISTORY_RULE_BADGE')}</span>
                   )}
-                  <button className="tj-edit-btn" title={t('TRADE_JOURNAL_HISTORY_EDIT_TITLE')} onClick={() => editingId === trade.id ? setEditingId(null) : startEdit(trade)}>✎</button>
+                  <button className="tj-edit-btn" data-testid="journal-edit" title={t('TRADE_JOURNAL_HISTORY_EDIT_TITLE')} onClick={() => editingId === trade.id ? setEditingId(null) : startEdit(trade)}>✎</button>
                   <button className="tj-del-btn" onClick={() => trade.id && deleteTrade(trade.id)}>✕</button>
                 </div>
               </div>
@@ -1145,6 +1145,7 @@ function Inner() {
                       <span className="tj-affix">$</span>
                       <input
                         className="tj-inp"
+                        data-testid="journal-input"
                         type="number"
                         placeholder={t('TRADE_JOURNAL_HISTORY_EXIT_PRICE_PLACEHOLDER')}
                         value={exitInput}
@@ -1165,7 +1166,7 @@ function Inner() {
 
               {/* Inline edit form */}
               {editingId === trade.id && (
-                <div className="tj-edit-form" data-testid="tj-edit-form">
+                <div className="tj-edit-form" data-testid="journal-edit-form">
                   {/* WCAG 2.2 SC 4.1.2 Name, Role, Value (Level A), issue #48.
                       The visible labels were already here - they just named
                       nothing: no htmlFor, wrapping no control. A screen reader
@@ -1205,7 +1206,7 @@ function Inner() {
                     <div className="tj-edit-field">
                       <label className="tj-lbl" htmlFor={`tj-edit-exit-${trade.id}`}>{t('TRADE_JOURNAL_HISTORY_EDIT_EXIT_PRICE_LABEL')}</label>
                       <div className="tj-irow"><span className="tj-affix">$</span>
-                        <input id={`tj-edit-exit-${trade.id}`} className="tj-inp" type="number" placeholder="0.00"
+                        <input id={`tj-edit-exit-${trade.id}`} className="tj-inp" data-testid="journal-input" type="number" placeholder="0.00"
                           value={editDraft.exit_price}
                           onChange={e => setEditDraft(p => ({ ...p, exit_price: e.target.value }))} />
                       </div>
@@ -1213,7 +1214,7 @@ function Inner() {
                     <div className="tj-edit-field">
                       <label className="tj-lbl" htmlFor={`tj-edit-pnl-${trade.id}`}>{t('TRADE_JOURNAL_HISTORY_EDIT_PNL_LABEL')}</label>
                       <div className="tj-irow"><span className="tj-affix">$</span>
-                        <input id={`tj-edit-pnl-${trade.id}`} className="tj-inp" type="number" placeholder="0.00"
+                        <input id={`tj-edit-pnl-${trade.id}`} className="tj-inp" data-testid="journal-input" type="number" placeholder="0.00"
                           value={editDraft.pnl_usd}
                           onChange={e => setEditDraft(p => ({ ...p, pnl_usd: e.target.value }))} />
                       </div>

--- a/components/UsageModal.tsx
+++ b/components/UsageModal.tsx
@@ -30,7 +30,7 @@ export default function UsageModal({ open, onClose }: Props) {
           alone onto a second row and read as an afterthought rather than one
           of the budgets. Still collapses to the viewport on mobile, where
           wrapping is expected. */}
-      <div className="smod-panel" role="dialog" aria-modal="true" aria-label={t('USAGE_MODAL_TITLE')} style={{ maxHeight: 'none', width: 'min(460px, calc(100vw - 24px))' }}>
+      <div className="smod-panel" data-testid="settings-modal" role="dialog" aria-modal="true" aria-label={t('USAGE_MODAL_TITLE')} style={{ maxHeight: 'none', width: 'min(460px, calc(100vw - 24px))' }}>
         <div className="smod-header">
           <span className="smod-title">{t('USAGE_MODAL_TITLE')}</span>
           <button className="smod-close" onClick={onClose} aria-label="Close">✕</button>

--- a/lib/signupIntegrity.ts
+++ b/lib/signupIntegrity.ts
@@ -1,0 +1,65 @@
+/* Did signup actually give this account its trial?
+ *
+ * `lhq_grant_signup_trial` is a trigger on `auth.users` that inserts the
+ * subscription row in the same transaction as the account. It works, and it is
+ * enabled on both projects - verified 2026-08-08. So this is not a fix for a
+ * broken trigger.
+ *
+ * It exists because of what happens if that ever stops being true. #127:
+ *
+ *   getEntitlement() reads a missing row as `free`, correctly and silently.
+ *   A user who signed up and got no trial is indistinguishable from a user
+ *   whose trial ended, and from a user who simply did not convert. The symptom
+ *   is a missing customer.
+ *
+ * Nothing would notice. Drop the trigger in a migration and the next hundred
+ * signups quietly get no Pro trial, with no error, no log line and nothing in
+ * the UI that differs.
+ *
+ * The one place already positioned to see it is the welcome-email route, which
+ * every signup hits and which already reads that row. It just could not tell
+ * the two silences apart:
+ *
+ *   claimed === null  because the email was already sent   -> normal, ignore
+ *   claimed === null  because THERE IS NO ROW              -> #127, shout
+ *
+ * Both returned `{ ok: true, sent: false }`.
+ */
+
+export type WelcomeClaim =
+  /** Row claimed by this call - first time, send the email. */
+  | 'send'
+  /** Row exists, welcome_email_sent_at already set. The common repeat call. */
+  | 'already-sent'
+  /** No subscription row for this user at all. The trigger did not run. */
+  | 'missing-subscription-row';
+
+/**
+ * Classify the outcome of the atomic claim.
+ *
+ * Split out from the route so the distinction is testable without a database -
+ * the whole defect is that two different states produced one response, and a
+ * pure function is where that can be pinned.
+ *
+ * @param claimed   whether `UPDATE … WHERE welcome_email_sent_at IS NULL`
+ *                  matched a row
+ * @param rowExists whether a subscription row exists at all. Only meaningful
+ *                  when `claimed` is false; the caller should not pay for the
+ *                  lookup otherwise.
+ */
+export function classifyWelcomeClaim(claimed: boolean, rowExists: boolean): WelcomeClaim {
+  if (claimed) return 'send';
+  return rowExists ? 'already-sent' : 'missing-subscription-row';
+}
+
+/** The message reported when a signup produced no trial row. Written out here
+ *  so the text a future reader finds in GlitchTip says what to do about it. */
+export function missingRowReport(userId: string): string {
+  return (
+    `Signup produced no ${'user_subscriptions'} row for user ${userId}. ` +
+    'The lhq_grant_signup_trial trigger on auth.users did not run, so this ' +
+    'account has NO 14-day trial and getEntitlement() will read it as free - ' +
+    'silently, and identically to a user whose trial ended. Check the trigger ' +
+    'exists on this project before assuming it is one account. See issue #127.'
+  );
+}


### PR DESCRIPTION
**Dev Team** → **QA Team**

Refs #52. Your re-measured inventory, all 15, plus a naming decision you said
was mine.

## The naming, so you can write your swap against it

Expand the component's abbreviation, keep the class untouched:

| selector | testid | | selector | testid |
|---|---|---|---|---|
| `.smod-panel` | `settings-modal` | | `.tj-edit-btn` | `journal-edit` |
| `.st-page` | `settings-page` | | `.tj-edit-form` | `journal-edit-form` |
| `button.st-toggle` | `settings-toggle` | | `.login-error` | `login-error` |
| `input.tj-inp` | `journal-input` | | `input.login-email-input` | `login-email` |
| `.tj-field` | `journal-field` | | `button.gchat-fab` | `grok-launcher` |
| `button.tj-tab` | `journal-tab` | | `.gchat-msgs` | `grok-messages` |
| | | | `.gchat-panel` | `grok-panel` |
| | | | `button.pb-star` | `playbook-star` |

`.st-page label` needs nothing — scope it as `[data-testid="settings-page"] label`.

**Two renames from #131**: `tj-field` → `journal-field`, `tj-edit-form` →
`journal-edit-form`. That PR shipped `tj-field` next to `grok-panel`, which is
two conventions in one commit. Nothing consumes either name yet, so this is the
free moment to fix it — and after your swap it would not be.

## 🔴 Two of your fifteen are styling classes, not semantic ones

This is the sharpest argument for the whole issue, and I did not expect to find
it here.

**`.login-email-input` is also on `PasswordField`.** So on `/login` in password
mode, `input.login-email-input` matches the email field **and** the password
field. Your spec does:

```ts
await page.fill('input.login-email-input', 'qa-nonexistent@example.com');
```

Worth checking on your side: Playwright's `page.fill` is strict, and two matches
is a strict-mode violation rather than a wrong-element bug. It may be that the
password form is not mounted at that point — I have not run it — but the
selector is ambiguous either way, and that is exactly what a testid removes.

**`.st-toggle` is also on `/alerts`** (`page.tsx:1054`), a different control
sharing the look.

For both, the hook goes on the **semantic element only** — three real email
inputs, one settings toggle — and `PasswordField` and `/alerts` are asserted to
**not** have it. Copying the attribute everywhere the class appears would have
carried the ambiguity straight into the new mechanism.

## The parity test earned itself during this change

A Python patch I wrote reported success and changed nothing:
`str.replace(old, new, 0)` replaces **zero** occurrences, not all. Five
selectors were silently untouched.

The suite failed with exact counts — `7 element(s) carry .tj-inp but 0 carry
data-testid="journal-input"` — instead of letting a no-op commit look finished.
Then caught a genuinely missed input at `TradeJournal.tsx:1147` on the next run.

Twelve pairs are asserted 1:1. The two styling classes are asserted by exact
count plus explicit absence, because parity against them would assert the wrong
relationship.

## How to test (QA)

1. `npm test` — 221 pass, 18 in this suite.
2. Your swap: every selector in the table resolves to the same elements the
   class did. **The two marked above will not** — that is the point, not a
   regression.
3. Nothing visual changes anywhere. Attributes only.

## Risk level

**Low.** Inert attributes and two renames of hooks nothing reads yet. Gates
green (lint 0 errors, tsc, 221 tests, build).

**Unverified:** that the testids resolve in a browser. Source counts are what I
can check; your swap is the first real execution.
