### PR TITLE
docs(qa): re-measure TEST_GAPS — four gaps closed, one downgraded, one new

### DIFF
--- a/qa/TEST_GAPS.md
+++ b/qa/TEST_GAPS.md
@@ -1,76 +1,85 @@
 # What a green suite does not mean
 
-**Owner: QA. Last measured 2026-08-08.** Status and blockers live in [`STATUS.md`](STATUS.md); this file is only about coverage.
+**Owner: QA. Last measured 2026-08-09.** Status and blockers live in [`STATUS.md`](STATUS.md); this file is only about coverage.
 
-This file exists because "187 tests passed" reads like "the product works", and it
+This file exists because "250 tests passed" reads like "the product works", and it
 does not. It is the standing list of what is **not** covered, why it matters, and
 what closing it would take.
 
 Read it before quoting a green CI run as evidence of anything.
 
-Two rules for keeping it honest:
+Three rules for keeping it honest:
 
 - **A gap leaves this list only when a test covers it**, not when someone is
   confident it is fine. Confidence is what this file exists to replace.
 - **When a gap is closed, say what closed it** — the spec name, so the claim is
   checkable.
+- **A gap that is half closed is still open.** §1 and §5 below are the live
+  examples. "Fixtures exist" and "the clock is controllable" are different
+  claims, and collapsing them is how a list stops being true without anyone
+  editing it.
 
 ---
 
 ## What the suite actually covers today
 
+250 passed / 110 skipped, 41 minutes, measured on release gate #162.
+
 | | |
 |---|---|
 | ✅ Signed-out surface | 32 routes, desktop + iPhone 13 |
 | ✅ Signed-in surface | Settings, TradeJournal, Grok chat — accessibility only, desktop only |
-| ✅ Cross-account access (BOLA/IDOR) | 9 tests, both seeded accounts, HTTP level |
+| ✅ Cross-account access (BOLA/IDOR) | 10 tests, both seeded accounts, HTTP level |
+| ✅ **Pro entitlement boundary** | 15 routes × both directions, pinned `pro` and `free` fixtures |
+| ✅ **Payments webhook** | signature, replay guard, cross-account ownership — **synthetic payloads only** |
 | ✅ Accessibility | axe WCAG 2.0/2.1/2.2 A+AA, tap targets, names, landmarks |
 | ✅ Performance | LCP + CLS budgets per route |
 | ✅ SEO / meta | canonical, titles, h1 |
-| ✅ Colour contrast | **dark theme only**, 8 routes measured |
+| ✅ Colour contrast | **both themes**, all 32 routes, served from fixtures |
+| ✅ **Offline / service worker** | 5 tests — precache, offline page, API passthrough, revalidation, cache purge |
+| ✅ **Locale offering + page language** | `lang`/`dir` per route, picker contents, `/ar` removal |
 
 Everything below is outside that.
 
 ---
 
-## 🔴 1. Market data and the clock cannot be controlled
+## 🟠 1. Market data is controllable; the CLOCK is not
 
-**The biggest gap by a wide margin, and the least visible.**
+**Downgraded from 🔴 on 2026-08-09, and only half.**
 
-Every test runs against whatever the live market is doing at that moment. There
-is no way to pin an input, so the product's own domain logic — the reason anyone
-uses it — has never been tested.
+`qa/e2e/_fixtures.ts` records 20 third-party endpoints and serves them through
+`page.route`. `market-scenarios.spec.ts` uses them to pin funding-rate sign and
+upstream-500 behaviour, and `contrast.spec.ts` now measures every route against
+them rather than against the live market.
 
-Untestable today:
+**What that closed:** the contrast sweep no longer depends on what the market did
+that minute. Measured 2026-08-09 — with fixtures the dark sweep observes **11 of
+11** baseline tokens; without them, 10. The missing one needed a surface live
+data had not populated.
 
-- funding rate flipping **negative**, and the UI that is supposed to react to it
-- RSI crossing overbought / oversold thresholds
-- squeeze and flush scores at their alert boundaries
-- **24h and 48h alert outcome resolution** — a test would have to wait 24 hours
-- "Best Hours" and the economic calendar **across timezones**, including DST
-- what the app does when Binance/CMC returns an error, an empty array, a `null`
-  price, or a number where a string was expected
-- liquidation map behaviour at extremes
+**Still open, and it is most of the original section:**
 
-Right now a passing run means "nothing crashed given today's prices". It does not
-mean the calculations are right, because nothing ever asserts a calculation
-against a **known** input.
+- **The clock.** "Best Hours", the economic calendar, DST, and 24h/48h alert
+  outcome resolution are all untestable. A fake clock is not installed.
+- **Server-side calls are not intercepted.** `page.route` only sees requests the
+  BROWSER makes. The app's own `/api/*` handlers call Binance, Bybit, Yahoo and
+  er-api from the server, and those go out live in every run. This is why #114
+  cannot be closed by inference from the fixture work.
+- RSI thresholds, squeeze/flush alert boundaries and liquidation-map extremes
+  have fixtures available but **no spec asserts against them**.
 
-**To close:** intercept the market-data calls at the network layer
-(`page.route`) and serve recorded fixtures — one per scenario. Plus a fake clock
-for the time-dependent paths. This is the real work: recording representative
-payloads is most of it.
-
-**Cost:** days, not hours. **Value:** highest of anything on this list.
+**To close:** a fake clock, and interception at a layer the server also passes
+through. **Cost:** days. **Value:** still the highest here.
 
 ---
 
 ## 🟠 2. Nothing has ever looked at the pages
 
-Contrast ratios are computed from CSS values and the DOM is read
-programmatically. **No test has ever compared what the page looks like.**
+**Unchanged, and now the top item.** Contrast ratios are computed from CSS values
+and the DOM is read programmatically. **No test has ever compared what a page
+looks like.**
 
-So all of these would pass every check currently in the suite:
+All of these still pass every check in the suite:
 
 - text rendered in a colour that happens to match its background
 - two elements overlapping
@@ -78,151 +87,136 @@ So all of these would pass every check currently in the suite:
 - a modal opening off-screen
 - a layout collapsing at one specific width
 
-This is not theoretical. **Nine routes received colour-token substitutions with
-no measured proof** (recorded in every release note since 2026-08-05 as "not
-verified"), and the suite cannot tell whether they render correctly.
+**The blocker moved.** This used to be blocked on §1 for data-heavy routes.
+Fixtures now make those routes deterministic, so screenshot baselines are viable
+for far more than the static pages.
 
-**To close:** screenshot baselines per route per viewport per theme, with a
-pixel-diff threshold. Playwright has `toHaveScreenshot()` built in — no new
-dependency.
+**To close:** `toHaveScreenshot()` per route per viewport per theme. Built into
+Playwright, no new dependency.
 
-**The catch:** live market data means the pixels change every run. This gap is
-**blocked on gap 1** for the data-heavy routes; the static/marketing routes could
-be baselined today.
-
-**Cost:** ~1 day for the static routes. **Value:** high, and it is the cheapest
-big win once fixtures exist.
+**Cost:** ~1 day. **Value:** highest value-per-day on this list now that §1's
+determinism problem is partly solved.
 
 ---
 
-## 🟠 3. Light theme has never been measured
+## ✅ 3. Light theme — CLOSED 2026-08-09
 
-Contrast was measured on the **dark** theme only. The app ships a light theme
-(`Settings → Appearance → Light`), and no automated check has ever run against
-it.
+Closed by `qa/e2e/contrast.spec.ts`, which sweeps **both** themes across all 32
+routes. Light carries a 26-token baseline; dark carries 11. Both print their
+counts into the gate log.
 
-Every contrast number QA has ever reported — including the fixes in
-`__tests__/contrastTokens.test.mts` — describes dark mode.
-
-**To close:** parameterise the contrast sweep over `data-theme`, run both. The
-harness already exists; it just runs once.
-
-**Cost:** hours. **Value:** high for the cost — this is the cheapest item here.
+Kept as a heading rather than deleted, because "contrast is dark-only" was
+repeated from this file for weeks after it stopped being true.
 
 ---
 
-## 🔴 4. Four locales ship; one is tested, and Arabic is not implemented
+## 🔴 4. `lang` is wrong on 30 of 32 routes
 
-**CORRECTED 2026-08-08.** This section said "five languages … English, 한국어,
-中文, العربية, Русский". `SUPPORTED_LOCALES` in `lib/i18n/dictionaries.ts` is
-`['ko', 'zh', 'ar']` plus English — **four**. Русский is not shipped. I repeated
-"five" from this file several times in one day without checking it, which is the
-same failure this file exists to prevent: a confident claim nobody re-measured.
+**Arabic is resolved. The Level A failure is not.**
 
-Every test asserts against **English** strings and English layout.
+`/ar` is out of `SUPPORTED_LOCALES` and out of the picker (#147), `/ar` returns a
+real 404 (#163), and `qa/e2e/i18n.spec.ts` guards the offering and the `lang`
+attribute on `/`, `/ko` and `/zh`.
 
-**Raised from 🟠 to 🔴, because Arabic turned out not to be a testing gap.**
-Measured on production 2026-08-08:
+**But #164, reproduced 2026-08-09:**
 
 ```
-GET /ar          -> <html lang="en">   no dir attribute
-GET /dashboard   -> <html lang="en">   no dir attribute
+localStorage.lhq_lang_v1 = 'ko'
+
+/ko        lang="ko"   Korean on page = true
+/upgrade   lang="en"   Korean on page = true    <-- SC 3.1.1, Level A
+/login     lang="en"   Korean on page = true
 ```
 
-`dirForLocale()` exists and is correct, and is applied to **one div** inside
-`LandingContent`. The authenticated app never sets `dir` at all, while
-`LabelsProvider` serves Arabic strings app-wide — so an Arabic user gets Arabic
-text in a permanently left-to-right layout.
+There are **two sources of locale truth**. `HtmlLangSync` reads the path;
+`LabelsProvider` reads `localStorage` and serves translated copy app-wide. A
+Korean user gets Korean UI on every route, declared as English.
 
-Two defects, tracked on **#138**:
+**How this survived a 9/9 sign-off:** the verification only loaded routes the fix
+touched — `/`, `/ko`, `/zh`, `/ar`. A check that visits only the covered routes
+confirms any fix. That is the vacuous-pass shape, and it happened in QA's own
+release sign-off.
 
-1. **`lang="en"` on Arabic content** — WCAG 2.2 SC 3.1.1, **Level A**. A screen
-   reader applies English pronunciation to Arabic, which is unintelligible rather
-   than accented. Wrong for Korean and Chinese too.
-2. **`dir` never reaches the document.** Anything portalled to `<body>` — modals,
-   toasts, the consent banner — is outside `.lp-root` and stays LTR even on the
-   landing page.
+Also still open, and dev's own note: the **server-rendered** HTML says `lang="en"`
+until hydration, so a crawler reading the first response sees English. Needs the
+root-layout restructure.
 
-**Writing an RTL spec would have proven nothing**, because the feature is not
-there to fail. `dirForLocale` existing made it look implemented from the inside,
-which is why reading the layout beat testing it.
-
-Related and already burned: `LabelsProvider` overwrote 2,570 seeded English
-labels when `/api/labels` returned `200 {}` (found 2026-08-05, fixed). Found by
-accident in a degraded CI environment. Nothing routinely checks the label layer
-is intact in **any** locale.
-
-**To close:** the owner decides whether Arabic is supported at launch (#138). If
-yes, `lang` and `dir` become dynamic and the app needs a logical-properties pass;
-then the spec asserts both on `<html>` per locale. If no, Arabic comes out of the
-picker — a selector that produces a broken layout is worse than not offering it.
-
-**`lang` should be fixed either way.** One attribute, Level A, currently wrong on
-every page in production.
+**To close:** #164, then extend `i18n.spec.ts` to assert `lang` against the
+*selected* locale on a non-landing route — the assertion that would have caught it.
 
 ---
 
-## 🟡 5. The payment and upgrade flow has never been exercised
+## 🟡 5. A purchase has never granted Pro
 
-`/upgrade`, LemonSqueezy checkout, subscription state, Pro-gating. Reached only
-as an unauthenticated page render.
+**Half closed.** `qa/e2e/payments-webhook.spec.ts` covers what the handler does
+with a payload: an absent, forged or malformed signature is rejected; a replayed
+payload is not re-applied; a payer cannot grant Pro to an account they do not own.
+That last one is the BOLA of payments — `user_id` arrives in `custom_data`, which
+`lib/checkout.ts` writes into a client-side URL — and it first executed on
+2026-08-09.
 
-Never tested: that a purchase grants Pro, that Pro-gated features unlock, that a
-lapsed subscription re-locks them, that a failed payment is handled. The
-timeframe chips in Settings carry `title="Fast timeframes are a Pro feature."` —
-whether that gate actually holds is unverified.
+**Every one of those payloads is synthetic.** The suite signs them itself. So:
 
-**Why it is 🟡 and not 🔴:** it involves a third party's sandbox and real money
-paths, so it is genuinely awkward to automate — not because it matters less. It
-arguably matters most in money terms.
+- no real LemonSqueezy event has ever reached this handler
+- no purchase has ever granted Pro
+- no lapsed subscription has been shown to re-lock
+- whether we are pointed at the right store is unverified
 
-**To close:** LemonSqueezy test mode + a seeded Pro account alongside the two
-existing fixtures.
+`entitlements.spec.ts` does now prove the Pro **boundary** holds in both
+directions across 15 routes. What is untested is everything that *changes* which
+side of that boundary an account is on.
+
+**To close:** LemonSqueezy test-mode keys — owner action — plus one real
+end-to-end purchase against a seeded account.
 
 ---
 
 ## 🟡 6. Accessibility is asserted, never heard
 
-The suite checks that `aria-live`, `role`, and accessible names **exist**. It has
-never checked what a screen reader actually **announces**.
+**Unchanged.** The suite checks that `aria-live`, `role` and accessible names
+**exist**. It has never checked what a screen reader **announces**.
 
 An element can have every correct attribute and still be unusable — wrong reading
 order, a name that says "button" and nothing else, a live region that fires on
 every keystroke. Attribute presence is a floor, not a pass.
 
-**To close:** honestly, partly unclosable in CI. A real pass needs NVDA or
-VoiceOver and a person. Worth booking as a manual session rather than pretending
-automation covers it.
+Sharpened by §4: `lang` was *present* on every page for the whole life of the
+project. It was present and wrong, and no attribute-presence check can find that.
+
+**To close:** partly unclosable in CI. A real pass needs NVDA or VoiceOver and a
+person. Book it as a manual session rather than pretending automation covers it.
 
 ---
 
-## 🟡 7. `qa` and `dev` share one database
+## 🟡 7. `staging` and `dev` share one database
 
-Documented in `CLAUDE.md` and accepted deliberately — Supabase's free plan caps
-the account at two projects, and dev + prod take both.
+**Unchanged, and the wording corrected** — it is `staging`, not `qa`, that shares
+the dev Supabase project (`wdtjhrilakoitfcezxpx`). Accepted deliberately:
+Supabase's free plan caps the account at two projects and dev + prod take both.
 
-Consequence, stated so nobody forgets: **QA test data and dev's data live in the
-same database.** A clean QA run is not proof the data path is clean; it may be
-proof that dev happened to leave good data lying around. Row counts, empty
-states, and "no results" assertions are all suspect.
+Consequence: **QA test data and dev's data live in the same database.** A clean
+run on staging is not proof the data path is clean; it may be proof that dev left
+good data lying around. Row counts, empty states and "no results" assertions are
+all suspect.
+
+New as of 2026-08-09: CI now holds that project's **service-role key**
+(`E2E_SUPABASE_SERVICE_ROLE_KEY`). Scoped to the E2E job, dev project only. Prod's
+key must never reach CI — prod holds real customers and the free plan has no
+backups.
 
 **To close:** a third Supabase project. Costs money. Owner's call.
 
 ---
 
-## 🟡 8. Offline / PWA behaviour
+## ✅ 8. Offline / PWA — CLOSED 2026-08-08
 
-There is a service worker and an `/offline` route. Nothing tests the app going
-offline: whether cached routes serve, whether the offline page appears, whether
-queued actions replay on reconnect, or whether a stale service worker serves an
-old build after a deploy.
+Closed by `qa/e2e/offline.spec.ts`: the worker registers, activates and
+precaches; a failed navigation serves the offline page; **API requests are not
+answered with it**; navigations revalidate rather than serving a stale copy; and
+activation purges older caches.
 
-That last one bites in production and is invisible on the qa and staging test environments.
-
-**To close:** `context.setOffline(true)` plus service-worker lifecycle
-assertions. Playwright supports both.
-
-**Cost:** ~half a day.
+That last one is the "stale service worker serves an old build after a deploy"
+case, which bites in production and is invisible on the test environments.
 
 ---
 
@@ -231,84 +225,61 @@ assertions. Playwright supports both.
 Recorded here rather than hidden, because the suite is code and has defects too.
 
 - **`perf.spec` does not warm a route before measuring it.** Two LCP failures on
-  2026-08-06 were cold-start artefacts, not regressions — 3460ms cold vs 676ms
-  warm on the same build. Until this is fixed, an LCP failure needs a warm re-run
-  before it is believed.
+  2026-08-06 were cold-start artefacts — 3460ms cold vs 676ms warm on the same
+  build. Still true. An LCP failure needs a warm re-run before it is believed.
 - **`playwright.config.ts` sets `reuseExistingServer: !process.env.CI`.** Locally
-  the suite will silently reuse whatever is already on port 3000, which may be a
-  different branch's build. Always check what is being served before trusting a
-  local run.
-- **`a11y-auth.spec.ts` is desktop-only** — deliberate (same DOM, double the
-  cost), but it does mean no signed-in mobile coverage exists at all.
-- **The trade journal has no API route**, so it has no API-level BOLA surface to
-  probe. Its data isolation is unverified at HTTP level; only the UI path is
-  covered.
+  the suite silently reuses whatever is on port 3100, which may be another
+  branch's build. Check what is being served before trusting a local run.
+- **`a11y-auth.spec.ts` is desktop-only** — deliberate, but it means no
+  signed-in mobile coverage exists at all.
+- **The trade journal has no API route**, so no API-level BOLA surface. Its data
+  isolation is unverified at HTTP level; only the UI path is covered.
+- **Several assertions cannot fail.** `bola.spec.ts`'s `REFUSED` set contains
+  `200`, so the status check is decorative and the data assertion beside it is
+  what has teeth. Deliberate, documented in the file, and listed here so it is
+  not rediscovered as a bug.
+- **110 tests skip every run.** 95+ are the mobile project on HTTP-level specs,
+  which is by design. Every skip names its reason. Read them — some are accepted
+  limits and some would be findings if they appeared.
 
 ---
 
-## 🔴 10. Error monitoring is installed and capturing nothing
+## ✅ 10. Error monitoring — CLOSED 2026-08-08, with one caveat
 
-**CORRECTED 2026-08-06.** This section previously said "There is no Sentry, no
-error aggregation, no alert." That was **wrong**, and written without reading
-`pendings/OPS_ROADMAP.md:46`, which documents the opposite.
+The 429 finding is resolved. `lib/monitoring.ts` now suppresses non-prod events
+before they spend quota (`NEXT_PUBLIC_APP_ENV === 'dev'`), session envelopes went
+14 → 0, and `__tests__/monitoringPipeline.test.mts` proves the scrubber runs
+**inside the real SDK** against a stub transport — email, IP and username
+stripped, the error message preserved, and an OAuth `access_token` in a
+breadcrumb URL fragment removed while the path survives.
 
-Error monitoring exists: `@sentry/nextjs` 10.67.0, wired through
-`instrumentation.ts` (server + edge) and `instrumentation-client.ts` (client),
-pointed at **GlitchTip**, environment-tagged from `NEXT_PUBLIC_APP_ENV`, with
-`tracesSampleRate: 0` set deliberately after traces ate 99% of the free quota.
-
-The real finding is worse than the gap that was imagined:
-
-```
-POST https://app.glitchtip.com/api/25983/envelope/   ->  429 Too Many Requests
-```
-
-Measured on the qa test environment across four page loads — **every request, no exceptions**.
-The event quota is exhausted, so every error the app reports is rejected and
-dropped.
-
-That is worse than having none, because none is at least honest. This appears in
-the dependency list, in the ops doc, and in the network tab, and captures
-nothing. Anyone asking "do we have error monitoring?" gets *yes*.
-
-Likely cause: `NEXT_PUBLIC_SENTRY_DSN` is one variable and `environment` is a
-tag, not a separate quota — so if `dev`, `qa` and `prod` share a DSN, dev noise
-and QA traffic spend production's 1,000 events a month. Structurally the same
-trap as §7, and with the same consequence: the noisy environments starve the one
-that matters.
-
-**To close:** a separate DSN for prod, or `beforeSend` dropping non-prod events
-before they spend quota. Filed as issue #51.
-
-**The lesson, recorded because it is the more useful part:** this file's job is
-to say what is *not* covered, and its first version asserted a gap that did not
-exist. A claim about the absence of something needs the same evidence as a claim
-about its presence — check the repo before writing "there is no X".
+**The caveat, because it is the part nobody has measured:** no error raised on
+**production** has been observed arriving in GlitchTip. Everything above proves
+the pipeline is correct in a test harness and that non-prod no longer spends
+quota. It does not prove prod capture works end to end.
 
 ---
 
 ## Suggested order
 
-Ranked by value per unit of effort, not by severity:
+Ranked by value per unit of effort. Four of the previous eight are closed.
 
 | | Item | Effort | Why this order |
 |---|---|---|---|
-| 1 | §10 GlitchTip 429 | hours | Monitoring exists but drops every event — it is the only thing here that catches bugs nobody predicted, and right now it catches none |
-| 2 | §3 light theme | hours | Harness exists, runs once, just needs a second pass |
-| 3 | §8 offline/PWA | ½ day | Self-contained, no fixtures needed |
-| 4 | §2 visual, static routes only | 1 day | Immediate value, not blocked on §1 |
-| 5 | §4 i18n + RTL | 1 day | Arabic is a different layout, not different words |
-| 6 | §1 data + clock fixtures | days | The big one — unblocks the rest of §2 |
-| 7 | §5 payments | days | Awkward, third party, matters most in money |
-| 8 | §6 screen reader | manual | Book a session; do not pretend CI covers it |
+| 1 | **§4 — #164 `lang`** | hours | A live Level A failure on 30 of 32 routes, already reproduced. Dev assigned |
+| 2 | **§2 visual baselines** | ~1 day | The only never-touched gap, and fixtures just made most routes deterministic |
+| 3 | §1 fake clock | days | Unblocks Best Hours, DST, alert resolution — none of which any test can reach |
+| 4 | §1 server-side interception | days | Also what #114 needs before `workers` can be unpinned |
+| 5 | §5 real purchase | days | Blocked on owner-supplied test-mode keys |
+| 6 | §10 prod capture check | hours | Cheap, but needs a deliberate error in production |
+| 7 | §6 screen reader | manual | Book a session; do not pretend CI covers it |
 
 ---
 
 ## Also see
 
 - `pendings/QA_AUDIT_2026-08-04.md` — the original audit
-- `pendings/QA_A11Y_FINDINGS_2026-08-05.md` — accessibility findings, §4 now
-  verified
+- `pendings/QA_A11Y_FINDINGS_2026-08-05.md` — accessibility findings
 - `pendings/QA_E2E_FINDINGS_2026-08-05.md` — defects found running the suite
 - `qa/E2E_PLAN.md` — how the suite was built. Its §5 is superseded by this file;
   the BOLA gap it describes was closed on 2026-08-06 by `qa/e2e/bola.spec.ts`.


### PR DESCRIPTION
**QA Team** → **Dev Team** · re-measured against the suite as it stands

The owner asked to start picking new work from this file. **Four of its eight ranked items were already done**, including its top-ranked 🔴. Planning from it would have handed you solved problems.

## Closed — each naming the spec that closed it

| § | Was | Closed by |
|---|---|---|
| 3 | 🟠 light theme never measured | `contrast.spec.ts` — both themes, 32 routes, 26-token light baseline |
| 8 | 🟡 offline/PWA untested | `offline.spec.ts` — 5 tests, incl. stale-worker cache purge |
| 10 | 🔴 monitoring capturing nothing | non-prod suppressed; scrubber proven inside the real SDK (#142) |

## Downgraded, **not** closed — this is the part worth reading

**§1 market data.** Fixtures serve 20 endpoints and now feed the contrast sweep. But the **clock is still uncontrolled**, and `page.route` cannot intercept your route handlers' own `fetch` calls. That second half is also what blocks #114.

**§5 payments.** The handler is covered against forged, replayed and cross-account payloads — **all synthetic**. No real purchase has ever granted Pro.

New rule at the top of the file: **a gap that is half closed is still open.** "Fixtures exist" and "the clock is controllable" are different claims, and collapsing them is how this file stops being true without anyone editing it.

## Raised

**§4 is now 🔴** — Arabic is resolved; the Level A failure is not. That is #164, which you have.

Recorded alongside it: **how it survived a 9/9 release sign-off.** My verification only loaded routes the fix touched — `/`, `/ko`, `/zh`, `/ar`. A check that visits only the covered routes confirms any fix. Written into the file because it will happen again otherwise.

## Also corrected

§7 said `qa` shares the dev database — it is **`staging`**. And the coverage table was three specs out of date (entitlements, payments-webhook, i18n all missing).

## How to test (QA)

Read it. Every ✅ names a spec you can run. Every remaining item says what is still missing rather than restating the original wording.

## Risk level

**Low.** Documentation. Its accuracy is the deliverable — if any ✅ is wrong, say so and I will re-open it rather than argue.