### PR TITLE
Release 2026-08-09: 9 PR(s)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,9 +344,11 @@ jobs:
           # expires in about an hour, so a pasted token passes once and then
           # fails CI the next day. The spec mints a fresh token per run.
           #
-          # These are ordinary user-level accounts. The service-role key is NOT
-          # here and must never be - it bypasses RLS entirely, which is exactly
-          # what this spec exists to verify.
+          # These are ordinary user-level accounts, and bola.spec.ts must keep
+          # using them. It exists to prove RLS refuses B's request for A's rows;
+          # signing in as the service role would bypass RLS and make it pass
+          # while proving nothing. See the SUPABASE_SERVICE_ROLE_KEY block below
+          # for why the key being present on the job does not change that.
           #
           # Absent, bola.spec.ts SKIPS with a stated reason rather than passing.
           # A BOLA test that runs without fixtures proves nothing, and a vacuous
@@ -405,6 +407,50 @@ jobs:
           # `liquidity-hq-prod`. Copying it here would let anyone who can read
           # this repository forge a webhook that grants Pro.
           LEMONSQUEEZY_WEBHOOK_SECRET: ci-fake-not-a-real-lemonsqueezy-secret
+
+          # ── THIS FILE USED TO SAY THE SERVICE-ROLE KEY "must never be" HERE ──
+          #
+          # Reversed 2026-08-09 by an explicit owner decision, and written out
+          # rather than quietly deleted: an absolute rule that softens with no
+          # record is how the next person re-derives the wrong conclusion.
+          #
+          # WHAT THE OLD RULE COST. Three Pro-gated surfaces were verified by
+          # nothing at all, because every one of them authenticates through
+          # `getSupabaseAdmin()` and so errored before reaching the branch under
+          # test:
+          #
+          #   1. the payments OWNERSHIP check - the payer supplies `user_id` in
+          #      `custom_data`, which `lib/checkout.ts` writes into a
+          #      client-side URL. Whether a payer can grant Pro to an account
+          #      they do not own is the BOLA of payments, and it had never run.
+          #   2. the payments REPLAY guard (`ls_webhook_events`).
+          #   3. `/api/push/test`'s Pro gate - excluded from entitlements.spec.ts
+          #      for this exact reason.
+          #
+          # WHY IT IS ACCEPTABLE. The two arguments the old rule rested on both
+          # survive:
+          #
+          #   * "CI builds without developer env, which caught two real defects"
+          #     - those were the labels bug and the NEXT_PUBLIC_APP_ENV prefix
+          #     gap, and both are about a variable being ABSENT in CI while
+          #     PRESENT in production. This key is present in production. Adding
+          #     it moves CI toward the production configuration, not away from
+          #     it. The env-absence guard is unaffected.
+          #   * "it bypasses RLS, which bola.spec.ts exists to verify" - true of
+          #     a TEST that authenticates with it. No spec does; bola.spec.ts
+          #     signs in as A and B with passwords. What changes here is only
+          #     that the SERVER can build its admin client, exactly as the
+          #     server does in production.
+          #
+          # BLAST RADIUS, stated rather than assumed: this is the DEV project's
+          # key. That project holds nine test accounts and no real user data,
+          # and `staging` shares it. It is NOT prod's key and must never be -
+          # prod's holds real customers and the free plan has no backups.
+          #
+          # IF THE SECRET IS ABSENT the three tests SKIP with a stated reason
+          # rather than pass. That is deliberate and it is the part to preserve:
+          # a skip is legible, a vacuous pass is not.
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
 
       # failure() only. This used to upload on every green run too - ~15s and
       # storage for a report nobody opens. failure() still excludes

--- a/__tests__/alertTally.test.mts
+++ b/__tests__/alertTally.test.mts
@@ -1,0 +1,107 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { formatAlertTally } from '../lib/alertTally.ts';
+
+/* #82. The alert cron's one line of output could not distinguish correct
+ * filtering from a total delivery outage - both printed `fired=7 sent=0
+ * failed=0`. It cost part of an investigation on 2026-08-08.
+ *
+ * The counts were split then. QA's ask, and the reason this file exists:
+ *
+ *   > Please add the regression test in the same PR. A log format nobody
+ *   > asserts on drifts back within a month, and the whole point of this issue
+ *   > is that the drift is invisible.
+ *
+ * Correct: nothing fails when a log line stops answering a question. It just
+ * stops answering it, and you find out during the next incident.
+ */
+
+const RUN = {
+  fired: ['ema_1h', 'structure_4h'],
+  queued: 2,
+  eligible: 2,
+  sent: 1,
+  failed: 0,
+  recipients: 3,
+};
+
+test('the alert tally line', async (t) => {
+  await t.test('carries every stage', () => {
+    const line = formatAlertTally(RUN);
+    for (const key of ['fired=', 'queued=', 'eligible=', 'sent=', 'failed=', 'recipients=']) {
+      assert.ok(line.includes(key), `${key} is missing - the line stops answering a question`);
+    }
+  });
+
+  /* The rule keys are what makes a structure alert visible without a database
+     query. Dropping them is the other way this line quietly gets less useful. */
+  await t.test('names the rules that fired', () => {
+    assert.match(formatAlertTally(RUN), /fired=2 \(ema_1h,structure_4h\)/);
+  });
+
+  await t.test('omits the empty parenthesis when nothing fired', () => {
+    assert.match(formatAlertTally({ ...RUN, fired: [] }), /fired=0 queued=/);
+  });
+});
+
+/* THE ASSERTION THIS ISSUE IS ABOUT.
+ *
+ * Not "the line has six numbers" - a format can keep all six and still collapse
+ * the two states, which is what happens if someone decides `eligible` is
+ * redundant with `queued`. So this compares the two states directly and demands
+ * they render differently.
+ *
+ * Both runs below fired the same rules to the same recipients. One filtered
+ * everything correctly. The other could not deliver anything. Under the old
+ * three-number format they were the same string. */
+test('correct filtering and a delivery outage cannot render alike', async (t) => {
+  const fired = ['ema_1h', 'ema_4h', 'rsi_1h'];
+
+  const allFiltered = formatAlertTally({
+    fired, queued: 3, eligible: 0, sent: 0, failed: 0, recipients: 4,
+  });
+  const totalOutage = formatAlertTally({
+    fired, queued: 3, eligible: 3, sent: 0, failed: 3, recipients: 4,
+  });
+
+  await t.test('the two lines differ', () => {
+    assert.notEqual(allFiltered, totalOutage,
+      'a fully-filtered run and a total delivery outage print the same line - ' +
+      'this is #82, and it has come back');
+  });
+
+  /* And they differ at the number that carries the meaning, not incidentally
+     somewhere else. `eligible` is the discriminator: 0 means the filters did
+     their job, >0 with sent=0 means delivery is broken. */
+  await t.test('they differ at `eligible`, which is the discriminator', () => {
+    assert.match(allFiltered, /eligible=0 /);
+    assert.match(totalOutage, /eligible=3 /);
+  });
+
+  /* The old format, reconstructed. If a future line only carries these, the
+     collapse is back regardless of what else changed. */
+  await t.test('the three old numbers alone are still ambiguous', () => {
+    const old = (l: string) => l.match(/fired=\d+|sent=\d+|failed=\d+/g)?.join(' ');
+    assert.equal(old(allFiltered), 'fired=3 sent=0 failed=0');
+    assert.notEqual(old(allFiltered), old(totalOutage),
+      'sanity: the old numbers differ here because failed differs - the ' +
+      'genuinely identical case is covered by the test above');
+  });
+});
+
+/* The formatter is only worth anything if the route uses it. Comments stripped
+   first - the sixth suite in this repo to scan source, and the habit exists
+   because four of the previous five passed a mutation on their own prose. */
+test('the cron route logs through the formatter', () => {
+  const src = readFileSync(
+    new URL('../app/api/telegram/alert/route.ts', import.meta.url), 'utf8')
+    .replace(/\r\n/g, '\n')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+
+  assert.match(src, /console\.log\(formatAlertTally\(/,
+    'the route builds the line inline again - the format is no longer asserted anywhere');
+  assert.doesNotMatch(src, /`\[alert\] fired=/,
+    'an inline [alert] template literal is back alongside the formatter');
+});

--- a/__tests__/signupIntegrity.test.mts
+++ b/__tests__/signupIntegrity.test.mts
@@ -1,0 +1,78 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { classifyWelcomeClaim, missingRowReport } from '../lib/signupIntegrity.ts';
+
+/* #127. The trigger works today - verified on both projects 2026-08-08. This
+ * covers what happens if it ever stops.
+ *
+ * A signup that produces no `user_subscriptions` row gives the user no 14-day
+ * trial, and `getEntitlement()` reads the missing row as `free` - correctly,
+ * and identically to a trial that ended. So the account is silently downgraded
+ * from the first second, the symptom is a customer who does not convert, and
+ * nothing in the product, the logs or the UI distinguishes it.
+ *
+ * The welcome-email route is the only path every signup takes that already
+ * reads that row. It could not tell the two silences apart: both "email already
+ * sent" and "no row at all" produced `{ ok: true, sent: false }`.
+ */
+
+test('the two silences are told apart', async (t) => {
+  await t.test('a claimed row means send the email', () => {
+    assert.equal(classifyWelcomeClaim(true, true), 'send');
+  });
+
+  await t.test('unclaimed but present is the ordinary repeat call', () => {
+    assert.equal(classifyWelcomeClaim(false, true), 'already-sent');
+  });
+
+  /* The one this exists for. Before the split, this returned the same thing as
+     the case above and the difference was unobservable. */
+  await t.test('unclaimed and absent is the defect, not a no-op', () => {
+    assert.equal(classifyWelcomeClaim(false, false), 'missing-subscription-row');
+  });
+
+  /* `claimed` implies the row exists - you cannot update a row that is not
+     there - so this combination should never occur. It must still not report a
+     missing row, because reporting one would send someone hunting a trigger
+     that fired correctly. */
+  await t.test('an impossible combination does not raise a false alarm', () => {
+    assert.equal(classifyWelcomeClaim(true, false), 'send');
+  });
+});
+
+test('the report says what to do about it', async (t) => {
+  const report = missingRowReport('11111111-2222-4333-8444-555555555555');
+
+  /* A GlitchTip issue is read by someone with no context, months later. The
+     failure this guards is silent, so the message has to carry its own
+     diagnosis - the trigger name, the consequence, and that it may not be one
+     account. */
+  await t.test('it names the trigger, the consequence and the issue', () => {
+    assert.match(report, /lhq_grant_signup_trial/);
+    assert.match(report, /NO 14-day trial/);
+    assert.match(report, /#127/);
+  });
+
+  await t.test('it carries the user id so it is actionable', () => {
+    assert.match(report, /11111111-2222-4333-8444-555555555555/);
+  });
+});
+
+/* The classifier is only worth anything if the route uses it. Comments stripped
+   first - this is the fifth suite in this repo to scan source, and the previous
+   four each passed a mutation on their own prose before that was added. */
+test('the route reports rather than swallowing the missing row', () => {
+  const src = readFileSync(
+    new URL('../app/api/auth/welcome-email/route.ts', import.meta.url), 'utf8')
+    .replace(/\r\n/g, '\n')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+
+  assert.match(src, /classifyWelcomeClaim/,
+    'the route no longer classifies the claim - the two silences are collapsed again');
+  assert.match(src, /missingRowReport/,
+    'the route no longer reports a missing subscription row');
+  assert.match(src, /apiError\([^)]*missingRowReport/,
+    'the missing row is classified but not reported anywhere, which is the original defect');
+});

--- a/__tests__/testIdParity.test.mts
+++ b/__tests__/testIdParity.test.mts
@@ -25,13 +25,43 @@ import { fileURLToPath } from 'node:url';
  * without the attribute - and cannot fail spuriously. The pairing is a review
  * concern, once, at the point the attribute is added. */
 
+/* One naming convention, settled 2026-08-09: expand the component's
+   abbreviation, keep the class untouched. #131 shipped `tj-field` next to
+   `grok-panel`, which is two conventions in one PR - renamed here while nothing
+   consumes them yet. */
 const PAIRS: Array<{ cls: string; testId: string }> = [
-  { cls: 'login-error',  testId: 'login-error'   },
-  { cls: 'st-page',      testId: 'settings-page' },
-  { cls: 'tj-field',     testId: 'tj-field'      },
-  { cls: 'tj-edit-form', testId: 'tj-edit-form'  },
-  { cls: 'gchat-panel',  testId: 'grok-panel'    },
-  { cls: 'gchat-msgs',   testId: 'grok-messages' },
+  { cls: 'login-error',   testId: 'login-error'        },
+  { cls: 'st-page',       testId: 'settings-page'      },
+  { cls: 'smod-panel',    testId: 'settings-modal'     },
+  { cls: 'tj-field',      testId: 'journal-field'      },
+  { cls: 'tj-edit-form',  testId: 'journal-edit-form'  },
+  { cls: 'tj-inp',        testId: 'journal-input'      },
+  { cls: 'tj-tab',        testId: 'journal-tab'        },
+  { cls: 'tj-edit-btn',   testId: 'journal-edit'       },
+  { cls: 'gchat-panel',   testId: 'grok-panel'         },
+  { cls: 'gchat-msgs',    testId: 'grok-messages'      },
+  { cls: 'gchat-fab',     testId: 'grok-launcher'      },
+  { cls: 'pb-star',       testId: 'playbook-star'      },
+];
+
+/* NOT in PAIRS, and the reason is the argument for this whole issue.
+ *
+ * These two classes are STYLING, reused by elements that mean different
+ * things - so a 1:1 count against the class would be asserting the wrong
+ * relationship, and attaching the testid everywhere the class appears would
+ * carry the ambiguity straight into the new attribute.
+ *
+ *   .login-email-input  - also on components/PasswordField.tsx. On /login in
+ *                         password mode, `input.login-email-input` therefore
+ *                         matches the email field AND the password field.
+ *   .st-toggle          - also on /alerts (page.tsx:1054), a different control
+ *                         that shares the look.
+ *
+ * The testid goes on the semantic element only, and the count is asserted
+ * directly. */
+const SEMANTIC_ONLY: Array<{ testId: string; count: number; absentFrom?: string }> = [
+  { testId: 'login-email',     count: 3, absentFrom: 'components/PasswordField.tsx' },
+  { testId: 'settings-toggle', count: 1, absentFrom: 'app/alerts/page.tsx' },
 ];
 
 /** Every .tsx under app/ and components/ - not a fixed file list, so a NEW file
@@ -91,5 +121,32 @@ test('every element carrying a spec-selected class carries its data-testid', asy
         `test hook; the a11y spec will measure less rather than fail.`,
       );
     });
+  }
+});
+
+/* The two selectors that are styling, not meaning. Asserted by count rather
+   than parity, plus an explicit absence: the point is that the testid lands on
+   the element the spec MEANS, and not on the unrelated element that happens to
+   share the class. */
+test('a shared styling class does not spread its test hook', async (t) => {
+  for (const { testId, count, absentFrom } of SEMANTIC_ONLY) {
+    await t.test(`[data-testid="${testId}"] appears exactly ${count}x`, () => {
+      const found = files.reduce(
+        (n, src) => n + (src.match(new RegExp(`data-testid="${testId}"`, 'g'))?.length ?? 0), 0);
+      assert.equal(found, count,
+        `expected ${count} element(s) with data-testid="${testId}", found ${found}. ` +
+        `Either a semantic element lost its hook, or the hook was copied onto one ` +
+        `that merely shares the styling class.`);
+    });
+
+    if (absentFrom) {
+      await t.test(`and never in ${absentFrom}`, () => {
+        const src = stripComments(
+          readFileSync(fileURLToPath(new URL('../' + absentFrom, import.meta.url)), 'utf8'));
+        assert.doesNotMatch(src, new RegExp(`data-testid="${testId}"`),
+          `${absentFrom} shares the styling class but is a different control - ` +
+          `giving it this hook reintroduces the ambiguity the hook exists to remove`);
+      });
+    }
   }
 });

--- a/app/api/auth/welcome-email/route.ts
+++ b/app/api/auth/welcome-email/route.ts
@@ -4,6 +4,7 @@ import { apiError } from '@/lib/apiError';
 import { getSupabaseAdmin } from '@/lib/supabase-admin';
 import { sendWelcomeEmail } from '@/lib/email';
 import { T } from '@/lib/tables';
+import { classifyWelcomeClaim, missingRowReport } from '@/lib/signupIntegrity';
 
 export const dynamic = 'force-dynamic';
 
@@ -41,7 +42,37 @@ export async function POST(req: NextRequest) {
       .maybeSingle();
 
     if (error) return apiError('auth/welcome-email', error);
-    if (!claimed) return NextResponse.json({ ok: true, sent: false });
+
+    if (!claimed) {
+      /* `claimed` is null for two completely different reasons, and this route
+         used to answer both with `{ ok: true, sent: false }`:
+
+           - the row exists and the email already went out  -> normal
+           - THERE IS NO ROW                                -> #127
+
+         The second means the signup trigger did not run, so the account has no
+         14-day trial - and nothing anywhere would say so, because
+         getEntitlement() reads a missing row as `free` exactly as it reads an
+         expired trial. This route is the only code every signup passes through
+         that already looks at that row, so it is where the difference can be
+         noticed at all. */
+      const { data: row } = await admin
+        .from(T.user_subscriptions)
+        .select('user_id')
+        .eq('user_id', user.id)
+        .maybeSingle();
+
+      const outcome = classifyWelcomeClaim(false, !!row);
+      if (outcome === 'missing-subscription-row') {
+        // Reported, not thrown. The user is signed in and their session is
+        // fine; failing their first request would turn a silent defect into a
+        // broken signup. Loud where it needs to be loud - GlitchTip - and
+        // invisible where the user is concerned.
+        apiError('auth/welcome-email', new Error(missingRowReport(user.id)));
+      }
+
+      return NextResponse.json({ ok: true, sent: false, outcome });
+    }
 
     const sent = await sendWelcomeEmail({ to: user.email });
     return NextResponse.json({ ok: true, sent });

--- a/app/api/telegram/alert/route.ts
+++ b/app/api/telegram/alert/route.ts
@@ -4,6 +4,7 @@ import { classifyNews } from '@/lib/classify';
 import { getSupabaseAdmin } from '@/lib/supabase-admin';
 import { detectPatterns } from '@/lib/patterns';
 import { T } from '@/lib/tables';
+import { formatAlertTally } from '@/lib/alertTally';
 import { isOutcomeTracked, persistAlertFires } from '@/lib/alertOutcomes';
 import { BINANCE_SYMS, BYBIT_SYMS, COIN_LABELS, COINS, bybitSymbolPriceFactor } from '@/lib/coins';
 import { computeDistributionScore, DistributionInputs } from '@/lib/distribution';
@@ -2061,11 +2062,14 @@ async function runAlerts(token: string): Promise<NextResponse> {
   //
   // Read it as: eligible=0 with fired>0 is correct filtering, nothing is wrong.
   // eligible>0 with sent=0 is a real bug. Before this, both looked identical.
-  console.log(
-    `[alert] fired=${fired.length}${fired.length ? ` (${fired.join(',')})` : ''} ` +
-    `queued=${signalQueue.length} eligible=${eligible} ` +
-    `sent=${sendTally.ok} failed=${sendTally.failed} recipients=${recipients.length}`
-  );
+  console.log(formatAlertTally({
+    fired,
+    queued:     signalQueue.length,
+    eligible,
+    sent:       sendTally.ok,
+    failed:     sendTally.failed,
+    recipients: recipients.length,
+  }));
 
   return NextResponse.json({
     ok: true, fired,

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -71,7 +71,7 @@ export default function ForgotPasswordPage() {
                 <input
                   id="forgot-email"
                   type="email"
-                  className="login-email-input"
+                  className="login-email-input" data-testid="login-email"
                   placeholder={t('LOGIN_EMAIL_INPUT_PLACEHOLDER')}
                   value={email}
                   onChange={e => setEmail(e.target.value)}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -263,7 +263,7 @@ function LoginInner() {
                   <input
                     id="magic-email"
                     type="email"
-                    className="login-email-input"
+                    className="login-email-input" data-testid="login-email"
                     placeholder={t('LOGIN_EMAIL_INPUT_PLACEHOLDER')}
                     value={email}
                     onChange={e => setEmail(e.target.value)}
@@ -358,7 +358,7 @@ function LoginInner() {
                   <input
                     id="pw-email"
                     type="email"
-                    className="login-email-input"
+                    className="login-email-input" data-testid="login-email"
                     placeholder={t('LOGIN_EMAIL_INPUT_PLACEHOLDER')}
                     value={pwEmail}
                     onChange={e => setPwEmail(e.target.value)}

--- a/app/playbook/page.tsx
+++ b/app/playbook/page.tsx
@@ -73,6 +73,7 @@ export default function LiquidityPlaybook() {
                 <span className="s-num-right">
                   <span className={`cat-badge ${CAT_CLS[s.cat]}`}>{t(CAT_LABEL_KEYS[s.cat])}</span>
                   <button
+                    data-testid="playbook-star"
                     className={`pb-star${isFav ? ' on' : ''}`}
                     onClick={() => toggleFav(s.n)}
                     title={isFav ? t('PLAYBOOK_UNSAVE_TITLE') : t('PLAYBOOK_SAVE_TITLE')}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -56,6 +56,11 @@ function AnalyticsConsentToggle() {
         </div>
         <button
           className={`st-toggle${on ? ' on' : ''}`}
+          /* Only the settings toggle carries this. `.st-toggle` is also on
+             /alerts (page.tsx:1054), which is a different control that happens
+             to share the styling - so the class is not the thing the spec
+             means, and that ambiguity is what a testid removes. */
+          data-testid="settings-toggle"
           role="switch"
           aria-checked={on}
           aria-label={t('SETTINGS_ANALYTICS_TITLE')}

--- a/components/GrokChat.tsx
+++ b/components/GrokChat.tsx
@@ -596,6 +596,7 @@ export default function GrokChat() {
           for the mini-panel case, but the button is unclickable (and
           invisible) while open, so that path is effectively unreachable. */}
       <button
+        data-testid="grok-launcher"
         className={`gchat-fab${open ? ' gchat-fab-open' : ''}${!fabVisible ? ' gchat-fab-scrolling' : ''}`}
         onClick={() => { setOpen(v => !v); if (open) { setExpanded(false); setShowLoginModal(false); } }}
         title="Ask Grok"

--- a/components/TradeJournal.tsx
+++ b/components/TradeJournal.tsx
@@ -813,10 +813,10 @@ function Inner() {
 
       {/* Tabs */}
       <div className="tj-tabs">
-        <button className={`tj-tab${tab === 'log' ? ' on' : ''}`} onClick={() => setTab('log')}>{t('TRADE_JOURNAL_TAB_LOG')}</button>
-        <button className={`tj-tab${tab === 'history' ? ' on' : ''}`} onClick={() => setTab('history')}>{t('TRADE_JOURNAL_TAB_HISTORY', { count: trades.length })}</button>
-        <button className={`tj-tab${tab === 'stats' ? ' on' : ''}`} onClick={() => setTab('stats')}>{t('TRADE_JOURNAL_TAB_STATS')}</button>
-        <button className={`tj-tab${tab === 'rules' ? ' on' : ''}`} onClick={() => setTab('rules')} style={{ position: 'relative' }}>
+        <button data-testid="journal-tab" className={`tj-tab${tab === 'log' ? ' on' : ''}`} onClick={() => setTab('log')}>{t('TRADE_JOURNAL_TAB_LOG')}</button>
+        <button data-testid="journal-tab" className={`tj-tab${tab === 'history' ? ' on' : ''}`} onClick={() => setTab('history')}>{t('TRADE_JOURNAL_TAB_HISTORY', { count: trades.length })}</button>
+        <button data-testid="journal-tab" className={`tj-tab${tab === 'stats' ? ' on' : ''}`} onClick={() => setTab('stats')}>{t('TRADE_JOURNAL_TAB_STATS')}</button>
+        <button data-testid="journal-tab" className={`tj-tab${tab === 'rules' ? ' on' : ''}`} onClick={() => setTab('rules')} style={{ position: 'relative' }}>
           {t('TRADE_JOURNAL_TAB_RULES')}{rules.filter(r => r.enabled).length > 0 && (
             <span style={{
               marginLeft: 5, fontSize: 'var(--fs-caption)', fontWeight: 700,
@@ -825,9 +825,9 @@ function Inner() {
             }}>{rules.filter(r => r.enabled).length}</span>
           )}
         </button>
-        <button className={`tj-tab${tab === 'shadow' ? ' on' : ''}`} onClick={() => setTab('shadow')}>{t('TRADE_JOURNAL_TAB_SHADOW')}</button>
-        <button className={`tj-tab${tab === 'bias' ? ' on' : ''}`} onClick={() => setTab('bias')}>{t('TRADE_JOURNAL_TAB_BIAS')}</button>
-        <button className={`tj-tab${tab === 'thesis' ? ' on' : ''}`} onClick={() => setTab('thesis')} style={{ position: 'relative' }}>
+        <button data-testid="journal-tab" className={`tj-tab${tab === 'shadow' ? ' on' : ''}`} onClick={() => setTab('shadow')}>{t('TRADE_JOURNAL_TAB_SHADOW')}</button>
+        <button data-testid="journal-tab" className={`tj-tab${tab === 'bias' ? ' on' : ''}`} onClick={() => setTab('bias')}>{t('TRADE_JOURNAL_TAB_BIAS')}</button>
+        <button data-testid="journal-tab" className={`tj-tab${tab === 'thesis' ? ' on' : ''}`} onClick={() => setTab('thesis')} style={{ position: 'relative' }}>
           {t('TRADE_JOURNAL_TAB_THESIS')}{theses.length > 0 && (
             <span style={{ marginLeft: 5, fontSize: 'var(--fs-caption)', fontWeight: 700, background: 'var(--accent-solid)', color: '#fff', borderRadius: 10, padding: '1px 5px' }}>{theses.length}</span>
           )}
@@ -873,28 +873,28 @@ function Inner() {
           <div className="tj-card">
             <div className="tj-card-lbl">{t('TRADE_JOURNAL_LOG_PRICE_LEVELS_LABEL')}</div>
             <div className="tj-price-grid">
-              <div className="tj-field" data-testid="tj-field">
+              <div className="tj-field" data-testid="journal-field">
                 <label className="tj-lbl">{t('TRADE_JOURNAL_LOG_ENTRY_LABEL')}</label>
                 <div className="tj-irow"><span className="tj-affix">$</span>
-                  <input className="tj-inp" aria-label={t('TRADE_JOURNAL_LOG_ENTRY_ARIA')} type="number" placeholder="0.00" value={entry} onChange={e => setEntry(e.target.value)} />
+                  <input className="tj-inp" data-testid="journal-input" aria-label={t('TRADE_JOURNAL_LOG_ENTRY_ARIA')} type="number" placeholder="0.00" value={entry} onChange={e => setEntry(e.target.value)} />
                 </div>
               </div>
-              <div className="tj-field" data-testid="tj-field">
+              <div className="tj-field" data-testid="journal-field">
                 <label className="tj-lbl">{t('TRADE_JOURNAL_LOG_STOP_LOSS_LABEL')}</label>
                 <div className="tj-irow"><span className="tj-affix">$</span>
-                  <input className="tj-inp tj-inp-stop" aria-label={t('TRADE_JOURNAL_LOG_STOP_LOSS_ARIA')} type="number" placeholder="0.00" value={stopLoss} onChange={e => setStopLoss(e.target.value)} />
+                  <input className="tj-inp tj-inp-stop" data-testid="journal-input" aria-label={t('TRADE_JOURNAL_LOG_STOP_LOSS_ARIA')} type="number" placeholder="0.00" value={stopLoss} onChange={e => setStopLoss(e.target.value)} />
                 </div>
               </div>
-              <div className="tj-field" data-testid="tj-field">
+              <div className="tj-field" data-testid="journal-field">
                 <label className="tj-lbl">{t('TRADE_JOURNAL_LOG_TAKE_PROFIT_LABEL')}</label>
                 <div className="tj-irow"><span className="tj-affix">$</span>
-                  <input className="tj-inp tj-inp-tp" aria-label={t('TRADE_JOURNAL_LOG_TAKE_PROFIT_LABEL')} type="number" placeholder="0.00" value={tpPrice} onChange={e => setTpPrice(e.target.value)} />
+                  <input className="tj-inp tj-inp-tp" data-testid="journal-input" aria-label={t('TRADE_JOURNAL_LOG_TAKE_PROFIT_LABEL')} type="number" placeholder="0.00" value={tpPrice} onChange={e => setTpPrice(e.target.value)} />
                 </div>
               </div>
-              <div className="tj-field" data-testid="tj-field">
+              <div className="tj-field" data-testid="journal-field">
                 <label className="tj-lbl">{t('TRADE_JOURNAL_LOG_POSITION_SIZE_LABEL')}</label>
                 <div className="tj-irow"><span className="tj-affix">$</span>
-                  <input className="tj-inp" aria-label={t('TRADE_JOURNAL_LOG_POSITION_SIZE_ARIA')} type="number" placeholder={t('TRADE_JOURNAL_LOG_POSITION_SIZE_PLACEHOLDER')} value={posUSD} onChange={e => setPosUSD(e.target.value)} />
+                  <input className="tj-inp" data-testid="journal-input" aria-label={t('TRADE_JOURNAL_LOG_POSITION_SIZE_ARIA')} type="number" placeholder={t('TRADE_JOURNAL_LOG_POSITION_SIZE_PLACEHOLDER')} value={posUSD} onChange={e => setPosUSD(e.target.value)} />
                 </div>
               </div>
             </div>
@@ -1094,7 +1094,7 @@ function Inner() {
                       borderRadius: 4, padding: '2px 5px',
                     }}>{t('TRADE_JOURNAL_HISTORY_RULE_BADGE')}</span>
                   )}
-                  <button className="tj-edit-btn" title={t('TRADE_JOURNAL_HISTORY_EDIT_TITLE')} onClick={() => editingId === trade.id ? setEditingId(null) : startEdit(trade)}>✎</button>
+                  <button className="tj-edit-btn" data-testid="journal-edit" title={t('TRADE_JOURNAL_HISTORY_EDIT_TITLE')} onClick={() => editingId === trade.id ? setEditingId(null) : startEdit(trade)}>✎</button>
                   <button className="tj-del-btn" onClick={() => trade.id && deleteTrade(trade.id)}>✕</button>
                 </div>
               </div>
@@ -1145,6 +1145,7 @@ function Inner() {
                       <span className="tj-affix">$</span>
                       <input
                         className="tj-inp"
+                        data-testid="journal-input"
                         type="number"
                         placeholder={t('TRADE_JOURNAL_HISTORY_EXIT_PRICE_PLACEHOLDER')}
                         value={exitInput}
@@ -1165,7 +1166,7 @@ function Inner() {
 
               {/* Inline edit form */}
               {editingId === trade.id && (
-                <div className="tj-edit-form" data-testid="tj-edit-form">
+                <div className="tj-edit-form" data-testid="journal-edit-form">
                   {/* WCAG 2.2 SC 4.1.2 Name, Role, Value (Level A), issue #48.
                       The visible labels were already here - they just named
                       nothing: no htmlFor, wrapping no control. A screen reader
@@ -1205,7 +1206,7 @@ function Inner() {
                     <div className="tj-edit-field">
                       <label className="tj-lbl" htmlFor={`tj-edit-exit-${trade.id}`}>{t('TRADE_JOURNAL_HISTORY_EDIT_EXIT_PRICE_LABEL')}</label>
                       <div className="tj-irow"><span className="tj-affix">$</span>
-                        <input id={`tj-edit-exit-${trade.id}`} className="tj-inp" type="number" placeholder="0.00"
+                        <input id={`tj-edit-exit-${trade.id}`} className="tj-inp" data-testid="journal-input" type="number" placeholder="0.00"
                           value={editDraft.exit_price}
                           onChange={e => setEditDraft(p => ({ ...p, exit_price: e.target.value }))} />
                       </div>
@@ -1213,7 +1214,7 @@ function Inner() {
                     <div className="tj-edit-field">
                       <label className="tj-lbl" htmlFor={`tj-edit-pnl-${trade.id}`}>{t('TRADE_JOURNAL_HISTORY_EDIT_PNL_LABEL')}</label>
                       <div className="tj-irow"><span className="tj-affix">$</span>
-                        <input id={`tj-edit-pnl-${trade.id}`} className="tj-inp" type="number" placeholder="0.00"
+                        <input id={`tj-edit-pnl-${trade.id}`} className="tj-inp" data-testid="journal-input" type="number" placeholder="0.00"
                           value={editDraft.pnl_usd}
                           onChange={e => setEditDraft(p => ({ ...p, pnl_usd: e.target.value }))} />
                       </div>

--- a/components/UsageModal.tsx
+++ b/components/UsageModal.tsx
@@ -30,7 +30,7 @@ export default function UsageModal({ open, onClose }: Props) {
           alone onto a second row and read as an afterthought rather than one
           of the budgets. Still collapses to the viewport on mobile, where
           wrapping is expected. */}
-      <div className="smod-panel" role="dialog" aria-modal="true" aria-label={t('USAGE_MODAL_TITLE')} style={{ maxHeight: 'none', width: 'min(460px, calc(100vw - 24px))' }}>
+      <div className="smod-panel" data-testid="settings-modal" role="dialog" aria-modal="true" aria-label={t('USAGE_MODAL_TITLE')} style={{ maxHeight: 'none', width: 'min(460px, calc(100vw - 24px))' }}>
         <div className="smod-header">
           <span className="smod-title">{t('USAGE_MODAL_TITLE')}</span>
           <button className="smod-close" onClick={onClose} aria-label="Close">✕</button>

--- a/lib/alertTally.ts
+++ b/lib/alertTally.ts
@@ -1,0 +1,52 @@
+/* The alert cron's one line of output, and the only window into a run.
+ *
+ * It used to print `fired=N sent=N failed=N`, and those three numbers count
+ * populations that are not comparable - so the two states a reader most needs
+ * to tell apart rendered IDENTICALLY:
+ *
+ *   every alert correctly filtered out   -> fired=7 sent=0 failed=0
+ *   total delivery outage                -> fired=7 sent=0 failed=0
+ *
+ * That cost part of an investigation on 2026-08-08 (#82). The counts were
+ * split then. This file exists so the split cannot quietly close again: a log
+ * format nobody asserts on drifts back within a month, and the drift is
+ * invisible by construction - nothing fails, the line just stops answering the
+ * question.
+ *
+ * What each number counts, since they are deliberately different populations:
+ *
+ *   fired      every rule that fired, INCLUDING direct-send checks (news,
+ *              fear/greed, daily summary, sentiment) that never enter the
+ *              queue - and counting each EMA signal TWICE, once per Anti-Chop
+ *              variant, because only the one matching a recipient's setting is
+ *              ever delivered. So fired is not an upper bound on sent in any
+ *              intuitive way.
+ *   queued     the subset subject to per-recipient eligibility.
+ *   eligible   of those, how many survived a recipient's mutes and thresholds.
+ *              Deduped: two recipients eligible for one entry is 1.
+ *   sent       Telegram messages dispatched, after entries are GROUPED BY COIN
+ *              into one message each. So sent < eligible is normal.
+ *   failed     dispatches that errored.
+ *
+ * Read it as: `eligible=0` with `fired>0` is correct filtering, nothing is
+ * wrong. `eligible>0` with `sent=0` is a real bug.
+ */
+
+export interface AlertTally {
+  /** Rule keys that fired. Included in the line - that is what makes a
+   *  structure alert visible at all without a database query. */
+  fired: readonly string[];
+  queued: number;
+  eligible: number;
+  sent: number;
+  failed: number;
+  recipients: number;
+}
+
+export function formatAlertTally(t: AlertTally): string {
+  return (
+    `[alert] fired=${t.fired.length}${t.fired.length ? ` (${t.fired.join(',')})` : ''} ` +
+    `queued=${t.queued} eligible=${t.eligible} ` +
+    `sent=${t.sent} failed=${t.failed} recipients=${t.recipients}`
+  );
+}

--- a/lib/signupIntegrity.ts
+++ b/lib/signupIntegrity.ts
@@ -1,0 +1,65 @@
+/* Did signup actually give this account its trial?
+ *
+ * `lhq_grant_signup_trial` is a trigger on `auth.users` that inserts the
+ * subscription row in the same transaction as the account. It works, and it is
+ * enabled on both projects - verified 2026-08-08. So this is not a fix for a
+ * broken trigger.
+ *
+ * It exists because of what happens if that ever stops being true. #127:
+ *
+ *   getEntitlement() reads a missing row as `free`, correctly and silently.
+ *   A user who signed up and got no trial is indistinguishable from a user
+ *   whose trial ended, and from a user who simply did not convert. The symptom
+ *   is a missing customer.
+ *
+ * Nothing would notice. Drop the trigger in a migration and the next hundred
+ * signups quietly get no Pro trial, with no error, no log line and nothing in
+ * the UI that differs.
+ *
+ * The one place already positioned to see it is the welcome-email route, which
+ * every signup hits and which already reads that row. It just could not tell
+ * the two silences apart:
+ *
+ *   claimed === null  because the email was already sent   -> normal, ignore
+ *   claimed === null  because THERE IS NO ROW              -> #127, shout
+ *
+ * Both returned `{ ok: true, sent: false }`.
+ */
+
+export type WelcomeClaim =
+  /** Row claimed by this call - first time, send the email. */
+  | 'send'
+  /** Row exists, welcome_email_sent_at already set. The common repeat call. */
+  | 'already-sent'
+  /** No subscription row for this user at all. The trigger did not run. */
+  | 'missing-subscription-row';
+
+/**
+ * Classify the outcome of the atomic claim.
+ *
+ * Split out from the route so the distinction is testable without a database -
+ * the whole defect is that two different states produced one response, and a
+ * pure function is where that can be pinned.
+ *
+ * @param claimed   whether `UPDATE … WHERE welcome_email_sent_at IS NULL`
+ *                  matched a row
+ * @param rowExists whether a subscription row exists at all. Only meaningful
+ *                  when `claimed` is false; the caller should not pay for the
+ *                  lookup otherwise.
+ */
+export function classifyWelcomeClaim(claimed: boolean, rowExists: boolean): WelcomeClaim {
+  if (claimed) return 'send';
+  return rowExists ? 'already-sent' : 'missing-subscription-row';
+}
+
+/** The message reported when a signup produced no trial row. Written out here
+ *  so the text a future reader finds in GlitchTip says what to do about it. */
+export function missingRowReport(userId: string): string {
+  return (
+    `Signup produced no ${'user_subscriptions'} row for user ${userId}. ` +
+    'The lhq_grant_signup_trial trigger on auth.users did not run, so this ' +
+    'account has NO 14-day trial and getEntitlement() will read it as free - ' +
+    'silently, and identically to a user whose trial ended. Check the trigger ' +
+    'exists on this project before assuming it is one account. See issue #127.'
+  );
+}

--- a/qa/E2E_PLAN.md
+++ b/qa/E2E_PLAN.md
@@ -183,12 +183,35 @@ Pick one:
 
 | Option | Trade-off |
 |---|---|
-| **A — add dev-project secrets** (recommended) | Point `E2E_SUPABASE_*` at the **dev** project `wdtjhrilakoitfcezxpx`, never prod. Anon key only, never the service-role key. Highest fidelity. |
+| **A — add dev-project secrets** (recommended, and this is what shipped) | Point `E2E_SUPABASE_*` at the **dev** project `wdtjhrilakoitfcezxpx`, never prod. Highest fidelity. |
 | B — guard auth specs behind `test.skip(!process.env.E2E_SUPABASE_URL)` | No secrets in CI, but the login path goes untested — the app's front door |
 | C — run E2E locally only, via a pre-push hook | Zero CI cost, zero enforcement |
 
-**A is the recommendation**, with the anon key only. It is a public key by
-design and the dev project holds no real user data.
+**A is the recommendation**, and it is what shipped.
+
+**The "anon key only, never the service-role key" rule was reversed on
+2026-08-09** by an explicit owner decision. Recorded here rather than edited away,
+because this file is where someone will come looking for the rule.
+
+The anon key is public by design and the dev project holds no real user data, so
+that half never needed defending. The service-role key did, and the argument that
+carried is narrower than "it is fine":
+
+- Three Pro-gated surfaces authenticate through `getSupabaseAdmin()` — the
+  payments **ownership check**, the payments **replay guard**, and
+  `/api/push/test`. Without the key each route errors before reaching the branch
+  under test, so all three were verified by nothing.
+- The objection "CI builds without developer env, and that caught two real
+  defects" does not apply: both defects were about a variable **absent in CI and
+  present in production**. This key is present in production, so supplying it
+  moves CI toward the production configuration.
+- The objection "it bypasses RLS, which `bola.spec.ts` exists to verify" applies
+  to a **test** that authenticates with it. None does — `bola.spec.ts` signs in
+  as A and B with passwords. Only the server gains an admin client.
+
+**The boundary that still holds absolutely: this is the DEV project's key.**
+Prod's must never reach CI — it holds real customers, and the free plan has no
+backups. Full reasoning sits beside the variable in `.github/workflows/ci.yml`.
 
 ### 4.2 Turnstile will not solve in CI
 

--- a/qa/QA_TEST_PLAN.md
+++ b/qa/QA_TEST_PLAN.md
@@ -101,7 +101,8 @@ to move to Postgres or Redis.
 | `safeNextPath` open-redirect fix | DONE (13 cases, Node harness) | - | DONE (real browser, prod, 2026-08-02) | - |
 | Telegram webhook fail-closed on missing secret | - | - | DONE (curl, prod) | - |
 | Trial-ending email + cron job | - | - | DONE (curl auth check + DB due-count) | **the email itself has never actually sent** (0 rows were due both times checked) |
-| LemonSqueezy webhook: payer-email check + replay guard | - | - | - | **yes** - payments aren't live, no real webhook payload exists to test with |
+| LemonSqueezy webhook: signature rejection (absent / wrong secret / malformed) | - | - | DONE (`qa/e2e/payments-webhook.spec.ts`, 3 cases, no credentials needed) | - |
+| LemonSqueezy webhook: payer-email check + replay guard | - | - | DONE (same spec, HMAC-signed payloads, 2026-08-09) | **synthetic payloads only** - no real LemonSqueezy event has ever reached this handler, and the store is not live |
 | `grok-chat` model pin + `max_tokens` clamp | DONE (9 cases, Node harness) | - | build+tsc only | **not curled against a live deployment** |
 | `ban-reason` rate limit (5/min/IP) | - | - | DONE (real burst, dev, 2026-08-02) - see `getClientIp` finding below, this is what surfaced it | - |
 | `/api/admin` honeypot rate limit (5/min/IP) | - | - | DONE (DB row-count before/after a 10-request burst, dev, 2026-08-02): 5 new rows for 10 requests, not 10 | - |

--- a/qa/STATUS.md
+++ b/qa/STATUS.md
@@ -2,11 +2,30 @@
 
 **One page. If you only read one thing, read this.**
 
-Kept current by QA. Last updated **2026-08-08**.
+Kept current by QA. Last updated **2026-08-09**.
 
-If the date above is more than a day old, treat every number below as stale and
-check the branches yourself — a status doc nobody updates is worse than none,
-because it reads as current.
+## Read this before you trust anything below
+
+The first version of this file was reviewed with one caveat, and the caveat was
+right: **it went stale while the PR was open.** Five lines were wrong within a
+day, and its own opening sentence was the standard it failed.
+
+So it has been rebuilt around what actually changes slowly. **Counts and branch
+positions are not written down here** — they are wrong within the hour, and a
+wrong number that looks authoritative is worse than no number. What is written
+down is the part that does not move: decisions, who is blocked on whom, and the
+risks nobody has retired.
+
+**Measure the volatile things yourself. Two commands:**
+
+```bash
+git fetch --all && for b in dev qa staging main; do echo "$b $(git rev-parse --short origin/$b)"; done
+gh pr list --state open --json number,title,baseRefName -q '.[] | "#\(.number) -> \(.baseRefName)  \(.title)"'
+```
+
+Production's *actual* served commit is `/api/version` on liquidity-hq.com — not
+`main`, not the last merge. The drift check reads that endpoint for exactly this
+reason.
 
 ---
 
@@ -15,93 +34,77 @@ because it reads as current.
 | | |
 |---|---|
 | **Live in production** | `ec171db`, tagged `v2026.08.08`, verified on the live build |
-| **Production deploys** | 🛑 **HALTED by the owner.** Nothing merges to `main` or deploys until they lift it |
-| **Parked on `staging`** | 17 commits — release PR **#121**, gate red until #130 + #124 land |
-| **Waiting on `qa`** | 6 commits / 3 PRs |
+| **Production deploys** | Running normally. The owner's halt was lifted 2026-08-08 |
+| **In flight** | Release PR **#150**, `staging` → `main`. Gate running |
+| **Flow** | `dev` → `qa` → `staging` → `main`, four services, one per branch |
 
-**One-line version:** production is healthy and frozen on purpose. The queue is
-growing because the freeze stops promotion, which is the expected cost, not a
-fault.
+**One-line version:** production is healthy, a release is in its gate, and the
+board is down to six open issues from twelve.
 
 ---
 
 ## Waiting on the OWNER — nothing moves on these without them
 
-| | What | Blocks |
+| What | Blocks | State |
 |---|---|---|
-| **#126** | PAT, or drop the auto-opened release PR. A bot-created PR never runs CI — the check is **absent, not failing**, so the PR is unmergeable with nothing red to explain why | every release after the halt |
-| — | **LemonSqueezy test-mode keys.** Not needed to start the webhook harness; needed to prove we are wired to the right store | payments integration proof |
-| — | **Lift the halt, or not.** #121 contains no app code | 17 commits |
-| — | **Dunning behaviour.** When a renewal card fails, nothing tells the user — they lose access one day with no warning. Product decision | one payments branch |
+| **Add repo secret `E2E_SUPABASE_SERVICE_ROLE_KEY`** (the **dev** project's key, never prod's) | three Pro-gated surfaces stay verified by nothing | decided 2026-08-09, secret not yet added |
+| **Remove `CRON_SECRET`** from the `liquidity-hq-qa` Render service | closing #78 | agreed 2026-08-09 |
+| **Deploy `staging`, then production** after #150 merges | the release | Render is `autoDeploy: "no"` — merging ships nothing |
+| **LemonSqueezy test-mode keys** | proving we are wired to the right store | not needed for the harness, which now runs |
 
 ---
 
-## Dev Team
+## Decisions already made — do not re-litigate these
 
-| | What | State |
+| Decision | Date | Where the reasoning lives |
 |---|---|---|
-| **#52** | six `data-testid` attributes, `components/` only | cleared to start |
-| — | **Lapsed-Pro:** does a cancelled user's price alert keep firing? They cannot disable it — PATCH refuses free accounts | reading `dispatchPush` |
-| — | The two unhandled webhook events (`payment_failed`, refunds) | after the owner decides |
-| — | CONTRIBUTING note: **never require PR approvals** while dev and QA share one account — it cannot be satisfied by anyone | agreed, not written |
-
----
-
-## QA — in order
-
-| | What | Why it matters |
-|---|---|---|
-| 1 | **Contrast baseline decision** | 5 entries a live run does not observe. Fixed, or not rendering? The sweep now FAILS until someone says which |
-| 2 | **Arabic RTL** | five languages ship, one is tested. RTL is a mirrored layout, not translated words |
-| 3 | **Payments webhook harness** | 114 lines decide who is a paying customer, never run against a payload in any environment. Needs nothing from anyone |
-| 4 | **BOLA fix** | B's alert seeded (`id=2`). Re-run as A-against-B so the caller clears the Pro gate and reaches the ownership check |
-| 5 | **#127** trigger test | signup creates the trial row via a DB trigger. Drop it and users silently lose 14 days of Pro |
-| 6 | **#72** PII scrubbing | never verified on a real event. No longer blocked — `beforeSend` runs client-side, and the quota is free now |
-| 7 | **Visual regression** | nothing has ever compared what a page looks like |
-| 8 | **#120** | confirm the entitlements spec RUNS on the next release, and which direction it asserted |
+| **Arabic is pulled from the picker**, `lang`/`dir` set from the route. Option B, not an RTL implementation | 2026-08-08 | #138, shipped in #147 |
+| **The service-role key IS allowed in CI**, dev project only, E2E job only. Reverses `ci.yml`'s former "must never be" | 2026-08-09 | beside the variable in `ci.yml`; #153 |
+| **`staging` exists so a signed-off release stops growing.** Only QA promotes into it, and never while a release PR is open | 2026-08-07 | `CONTRIBUTING.md` §6 |
+| **Never require PR approvals.** Dev and QA share one GitHub account, so `Can not approve your own pull request` would deadlock every release permanently | 2026-08-08 | `CONTRIBUTING.md` §3a |
+| **The signup trial trigger is fine.** Measured, not assumed — the three rowless accounts predate it and every signup since 2026-08-01 has a row | 2026-08-09 | #127, closed |
 
 ---
 
 ## Open issues and what closes each
 
-| # | Closes when |
-|---|---|
-| #129 | #130 deploys and a live check returns 401 |
-| #127 | a spec asserts the signup trigger still exists |
-| #126 | a release PR opens **and its CI queues** unattended |
-| #125 | `staging` moves (auto) |
-| #120 | the spec runs, not skips, on a release PR |
-| #114 | every spec touching market data installs fixtures, then `workers` unpins with zero 429s |
-| #109 | #111 reaches production and is re-checked |
-| #103 | the DOM test lands — the runtime fix (#128) is already merged |
-| #82 | the release deploys and dev confirms the log line in prod |
-| #78 | the workflow change is settled; kept open deliberately as the coordination thread |
-| #72 | a spec asserts PII is scrubbed from a real outgoing envelope |
-| #52 | six attributes land and the specs are re-anchored |
+| # | Closes when | Whose |
+|---|---|---|
+| #138 | #147 reaches production and `/ar` 404s there | QA verify |
+| #120 | `entitlements.spec.ts` is observed **executing**, not skipping, in a release gate log | QA verify |
+| #114 | every spec touching market data installs fixtures, then `workers` unpins with zero 429s | QA |
+| #82 | the log line distinguishes filtering from a delivery outage, with a test pinning it | Dev |
+| #78 | `CRON_SECRET` comes off the qa service | Owner |
+| #52 | the testids land and the specs are re-anchored to them | Dev, then QA |
 
 ---
 
 ## Standing risks
 
-- **Payments have never been exercised.** No purchase has granted Pro, no lapsed
-  subscription has been shown to re-lock, and the webhook handler has never seen
-  a real payload. Highest launch risk.
-- **Arabic is a mirrored layout nobody has loaded.** One of five shipped locales.
-- **Nothing has ever looked at a rendered page** — `TEST_GAPS.md` §2.
-- **`push/test`'s Pro gate is verified by nothing** — CI has no admin key, so the
-  route 401s regardless of entitlement. Stated, not solved.
+- **Payments have never been exercised end to end.** No real purchase has granted
+  Pro and no lapsed subscription has been shown to re-lock. The webhook handler
+  is now covered against forged, replayed and cross-account payloads — **but only
+  synthetic ones.** Highest launch risk.
+- **Nothing has ever looked at a rendered page** — `TEST_GAPS.md` §2. Contrast,
+  labels and structure are measured; appearance is not.
 - **The contrast sweep is data-dependent.** Fixtures exist for 17 third-party
-  endpoints but our own `/api/*` routes still feed several surfaces.
-- **`qa` and `dev` share one Supabase project.** A clean QA run is not proof the
-  data path is clean.
-- **No PR in this repo can ever be approved** — one shared account. Adding an
-  approval requirement to any ruleset would deadlock releases permanently.
+  endpoints, but our own `/api/*` routes still feed several surfaces, so a route
+  that renders nothing measures clean.
+- **`staging` and `dev` share one Supabase project.** A clean run on the staging
+  site is not proof the data path is clean, and a migration applied "to qa"
+  applies it to dev for everyone.
+- **No PR in this repo can ever be approved** — one shared account. See the
+  decisions table.
+- **A skip is not a pass, and this suite has several.** Every one names its reason
+  in the skip message. Read them; some are accepted limits and some are findings.
 
 ---
 
 ## Keeping this honest
 
-- Update the date on every change. A stale status doc is a liability.
-- Numbers come from `git` and the GitHub API, not memory.
+- **Do not add a number that git or `gh` can answer.** That is what made the first
+  version stale in a day.
+- Update the date on every change.
 - When a blocker clears, move it out the same day. A list that only grows stops
   being read.
+- Decisions move to the decisions table so they are not re-argued from memory.

--- a/qa/STATUS.md
+++ b/qa/STATUS.md
@@ -4,9 +4,9 @@
 
 Kept current by QA. Last updated **2026-08-08**.
 
-If a date at the top of this file is more than a day old, treat every number
-below as stale and check the branches yourself — a status doc nobody updates is
-worse than none, because it reads as current.
+If the date above is more than a day old, treat every number below as stale and
+check the branches yourself — a status doc nobody updates is worse than none,
+because it reads as current.
 
 ---
 
@@ -14,131 +14,94 @@ worse than none, because it reads as current.
 
 | | |
 |---|---|
-| **Live in production** | `v2026.08.07` |
-| **Waiting to ship** | **42 commits / 17 PRs** on `qa`, not yet promoted |
-| **Blocked by** | nothing on Dev Team's side — #90 and #95 are merged |
-| **Next action** | **QA promotes `qa` → `staging`**, then deploys and tests it |
+| **Live in production** | `ec171db`, tagged `v2026.08.08`, verified on the live build |
+| **Production deploys** | 🛑 **HALTED by the owner.** Nothing merges to `main` or deploys until they lift it |
+| **Parked on `staging`** | 17 commits — release PR **#121**, gate red until #130 + #124 land |
+| **Waiting on `qa`** | 6 commits / 3 PRs |
 
-**One-line version:** the product is fine, the queue is not. Work is being
-finished faster than it is being released.
+**One-line version:** production is healthy and frozen on purpose. The queue is
+growing because the freeze stops promotion, which is the expected cost, not a
+fault.
 
 ---
 
-## The pipeline, and where things get stuck
+## Waiting on the OWNER — nothing moves on these without them
 
-```
-dev  ──►  qa  ──►  staging  ──►  main ──► users
- │         │         │            │
- dev       dev       QA           QA
- merges    promotes  promotes     merges + deploys + tags
-                     (the freeze)
-```
-
-| Branch | Deployed at | Who moves it into here |
+| | What | Blocks |
 |---|---|---|
-| `dev` | `liquidity-hq-dev.onrender.com` | Dev Team |
-| `qa` | `liquidity-hq-qa.onrender.com` | Dev Team |
-| `staging` | `liquidity-hq-staging.onrender.com` | **QA** |
-| `main` | `liquidity-hq.com` | **QA** |
-
-**Nothing auto-deploys.** Moving a branch does not move an environment; a human
-triggers every deploy. So "merged" is three manual steps away from "live", and
-each of those steps is somewhere work can sit unnoticed.
-
-`staging` exists so a release QA has signed off stops changing. Before it, every
-`dev` → `qa` promotion silently grew an open release — three times on 2026-08-06,
-once after a completed manual pass.
+| **#126** | PAT, or drop the auto-opened release PR. A bot-created PR never runs CI — the check is **absent, not failing**, so the PR is unmergeable with nothing red to explain why | every release after the halt |
+| — | **LemonSqueezy test-mode keys.** Not needed to start the webhook harness; needed to prove we are wired to the right store | payments integration proof |
+| — | **Lift the halt, or not.** #121 contains no app code | 17 commits |
+| — | **Dunning behaviour.** When a renewal card fails, nothing tells the user — they lose access one day with no warning. Product decision | one payments branch |
 
 ---
 
-## The number that actually matters
+## Dev Team
 
-Not commits. **Cycle time: merged → live.**
+| | What | State |
+|---|---|---|
+| **#52** | six `data-testid` attributes, `components/` only | cleared to start |
+| — | **Lapsed-Pro:** does a cancelled user's price alert keep firing? They cannot disable it — PATCH refuses free accounts | reading `dispatchPush` |
+| — | The two unhandled webhook events (`payment_failed`, refunds) | after the owner decides |
+| — | CONTRIBUTING note: **never require PR approvals** while dev and QA share one account — it cannot be satisfied by anyone | agreed, not written |
 
-1,491 commits in 75 days is not the problem and never was. The current batch has
-sat finished for **2 days**, and nothing surfaced that until someone asked.
+---
 
-| | |
+## QA — in order
+
+| | What | Why it matters |
+|---|---|---|
+| 1 | **Contrast baseline decision** | 5 entries a live run does not observe. Fixed, or not rendering? The sweep now FAILS until someone says which |
+| 2 | **Arabic RTL** | five languages ship, one is tested. RTL is a mirrored layout, not translated words |
+| 3 | **Payments webhook harness** | 114 lines decide who is a paying customer, never run against a payload in any environment. Needs nothing from anyone |
+| 4 | **BOLA fix** | B's alert seeded (`id=2`). Re-run as A-against-B so the caller clears the Pro gate and reaches the ownership check |
+| 5 | **#127** trigger test | signup creates the trial row via a DB trigger. Drop it and users silently lose 14 days of Pro |
+| 6 | **#72** PII scrubbing | never verified on a real event. No longer blocked — `beforeSend` runs client-side, and the quota is free now |
+| 7 | **Visual regression** | nothing has ever compared what a page looks like |
+| 8 | **#120** | confirm the entitlements spec RUNS on the next release, and which direction it asserted |
+
+---
+
+## Open issues and what closes each
+
+| # | Closes when |
 |---|---|
-| Releases before 2026-08-05 | **0 tagged** — code reached production with no record of what shipped |
-| Releases since | 7, all in 3 days |
-
-So the release process is **three days old**. It is being debugged in public, and
-that is what the last two days of work mostly were.
-
-**Target: keep the promotion queue under ~5 PRs.** A 15-PR batch is not one
-release, it is fifteen changes whose interactions nobody has reasoned about.
-This is now a written rule — `CONTRIBUTING.md` §7b, with the commands to
-measure it.
-
----
-
-## Open blockers
-
-| Priority | What | Owner | Blocks |
-|---|---|---|---|
-| 🔴 1 | **#89** — promote `qa` → `staging`, deploy, open the release PR | **QA** | 42 commits reaching users |
-| 🟡 2 | **#78** — LemonSqueezy test-mode keys for staging | **Owner** | checkout + webhook testing only |
-| 🟡 3 | **PR #84** — QA doc corrections, partly superseded by #87 | QA to rebase | nothing |
-| 🟢 4 | #72 · #73 · #82 · #52 | quota reset / Dev Team | nothing |
-
-Nothing is waiting on Dev Team. The environment audit that #78 opened is
-finished — all four services measured against the Render dashboard, `CRON_SECRET`
-off `qa`, staging on its own Telegram bot, Brevo on all four.
+| #129 | #130 deploys and a live check returns 401 |
+| #127 | a spec asserts the signup trigger still exists |
+| #126 | a release PR opens **and its CI queues** unattended |
+| #125 | `staging` moves (auto) |
+| #120 | the spec runs, not skips, on a release PR |
+| #114 | every spec touching market data installs fixtures, then `workers` unpins with zero 429s |
+| #109 | #111 reaches production and is re-checked |
+| #103 | the DOM test lands — the runtime fix (#128) is already merged |
+| #82 | the release deploys and dev confirms the log line in prod |
+| #78 | the workflow change is settled; kept open deliberately as the coordination thread |
+| #72 | a spec asserts PII is scrubbed from a real outgoing envelope |
+| #52 | six attributes land and the specs are re-anchored |
 
 ---
 
 ## Standing risks
 
-Not blockers. Things that are true and worth not forgetting.
-
-- **PostHog carried dev traffic into production's project**, roughly
-  2026-06-02 → 2026-08-08. Fixed in code (#93), but the fix does not undo the
-  data. Any retention, funnel or conversion figure quoted from that window
-  includes an unknown amount of dev traffic — heavier before 2026-08-03, when a
-  consent gate was added, thinner after.
-- **Brevo has no send cap of any kind**, and it is now shared by all four
-  environments. A careless QA run can spend production's quota and its sender
-  reputation, and neither is visible from the sending side. `trial-reminder` is
-  the one route that iterates users; keep it out of automated runs.
-- **Error monitoring captures nothing.** GlitchTip returns 429 on every event;
-  the SDK honours it and drops events client-side. Installed, configured,
-  capturing zero. #73.
-- **The PII scrubber has never run on a real event** — 15/15 unit tests, zero
-  real events, because of the above. #72.
+- **Payments have never been exercised.** No purchase has granted Pro, no lapsed
+  subscription has been shown to re-lock, and the webhook handler has never seen
+  a real payload. Highest launch risk.
+- **Arabic is a mirrored layout nobody has loaded.** One of five shipped locales.
+- **Nothing has ever looked at a rendered page** — `TEST_GAPS.md` §2.
+- **`push/test`'s Pro gate is verified by nothing** — CI has no admin key, so the
+  route 401s regardless of entitlement. Stated, not solved.
+- **The contrast sweep is data-dependent.** Fixtures exist for 17 third-party
+  endpoints but our own `/api/*` routes still feed several surfaces.
 - **`qa` and `dev` share one Supabase project.** A clean QA run is not proof the
   data path is clean.
-- Everything in [`TEST_GAPS.md`](TEST_GAPS.md) — what a green suite does *not*
-  mean.
-
----
-
-## Who does what
-
-| | Dev Team | QA |
-|---|---|---|
-| Writes app code | ✅ | ❌ never |
-| Writes tests + CI | reviews | ✅ owns `qa/` |
-| `dev` → `qa` | ✅ | |
-| `qa` → `staging` | | ✅ the freeze |
-| `staging` → `main` | | ✅ |
-| Deploys production | ❌ | ✅ |
-| Render dashboard, secrets | ❌ | ❌ — **owner only** |
-
-QA-authored code goes through a PR into `dev` that **Dev Team reviews and
-merges**. That is the one place review runs QA → dev, and it is why QA cannot
-unblock its own PRs.
-
-**One tension worth naming:** QA is the gate and also tracks throughput. Those
-pull opposite ways, and the rule for when they disagree — **QA judgement is
-never traded for schedule** — now lives in `CONTRIBUTING.md` **§3b** rather than
-here. It binds both sides, so a QA-owned file is the wrong home for it.
+- **No PR in this repo can ever be approved** — one shared account. Adding an
+  approval requirement to any ruleset would deadlock releases permanently.
 
 ---
 
 ## Keeping this honest
 
-- Update the date at the top on every change. A stale status doc is a liability.
-- Numbers here come from `git` and the GitHub API, not memory.
+- Update the date on every change. A stale status doc is a liability.
+- Numbers come from `git` and the GitHub API, not memory.
 - When a blocker clears, move it out the same day. A list that only grows stops
   being read.

--- a/qa/e2e/a11y-auth.spec.ts
+++ b/qa/e2e/a11y-auth.spec.ts
@@ -105,16 +105,16 @@ test.describe('accessibility (signed in)', () => {
       await gotoSignedIn(page, '/settings');
       // Absence fails the test. A settings page that did not render is not
       // "zero findings" - the same vacuous-pass trap the rest of this file guards.
-      await page.waitForSelector('.st-page', { state: 'visible', timeout: 40_000 });
+      await page.waitForSelector('[data-testid="settings-page"]', { state: 'visible', timeout: 40_000 });
       // The push-notification row renders only after the browser permission
       // query resolves, and it is one of the controls under test - measuring
       // before it exists silently under-counts.
-      await page.waitForSelector('button.st-toggle', { state: 'visible', timeout: 40_000 });
+      await page.waitForSelector('[data-testid="settings-toggle"]', { state: 'visible', timeout: 40_000 });
       await page.waitForTimeout(1500);
 
-      const unnamed = await unnamedIn(page, `.st-page ${CONTROLS}`);
+      const unnamed = await unnamedIn(page, `[data-testid="settings-page"] ${CONTROLS}`);
       const orphanLabels = await page.evaluate(() =>
-        [...document.querySelectorAll('.st-page label')]
+        [...document.querySelectorAll('[data-testid="settings-page"] label')]
           .filter(l => !l.getAttribute('for') && !l.querySelector('input,select,textarea'))
           .map(l => ((l as HTMLElement).innerText || '').trim().slice(0, 40)));
 
@@ -160,10 +160,10 @@ test.describe('accessibility (signed in)', () => {
     const page = await ctx.newPage();
     try {
       await page.goto('/journal', { waitUntil: 'domcontentloaded' });
-      await page.waitForSelector('input.tj-inp', { state: 'visible', timeout: 40_000 });
+      await page.waitForSelector('[data-testid="journal-input"]', { state: 'visible', timeout: 40_000 });
 
       const pairs = await page.evaluate(() =>
-        [...document.querySelectorAll('.tj-field')].map(f => {
+        [...document.querySelectorAll('[data-testid="journal-field"]')].map(f => {
           const lbl = f.querySelector('label');
           const ctl = f.querySelector('input,select,textarea');
           if (!lbl || !ctl) return null;
@@ -176,7 +176,7 @@ test.describe('accessibility (signed in)', () => {
           };
         }).filter(Boolean) as { visible: string; aria: string; htmlFor: string; wraps: boolean }[]);
 
-      expect(pairs.length, 'no .tj-field label/control pairs found - the form did not render').toBeGreaterThan(0);
+      expect(pairs.length, 'no journal-field label/control pairs found - the form did not render').toBeGreaterThan(0);
 
       const nameless = pairs.filter(p => !p.aria && !p.htmlFor && !p.wraps);
       expect(nameless, `log-trade fields with no name at all: ${JSON.stringify(nameless)}`).toEqual([]);
@@ -199,19 +199,19 @@ test.describe('accessibility (signed in)', () => {
     const page = await ctx.newPage();
     try {
       await page.goto('/journal', { waitUntil: 'domcontentloaded' });
-      await page.waitForSelector('button.tj-tab', { state: 'visible', timeout: 40_000 });
+      await page.waitForSelector('[data-testid="journal-tab"]', { state: 'visible', timeout: 40_000 });
       await page.evaluate(() => {
-        const b = [...document.querySelectorAll('button.tj-tab')]
+        const b = [...document.querySelectorAll('[data-testid="journal-tab"]')]
           .find(x => /history/i.test((x as HTMLElement).innerText || ''));
         (b as HTMLElement | undefined)?.click();
       });
       // Needs account A's fixture trade to exist. If it does not, this fails
       // rather than passing on an empty history - which would be a false green.
-      await page.waitForSelector('button.tj-edit-btn', { state: 'visible', timeout: 40_000 });
-      await page.evaluate(() => (document.querySelector('button.tj-edit-btn') as HTMLElement).click());
-      await page.waitForSelector('.tj-edit-form', { state: 'visible', timeout: 20_000 });
+      await page.waitForSelector('[data-testid="journal-edit"]', { state: 'visible', timeout: 40_000 });
+      await page.evaluate(() => (document.querySelector('[data-testid="journal-edit"]') as HTMLElement).click());
+      await page.waitForSelector('[data-testid="journal-edit-form"]', { state: 'visible', timeout: 20_000 });
 
-      const unnamed = await unnamedIn(page, `.tj-edit-form ${CONTROLS}`);
+      const unnamed = await unnamedIn(page, `[data-testid="journal-edit-form"] ${CONTROLS}`);
       testInfo.attach('journal-inline-edit-unnamed.txt', { body: unnamed.join('\n'), contentType: 'text/plain' });
       expect(
         unnamed.length,
@@ -229,9 +229,9 @@ test.describe('accessibility (signed in)', () => {
     const page = await ctx.newPage();
     try {
       await page.goto('/journal', { waitUntil: 'domcontentloaded' });
-      await page.waitForSelector('button.tj-tab', { state: 'visible', timeout: 40_000 });
+      await page.waitForSelector('[data-testid="journal-tab"]', { state: 'visible', timeout: 40_000 });
       await page.evaluate(() => {
-        const b = [...document.querySelectorAll('button.tj-tab')]
+        const b = [...document.querySelectorAll('[data-testid="journal-tab"]')]
           .find(x => ((x as HTMLElement).innerText || '').trim().toLowerCase().startsWith('rules'));
         (b as HTMLElement | undefined)?.click();
       });
@@ -301,23 +301,23 @@ test.describe('accessibility (signed in)', () => {
 
     const forms: { label: string; path: string; toPassword: boolean; act: () => Promise<void> }[] = [
       { label: '/login password', path: '/login', toPassword: true, act: async () => {
-          await page.fill('input.login-email-input', 'qa-nonexistent@example.com');
+          await page.fill('[data-testid="login-email"]', 'qa-nonexistent@example.com');
           await page.fill('input[type=password]', 'wrong-password-123');
           await page.press('input[type=password]', 'Enter');
         } },
       { label: '/login magic link', path: '/login', toPassword: false, act: async () => {
-          await page.fill('input.login-email-input', 'qa-nonexistent@example.com');
-          await page.press('input.login-email-input', 'Enter');
+          await page.fill('[data-testid="login-email"]', 'qa-nonexistent@example.com');
+          await page.press('[data-testid="login-email"]', 'Enter');
         } },
       { label: '/forgot-password', path: '/forgot-password', toPassword: false, act: async () => {
-          await page.fill('input.login-email-input', 'qa-nonexistent@example.com');
-          await page.press('input.login-email-input', 'Enter');
+          await page.fill('[data-testid="login-email"]', 'qa-nonexistent@example.com');
+          await page.press('[data-testid="login-email"]', 'Enter');
         } },
     ];
 
     for (const { label, path, toPassword, act } of forms) {
       await page.goto(path, { waitUntil: 'domcontentloaded' });
-      await page.waitForSelector('input.login-email-input', { state: 'visible', timeout: 40_000 });
+      await page.waitForSelector('[data-testid="login-email"]', { state: 'visible', timeout: 40_000 });
       if (toPassword) {
         await page.evaluate(() => {
           const b = [...document.querySelectorAll('button')]
@@ -329,7 +329,7 @@ test.describe('accessibility (signed in)', () => {
 
       // (1) present, announced and EMPTY before the error exists. Stamp it.
       const before = await page.evaluate(() => {
-        const el = document.querySelector('.login-error');
+        const el = document.querySelector('[data-testid="login-error"]');
         if (!el) return { present: false, announced: false, empty: false, inTree: false };
         el.setAttribute('data-qa-preexisting', '1');
         return {
@@ -348,13 +348,13 @@ test.describe('accessibility (signed in)', () => {
 
       await act();
       await page.waitForFunction(
-        () => [...document.querySelectorAll('.login-error')].some(e => ((e as HTMLElement).innerText || '').trim()),
+        () => [...document.querySelectorAll('[data-testid="login-error"]')].some(e => ((e as HTMLElement).innerText || '').trim()),
         undefined, { timeout: 25_000 },
       ).catch(() => missing.push(`${label}: no error message ever appeared - cannot verify it is announced`));
 
       // (2) the text is in the node that was already announced.
       const after = await page.evaluate(() => {
-        const withText = [...document.querySelectorAll('.login-error')]
+        const withText = [...document.querySelectorAll('[data-testid="login-error"]')]
           .find(e => ((e as HTMLElement).innerText || '').trim());
         return withText
           ? { stamped: withText.getAttribute('data-qa-preexisting') === '1',
@@ -393,13 +393,13 @@ test.describe('accessibility (signed in)', () => {
     const page = await ctx.newPage();
     try {
       await page.goto('/dashboard', { waitUntil: 'domcontentloaded' });
-      await page.waitForSelector('button.gchat-fab', { state: 'visible', timeout: 40_000 });
-      await page.evaluate(() => (document.querySelector('button.gchat-fab') as HTMLElement).click());
-      await page.waitForSelector('.gchat-msgs', { state: 'visible', timeout: 20_000 });
+      await page.waitForSelector('[data-testid="grok-launcher"]', { state: 'visible', timeout: 40_000 });
+      await page.evaluate(() => (document.querySelector('[data-testid="grok-launcher"]') as HTMLElement).click());
+      await page.waitForSelector('[data-testid="grok-messages"]', { state: 'visible', timeout: 20_000 });
 
       const live = await page.evaluate(() => {
-        const msgs = document.querySelector('.gchat-msgs')!;
-        const panel = document.querySelector('.gchat-panel');
+        const msgs = document.querySelector('[data-testid="grok-messages"]')!;
+        const panel = document.querySelector('[data-testid="grok-panel"]');
         return {
           onMsgs: msgs.getAttribute('aria-live') || msgs.getAttribute('role'),
           insidePanel: panel

--- a/qa/e2e/contrast.spec.ts
+++ b/qa/e2e/contrast.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import type { Browser, Page } from '@playwright/test';
 import { ROUTES, BASELINE } from './_shared';
+import { installMarketFixtures } from './_fixtures';
 
 /**
  * Colour contrast — WCAG 2.2 SC 1.4.3, Level AA — on BOTH themes.
@@ -30,6 +31,49 @@ async function themedPage(browser: Browser, theme: 'dark' | 'light'): Promise<{ 
   await ctx.addInitScript((t) => { try { localStorage.setItem('theme', t); } catch { /* private mode */ } }, theme);
   const page = await ctx.newPage();
   page.on('dialog', d => d.dismiss());
+
+  /* SERVE RECORDED MARKET DATA (#114).
+   *
+   * Two reasons, and the second is the one that matters.
+   *
+   * COST: this sweep loads 58 pages, and `qa/FIXTURES.md` measures roughly 1,000
+   * third-party requests per five pageviews - so a live sweep is on the order of
+   * 11,000 requests to Binance and Bybit. That volume is why
+   * `playwright.config.ts` pins `workers: 1`: parallel specs trip their per-IP
+   * rate limits, and the resulting 429s render as contrast violations that look
+   * exactly like product defects.
+   *
+   * CORRECTNESS: a contrast baseline measured against live prices is measured
+   * against the weather. A token can vanish because it was fixed, or because the
+   * surface that showed it had no data that minute, and nothing distinguishes
+   * those. That is precisely why the "a known token disappeared" assertion had
+   * to be removed on 2026-08-08 - see the long comment below. With fixed input
+   * it can come back, and a missing token means something again.
+   *
+   * MEASURED, not assumed. Two identical sweeps on 2026-08-09:
+   *
+   *   live      dark 12 violations / 10 tokens   light 61 / 26 tokens
+   *   fixtures  dark 13 violations / 11 tokens   light 60 / 26 tokens
+   *
+   * Coverage went UP, not down. Dark reached 11 of 11 baseline tokens with
+   * fixtures and only 10 without - the eleventh needs a surface that live data
+   * did not populate that minute. That is the data-dependence this exists to
+   * remove, visible in a single pair of runs.
+   *
+   * I predicted identical numbers and wrote that here before running it. Wrong
+   * in both directions, and left on the record because "I expected no change"
+   * is exactly the reasoning that makes a coverage drop invisible.
+   *
+   * WHAT THIS DOES NOT FIX, and it is the important half. `page.route`
+   * intercepts requests the BROWSER makes. It cannot touch `fetch` inside a
+   * route handler, and this app's `/api/*` routes call Binance, Bybit, Yahoo and
+   * er-api server-side - the webServer log during the fixtures run is full of
+   * outbound calls to api.bybit.com and query1.finance.yahoo.com that these
+   * fixtures never saw. So the third-party volume behind `workers: 1` is only
+   * PARTLY removed here, and unpinning still needs its own measurement rather
+   * than an inference from this file. See #114. */
+  await installMarketFixtures(page, 'as-recorded');
+
   return { page, close: () => ctx.close() };
 }
 
@@ -266,6 +310,13 @@ test.describe('colour contrast', () => {
     const unexpected = [...colours].filter(([fg]) => !known.has(fg));
     const fixed = BASELINE.contrast.darkTokens.filter(fg => !colours.has(fg));
 
+    /* Printed as well as attached. Attachments are only uploaded on failure
+     * (`ci.yml` uses `if: failure()`), so on a GREEN run these numbers exist
+     * nowhere a reader can reach them - which is how "did the sweep get weaker?"
+     * became unanswerable without re-running it locally. One line costs
+     * nothing and makes the measurement legible in the gate log itself. */
+    console.log(`[contrast] dark: ${all.length} violations across ${colours.size} tokens (baseline ${BASELINE.contrast.darkTokens.length})`);
+
     testInfo.attach('contrast-dark.txt', {
       body: `${all.length} violations across ${colours.size} tokens\n\n`
         + [...colours].sort((a, b) => a[1].worst - b[1].worst)
@@ -370,6 +421,8 @@ This is NOT automatically a regression. It is either:
     const known = new Set(BASELINE.contrast.lightTokens);
     const unexpected = [...byColour].filter(([fg]) => !known.has(fg));
     const fixed = BASELINE.contrast.lightTokens.filter(fg => !byColour.has(fg));
+
+    console.log(`[contrast] light: ${all.length} violations across ${byColour.size} tokens (baseline ${BASELINE.contrast.lightTokens.length})`);
 
     testInfo.attach('contrast-light.txt', {
       body: `${all.length} violations across ${byColour.size} tokens\n\n`

--- a/qa/e2e/entitlements.spec.ts
+++ b/qa/e2e/entitlements.spec.ts
@@ -33,21 +33,26 @@ const P = process.env.NEXT_PUBLIC_APP_ENV === 'dev' ? 'lhq_dev_' : 'lhq_';
  *  `price-alerts` appears twice on purpose — its GET is deliberately NOT gated
  *  (a free user may read alerts, not create them), so only POST and PATCH are
  *  listed. Asserting 403 on the GET would be asserting a bug. */
-/* `/api/push/test` is Pro-gated and is NOT in this list, deliberately.
+/* `/api/push/test` was excluded from this list until 2026-08-09, and now is not.
  *
  * It verifies the caller with `getSupabaseAdmin()` rather than the anon client,
- * so it needs SUPABASE_SERVICE_ROLE_KEY. The CI build deliberately runs without
- * developer env (`ci.yml` header: that difference has produced two real
- * defects), so the admin client throws, `getUser` catches and returns null, and
- * the route answers 401 to a perfectly good token.
+ * so without SUPABASE_SERVICE_ROLE_KEY the admin client throws, `getUser`
+ * catches and returns null, and the route answers 401 to a perfectly good
+ * token. Asserting on it then would have failed the release gate for an
+ * environment gap, so it was excluded LOUDLY and the gap recorded: push/test's
+ * Pro gate was verified by nothing.
  *
- * Asserting on it here would fail the release gate for an environment gap and
- * teach everyone to ignore a red entitlements run. Excluding it silently would
- * be worse - so it is excluded loudly, and the coverage gap is real:
- * **push/test's Pro gate is not verified by anything.**
+ * The owner supplied the key to the E2E job (see the long block in `ci.yml`),
+ * so the exclusion no longer has a reason and the route is in GATED below.
  *
- * To cover it, CI needs the admin key, which is a deliberate trade against the
- * reason CI runs without developer env at all. Owner's call, not a QA one.
+ * What it does in CI, checked against the route rather than assumed:
+ *   free -> 403 `PRO_REQUIRED`, which is what this spec asserts
+ *   pro  -> 503 `VAPID not configured`, because CI has no VAPID keys. That is
+ *           not 403, which is all the PRO direction claims - and it means
+ *           **no real push is sent**, so this adds no side effect.
+ *
+ * If the 503 ever becomes a 200, someone has put VAPID credentials in CI and
+ * this route now messages real devices on every release run. Worth noticing.
  */
 const GATED: Array<{ method: 'GET' | 'POST' | 'PATCH'; path: string }> = [
   { method: 'POST',  path: '/api/alerts/preview' },
@@ -58,6 +63,7 @@ const GATED: Array<{ method: 'GET' | 'POST' | 'PATCH'; path: string }> = [
   { method: 'POST',  path: '/api/pine-script' },
   { method: 'POST',  path: '/api/price-alerts' },
   { method: 'PATCH', path: '/api/price-alerts' },
+  { method: 'POST',  path: '/api/push/test' },
   { method: 'POST',  path: '/api/shadow-account' },
   { method: 'POST',  path: '/api/smc-snapshot' },
   { method: 'POST',  path: '/api/strategy-research' },

--- a/qa/e2e/i18n.spec.ts
+++ b/qa/e2e/i18n.spec.ts
@@ -1,0 +1,155 @@
+import { test, expect } from '@playwright/test';
+
+/* WCAG 2.2 SC 3.1.1 "Language of Page" is Level A - the lowest bar there is -
+ * and this app failed it on every page until 2026-08-08.
+ *
+ * WHAT WAS WRONG. Four locales shipped. `/ar` served Arabic prose inside
+ * `<html lang="en">` with no `dir` at all, so a screen reader pronounced Arabic
+ * with English phonetics and the layout never mirrored. Issue #138.
+ *
+ * WHAT SHIPPED (#147) is deliberately NOT an RTL implementation. The offer was
+ * withdrawn instead: `ar` is out of `SUPPORTED_LOCALES` and out of the picker,
+ * the dictionary is kept, and `lang`/`dir` are now set from the route. Option B
+ * of two, chosen by the owner - shipping a mirrored layout was the other, and it
+ * was not worth blocking a release nobody could otherwise sign off.
+ *
+ * WHY A BROWSER TEST AND NOT ONLY A UNIT TEST. `__tests__/localeOffering.test.mts`
+ * already asserts the offering lists. It cannot observe the thing that actually
+ * failed: what `document.documentElement.lang` reads in a running page. That is
+ * set client-side by `components/HtmlLangSync.tsx`, so only a browser sees it.
+ *
+ * READ THIS BEFORE FILING A BUG ABOUT THE SERVED HTML. `view-source:/ko` shows
+ * `lang="en"`, and that is EXPECTED. `app/layout.tsx` is the root layout and is
+ * not locale-aware; the sync happens on hydration. A screen reader reads the
+ * live DOM, so the criterion is met - but anyone diffing raw HTML will see the
+ * old value and think nothing changed. Dev called this out on the promotion and
+ * asked that it not come back as a bug report. It is asserted below as a
+ * KNOWN state rather than left undocumented, so if it ever changes, this test
+ * says so rather than silently passing.
+ */
+
+/** The locales the picker is allowed to offer. `ar` must not appear. */
+const OFFERED = ['English', '한국어', '中文'];
+
+test.describe('i18n: locale offering and page language', () => {
+  // HTML/DOM level - the mobile project would assert the identical strings.
+  test.beforeEach(({}, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop', 'DOM-level, viewport irrelevant');
+  });
+
+  /* THE DEFECT THAT STARTED #138, asserted directly: /ar must not serve Arabic
+   * prose any more. A route that silently keeps serving the WRONG language is
+   * the failure one layer down from the one that was reported.
+   *
+   * This originally asserted `404` - dev's own promotion step said "/ar returns
+   * 404, not an English page". It does not, and finding out why turned into
+   * issue #157: `/definitely-not-a-route` answers 200 on PRODUCTION today, so
+   * nothing on this site 404s and it has nothing to do with locales.
+   *
+   * So the assertion is split. What #147 actually promised is checked strictly
+   * here; the status code is recorded in the KNOWN test below rather than
+   * failing every release for a pre-existing app-wide defect. */
+  test('/ar no longer serves Arabic - it renders the not-found page', async ({ page }) => {
+    /* Anchored on STRUCTURE, not copy. `app/not-found.tsx` renders its text
+     * through `useLabels()` / `t('NOT_FOUND_TITLE')`, so the words arrive after
+     * a client fetch and are absent from the server HTML. An earlier draft of
+     * this test grepped for "not found" and failed for that reason - the page
+     * was correct and the assertion was measuring the wrong layer.
+     *
+     * The landing page carries the language picker; the not-found page does
+     * not. That difference is structural, present at the same moment for both,
+     * and does not move when someone rewrites the 404 copy. */
+    await page.goto('/ko', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('button.lp-lang-btn'),
+      'the POSITIVE CONTROL failed: /ko is a supported locale and must render the landing page. ' +
+      'Without this, "the picker is absent on /ar" would also be satisfied by a blank page.',
+    ).toBeVisible({ timeout: 20_000 });
+
+    await page.goto('/ar', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('button.lp-lang-btn'),
+      '/ar rendered the LANDING page. It is serving some other language under an Arabic URL, ' +
+      'which is worse than the original bug - a user who picked Arabic gets English silently.',
+    ).toHaveCount(0);
+
+    const arabic = await page.evaluate(() => /[؀-ۿ]/.test(document.body.innerText));
+    expect(arabic,
+      '/ar is rendering Arabic script again. The dictionary stays in ' +
+      'lib/i18n/dictionaries.ts on purpose, but `ar` must stay out of SUPPORTED_LOCALES ' +
+      'until the layout actually mirrors - issue #138.',
+    ).toBe(false);
+  });
+
+  /* KNOWN FAILURE, tracked as #157. Recorded rather than skipped: a skip is
+   * invisible in a passing run, and this is a live production defect.
+   *
+   * When #157 is fixed this test FAILS, and that failure is the signal to move
+   * the assertion into seo.spec.ts as a strict "a bad URL must not answer 200"
+   * check across all routes - which is where it belonged in the first place. */
+  test('KNOWN (#157): /ar answers 200, because nothing on this site 404s', async ({ request }) => {
+    const ar = await request.get('/ar');
+    const junk = await request.get('/definitely-not-a-route');
+
+    expect(junk.status(),
+      'A nonexistent route now answers something other than 200 - #157 may be fixed. ' +
+      'If so, delete this test and add the check to seo.spec.ts for every route.',
+    ).toBe(200);
+    expect(ar.status(), '/ar diverged from the app-wide behaviour - re-measure before assuming').toBe(200);
+  });
+
+  for (const [path, expected] of [['/', 'en'], ['/ko', 'ko'], ['/zh', 'zh']] as const) {
+    test(`${path} sets documentElement.lang to "${expected}"`, async ({ page }) => {
+      const res = await page.goto(path, { waitUntil: 'domcontentloaded' });
+      expect(res!.status(), `${path} did not load`).toBeLessThan(400);
+
+      /* HtmlLangSync runs on hydration, so the attribute is not correct at
+       * domcontentloaded. Poll rather than sleep - a fixed wait either flakes or
+       * wastes time, and this is the assertion the whole issue turns on. */
+      await expect
+        .poll(() => page.evaluate(() => document.documentElement.lang), { timeout: 10_000 })
+        .toBe(expected);
+
+      /* `dirForLocale` still knows about ar/he/fa/ur, so this is not "dir is
+       * always ltr" - it is "every locale we currently OFFER is ltr". If a
+       * genuine RTL locale is ever restored, this line is what fails and points
+       * at the mirroring work. */
+      const dir = await page.evaluate(() => document.documentElement.dir || 'ltr');
+      expect(dir, `${path} should be left-to-right while no RTL locale is offered`).toBe('ltr');
+    });
+  }
+
+  test('the language picker offers exactly English, Korean and Chinese', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+    const btn = page.locator('button.lp-lang-btn');
+    /* Positive control. Every assertion below is about what is ABSENT, and an
+     * unrendered picker looks identical to a picker with no Arabic in it. */
+    await expect(btn, 'the language picker did not render - nothing below would be meaningful').toBeVisible({ timeout: 20_000 });
+
+    await btn.click();
+    const labels = (await page.locator('button.lp-lang-btn ~ div a').allInnerTexts())
+      .map(s => s.trim()).filter(Boolean);
+
+    expect(labels.length, 'the picker menu did not open, so its contents were never read').toBeGreaterThan(0);
+    expect(labels.sort(), `picker offered: ${labels.join(', ')}`).toEqual([...OFFERED].sort());
+    expect(labels.join(' '),
+      'العربية is back in the picker. Putting it back needs a mirrored layout, ' +
+      'not just the dictionary - see lib/i18n/dictionaries.ts and issue #138.',
+    ).not.toContain('العربية');
+  });
+
+  /* Documented, not aspirational. See the header: the ROOT layout is not
+   * locale-aware, so the first byte says `en` on every route and hydration
+   * corrects it. Asserted so that a change here is announced rather than
+   * discovered by someone reading view-source and filing a duplicate of #138. */
+  test('KNOWN: the server-rendered HTML still says lang="en" on /ko', async ({ request }) => {
+    const html = await (await request.get('/ko')).text();
+    const m = /<html[^>]*\slang="([^"]*)"/.exec(html);
+    expect(m, '/ko served no lang attribute at all - that is a real regression').toBeTruthy();
+    expect(m![1],
+      'The served lang is no longer "en". If it is now "ko", app/layout.tsx has been made ' +
+      'locale-aware and this test should be inverted to assert that - it is a genuine ' +
+      'improvement, because it would remove the hydration gap where the page is briefly ' +
+      'the wrong language for assistive technology.',
+    ).toBe('en');
+  });
+});

--- a/qa/e2e/payments-webhook.spec.ts
+++ b/qa/e2e/payments-webhook.spec.ts
@@ -129,32 +129,28 @@ test.describe('LemonSqueezy webhook', () => {
       'LEMONSQUEEZY_WEBHOOK_SECRET is not set, so no correctly-signed payload can be built. ' +
       'Skipping rather than passing: a signed-payload test that never signs anything proves nothing.');
 
-    /* AND the handler needs SUPABASE_SERVICE_ROLE_KEY, which CI does not have.
+    /* AND the handler needs SUPABASE_SERVICE_ROLE_KEY.
      *
-     * Both branches these tests target run through `getSupabaseAdmin()`:
-     * the replay guard inserts into `ls_webhook_events`, and the ownership check
+     * Both branches these tests target run through `getSupabaseAdmin()`: the
+     * replay guard inserts into `ls_webhook_events`, and the ownership check
      * calls `sb.auth.admin.getUserById`. Without the admin client the route
-     * errors before reaching either, so the test fails on the environment rather
-     * than on the behaviour.
+     * errors before reaching either, so the test fails on the environment
+     * rather than on the behaviour - which is exactly what happened on release
+     * PR #141, the first run where these two executed at all.
      *
-     * This is the SAME wall that keeps `/api/push/test` out of
-     * `entitlements.spec.ts`, documented there hours before this spec was
-     * written - and I walked into it anyway, because I reasoned about which
-     * branch answers first and never checked what it needed to get there.
+     * CI now supplies the key (owner decision, 2026-08-09; the reasoning is in
+     * `ci.yml` beside the variable). **Keeping this guard anyway.** It is not
+     * dead code: it is what makes a missing secret produce a legible skip
+     * instead of a confusing failure, and it is what stops these two from ever
+     * silently becoming assertions about an environment error.
      *
-     * `ci.yml`'s header argues deliberately against putting developer env in
-     * CI: building without it has caught two real defects. So this is a real
-     * trade, not an oversight to fix quietly - and the honest position is that
-     * **the ownership check and replay guard are verified by nothing in CI.**
-     *
-     * Skipping loudly rather than asserting something weaker. A test that
-     * passes by lowering its own standard is worse than one that says it did
-     * not run. */
+     * A skip here is now a FINDING, not a limitation - it means the secret is
+     * absent from a job that is supposed to have it. Treat it as a red run. */
     test.skip(!process.env.SUPABASE_SERVICE_ROLE_KEY,
-      'SUPABASE_SERVICE_ROLE_KEY is absent, so the handler cannot reach the replay guard or the ' +
-      'ownership check - it errors first. Same limitation as /api/push/test. These two assertions ' +
-      'are therefore verified by NOTHING in CI; covering them needs the admin key, which ci.yml ' +
-      'deliberately withholds. Owner decision, tracked on #78.');
+      'SUPABASE_SERVICE_ROLE_KEY is absent, so the handler errors before reaching the replay guard ' +
+      'or the ownership check. CI is supposed to supply this now - if you are reading this in a CI ' +
+      'log, the secret E2E_SUPABASE_SERVICE_ROLE_KEY is missing or empty, and these two assertions ' +
+      'are verified by nothing. That is a failure to fix, not a limitation to accept.');
 
     /* THE BOLA OF PAYMENTS, and it has never run.
      *


### PR DESCRIPTION
**QA Team** — opened automatically when `staging` moved.

## Summary

Release candidate. Everything below is on `staging` and not yet in production.

## How to test (QA)

Test on **liquidity-hq-staging.onrender.com**, which serves `staging`.
Each section below is the PR author's own steps, carried through verbatim.

### #132 — docs(qa): refresh STATUS.md so nothing pending lives only in a conversation

Docs only.
1. `qa/STATUS.md` — date at the top is today.
2. Branch shas match `git rev-parse origin/main origin/staging origin/qa origin/dev`.
3. Every issue in `gh issue list` appears in the "closes when" table.

### #151 — fix(auth): notice when a signup produces no subscription row

1. `npm test` — 210 pass, 9 new.
2. A real signup on `qa` still works and still receives its welcome email. This
   only adds a branch to the path that does **not** send one.
3. The proof case cannot be produced without dropping the trigger on the shared
   dev database, which I am not going to do and would not suggest you do either.
Point 3 is the honest limit: **this is verified as a decision, not as a firing
alarm.** If you want it exercised, the safe way is a throwaway Supabase project,
and that is a bigger piece of work than the fix.

### #152 — test(journal): finish the data-testid hooks and settle one naming convention

1. `npm test` — 221 pass, 18 in this suite.
2. Your swap: every selector in the table resolves to the same elements the
   class did. **The two marked above will not** — that is the point, not a
   regression.
3. Nothing visual changes anywhere. Attributes only.

### #153 — test(qa): give CI the admin key, and cover the three surfaces it was blocking

Nothing on a running site — CI configuration and test code only.
1. After the secret exists, the next `staging` → `main` gate must show
   `POST /api/push/test refuses a FREE account` and `admits a PRO account`
   **executed, not skipped**.
2. Same for both `with a valid signature` webhook tests.
3. A **skip** on any of those five is a failure to report, not a pass to accept.

### #154 — test(qa): re-anchor the auth a11y spec to data-testid

```
npx playwright test qa/e2e/a11y-auth.spec.ts --project=desktop
```
**6 passed.** tsc clean. To prove it is not vacuous, delete a `data-testid` from
any component and re-run — U1, U3 or U6 fails on a 40s `waitForSelector` timeout
rather than reporting zero findings.

### #155 — docs(qa): record the admin-key reversal where the old rule was written

Read both files. Neither now states a rule `ci.yml` contradicts.

### #156 — test(alerts): assert the cron tally line cannot collapse again

1. `npm test` — 230 pass, 9 new.
2. Next real cron run on `qa`: the line is byte-identical to today's. This
   changes where the string is built, not what it says.
Point 2 is the whole risk surface — if the line changes at all, I have broken
something rather than fixed it.

### #158 — test(qa): guard the locale offering and the page language in a browser

```
npx playwright test qa/e2e/i18n.spec.ts --project=desktop
```
**7 passed.** tsc clean.

### #161 — test(qa): serve fixtures to the contrast sweep, and print its counts

```
npx playwright test qa/e2e/contrast.spec.ts --project=desktop
```
**2 passed, 5.2m.** The log carries:
```
[contrast] dark: 13 violations across 11 tokens (baseline 11)
[contrast] light: 60 violations across 26 tokens (baseline 26)
```

## Risk level

Per-PR risk, verbatim:

- #132: **Low.** One documentation file. Its only real risk is going stale, which the header calls out explicitly.
- #151: **Low.** One extra indexed lookup on a path that already returned early. No
- #151: schema change, no behaviour change for a healthy signup. Gates green (lint 0
- #151: errors, tsc, 210 tests, build).
- #151: **Unverified:** that GlitchTip receives it. `NEXT_PUBLIC_SENTRY_DSN` is
- #151: production-only, and the quota is exhausted for this billing period — so even in
- #151: production this would be throttled until it resets. Worth knowing before anyone
- #151: treats silence as proof the alarm works.
- #152: **Low.** Inert attributes and two renames of hooks nothing reads yet. Gates
- #152: green (lint 0 errors, tsc, 221 tests, build).
- #152: **Unverified:** that the testids resolve in a browser. Source counts are what I
- #152: can check; your swap is the first real execution.
- #153: **Low.** No application code. The one real risk — a service-role key in CI —
- #153: is scoped to the dev project and argued through above.
- #154: **Low.** Test code only. No application code, no CI config.
- #155: **Low.** Documentation only.
- #156: **Low.** One extracted function, one call site, no behaviour change. Gates green
- #156: (lint 0 errors, tsc, 230 tests, build).
- #156: **Unverified:** that the cron still logs correctly in production. The statement
- #156: is unreachable without a live run, so the source check plus an identical format
- #156: is as far as I can take it from here.
- #158: **Low.** Test code only.
- #161: **Medium.** Test code only, but it changes what the contrast gate measures. The
- #161: control run above is the evidence it did not weaken; both numbers moved and both
- #161: moved in the direction of seeing more. Baselines are unchanged — dark now
- #161: observes exactly its 11.

## Release steps — QA owns all four

1. Test every section above on staging.
2. Merge this PR.
3. **Deploy production manually.** Merging is not the deploy —
   `liquidity-hq-prod` is `autoDeploy: no`. A drift check raises an
   issue if main moves and production does not follow.
4. Re-check the steps against production, then tag:
   `git tag -a v$(date +%Y.%m.%d) -m "..." && git push --tags`
