### PR TITLE
test(qa): give CI the admin key, and cover the three surfaces it was blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,9 +344,11 @@ jobs:
           # expires in about an hour, so a pasted token passes once and then
           # fails CI the next day. The spec mints a fresh token per run.
           #
-          # These are ordinary user-level accounts. The service-role key is NOT
-          # here and must never be - it bypasses RLS entirely, which is exactly
-          # what this spec exists to verify.
+          # These are ordinary user-level accounts, and bola.spec.ts must keep
+          # using them. It exists to prove RLS refuses B's request for A's rows;
+          # signing in as the service role would bypass RLS and make it pass
+          # while proving nothing. See the SUPABASE_SERVICE_ROLE_KEY block below
+          # for why the key being present on the job does not change that.
           #
           # Absent, bola.spec.ts SKIPS with a stated reason rather than passing.
           # A BOLA test that runs without fixtures proves nothing, and a vacuous
@@ -405,6 +407,50 @@ jobs:
           # `liquidity-hq-prod`. Copying it here would let anyone who can read
           # this repository forge a webhook that grants Pro.
           LEMONSQUEEZY_WEBHOOK_SECRET: ci-fake-not-a-real-lemonsqueezy-secret
+
+          # ── THIS FILE USED TO SAY THE SERVICE-ROLE KEY "must never be" HERE ──
+          #
+          # Reversed 2026-08-09 by an explicit owner decision, and written out
+          # rather than quietly deleted: an absolute rule that softens with no
+          # record is how the next person re-derives the wrong conclusion.
+          #
+          # WHAT THE OLD RULE COST. Three Pro-gated surfaces were verified by
+          # nothing at all, because every one of them authenticates through
+          # `getSupabaseAdmin()` and so errored before reaching the branch under
+          # test:
+          #
+          #   1. the payments OWNERSHIP check - the payer supplies `user_id` in
+          #      `custom_data`, which `lib/checkout.ts` writes into a
+          #      client-side URL. Whether a payer can grant Pro to an account
+          #      they do not own is the BOLA of payments, and it had never run.
+          #   2. the payments REPLAY guard (`ls_webhook_events`).
+          #   3. `/api/push/test`'s Pro gate - excluded from entitlements.spec.ts
+          #      for this exact reason.
+          #
+          # WHY IT IS ACCEPTABLE. The two arguments the old rule rested on both
+          # survive:
+          #
+          #   * "CI builds without developer env, which caught two real defects"
+          #     - those were the labels bug and the NEXT_PUBLIC_APP_ENV prefix
+          #     gap, and both are about a variable being ABSENT in CI while
+          #     PRESENT in production. This key is present in production. Adding
+          #     it moves CI toward the production configuration, not away from
+          #     it. The env-absence guard is unaffected.
+          #   * "it bypasses RLS, which bola.spec.ts exists to verify" - true of
+          #     a TEST that authenticates with it. No spec does; bola.spec.ts
+          #     signs in as A and B with passwords. What changes here is only
+          #     that the SERVER can build its admin client, exactly as the
+          #     server does in production.
+          #
+          # BLAST RADIUS, stated rather than assumed: this is the DEV project's
+          # key. That project holds nine test accounts and no real user data,
+          # and `staging` shares it. It is NOT prod's key and must never be -
+          # prod's holds real customers and the free plan has no backups.
+          #
+          # IF THE SECRET IS ABSENT the three tests SKIP with a stated reason
+          # rather than pass. That is deliberate and it is the part to preserve:
+          # a skip is legible, a vacuous pass is not.
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
 
       # failure() only. This used to upload on every green run too - ~15s and
       # storage for a report nobody opens. failure() still excludes

--- a/qa/e2e/entitlements.spec.ts
+++ b/qa/e2e/entitlements.spec.ts
@@ -33,21 +33,26 @@ const P = process.env.NEXT_PUBLIC_APP_ENV === 'dev' ? 'lhq_dev_' : 'lhq_';
  *  `price-alerts` appears twice on purpose — its GET is deliberately NOT gated
  *  (a free user may read alerts, not create them), so only POST and PATCH are
  *  listed. Asserting 403 on the GET would be asserting a bug. */
-/* `/api/push/test` is Pro-gated and is NOT in this list, deliberately.
+/* `/api/push/test` was excluded from this list until 2026-08-09, and now is not.
  *
  * It verifies the caller with `getSupabaseAdmin()` rather than the anon client,
- * so it needs SUPABASE_SERVICE_ROLE_KEY. The CI build deliberately runs without
- * developer env (`ci.yml` header: that difference has produced two real
- * defects), so the admin client throws, `getUser` catches and returns null, and
- * the route answers 401 to a perfectly good token.
+ * so without SUPABASE_SERVICE_ROLE_KEY the admin client throws, `getUser`
+ * catches and returns null, and the route answers 401 to a perfectly good
+ * token. Asserting on it then would have failed the release gate for an
+ * environment gap, so it was excluded LOUDLY and the gap recorded: push/test's
+ * Pro gate was verified by nothing.
  *
- * Asserting on it here would fail the release gate for an environment gap and
- * teach everyone to ignore a red entitlements run. Excluding it silently would
- * be worse - so it is excluded loudly, and the coverage gap is real:
- * **push/test's Pro gate is not verified by anything.**
+ * The owner supplied the key to the E2E job (see the long block in `ci.yml`),
+ * so the exclusion no longer has a reason and the route is in GATED below.
  *
- * To cover it, CI needs the admin key, which is a deliberate trade against the
- * reason CI runs without developer env at all. Owner's call, not a QA one.
+ * What it does in CI, checked against the route rather than assumed:
+ *   free -> 403 `PRO_REQUIRED`, which is what this spec asserts
+ *   pro  -> 503 `VAPID not configured`, because CI has no VAPID keys. That is
+ *           not 403, which is all the PRO direction claims - and it means
+ *           **no real push is sent**, so this adds no side effect.
+ *
+ * If the 503 ever becomes a 200, someone has put VAPID credentials in CI and
+ * this route now messages real devices on every release run. Worth noticing.
  */
 const GATED: Array<{ method: 'GET' | 'POST' | 'PATCH'; path: string }> = [
   { method: 'POST',  path: '/api/alerts/preview' },
@@ -58,6 +63,7 @@ const GATED: Array<{ method: 'GET' | 'POST' | 'PATCH'; path: string }> = [
   { method: 'POST',  path: '/api/pine-script' },
   { method: 'POST',  path: '/api/price-alerts' },
   { method: 'PATCH', path: '/api/price-alerts' },
+  { method: 'POST',  path: '/api/push/test' },
   { method: 'POST',  path: '/api/shadow-account' },
   { method: 'POST',  path: '/api/smc-snapshot' },
   { method: 'POST',  path: '/api/strategy-research' },

--- a/qa/e2e/payments-webhook.spec.ts
+++ b/qa/e2e/payments-webhook.spec.ts
@@ -129,32 +129,28 @@ test.describe('LemonSqueezy webhook', () => {
       'LEMONSQUEEZY_WEBHOOK_SECRET is not set, so no correctly-signed payload can be built. ' +
       'Skipping rather than passing: a signed-payload test that never signs anything proves nothing.');
 
-    /* AND the handler needs SUPABASE_SERVICE_ROLE_KEY, which CI does not have.
+    /* AND the handler needs SUPABASE_SERVICE_ROLE_KEY.
      *
-     * Both branches these tests target run through `getSupabaseAdmin()`:
-     * the replay guard inserts into `ls_webhook_events`, and the ownership check
+     * Both branches these tests target run through `getSupabaseAdmin()`: the
+     * replay guard inserts into `ls_webhook_events`, and the ownership check
      * calls `sb.auth.admin.getUserById`. Without the admin client the route
-     * errors before reaching either, so the test fails on the environment rather
-     * than on the behaviour.
+     * errors before reaching either, so the test fails on the environment
+     * rather than on the behaviour - which is exactly what happened on release
+     * PR #141, the first run where these two executed at all.
      *
-     * This is the SAME wall that keeps `/api/push/test` out of
-     * `entitlements.spec.ts`, documented there hours before this spec was
-     * written - and I walked into it anyway, because I reasoned about which
-     * branch answers first and never checked what it needed to get there.
+     * CI now supplies the key (owner decision, 2026-08-09; the reasoning is in
+     * `ci.yml` beside the variable). **Keeping this guard anyway.** It is not
+     * dead code: it is what makes a missing secret produce a legible skip
+     * instead of a confusing failure, and it is what stops these two from ever
+     * silently becoming assertions about an environment error.
      *
-     * `ci.yml`'s header argues deliberately against putting developer env in
-     * CI: building without it has caught two real defects. So this is a real
-     * trade, not an oversight to fix quietly - and the honest position is that
-     * **the ownership check and replay guard are verified by nothing in CI.**
-     *
-     * Skipping loudly rather than asserting something weaker. A test that
-     * passes by lowering its own standard is worse than one that says it did
-     * not run. */
+     * A skip here is now a FINDING, not a limitation - it means the secret is
+     * absent from a job that is supposed to have it. Treat it as a red run. */
     test.skip(!process.env.SUPABASE_SERVICE_ROLE_KEY,
-      'SUPABASE_SERVICE_ROLE_KEY is absent, so the handler cannot reach the replay guard or the ' +
-      'ownership check - it errors first. Same limitation as /api/push/test. These two assertions ' +
-      'are therefore verified by NOTHING in CI; covering them needs the admin key, which ci.yml ' +
-      'deliberately withholds. Owner decision, tracked on #78.');
+      'SUPABASE_SERVICE_ROLE_KEY is absent, so the handler errors before reaching the replay guard ' +
+      'or the ownership check. CI is supposed to supply this now - if you are reading this in a CI ' +
+      'log, the secret E2E_SUPABASE_SERVICE_ROLE_KEY is missing or empty, and these two assertions ' +
+      'are verified by nothing. That is a failure to fix, not a limitation to accept.');
 
     /* THE BOLA OF PAYMENTS, and it has never run.
      *


### PR DESCRIPTION
**QA Team** → **Dev Team** · **owner decision, 2026-08-09** · closes the last blocker on #78

## What was broken

Three Pro-gated surfaces were verified by **nothing**, all for one reason: each
authenticates through `getSupabaseAdmin()`, so without the admin key the route
errored before reaching the branch under test.

| surface | why it mattered |
|---|---|
| payments **ownership check** | `user_id` arrives in `custom_data`, which `lib/checkout.ts` writes into a **client-side URL** — the payer picks it. This is the BOLA of payments and it had **never run once**. |
| payments **replay guard** | `ls_webhook_events`. Same wall. |
| `/api/push/test` **Pro gate** | excluded from `entitlements.spec.ts` for exactly this. |

## What changed

`ci.yml` passes `SUPABASE_SERVICE_ROLE_KEY` to the E2E job, from a new secret
`E2E_SUPABASE_SERVICE_ROLE_KEY` (**dev project**). `/api/push/test` joins
`GATED`. Both webhook tests now reach their assertions.

## The rule this reverses, stated rather than deleted

`ci.yml` said the service-role key **"must never be"** here. It now says the
opposite, with the reasoning inline — an absolute rule that softens with no
record is how the next person re-derives the wrong conclusion.

Both original arguments survive, which is why this is safe:

- **"CI builds without developer env, and that caught two real defects."** Those
  were the labels bug and the `NEXT_PUBLIC_APP_ENV` prefix gap — both about a
  variable **absent in CI and present in production**. This key **is** present in
  production. Adding it moves CI *toward* the production config. Guard untouched.
- **"It bypasses RLS, which `bola.spec.ts` exists to verify."** True of a *test*
  that authenticates with it. **None does** — `bola.spec.ts` signs in as A and B
  with passwords. Only the **server** gains an admin client, exactly as in prod.

**Blast radius:** the dev project — nine test accounts, no real user data,
shared with `staging`. **Not prod's key, and prod's must never come here** — it
holds real customers and the free plan has no backups.

## Verified BEFORE the secret exists

Rather than merging and hoping, I supplied the same env locally:

```
npx playwright test qa/e2e/payments-webhook.spec.ts qa/e2e/entitlements.spec.ts --project=desktop
```

**37 passed, 0 skipped** — previously **3 passed, 34 skipped**. The webServer log
shows the ownership branch actually executing rather than the route erroring:

```
[lemonsqueezy/webhook] Payer/account email mismatch - refusing to grant.
  event=subscription_created user_id=00000000-... payer=attacker@example.test
```

## The skip guards stay, and now mean the opposite

They are not dead code. They turn a missing secret into a **legible skip**
instead of a confusing failure. Their messages are rewritten so a skip now reads
as a **finding** — the secret is missing from a job that should have it — rather
than an accepted limitation.

**So this does not block a release if the secret is late.** The three tests skip,
loudly, and the gate stays green.

## Owner action still outstanding

**Add repo secret `E2E_SUPABASE_SERVICE_ROLE_KEY`** = the **dev** project's
service-role key. Until then the three tests skip. Everything else here is inert
and safe to merge now.

## How to test (QA)

Nothing on a running site — CI configuration and test code only.

1. After the secret exists, the next `staging` → `main` gate must show
   `POST /api/push/test refuses a FREE account` and `admits a PRO account`
   **executed, not skipped**.
2. Same for both `with a valid signature` webhook tests.
3. A **skip** on any of those five is a failure to report, not a pass to accept.

## Risk level

**Low.** No application code. The one real risk — a service-role key in CI —
is scoped to the dev project and argued through above.
