### PR TITLE
feat(api): fetch ETF flows from SoSoValue's authenticated API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,21 @@ AI_GLOBAL_DAILY_MAX=
 # Powers: BTC liquidation heatmap (Arena), exchange net flow
 COINGLASS_API_KEY=your_coinglass_key_here
 
+# ── SoSoValue ────────────────────────────────────────────────────────────────
+# BTC + ETH spot ETF daily net flows. Powers the ETF card on /briefing and the
+# ETF lines in the AI market context (briefing prompt + Ask AI).
+#
+# PRODUCTION ONLY, and the reason is the quota rather than secrecy. The Demo
+# plan allows 10,000 calls/month and 10/min per key. The route makes 2 calls
+# per refresh and caches for an hour: ~1,460/month, about 15% of the allowance.
+# A second environment sharing the same key doubles that; four would leave no
+# headroom for a busy month.
+#
+# Absent, the route makes no call, reports no health row, and the ETF card
+# simply does not render - which is exactly how every non-prod environment
+# behaved before this existed. See issue #175.
+SOSOVALUE_API_KEY=your_sosovalue_key_here
+
 # ── Finnhub ───────────────────────────────────────────────────────────────────
 FINNHUB_KEY=your_finnhub_key_here
 

--- a/__tests__/etfFlows.test.mts
+++ b/__tests__/etfFlows.test.mts
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { etfFlowMillions } from '../lib/etfFlows.ts';
+
+/* #175. The previous ETF integration never succeeded once - 301 failures with
+ * last_ok_at NULL - because it was written against a guessed endpoint shape and
+ * never verified. These cover the two ways the replacement can go wrong
+ * quietly. */
+
+const DOC_RECORD = {
+  date: '2024-04-12',
+  total_net_inflow: -55066297.0,
+  total_value_traded: 4706120449.0,
+  total_net_assets: 56216535367.0,
+  cum_net_inflow: 13534833596.095,
+};
+
+test('the unit is millions, not dollars', async (t) => {
+  /* THE ONE THAT LOOKS LIKE DATA. /briefing renders `$${v}M`, so returning
+     dollars here shows a 55-million-dollar outflow as "-$55066297M" - fifty-five
+     trillion. Nothing errors, nothing logs, and the number is plausible enough
+     in shape that it reads as a market event. */
+  await t.test("the docs' own example converts correctly", () => {
+    assert.equal(etfFlowMillions({ data: [DOC_RECORD] }), -55.066297);
+  });
+
+  await t.test('a large inflow stays in millions', () => {
+    assert.equal(etfFlowMillions({ data: [{ total_net_inflow: 1_200_000_000 }] }), 1200);
+  });
+
+  /* Zero is a real trading day, not missing data. `if (btc)` in the old client
+     would have discarded it; the parse must return it. */
+  await t.test('zero flow is a value, not an absence', () => {
+    assert.equal(etfFlowMillions({ data: [{ total_net_inflow: 0 }] }), 0);
+  });
+
+  /* The API returns these as high-precision decimals; some JSON producers emit
+     them as strings. */
+  await t.test('a numeric string is accepted', () => {
+    assert.equal(etfFlowMillions({ data: [{ total_net_inflow: '-55066297.0000' }] }), -55.066297);
+  });
+});
+
+test('shape tolerance, without guessing', async (t) => {
+  await t.test('list under data, bare list, and a bare object all work', () => {
+    assert.equal(etfFlowMillions({ data: [DOC_RECORD] }), -55.066297);
+    assert.equal(etfFlowMillions([DOC_RECORD]), -55.066297);
+    assert.equal(etfFlowMillions(DOC_RECORD), -55.066297);
+    assert.equal(etfFlowMillions({ data: DOC_RECORD }), -55.066297);
+  });
+
+  await t.test('newest first - the first record wins', () => {
+    assert.equal(etfFlowMillions({ data: [{ total_net_inflow: 1e6 }, { total_net_inflow: 9e9 }] }), 1);
+  });
+
+  /* THROWS rather than returning null. The caller turns a throw into a health
+     failure; a null would be indistinguishable from a genuine no-flow day and
+     would have reproduced #175 with a green health table. */
+  await t.test('an unusable payload throws instead of reading as no flow', () => {
+    for (const bad of [null, undefined, {}, [], { data: [] }, { data: [{}] },
+                       { data: [{ total_net_inflow: null }] },
+                       { data: [{ total_net_inflow: 'n/a' }] },
+                       { error: 'unauthorized' }]) {
+      assert.throws(() => etfFlowMillions(bad), /total_net_inflow/,
+        `should have thrown for ${JSON.stringify(bad)}`);
+    }
+  });
+});

--- a/app/api/proxy/route.ts
+++ b/app/api/proxy/route.ts
@@ -13,6 +13,7 @@ import { createClient } from '@supabase/supabase-js';
 import { apiError } from '@/lib/apiError';
 import { rateLimit, getClientIp } from '@/lib/rateLimit';
 import { cached } from '@/lib/apiCache';
+import { etfFlowMillions } from '@/lib/etfFlows';
 import { trackHealth, reportHealth } from '@/lib/apiHealth';
 
 // Google Trends' 7-day bitcoin score barely moves hour to hour, and the
@@ -162,50 +163,88 @@ export async function GET(req: NextRequest) {
 
     /* ── SoSoValue: BTC + ETH spot ETF net flows ── */
     if (type === 'etf') {
-      /* sosovalue.xyz is dead - try sosovalue.com with browser headers.
-         Server-side (Render) requests often bypass 403 blocks that hit headless clients. */
-      const SSV_HEADERS = {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
-        'Accept': 'application/json, text/plain, */*',
-        'Accept-Language': 'en-US,en;q=0.9',
-        'Origin': 'https://sosovalue.com',
-        'Referer': 'https://sosovalue.com/',
-      };
+      /* REWRITTEN 2026-08-10 (#175). The previous version scraped an
+         unauthenticated JSON path and had NEVER succeeded - 301 consecutive
+         failures with last_ok_at NULL in prod's health table. Measured before
+         rewriting rather than assumed:
 
-      async function fetchSoSo(path: string) {
-        // Try .com first, fall back to .xyz (dead but harmless to retry)
-        const urls = [
-          `https://sosovalue.com/api/etf/${path}?language=en`,
-          `https://api.sosovalue.com/etf/${path}?language=en`,
-        ];
-        for (const url of urls) {
-          try {
-            const r = await fetch(url, {
-              headers: SSV_HEADERS,
-              signal: AbortSignal.timeout(8000),
-              next: { revalidate: 1800 },
-            } as RequestInit);
-            if (r.ok) return await r.json();
-          } catch { /* try next */ }
-        }
-        return null;
+             https://sosovalue.com/api/etf/us-btc-spot   -> HTTP 404
+             https://api.sosovalue.com/etf/us-btc-spot   -> DNS does not resolve
+
+         So it was not a 403 or a region block, which is what the old comment
+         theorised and what its browser-headers workaround was solving for. The
+         endpoint was gone, and its `.xyz -> .com` migration had never been
+         verified against a live response.
+
+         SoSoValue now runs an authenticated API:
+           GET https://openapi.sosovalue.com/openapi/v1/etfs/summary-history
+           header  x-soso-api-key
+           params  symbol=BTC|ETH, country_code=US, limit
+
+         QUOTA IS THE CONSTRAINT, and it is why this caches aggressively.
+         The account is on the Demo plan: 10,000 calls/month and 10/min. Two
+         calls per refresh (BTC + ETH) at one refresh per hour is 48/day, about
+         1,460/month - roughly 15% of the allowance, leaving room for the other
+         environments if a key is ever added to one.
+
+         An hour is generous for the data itself: `total_net_inflow` is a DAILY
+         figure and only changes after a US trading session closes. */
+      const ETF_TTL_MS = 60 * 60 * 1000;
+
+      async function fetchSoSoFlow(symbol: 'BTC' | 'ETH'): Promise<number | null> {
+        const apiKey = process.env.SOSOVALUE_API_KEY;
+        /* No key: make no call and report nothing. Reporting a failure here
+           would fill the health table on every environment that deliberately
+           has no key, which is the noise #176 is about. Not configured is not
+           unhealthy. */
+        if (!apiKey) return null;
+
+        return cached(`sosovalue:etf:${symbol}`, ETF_TTL_MS, async () => {
+          const url = 'https://openapi.sosovalue.com/openapi/v1/etfs/summary-history'
+            + `?symbol=${symbol}&country_code=US&limit=1`;
+          const r = await fetch(url, {
+            headers: { 'x-soso-api-key': apiKey, Accept: 'application/json' },
+            signal: AbortSignal.timeout(8000),
+          });
+          if (!r.ok) throw new Error(`sosovalue ${symbol} HTTP ${r.status}`);
+          const body = await r.json();
+
+          /* Parsing and the unit conversion live in lib/etfFlows.ts so both are
+             testable without a key or a network call - see the comment there
+             for why the unit is the dangerous half. Throws on an unusable
+             payload, which the caller turns into a health failure rather than
+             a silent zero. */
+          return etfFlowMillions(body);
+        });
       }
 
-      const [btc, eth] = await Promise.all([
-        fetchSoSo('us-btc-spot'),
-        fetchSoSo('us-eth-spot'),
+      const [btcRes, ethRes] = await Promise.allSettled([
+        fetchSoSoFlow('BTC'),
+        fetchSoSoFlow('ETH'),
       ]);
+      const btc = btcRes.status === 'fulfilled' ? btcRes.value : null;
+      const eth = ethRes.status === 'fulfilled' ? ethRes.value : null;
 
-      // fetchSoSo returns null after exhausting both hosts, and this route then
-      // answers 200 with {btc:null, eth:null} - indistinguishable from a day
-      // with no ETF flows. One source for the provider rather than two: both
-      // paths go to the same host behind the same headers and fail together,
-      // and the useful question is whether SoSoValue is answering at all.
-      const got = [btc, eth].filter(Boolean).length;
-      reportHealth('sosovalue:etf-flows', 'market', got === 2,
-        got === 2 ? 'btc + eth' : got === 1 ? 'only one of btc/eth' : 'no response from either host',
-        got);
+      /* Only report health when a key exists. Otherwise every keyless
+         environment reports a failure for a call it never made. */
+      if (process.env.SOSOVALUE_API_KEY) {
+        const got = [btc, eth].filter(v => v != null).length;
+        const why = [btcRes, ethRes]
+          .filter((x): x is PromiseRejectedResult => x.status === 'rejected')
+          .map(x => String(x.reason?.message ?? x.reason)).join('; ');
+        reportHealth('sosovalue:etf-flows', 'market', got === 2,
+          got === 2 ? 'btc + eth' : why || (got === 1 ? 'only one of btc/eth' : 'no data'),
+          got);
+      }
 
+      /* btc/eth are now plain numbers in MILLIONS, or null.
+
+         This DID need a client change and my first comment here claimed it did
+         not. MarketProvider read four nested shapes off the raw payload
+         (`btc?.data?.list?.[0]?.totalNetInflow` and friends); every one of them
+         is undefined on a number, so the store would silently never have been
+         set and the panel would have stayed exactly as broken as before, with
+         the health table now green. Updated alongside this. */
       return NextResponse.json({ btc, eth });
     }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -5045,6 +5045,27 @@ html[lang="ar"] .lp-h1-accent {
 body.nav-drawer-open .mobile-tab-bar { display: none !important; }
 @media (max-width: 640px) {
   .mobile-tab-bar { display: flex; position: fixed; bottom: 0; left: 0; right: 0; z-index: 997; height: 56px; background: #0a0a0e; border-top: 0.5px solid var(--bdr); }
+
+  /* RESERVE THE BAND THE TAB BAR SITS OVER (#173).
+
+     The bar is `position: fixed`, so it is out of flow and takes up no space in
+     the document. `.app-content` ends with `padding-bottom: 2rem` = 32px, and
+     the bar owns the last 56px - so the final 24px of EVERY page on a phone was
+     underneath it, unreachable.
+
+     Mostly that landed on footer links, which is why it read as cosmetic for so
+     long. On /calc it landed on `input.ps-inp`, a position-size field: tapping
+     it hits the tab bar instead. Found by qa/e2e/layout.spec.ts, which measures
+     what is at each control's own centre point rather than whether it exists.
+
+     Components have been clearing this by hand one at a time - `.gchat-fab`
+     at 76px, `.consent-bar` at 56px - which works for fixed overlays and does
+     nothing for page content. This is the reservation that was missing.
+
+     env(safe-area-inset-bottom) on top, because on a phone with a home
+     indicator the bar's own 56px starts above the inset. Falls back to 0px
+     everywhere else, so it costs nothing on Android or in a desktop viewport. */
+  .app-content { padding-bottom: calc(56px + env(safe-area-inset-bottom, 0px) + 1rem); }
   [data-theme="light"] .mobile-tab-bar { background: #ffffff; border-top-color: rgba(0,0,0,0.10); }
   /* On phones the bottom bar owns navigation; the top hamburger would just be
      a redundant second opener for the same drawer, so hide it here. Tablet

--- a/components/MarketProvider.tsx
+++ b/components/MarketProvider.tsx
@@ -1068,20 +1068,15 @@ export default function MarketProvider({ children }: { children: React.ReactNode
         headers: token ? { Authorization: `Bearer ${token}` } : undefined,
       });
       const { btc, eth } = await res.json();
-      if (btc) {
-        const raw = btc?.data?.list?.[0]?.totalNetInflow
-          ?? btc?.data?.totalNetInflow
-          ?? btc?.list?.[0]?.totalNetInflow
-          ?? btc?.totalNetInflow;
-        if (raw != null) setStore(s => ({ ...s, etfNetFlow: parseFloat(String(raw)) }));
-      }
-      if (eth) {
-        const raw = eth?.data?.list?.[0]?.totalNetInflow
-          ?? eth?.data?.totalNetInflow
-          ?? eth?.list?.[0]?.totalNetInflow
-          ?? eth?.totalNetInflow;
-        if (raw != null) setStore(s => ({ ...s, ethEtfNetFlow: parseFloat(String(raw)) }));
-      }
+      /* Plain numbers in MILLIONS since #175. The route used to hand back
+         SoSoValue's raw payload and this read four possible nesting shapes out
+         of it; the authenticated API returns one documented field, so the route
+         now extracts and converts it and this just stores it.
+
+         `!= null` rather than a truthiness check on purpose: a zero-flow day is
+         real data and `if (btc)` would discard it. */
+      if (btc != null && Number.isFinite(btc)) setStore(s => ({ ...s, etfNetFlow: btc as number }));
+      if (eth != null && Number.isFinite(eth)) setStore(s => ({ ...s, ethEtfNetFlow: eth as number }));
     } catch { /* fail silently */ }
   }, []);
 

--- a/lib/etfFlows.ts
+++ b/lib/etfFlows.ts
@@ -1,0 +1,53 @@
+/* Reading SoSoValue's ETF summary-history response.
+ *
+ * Split out from app/api/proxy/route.ts so the two things that can silently go
+ * wrong are testable without a network call or an API key:
+ *
+ *   1. THE UNIT. The API documents `total_net_inflow` in DOLLARS. `/briefing`
+ *      renders `$${value}M` and GrokChat labels it `$…M`, so the store holds
+ *      MILLIONS. Miss the divide and a -55,066,297 USD outflow renders as
+ *      "-$55066297M" - a fifty-five-trillion-dollar day. That does not look
+ *      like a bug on a dashboard, it looks like a number.
+ *
+ *   2. THE SHAPE. The docs show one record inline and document a `limit`
+ *      parameter, so the payload is a list in some form. Guessing at nesting is
+ *      exactly how the previous integration was written, and it never once
+ *      succeeded (#175) - so this accepts the plausible shapes and THROWS on
+ *      anything else rather than returning null and looking like a quiet day
+ *      with no flows.
+ */
+
+/** The documented record. Only the field this app uses is named. */
+interface SummaryHistoryRecord {
+  total_net_inflow?: unknown;
+}
+
+/**
+ * Net inflow for the most recent session, in MILLIONS of USD.
+ *
+ * @throws if no usable record is present. Deliberate: the caller reports health
+ *   on the throw, and "no data" must not be indistinguishable from "zero flow".
+ *   Zero IS a real value and is returned as 0, not treated as missing.
+ */
+export function etfFlowMillions(body: unknown): number {
+  const rec = pickRecord(body);
+  const raw = (rec as SummaryHistoryRecord | null)?.total_net_inflow;
+
+  if (raw == null || raw === '' || !Number.isFinite(Number(raw))) {
+    throw new Error('no total_net_inflow in response');
+  }
+  return Number(raw) / 1e6;
+}
+
+/** Newest-first per the docs, so the first record is the latest session. */
+function pickRecord(body: unknown): unknown {
+  if (Array.isArray(body)) return body[0] ?? null;
+
+  if (body && typeof body === 'object') {
+    const data = (body as { data?: unknown }).data;
+    if (Array.isArray(data)) return data[0] ?? null;
+    if (data && typeof data === 'object') return data;
+    return body;
+  }
+  return null;
+}


### PR DESCRIPTION
**Dev Team** → **QA Team**

Refs #175. Owner has an API key. **Not verified end to end yet** — see Risk.

## Where to put the key: PRODUCTION ONLY

The owner's plan is tighter than the public docs advertise:

| | docs say | actual (Demo plan) |
|---|---|---|
| Monthly calls | 100,000 | **10,000** |
| Per minute | 20 | **10** |

Valid to 2029-12-31.

That decides placement, on arithmetic rather than preference:

```
2 calls per refresh (BTC + ETH) × 1 refresh/hour = 48/day ≈ 1,460/month
                                                  ≈ 15% of the allowance
```

One environment is comfortable. Four share one key and there is no headroom for
a busy month — and `MarketProvider` mounts on **every** page, so `qa` and
`staging` traffic is not incidental.

**`SOSOVALUE_API_KEY` on `liquidity-hq-prod` only.** Documented in
`.env.example` with that reasoning, so the next person does not add it to
`staging` as a courtesy.

## What was actually wrong

Measured both old hosts with the exact headers the code sent:

```
sosovalue.com/api/etf/us-btc-spot   HTTP 404
api.sosovalue.com/etf/us-btc-spot   DNS does not resolve
```

Not a 403, not a region block — which is what the old comment theorised and what
its browser-headers workaround was solving for. The endpoint was gone, and its
previous `.xyz → .com` migration had never been checked against a live response.
That is what 301 failures with `last_ok_at NULL` looks like.

## The new contract

```
GET https://openapi.sosovalue.com/openapi/v1/etfs/summary-history
    ?symbol=BTC|ETH&country_code=US&limit=1
    header  x-soso-api-key
    field   total_net_inflow   (USD, negative = outflow, newest first)
```

## 🔴 Two things that would have failed silently

**The unit.** The API documents **dollars**. `/briefing` renders `$${v}M` and
GrokChat labels it `$…M`, so the store holds **millions**. Without the divide, a
−$55,066,297 outflow renders as **−$55066297M** — a fifty-five-trillion-dollar
day. Nothing errors. It does not look like a bug, it looks like a number.

**Missing data throws** rather than returning null, because null is
indistinguishable from a genuine zero-flow day — which is precisely how the
previous version stayed invisible for its entire life. Zero is returned as `0`.

Both live in `lib/etfFlows.ts`, pure, testable with no key and no network.
Mutations: removing the divide fails 7, returning 0 instead of throwing fails 2.

## And one I got wrong mid-change

My first version commented that `MarketProvider` needed no update because it
"tolerates a plain number". **It does not.** It read four nested shapes
(`btc?.data?.list?.[0]?.totalNetInflow` and friends), every one of which is
`undefined` on a number — so the store would never have been set, the panel
would have stayed exactly as broken, and the health table would have turned
green. Fixed, and the comment now says so.

## No key = no call

No request, no health row, no card. Not configured is not unhealthy, and
reporting it would add to the noise #176 is about. `qa` and `staging` behave
exactly as they do today.

## How to test (QA)

**Nothing to test until the owner sets the key on prod** — this is inert
everywhere else, by design.

Once set:

1. `select source, ok, consecutive_failures, last_ok_at from lhq_api_health
   where source = 'sosovalue:etf-flows';` → **`ok = true`, `last_ok_at` not null**
2. `/briefing` on prod renders the ETF Flow card, with a value in the **tens or
   hundreds**, not millions. A figure above ~10,000 means the unit conversion is
   wrong in the other direction
3. Ask AI → the context block shows `BTC ETF flow: $…M`, not `-`
4. `npm test` — 260 pass, 9 new

**Step 2's magnitude check is the real assertion.** Daily US spot ETF flows run
in the low hundreds of millions; anything much larger is a unit bug wearing a
plausible face.

## Risk level

**Medium.** Gates green (lint 0 errors, tsc, 260 tests, build), and every
decision that can be tested without a key is tested.

**Unverified: the live call.** I have no key and will not handle one. Nobody has
seen a 200 from this endpoint yet — the response *shape* is from the docs, not
from traffic. If `data` is nested differently than documented, the parse throws,
health goes red with the reason attached, and the card stays absent. That is the
designed failure, and it is the same as today's state rather than worse.

**The endpoint has never returned data to this codebase.** Treat the first prod
health row as the real test.
