### PR TITLE
fix(i18n): return a real 404 for unknown single-segment URLs

### DIFF
--- a/__tests__/localeOffering.test.mts
+++ b/__tests__/localeOffering.test.mts
@@ -76,3 +76,53 @@ test('the Arabic work is preserved, not deleted', async (t) => {
     assert.ok(getDictionary('klingon'));
   });
 });
+
+/* #157 — a bad URL answered HTTP 200.
+ *
+ * The site was not missing a 404 page. It had a CATCH-ALL in front of one:
+ * `app/[locale]/page.tsx` is a single-segment dynamic route, so /nope, /pricing
+ * and /admin-typo all matched it, reached `notFound()`, and answered 200 —
+ * because by then the response had started streaming and, per Next's own docs,
+ * "the status code of the response cannot be updated".
+ *
+ * Measured on a production build before and after:
+ *
+ *            before   after
+ *   /nope      200      404
+ *   /ar        200      404
+ *   /ko        200      200
+ *
+ * Multi-segment paths like /nope/deeper were genuinely unmatched and returned
+ * 404 all along, which is why the issue looked like "no 404 anywhere" from the
+ * outside while `app/not-found.tsx` was working correctly.
+ *
+ * `dynamicParams = false` moves the decision to routing, before anything
+ * renders. It only works BECAUSE generateStaticParams enumerates the locales -
+ * the two are one mechanism, so both are asserted together. Deriving that list
+ * from SUPPORTED_LOCALES is what stops a locale being removed from the picker
+ * and left reachable here.
+ */
+test('an unknown locale is refused at routing, not while rendering', async (t) => {
+  const src = read('app/[locale]/page.tsx');
+
+  await t.test('dynamicParams is disabled', () => {
+    assert.match(src, /export\s+const\s+dynamicParams\s*=\s*false/,
+      'without this a bad URL renders, streams, and answers 200 - see #157');
+  });
+
+  /* dynamicParams=false 404s anything generateStaticParams did not list, so an
+     empty or hardcoded list silently changes which URLs exist. */
+  await t.test('the generated list still derives from SUPPORTED_LOCALES', () => {
+    assert.match(src, /generateStaticParams[\s\S]{0,200}SUPPORTED_LOCALES/,
+      'generateStaticParams no longer derives from SUPPORTED_LOCALES - with ' +
+      'dynamicParams=false that decides which URLs return 404');
+  });
+
+  /* Kept as defence and now unreachable in production. Removing it is safe
+     today and unsafe the moment dynamicParams changes, which is exactly the
+     kind of coupling worth pinning. */
+  await t.test('the runtime guard is still there as a second line', () => {
+    assert.match(src, /isSupportedLocale\(locale\)/);
+    assert.match(src, /notFound\(\)/);
+  });
+});

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -12,6 +12,29 @@ export function generateStaticParams() {
   return SUPPORTED_LOCALES.map(locale => ({ locale }));
 }
 
+/* THIS IS WHAT MAKES A BAD URL A REAL 404 (#157).
+ *
+ * `[locale]` is a single-segment dynamic route, so it matches EVERY
+ * single-segment path - /nope, /pricing, /admin-typo. Every one of them reached
+ * this page, hit the `notFound()` below, and answered **200**, because by then
+ * the response had already started streaming and per Next's docs "the status
+ * code of the response cannot be updated".
+ *
+ * That is the whole of #157: the site was not missing a 404 page, it had a
+ * catch-all in front of one. Multi-segment paths like /nope/deeper were
+ * genuinely unmatched and did return 404 all along.
+ *
+ * `dynamicParams = false` moves the decision to routing: a locale not in
+ * generateStaticParams 404s before anything renders. From the docs -
+ *
+ *   > **false**: Dynamic route segments not included in `generateStaticParams`
+ *   > will return a 404.
+ *
+ * The `isSupportedLocale` guard below stays as defence. It is now unreachable
+ * in production, and that is fine - it costs nothing and it is the thing that
+ * still works if this line is ever removed. */
+export const dynamicParams = false;
+
 export async function generateMetadata({ params }: { params: Promise<Params> }): Promise<Metadata> {
   const { locale } = await params;
   if (!isSupportedLocale(locale)) return {};


### PR DESCRIPTION
**Dev Team** → **QA Team**

Closes #157. **One line**, and the reasoning is worth more than the change.

## The diagnosis is not what the issue assumed

The site was not missing a 404 page. **It had a catch-all in front of one.**

`app/[locale]/page.tsx` is a single-segment dynamic route, so `/nope`,
`/pricing`, `/admin-typo` — every one of them **matched** it, reached
`notFound()`, and answered 200. Per Next's own docs:

> Because the response headers have already been sent to the client, the status
> code of the response cannot be updated.

Meanwhile `/nope/deeper` — genuinely unmatched — **returned 404 the whole
time.** That is why this read as "no 404 anywhere" from outside while
`app/not-found.tsx` was working correctly.

## The fix

```ts
export const dynamicParams = false;
```

> **false**: Dynamic route segments not included in `generateStaticParams` will
> return a 404.

Measured on a production build, before and after:

| | before | after | | | before | after |
|---|---|---|---|---|---|---|
| `/nope` | 200 | **404** | | `/ko` | 200 | 200 |
| `/ar` | 200 | **404** | | `/` | 200 | 200 |
| `/nope/deeper` | 404 | 404 | | `/dashboard` | 200 | 200 |

`/ar` now 404s properly, which finishes #138 — I had claimed that on #147 and it
was not true.

## 🔴 What I almost shipped, which is the more useful half

I first built **`app/global-not-found.tsx` plus `experimental.globalNotFound`** —
the documented answer for unmatched URLs. A 110-line duplicate 404 page and an
experimental Next flag.

Then I tested it with the flag set to `false`. **Every path still returned 404.**
It was doing nothing, because nothing in this app is ever unmatched at one
segment — the catch-all sees to that. Deleted both.

Two experimental-flag-shaped things nearly went into production on the strength
of a doc that described a different situation. The experiment took four minutes.

## The SEO argument is smaller than the issue states

Next **already** injects `<meta name="robots" content="noindex">` into the
streamed 404, and the docs are explicit:

> Some crawlers may label these responses as "soft 404s". In the streaming case,
> this does not lead to indexation because the page is explicitly marked
> `noindex`.

Verified present on production and on `qa` before writing anything. I also
briefly thought `/ar` was missing that tag and nearly reported it — my grep
pattern was wrong, not the page.

So the real gains here are the two you listed second: **an honest status for
monitoring**, and **clients that check `res.ok`**. Worth doing; not the SEO
emergency it looked like.

## Not fixed, and out of scope

A route that matches and streams before failing still cannot set 404. Per the
same docs that needs a `proxy.ts` rewrite, and there is no such route today —
`dynamicParams` covers every case this app actually has.

## How to test (QA)

```bash
curl -s -o /dev/null -w '%{http_code}\n' https://liquidity-hq-qa.onrender.com/definitely-not-a-route   # 404
curl -s -o /dev/null -w '%{http_code}\n' https://liquidity-hq-qa.onrender.com/ar                       # 404
curl -s -o /dev/null -w '%{http_code}\n' https://liquidity-hq-qa.onrender.com/ko                       # 200
```

Your `seo.spec.ts` assertion is the right home for the first one. The `/ko` check
matters as much as the other two — `dynamicParams=false` 404s anything
`generateStaticParams` omits, so a mistake there takes real pages offline.

## Risk level

**Medium**, and the reason is that last sentence.

The change itself is one line and gates are green (lint 0 errors, tsc, 234
tests, build). But the failure mode is asymmetric: get the generated list wrong
and `/ko` and `/zh` 404 in production. That list derives from
`SUPPORTED_LOCALES`, and the test asserts **both** halves, because they are one
mechanism rather than two facts.

**Verified locally on a production build** — `npm run build && npm start`, all
seven paths above. Not verified on `qa` yet; that is step one.
