### PR TITLE
chore(ci): let staging accumulate without opening a release PR

### DIFF
--- a/.github/workflows/release-signals.yml
+++ b/.github/workflows/release-signals.yml
@@ -36,8 +36,33 @@ permissions:
 
 jobs:
   # ── qa -> staging: open the release PR, do not wait to be asked ───────────
+  #
+  # PAUSE SWITCH — `vars.RELEASE_PR_PAUSED`.
+  #
+  # Set it to `1` to let `staging` ACCUMULATE without a release PR existing.
+  # Unset or delete it to resume; the next push to `staging` opens the PR for
+  # everything piled up since.
+  #
+  # Why this exists. Opening the PR automatically is deliberate (#133) - it is
+  # what stopped promotions going out unannounced. But it has a cost the author
+  # of that automation did not have to pay: the release PR's base is `main`, so
+  # every push to `staging` fires `synchronize` on it and re-runs the FULL
+  # 41-minute browser suite. Parking work on `staging` for a day therefore
+  # billed a gate run per promotion, for a release nobody intended to ship yet.
+  #
+  # Deliberately a repo VARIABLE, not a secret and not a file:
+  #   - it is not sensitive, and as a secret its value would be redacted from
+  #     every log, which is the last thing a switch like this needs
+  #   - it is visible in Settings -> Variables, so "why did no PR open?" has an
+  #     answer someone can find without reading this file
+  #   - changing it needs no commit, so resuming does not itself push to staging
+  #
+  # SCOPED TO THIS JOB ONLY. `prod-drift` below MUST keep running - it is what
+  # notices production and `main` have diverged, which is exactly the risk that
+  # grows while releases are parked. Disabling the whole workflow to get this
+  # effect would switch off the check that matters most while it is paused.
   release-pr:
-    if: github.ref == 'refs/heads/staging'
+    if: github.ref == 'refs/heads/staging' && vars.RELEASE_PR_PAUSED != '1'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -259,7 +284,10 @@ jobs:
   # up to the final API call had succeeded, which is why this stays useful.
   release-pr-failed:
     needs: release-pr
-    if: failure() && github.ref == 'refs/heads/staging'
+    # Same pause guard as the job it reports on. Without it, a paused run would
+    # report "the release PR could not be opened" every single promotion - an
+    # alarm for something nobody asked to happen.
+    if: failure() && github.ref == 'refs/heads/staging' && vars.RELEASE_PR_PAUSED != '1'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
**QA Team** → **Dev Team** · owner request: pile changes on `staging`, no PR to `main`

## Why this is not just "close the PR"

Pushing to `staging` **auto-opens the release PR** (#133, and rightly — it is what stopped promotions going out unannounced). But the release PR's base is `main`, so **every subsequent push to `staging` fires `synchronize` and re-runs the full 41-minute browser suite.**

Parking work on `staging` for a day therefore bills a gate run per promotion, for a release nobody intends to ship yet. Today there is no way to express "accumulate, do not announce".

## The switch

Repo variable **`RELEASE_PR_PAUSED`**. Set to `1` to accumulate; unset to resume — the next push to `staging` then opens a PR covering everything piled up.

A **variable**, not a secret and not a file:
- not sensitive, and as a secret its value would be **redacted from every log** — the last thing a switch like this needs
- visible in Settings → Variables, so *"why did no PR open?"* has an answer someone can find without reading the workflow
- changing it needs no commit, so **resuming does not itself push to `staging`**

## 🔴 The part I want reviewed

**`prod-drift` is deliberately untouched.**

The obvious one-liner here is `gh workflow disable release-signals.yml`. That would also switch off the job that notices production and `main` have diverged — **and that risk grows while releases are parked**, which is exactly when we are asking for it to be off. It would have suppressed #159, which opened correctly this afternoon.

`release-pr-failed` carries the same guard, or a paused run reports "the release PR could not be opened" on every promotion — an alarm for something nobody asked to happen.

## One-time cost, stated plainly

Workflows run from the file on the **triggering ref**, so the guard only takes effect once this reaches `staging`. The promotion that carries it will still open a PR under the old file. I will disable the workflow for that single push and re-enable immediately after, so it costs no E2E run.

## How to test (QA)

1. `gh variable set RELEASE_PR_PAUSED --body 1`
2. Promote `qa` → `staging` — **no release PR opens**, and no E2E runs
3. `gh run list --workflow=release-signals.yml` — `prod-drift` still runs on its schedule
4. `gh variable delete RELEASE_PR_PAUSED`, promote again — PR opens covering the whole pile

## Risk level

**Medium.** It disables an announcement that exists because promotions were once going out unannounced. The mitigation is that it is one variable, visible in Settings, and the thing it silences is the *PR*, not the drift check.