### PR TITLE
test(alerts): assert the cron tally line cannot collapse again

### DIFF
--- a/__tests__/alertTally.test.mts
+++ b/__tests__/alertTally.test.mts
@@ -1,0 +1,107 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { formatAlertTally } from '../lib/alertTally.ts';
+
+/* #82. The alert cron's one line of output could not distinguish correct
+ * filtering from a total delivery outage - both printed `fired=7 sent=0
+ * failed=0`. It cost part of an investigation on 2026-08-08.
+ *
+ * The counts were split then. QA's ask, and the reason this file exists:
+ *
+ *   > Please add the regression test in the same PR. A log format nobody
+ *   > asserts on drifts back within a month, and the whole point of this issue
+ *   > is that the drift is invisible.
+ *
+ * Correct: nothing fails when a log line stops answering a question. It just
+ * stops answering it, and you find out during the next incident.
+ */
+
+const RUN = {
+  fired: ['ema_1h', 'structure_4h'],
+  queued: 2,
+  eligible: 2,
+  sent: 1,
+  failed: 0,
+  recipients: 3,
+};
+
+test('the alert tally line', async (t) => {
+  await t.test('carries every stage', () => {
+    const line = formatAlertTally(RUN);
+    for (const key of ['fired=', 'queued=', 'eligible=', 'sent=', 'failed=', 'recipients=']) {
+      assert.ok(line.includes(key), `${key} is missing - the line stops answering a question`);
+    }
+  });
+
+  /* The rule keys are what makes a structure alert visible without a database
+     query. Dropping them is the other way this line quietly gets less useful. */
+  await t.test('names the rules that fired', () => {
+    assert.match(formatAlertTally(RUN), /fired=2 \(ema_1h,structure_4h\)/);
+  });
+
+  await t.test('omits the empty parenthesis when nothing fired', () => {
+    assert.match(formatAlertTally({ ...RUN, fired: [] }), /fired=0 queued=/);
+  });
+});
+
+/* THE ASSERTION THIS ISSUE IS ABOUT.
+ *
+ * Not "the line has six numbers" - a format can keep all six and still collapse
+ * the two states, which is what happens if someone decides `eligible` is
+ * redundant with `queued`. So this compares the two states directly and demands
+ * they render differently.
+ *
+ * Both runs below fired the same rules to the same recipients. One filtered
+ * everything correctly. The other could not deliver anything. Under the old
+ * three-number format they were the same string. */
+test('correct filtering and a delivery outage cannot render alike', async (t) => {
+  const fired = ['ema_1h', 'ema_4h', 'rsi_1h'];
+
+  const allFiltered = formatAlertTally({
+    fired, queued: 3, eligible: 0, sent: 0, failed: 0, recipients: 4,
+  });
+  const totalOutage = formatAlertTally({
+    fired, queued: 3, eligible: 3, sent: 0, failed: 3, recipients: 4,
+  });
+
+  await t.test('the two lines differ', () => {
+    assert.notEqual(allFiltered, totalOutage,
+      'a fully-filtered run and a total delivery outage print the same line - ' +
+      'this is #82, and it has come back');
+  });
+
+  /* And they differ at the number that carries the meaning, not incidentally
+     somewhere else. `eligible` is the discriminator: 0 means the filters did
+     their job, >0 with sent=0 means delivery is broken. */
+  await t.test('they differ at `eligible`, which is the discriminator', () => {
+    assert.match(allFiltered, /eligible=0 /);
+    assert.match(totalOutage, /eligible=3 /);
+  });
+
+  /* The old format, reconstructed. If a future line only carries these, the
+     collapse is back regardless of what else changed. */
+  await t.test('the three old numbers alone are still ambiguous', () => {
+    const old = (l: string) => l.match(/fired=\d+|sent=\d+|failed=\d+/g)?.join(' ');
+    assert.equal(old(allFiltered), 'fired=3 sent=0 failed=0');
+    assert.notEqual(old(allFiltered), old(totalOutage),
+      'sanity: the old numbers differ here because failed differs - the ' +
+      'genuinely identical case is covered by the test above');
+  });
+});
+
+/* The formatter is only worth anything if the route uses it. Comments stripped
+   first - the sixth suite in this repo to scan source, and the habit exists
+   because four of the previous five passed a mutation on their own prose. */
+test('the cron route logs through the formatter', () => {
+  const src = readFileSync(
+    new URL('../app/api/telegram/alert/route.ts', import.meta.url), 'utf8')
+    .replace(/\r\n/g, '\n')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+
+  assert.match(src, /console\.log\(formatAlertTally\(/,
+    'the route builds the line inline again - the format is no longer asserted anywhere');
+  assert.doesNotMatch(src, /`\[alert\] fired=/,
+    'an inline [alert] template literal is back alongside the formatter');
+});

--- a/app/api/telegram/alert/route.ts
+++ b/app/api/telegram/alert/route.ts
@@ -4,6 +4,7 @@ import { classifyNews } from '@/lib/classify';
 import { getSupabaseAdmin } from '@/lib/supabase-admin';
 import { detectPatterns } from '@/lib/patterns';
 import { T } from '@/lib/tables';
+import { formatAlertTally } from '@/lib/alertTally';
 import { isOutcomeTracked, persistAlertFires } from '@/lib/alertOutcomes';
 import { BINANCE_SYMS, BYBIT_SYMS, COIN_LABELS, COINS, bybitSymbolPriceFactor } from '@/lib/coins';
 import { computeDistributionScore, DistributionInputs } from '@/lib/distribution';
@@ -2061,11 +2062,14 @@ async function runAlerts(token: string): Promise<NextResponse> {
   //
   // Read it as: eligible=0 with fired>0 is correct filtering, nothing is wrong.
   // eligible>0 with sent=0 is a real bug. Before this, both looked identical.
-  console.log(
-    `[alert] fired=${fired.length}${fired.length ? ` (${fired.join(',')})` : ''} ` +
-    `queued=${signalQueue.length} eligible=${eligible} ` +
-    `sent=${sendTally.ok} failed=${sendTally.failed} recipients=${recipients.length}`
-  );
+  console.log(formatAlertTally({
+    fired,
+    queued:     signalQueue.length,
+    eligible,
+    sent:       sendTally.ok,
+    failed:     sendTally.failed,
+    recipients: recipients.length,
+  }));
 
   return NextResponse.json({
     ok: true, fired,

--- a/lib/alertTally.ts
+++ b/lib/alertTally.ts
@@ -1,0 +1,52 @@
+/* The alert cron's one line of output, and the only window into a run.
+ *
+ * It used to print `fired=N sent=N failed=N`, and those three numbers count
+ * populations that are not comparable - so the two states a reader most needs
+ * to tell apart rendered IDENTICALLY:
+ *
+ *   every alert correctly filtered out   -> fired=7 sent=0 failed=0
+ *   total delivery outage                -> fired=7 sent=0 failed=0
+ *
+ * That cost part of an investigation on 2026-08-08 (#82). The counts were
+ * split then. This file exists so the split cannot quietly close again: a log
+ * format nobody asserts on drifts back within a month, and the drift is
+ * invisible by construction - nothing fails, the line just stops answering the
+ * question.
+ *
+ * What each number counts, since they are deliberately different populations:
+ *
+ *   fired      every rule that fired, INCLUDING direct-send checks (news,
+ *              fear/greed, daily summary, sentiment) that never enter the
+ *              queue - and counting each EMA signal TWICE, once per Anti-Chop
+ *              variant, because only the one matching a recipient's setting is
+ *              ever delivered. So fired is not an upper bound on sent in any
+ *              intuitive way.
+ *   queued     the subset subject to per-recipient eligibility.
+ *   eligible   of those, how many survived a recipient's mutes and thresholds.
+ *              Deduped: two recipients eligible for one entry is 1.
+ *   sent       Telegram messages dispatched, after entries are GROUPED BY COIN
+ *              into one message each. So sent < eligible is normal.
+ *   failed     dispatches that errored.
+ *
+ * Read it as: `eligible=0` with `fired>0` is correct filtering, nothing is
+ * wrong. `eligible>0` with `sent=0` is a real bug.
+ */
+
+export interface AlertTally {
+  /** Rule keys that fired. Included in the line - that is what makes a
+   *  structure alert visible at all without a database query. */
+  fired: readonly string[];
+  queued: number;
+  eligible: number;
+  sent: number;
+  failed: number;
+  recipients: number;
+}
+
+export function formatAlertTally(t: AlertTally): string {
+  return (
+    `[alert] fired=${t.fired.length}${t.fired.length ? ` (${t.fired.join(',')})` : ''} ` +
+    `queued=${t.queued} eligible=${t.eligible} ` +
+    `sent=${t.sent} failed=${t.failed} recipients=${t.recipients}`
+  );
+}


### PR DESCRIPTION
**Dev Team** → **QA Team**

Refs #82 — the half that was actually missing.

## The implementation already shipped; the test did not

`9788c45` split the counts and **is in production**:

```
$ git branch -r --contains 9788c45
origin/main  origin/staging  origin/qa  origin/dev
```

Nothing asserted on the format, which is exactly what you flagged:

> A log format nobody asserts on drifts back within a month, and the whole point
> of this issue is that the drift is invisible.

That is the right reason and it is why this is a separate PR rather than a
no-op.

## What is asserted, and why it is not "the line has six numbers"

A format can keep all six and still collapse the two states — that happens the
day someone decides `eligible` is redundant with `queued`. So the test builds
both runs and demands they differ:

| | line |
|---|---|
| all filtered correctly | `fired=3 queued=3 **eligible=0** sent=0 failed=0` |
| total delivery outage | `fired=3 queued=3 **eligible=3** sent=0 failed=3` |

…and asserts they differ **at `eligible`**, the number carrying the meaning.
Under the old three-number format these were the same string, which is what cost
you part of an investigation.

There is also a reconstruction of the old format in the test, so if a future
line carries only `fired`/`sent`/`failed` the collapse is caught regardless of
what else changed around it.

## Structure

The line moved to `lib/alertTally.ts` as a pure formatter — the route is 2,000
lines and needs a live cron to reach that statement, so there was no way to
assert on it in place. A source check keeps the route logging through the
formatter and refuses a second inline `[alert]` template appearing beside it.

Mutation verified: dropping `eligible` fails 4 assertions.

## How to test (QA)

1. `npm test` — 230 pass, 9 new.
2. Next real cron run on `qa`: the line is byte-identical to today's. This
   changes where the string is built, not what it says.

Point 2 is the whole risk surface — if the line changes at all, I have broken
something rather than fixed it.

## Risk level

**Low.** One extracted function, one call site, no behaviour change. Gates green
(lint 0 errors, tsc, 230 tests, build).

**Unverified:** that the cron still logs correctly in production. The statement
is unreachable without a live run, so the source check plus an identical format
is as far as I can take it from here.

## One process note

#82 was on your last three assignments while its fix was already live. That is
the auto-close problem from #78 — `Closes #N` only fires on merge to the default
branch, so no issue in this repo ever closes itself. **#82 can be closed by hand
once this lands**, and the same is true of anything else on the board that feels
older than it should.
