### PR TITLE
chore(qa): step workers 1 → 2, with the measurement the pin lacked

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,10 +29,37 @@ export default defineConfig({
   // A flaky pass is worse than a fail - it teaches everyone to re-run until
   // green. Retries only in CI, and only to absorb genuine cold-start noise.
   retries: process.env.CI ? 1 : 0,
-  // Market data comes from shared third-party APIs (Binance/Bybit). Running
-  // specs in parallel multiplies that traffic and can trip the app's own
-  // per-IP rate limiter, producing 429s that look like product bugs.
-  workers: 1,
+  // WAS `workers: 1` until 2026-08-09, for a reason that has been measured and
+  // turned out to be much smaller than stated. Issue #114.
+  //
+  // The old comment said: market data comes from shared third-party APIs
+  // (Binance/Bybit), parallel specs multiply that traffic and trip the app's own
+  // per-IP rate limiter, and the resulting 429s look like product bugs. That was
+  // sized at ~11,000 third-party requests per sweep.
+  //
+  // THAT NUMBER COUNTED BROWSER REQUESTS, and `qa/e2e/_fixtures.ts` now
+  // intercepts those (#161). Measured on a full contrast sweep with fixtures
+  // installed, what actually leaves the machine is the app's OWN server-side
+  // calls:
+  //
+  //     101 [cmc] · 58 [proxy] · 4 [econ-calendar]  =  ~159 per sweep, ~25/min
+  //
+  // Two orders of magnitude below the figure the pin was justified with. A local
+  // run at `--workers=2` produced ZERO 429s or rate-limit errors.
+  //
+  // STEPPED TO 2, NOT 4, DELIBERATELY. Rate limits are per-IP and the
+  // measurement above is from one developer machine, not CI's shared egress. A
+  // clean local number proves the volume is low; it does not prove CI is under
+  // the threshold. Two is the smallest step that tests the theory in the place
+  // that matters. Raise it only after a green gate at 2.
+  //
+  // DO NOT EXPECT THE SAVING #114 CLAIMS. With `fullyParallel: false` Playwright
+  // parallelises by FILE, and `contrast.spec.ts` is 2 tests in one file taking
+  // ~19 of the gate's 41 minutes. It runs on a single worker whatever this
+  // number says, so it is the floor. Realistically 41 -> ~20 min, not ~10.
+  // Going below that needs contrast split into more files, which is its own
+  // change and moves how its baselines are grouped.
+  workers: 2,
   fullyParallel: false,
 
   forbidOnly: !!process.env.CI,


### PR DESCRIPTION
**QA Team** → **Dev Team** · closes the QA half of #114

## The pin rested on a number that counted the wrong thing

It was justified with *"~11,000 third-party requests per sweep trip Binance/Bybit per-IP limits"*. **That counted BROWSER requests**, and `_fixtures.ts` now intercepts those (#161).

Measured on a full contrast sweep with fixtures installed — what actually leaves the machine is the app's **own server-side** calls:

```
101 [cmc] · 58 [proxy] · 4 [econ-calendar]  =  ~159 per sweep, ~25/min
```

**Two orders of magnitude below the figure the pin rested on.** I had been repeating that number for days without once checking what it counted.

## Evidence

| check | result |
|---|---|
| `contrast.spec` at `--workers=2` | 0 rate-limit errors, 0 429s |
| full desktop suite at `workers: 2` | **135 passed, 0 failed**, 0 rate-limit hits |
| coverage | **unchanged** — dark 11/11 tokens, light 26/26, layout 0 obscured |

That last row is the one that mattered most to me. A faster suite that sees less is a regression wearing a green tick.

## 🔴 Two things I am deliberately NOT claiming

**No speedup.** I never ran the full desktop suite at `workers: 1` locally, so there is no control. Quoting 17.7 min as an improvement against a number I never measured would be the exact error this PR exists to correct. **CI's 41-minute gate is the real before/after.**

**Not 4 workers.** Rate limits are per-IP and every measurement here is from one dev machine, not CI's shared egress. A clean local number proves the volume is low — not that CI sits under the threshold. **2 is the smallest step that tests the theory where it matters.** Raise it after a green gate at 2.

## And #114's saving is smaller than it claims

`fullyParallel: false` parallelises by **file**, and `contrast.spec.ts` is **2 tests in one file** taking ~19 of the gate's 41 minutes. It runs on **one worker regardless of this setting** — so it is a hard floor.

Expect **~20 min, not ~10**. Going below needs contrast split across files, which also regroups its baselines and is its own change.

## How to test (QA)

```
npx playwright test --project=desktop
```

**135 passed, 17.7m, zero rate-limit errors.** tsc clean.

The real check is the next release gate: it must stay green, and the `[contrast]` counts in its log must still read 11 and 26. **If either drops, revert to 1** — a lower count means parallelism cost us coverage, not that the app improved.

## Risk level

**Medium.** It changes how every gate runs, and the failure mode is 429s that look like product defects. Mitigated by stepping to 2 rather than 4, and by the coverage counts now being printed in the gate log so a silent loss is visible.