### PR TITLE
test(qa): assert lang against the SELECTED locale, and 404 across all routes

### DIFF
--- a/qa/e2e/i18n.spec.ts
+++ b/qa/e2e/i18n.spec.ts
@@ -79,21 +79,29 @@ test.describe('i18n: locale offering and page language', () => {
     ).toBe(false);
   });
 
-  /* KNOWN FAILURE, tracked as #157. Recorded rather than skipped: a skip is
-   * invisible in a passing run, and this is a live production defect.
+  /* THE KNOWN-FAILURE TEST THAT USED TO LIVE HERE HAS BEEN DELETED, AND THAT IS
+   * THE POINT OF IT.
    *
-   * When #157 is fixed this test FAILS, and that failure is the signal to move
-   * the assertion into seo.spec.ts as a strict "a bad URL must not answer 200"
-   * check across all routes - which is where it belonged in the first place. */
-  test('KNOWN (#157): /ar answers 200, because nothing on this site 404s', async ({ request }) => {
-    const ar = await request.get('/ar');
-    const junk = await request.get('/definitely-not-a-route');
-
-    expect(junk.status(),
-      'A nonexistent route now answers something other than 200 - #157 may be fixed. ' +
-      'If so, delete this test and add the check to seo.spec.ts for every route.',
-    ).toBe(200);
-    expect(ar.status(), '/ar diverged from the app-wide behaviour - re-measure before assuming').toBe(200);
+   * It asserted `/ar` answers 200 "because nothing on this site 404s" (#157),
+   * and it carried its own instruction: when #157 is fixed this test FAILS, and
+   * that failure is the signal to move the check into seo.spec.ts across all
+   * routes.
+   *
+   * #163 fixed it - `dynamicParams = false`, so an unmatched locale is refused
+   * at ROUTING rather than after the response has started streaming. The test
+   * failed on the next run, exactly as designed, and the strict check now lives
+   * in `seo.spec.ts` where it applies to every route rather than to /ar alone.
+   *
+   * Worth keeping the note: a known failure recorded as a passing test that
+   * inverts when fixed is the only form of "we know about this" that cannot rot.
+   * A skip would have stayed silent forever. */
+  test('/ar returns a real 404, not a 200 with a not-found page', async ({ request }) => {
+    const res = await request.get('/ar');
+    expect(res.status(),
+      '/ar must 404. It renders the not-found page either way, so a 200 here means ' +
+      '`dynamicParams = false` was removed from app/[locale]/page.tsx and every unknown ' +
+      'URL is a soft 404 again - see #157 and #163.',
+    ).toBe(404);
   });
 
   for (const [path, expected] of [['/', 'en'], ['/ko', 'ko'], ['/zh', 'zh']] as const) {
@@ -116,6 +124,77 @@ test.describe('i18n: locale offering and page language', () => {
       expect(dir, `${path} should be left-to-right while no RTL locale is offered`).toBe('ltr');
     });
   }
+
+  /* THE ASSERTION NEITHER SIDE HAD, AND THE REASON #164 SURVIVED A 9/9 SIGN-OFF.
+   *
+   * Everything above pins `lang` on the three routes that carry a locale in the
+   * URL - and those were the only routes ever checked. They were also the only
+   * routes that already worked. A verification that visits only the surface a
+   * fix touched will confirm any fix, which is what happened: 9 of 9 passed
+   * against production while 30 of 32 routes served Korean copy under
+   * `lang="en"`.
+   *
+   * The locale that actually decides the UI is the SELECTED one - stored in
+   * `lhq_lang_v1` by lib/labels.ts, and on the server in
+   * `user_settings.language`. `/upgrade` carries no locale segment, so it can
+   * only be right if the attribute follows the selection rather than the path.
+   *
+   * `ru` is in here because AVAILABLE_LOCALES offers Russian in the app pickers
+   * while the landing picker offers three - so Russian is reachable and had
+   * never once been asserted. */
+  for (const [stored, expected] of [['ko', 'ko'], ['zh', 'zh'], ['ru', 'ru']] as const) {
+    test(`a selected locale "${stored}" sets lang on a route with no locale in its URL`, async ({ browser }) => {
+      const ctx = await browser.newContext();
+      await ctx.addInitScript((v: string) => {
+        try { localStorage.setItem('lhq_lang_v1', v); } catch { /* private mode */ }
+      }, stored);
+      const page = await ctx.newPage();
+      try {
+        await page.goto('/upgrade', { waitUntil: 'domcontentloaded' });
+        await expect
+          .poll(() => page.evaluate(() => document.documentElement.lang), { timeout: 10_000 })
+          .toBe(expected);
+      } finally { await ctx.close(); }
+    });
+  }
+
+  /* A WITHDRAWN LOCALE MUST RESOLVE, NOT PERSIST.
+   *
+   * Arabic is still in SUPPORTED_LOCALES on purpose - that list answers "is this
+   * a code we recognise", and anyone who selected Arabic before it was withdrawn
+   * still has `ar` in storage. It must resolve to English rather than fail.
+   *
+   * Measured 2026-08-09, and it took two attempts to get right: the first fix
+   * fell back to English LABELS while `lang`/`dir` still followed the stored
+   * value, so the page rendered English declared as Arabic in a right-to-left
+   * layout - the same defect as #164 with the operands swapped. This asserts all
+   * three agree, because agreeing is the actual requirement. */
+  test('a withdrawn locale in storage resolves to English, in every signal', async ({ browser }) => {
+    const ctx = await browser.newContext();
+    await ctx.addInitScript(() => {
+      try { localStorage.setItem('lhq_lang_v1', 'ar'); } catch { /* private mode */ }
+    });
+    const page = await ctx.newPage();
+    try {
+      await page.goto('/upgrade', { waitUntil: 'domcontentloaded' });
+      await expect
+        .poll(() => page.evaluate(() => document.documentElement.lang), { timeout: 10_000 })
+        .toBe('en');
+
+      const state = await page.evaluate(() => ({
+        dir: document.documentElement.dir || 'ltr',
+        arabic: /[؀-ۿ]/.test(document.body.innerText),
+        len: document.body.innerText.length,
+      }));
+
+      expect(state.len, 'the page did not render, so nothing below is meaningful').toBeGreaterThan(200);
+      expect(state.dir, 'lang resolved to English but dir stayed rtl - the two disagree').toBe('ltr');
+      expect(state.arabic,
+        'lang says English and the page is rendering Arabic. That is #164 inverted: ' +
+        'a screen reader would apply English pronunciation to Arabic text.',
+      ).toBe(false);
+    } finally { await ctx.close(); }
+  });
 
   test('the language picker offers exactly English, Korean and Chinese', async ({ page }) => {
     await page.goto('/', { waitUntil: 'domcontentloaded' });

--- a/qa/e2e/seo.spec.ts
+++ b/qa/e2e/seo.spec.ts
@@ -21,6 +21,50 @@ test.describe('seo', () => {
     expect(await sitemap.text()).toContain('<urlset');
   });
 
+  /* A URL THAT DOES NOT EXIST MUST NOT ANSWER 200.
+   *
+   * Moved here from i18n.spec.ts, which is where it was discovered but not where
+   * it belongs - it was never about locales.
+   *
+   * #157: every unknown URL answered 200 on production. The site was not missing
+   * a 404 page; `app/[locale]/page.tsx` is a single-segment dynamic route, so
+   * /nope, /pricing and /admin-typo all MATCHED it, reached `notFound()`, and by
+   * then the response had started streaming - and per Next's docs the status can
+   * no longer be changed. Multi-segment paths like /nope/deeper were genuinely
+   * unmatched and returned 404 all along, which is why it read as "no 404
+   * anywhere" from outside while app/not-found.tsx worked correctly.
+   *
+   * Fixed in #163 with `dynamicParams = false`, which moves the decision to
+   * routing, before anything renders.
+   *
+   * WHY THIS SITS IN THE SEO SPEC. A crawler reads 200 as "index this", so every
+   * typo and dead share link becomes an indexable duplicate of the 404 page.
+   * This file already covers robots, sitemap, titles and canonicals and did not
+   * catch it, because nothing here had ever asserted a STATUS CODE for a URL
+   * that should not exist.
+   *
+   * Both shapes are checked. The single-segment case is the one that regressed;
+   * the multi-segment case is the control that proves the probe itself works. */
+  test('a URL that does not exist returns 404, not a soft 404', async ({ request }) => {
+    const cases = [
+      ['/definitely-not-a-route', 'single segment - the shape #157 was about'],
+      ['/admin-typo', 'single segment, plausible typo'],
+      ['/nope/deeper', 'multi segment - the control; this returned 404 even while #157 was open'],
+    ] as const;
+
+    const wrong: string[] = [];
+    for (const [path, why] of cases) {
+      const status = (await request.get(path)).status();
+      if (status !== 404) wrong.push(`${path} -> ${status} (${why})`);
+    }
+
+    expect(wrong,
+      'A nonexistent URL answered something other than 404. If `dynamicParams = false` was ' +
+      'removed from app/[locale]/page.tsx, every unknown single-segment URL is a soft 404 ' +
+      'again and crawlers will index them - see #157 and #163.\n' + wrong.join('\n'),
+    ).toEqual([]);
+  });
+
   test('every page has a non-empty title', async ({ page }) => {
     const bad: string[] = [];
     for (const route of ROUTES) {


### PR DESCRIPTION
**QA Team** → **Dev Team** · the assertion neither of us had

## The test that would have caught #164

Every existing `lang` assertion pinned `/`, `/ko` and `/zh` — **the only routes with a locale in the URL, and the only routes that already worked.**

My production sign-off for #138 ran nine checks and passed nine. Every one visited a route the fix had touched. Thirty of thirty-two routes were serving Korean copy under `lang="en"` at that moment.

**A verification that only visits the surface a fix changed will confirm any fix.**

So: `lang` on `/upgrade` — no locale in the URL — driven by the stored selection. It can only be right if the attribute follows the *selection* rather than the path.

## 🟢 Russian passes, and nothing had ever checked it

`AVAILABLE_LOCALES` offers **en · ko · zh · ru** in the app pickers, while the landing picker offers three. Russian is reachable and had never once been asserted. It works — but that was luck, not coverage.

## The withdrawn-locale test asserts agreement, not just `lang`

`lang`, `dir` **and** rendered text must agree. Your first attempt fell back to English *labels* while `lang`/`dir` still followed the stored value — English text declared as Arabic in an RTL layout, which is #164 with the operands swapped. Asserting only `lang === 'en'` would have passed that.

## The #157 test deleted itself, as designed

It asserted the bug as a **passing** test carrying its own instruction: *when #157 is fixed this fails, and that failure is the signal to move the check into `seo.spec.ts`.* Your #163 fixed it, it failed on the next run, and this is that move.

A skip would have stayed silent forever. **A known failure written as an inverting assertion cannot rot.**

## The 404 check moved to seo.spec.ts

It was never about locales. A crawler reads 200 as "index this", so every typo became an indexable duplicate of the 404 page. That file already covered robots, sitemap, titles and canonicals and missed this — nothing in it had ever asserted a **status code for a URL that should not exist**.

Checks both shapes: single-segment (what regressed) and `/nope/deeper` (the control that returned 404 even while #157 was open — it proves the probe works).

## How to test (QA)

```
npx playwright test qa/e2e/i18n.spec.ts qa/e2e/seo.spec.ts --project=desktop
```

**17 passed.** tsc clean.

## Risk level

**Low.** Test code only.

## ⚠️ Merge order note

**#168 must merge and reach `staging` before the next promotion**, or the release PR auto-opens and burns a 41-minute gate. When we promote I will disable `release-signals` for that single push and re-enable immediately — the guard only takes effect once the file is *on* `staging`.