### PR TITLE
docs(qa): record the admin-key reversal where the old rule was written

### DIFF
--- a/qa/E2E_PLAN.md
+++ b/qa/E2E_PLAN.md
@@ -183,12 +183,35 @@ Pick one:
 
 | Option | Trade-off |
 |---|---|
-| **A — add dev-project secrets** (recommended) | Point `E2E_SUPABASE_*` at the **dev** project `wdtjhrilakoitfcezxpx`, never prod. Anon key only, never the service-role key. Highest fidelity. |
+| **A — add dev-project secrets** (recommended, and this is what shipped) | Point `E2E_SUPABASE_*` at the **dev** project `wdtjhrilakoitfcezxpx`, never prod. Highest fidelity. |
 | B — guard auth specs behind `test.skip(!process.env.E2E_SUPABASE_URL)` | No secrets in CI, but the login path goes untested — the app's front door |
 | C — run E2E locally only, via a pre-push hook | Zero CI cost, zero enforcement |
 
-**A is the recommendation**, with the anon key only. It is a public key by
-design and the dev project holds no real user data.
+**A is the recommendation**, and it is what shipped.
+
+**The "anon key only, never the service-role key" rule was reversed on
+2026-08-09** by an explicit owner decision. Recorded here rather than edited away,
+because this file is where someone will come looking for the rule.
+
+The anon key is public by design and the dev project holds no real user data, so
+that half never needed defending. The service-role key did, and the argument that
+carried is narrower than "it is fine":
+
+- Three Pro-gated surfaces authenticate through `getSupabaseAdmin()` — the
+  payments **ownership check**, the payments **replay guard**, and
+  `/api/push/test`. Without the key each route errors before reaching the branch
+  under test, so all three were verified by nothing.
+- The objection "CI builds without developer env, and that caught two real
+  defects" does not apply: both defects were about a variable **absent in CI and
+  present in production**. This key is present in production, so supplying it
+  moves CI toward the production configuration.
+- The objection "it bypasses RLS, which `bola.spec.ts` exists to verify" applies
+  to a **test** that authenticates with it. None does — `bola.spec.ts` signs in
+  as A and B with passwords. Only the server gains an admin client.
+
+**The boundary that still holds absolutely: this is the DEV project's key.**
+Prod's must never reach CI — it holds real customers, and the free plan has no
+backups. Full reasoning sits beside the variable in `.github/workflows/ci.yml`.
 
 ### 4.2 Turnstile will not solve in CI
 

--- a/qa/QA_TEST_PLAN.md
+++ b/qa/QA_TEST_PLAN.md
@@ -101,7 +101,8 @@ to move to Postgres or Redis.
 | `safeNextPath` open-redirect fix | DONE (13 cases, Node harness) | - | DONE (real browser, prod, 2026-08-02) | - |
 | Telegram webhook fail-closed on missing secret | - | - | DONE (curl, prod) | - |
 | Trial-ending email + cron job | - | - | DONE (curl auth check + DB due-count) | **the email itself has never actually sent** (0 rows were due both times checked) |
-| LemonSqueezy webhook: payer-email check + replay guard | - | - | - | **yes** - payments aren't live, no real webhook payload exists to test with |
+| LemonSqueezy webhook: signature rejection (absent / wrong secret / malformed) | - | - | DONE (`qa/e2e/payments-webhook.spec.ts`, 3 cases, no credentials needed) | - |
+| LemonSqueezy webhook: payer-email check + replay guard | - | - | DONE (same spec, HMAC-signed payloads, 2026-08-09) | **synthetic payloads only** - no real LemonSqueezy event has ever reached this handler, and the store is not live |
 | `grok-chat` model pin + `max_tokens` clamp | DONE (9 cases, Node harness) | - | build+tsc only | **not curled against a live deployment** |
 | `ban-reason` rate limit (5/min/IP) | - | - | DONE (real burst, dev, 2026-08-02) - see `getClientIp` finding below, this is what surfaced it | - |
 | `/api/admin` honeypot rate limit (5/min/IP) | - | - | DONE (DB row-count before/after a 10-request burst, dev, 2026-08-02): 5 new rows for 10 requests, not 10 | - |


### PR DESCRIPTION
**QA Team** → **Dev Team** · follow-up to #153

#153 reversed `ci.yml`'s "the service-role key must never be here". Two QA documents still asserted the old rule as current — including `E2E_PLAN.md`, whose whole job is to state it.

## What changed

| File | Was | Now |
|---|---|---|
| `qa/E2E_PLAN.md` | "Anon key only, never the service-role key" | records the reversal, the argument, and the boundary that still holds |
| `qa/QA_TEST_PLAN.md` | webhook payer-email + replay guard: **untestable**, "no real payload exists" | **DONE**, with the caveat kept |

## Written out, not edited away

A rule that softens with no record is how the next person re-derives the wrong conclusion — the same reason #153 kept the old text in `ci.yml`.

Both original objections survive in narrower form: CI still builds without developer env, and **no test authenticates with the service role**. What changed is only that the *server* can build its admin client, as it does in production.

**The boundary that still holds absolutely:** this is the **dev** project's key. Prod's must never reach CI — real customers, no backups on the free plan.

## The caveat I did not drop

The webhook row now reads DONE **and** keeps "synthetic payloads only". Those tests sign their own payloads, so they prove the handler's logic and prove **nothing** about whether we are wired to the right LemonSqueezy store. "Covered" and "proven end to end" are different states and the table should not blur them.

## How to test (QA)

Read both files. Neither now states a rule `ci.yml` contradicts.

## Risk level

**Low.** Documentation only.