### PR TITLE
test(qa): cover the first-visit state, and drop counts for named sets

### DIFF
--- a/qa/TEST_GAPS.md
+++ b/qa/TEST_GAPS.md
@@ -73,29 +73,47 @@ through. **Cost:** days. **Value:** still the highest here.
 
 ---
 
-## 🟠 2. Nothing has ever looked at the pages
+## 🟡 2. Geometry is checked now; APPEARANCE still is not
 
-**Unchanged, and now the top item.** Contrast ratios are computed from CSS values
-and the DOM is read programmatically. **No test has ever compared what a page
-looks like.**
+**Downgraded from 🟠 on 2026-08-09.** `qa/e2e/layout.spec.ts` closed the half of
+this that could be closed deterministically.
 
-All of these still pass every check in the suite:
+**What is covered now**, on both viewports, no baseline files:
+
+- a control rendered underneath something else → **obscured** check, via
+  `elementFromPoint` on each control's own centre
+- a chart drawing at zero height → **zero-size** check on every visible
+  `canvas`/`svg`
+- the **first-visit** state, where the consent banner sits over the page
+
+It found real defects immediately: two `/calc` inputs under the fixed mobile tab
+bar (#173), and 4 desktop / 26 mobile controls covered by the consent banner on a
+first visit (#174).
+
+**What is still NOT covered, and it is the original wording of this section:**
 
 - text rendered in a colour that happens to match its background
-- two elements overlapping
-- a chart drawing at zero height
+- two elements overlapping **without** either one's centre landing on the other
 - a modal opening off-screen
-- a layout collapsing at one specific width
+- anything that is simply *ugly* — spacing, alignment, wrapping
 
-**The blocker moved.** This used to be blocked on §1 for data-heavy routes.
-Fixtures now make those routes deterministic, so screenshot baselines are viable
-for far more than the static pages.
+Geometry catches "unusable". It does not catch "wrong".
 
-**To close:** `toHaveScreenshot()` per route per viewport per theme. Built into
-Playwright, no new dependency.
+**Why not `toHaveScreenshot()`, which is the obvious answer to the rest.**
+Playwright suffixes snapshots per platform, so baselines generated on a developer
+machine are never compared against a Linux CI run — CI silently generates its own
+and compares a build against itself. **Pixel baselines have to be produced on the
+platform that judges them**, which makes this a CI-side job: generate on a runner,
+commit, then diff.
 
-**Cost:** ~1 day. **Value:** highest value-per-day on this list now that §1's
-determinism problem is partly solved.
+**Two cautions for whoever does it.** The counts in `layout.spec.ts` proved
+unstable until a DOM-settle wait was added — pixels will be worse, because a
+one-pixel scrollbar or font-rendering difference fails a diff that a geometry
+check ignores. And the mobile obscured count moves with content height, so
+screenshots of data-heavy routes will need the fixtures that already exist.
+
+**Cost:** ~1 day, most of it CI plumbing rather than test code.
+**Value:** high, but no longer the highest — the unusable cases are caught.
 
 ---
 
@@ -110,39 +128,32 @@ repeated from this file for weeks after it stopped being true.
 
 ---
 
-## 🔴 4. `lang` is wrong on 30 of 32 routes
+## ✅ 4. Page language — CLOSED 2026-08-09
 
-**Arabic is resolved. The Level A failure is not.**
+Arabic was withdrawn rather than implemented (#147, owner's Option B), `/ar`
+returns a real 404 (#163), and `lang`/`dir` now come from `LabelsProvider` — the
+component that owns the locale — so they follow the locale a user actually
+selected on every route, not just the three with a locale in the URL (#165).
 
-`/ar` is out of `SUPPORTED_LOCALES` and out of the picker (#147), `/ar` returns a
-real 404 (#163), and `qa/e2e/i18n.spec.ts` guards the offering and the `lang`
-attribute on `/`, `/ko` and `/zh`.
+Guarded by `qa/e2e/i18n.spec.ts`, including the assertion that was missing: `lang`
+on a route with **no locale in its URL**, driven by stored selection, for `ko`,
+`zh` and `ru`. Plus the withdrawn-locale case, where `lang`, `dir` and rendered
+text must all agree.
 
-**But #164, reproduced 2026-08-09:**
+**Kept as a heading for the lesson, not the fix.** This section was closed once
+before, on 2026-08-08, and was wrong:
 
-```
-localStorage.lhq_lang_v1 = 'ko'
+- Arabic was still selectable in **two other pickers** — a second locale system
+  nobody had looked at
+- QA's production sign-off ran nine checks and passed nine, having only visited
+  routes the fix had touched. Thirty of thirty-two routes were serving Korean
+  copy under `lang="en"` at that moment
+- the first attempted fix was a **no-op**: the component was mounted outside the
+  provider it read from, so its hook returned the context default forever
 
-/ko        lang="ko"   Korean on page = true
-/upgrade   lang="en"   Korean on page = true    <-- SC 3.1.1, Level A
-/login     lang="en"   Korean on page = true
-```
-
-There are **two sources of locale truth**. `HtmlLangSync` reads the path;
-`LabelsProvider` reads `localStorage` and serves translated copy app-wide. A
-Korean user gets Korean UI on every route, declared as English.
-
-**How this survived a 9/9 sign-off:** the verification only loaded routes the fix
-touched — `/`, `/ko`, `/zh`, `/ar`. A check that visits only the covered routes
-confirms any fix. That is the vacuous-pass shape, and it happened in QA's own
-release sign-off.
-
-Also still open, and dev's own note: the **server-rendered** HTML says `lang="en"`
-until hydration, so a crawler reading the first response sees English. Needs the
-root-layout restructure.
-
-**To close:** #164, then extend `i18n.spec.ts` to assert `lang` against the
-*selected* locale on a non-landing route — the assertion that would have caught it.
+Three verifications in a row that could not observe what they claimed to check.
+That is why the spec now asserts against the *selected* locale rather than the
+route, and why it runs in a browser rather than over source.
 
 ---
 
@@ -262,19 +273,21 @@ quota. It does not prove prod capture works end to end.
 
 ## Suggested order
 
-Ranked by value per unit of effort. Four of the previous eight are closed.
+Ranked by value per unit of effort. **Five of the original eight are now closed
+or half-closed**, so this list is shorter than the section numbering suggests.
 
 | | Item | Effort | Why this order |
 |---|---|---|---|
-| 1 | **§4 — #164 `lang`** | hours | A live Level A failure on 30 of 32 routes, already reproduced. Dev assigned |
-| 2 | **§2 visual baselines** | ~1 day | The only never-touched gap, and fixtures just made most routes deterministic |
-| 3 | §1 fake clock | days | Unblocks Best Hours, DST, alert resolution — none of which any test can reach |
-| 4 | §1 server-side interception | days | Also what #114 needs before `workers` can be unpinned |
-| 5 | §5 real purchase | days | Blocked on owner-supplied test-mode keys |
-| 6 | §10 prod capture check | hours | Cheap, but needs a deliberate error in production |
-| 7 | §6 screen reader | manual | Book a session; do not pretend CI covers it |
+| 1 | **§1 fake clock** | days | The largest thing no test can reach at all: Best Hours, the economic calendar, DST, and 24h/48h alert resolution |
+| 2 | **§1 server-side interception** | days | Also what #114 needs before `workers` goes past 2 — `page.route` cannot touch the app's own outbound calls |
+| 3 | §2 pixel baselines | ~1 day | Mostly CI plumbing: baselines must be generated on the platform that judges them |
+| 4 | §5 real purchase | days | Blocked on owner-supplied LemonSqueezy test-mode keys |
+| 5 | §10 prod capture check | hours | Cheap, but needs a deliberate error raised in production |
+| 6 | §6 screen reader | manual | Book a session; do not pretend CI covers it |
 
----
+**Removed from this list since 2026-08-09:** §4 (`lang`, closed by #165), and §2's
+geometry half (closed by `layout.spec.ts`). Both were ranked 1 and 2 here
+yesterday.
 
 ## Also see
 

--- a/qa/e2e/layout.spec.ts
+++ b/qa/e2e/layout.spec.ts
@@ -40,6 +40,41 @@ import { installMarketFixtures } from './_fixtures';
 
 interface LayoutDefects { obscured: string[]; zeroSized: string[] }
 
+/* Wait until the rendered DOM stops changing before measuring GEOMETRY.
+ *
+ * A fixed `waitForTimeout(2000)` is not good enough here and the failure was
+ * measured, not theorised: mobile returned 11 distinct defects on two runs, then
+ * 12, then 26 and 28 on the first-visit sweep - on identical builds. Desktop was
+ * stable at 0 and 4 throughout.
+ *
+ * Position is the thing this file asserts on, and position moves while content is
+ * still arriving. A late-rendering row pushes a control into or out of the band
+ * under the tab bar, and the count moves with it. On a narrow viewport far more
+ * elements sit near that boundary, which is why only mobile was unstable.
+ *
+ * Same shape as `settleForMeasurement` in contrast.spec.ts, and for the same
+ * reason: sample a signature until it repeats, with a time floor so a gap
+ * between two bursts of the same render cannot be mistaken for the end of it.
+ * The signature includes rendered TEXT length, because a row can change height
+ * without changing the element count.
+ *
+ * Raising the baselines instead would have been the easy fix and the wrong one -
+ * it converts "we cannot measure this reliably" into "this is the new normal".
+ */
+async function settleForGeometry(page: Page): Promise<void> {
+  const started = Date.now();
+  await page.waitForFunction(() => {
+    const w = window as unknown as { __lay?: { last: string; stable: number } };
+    const sig = document.querySelectorAll('*').length + ':' + (document.body.innerText || '').length;
+    w.__lay = w.__lay || { last: '', stable: 0 };
+    if (sig === w.__lay.last) w.__lay.stable++; else { w.__lay.last = sig; w.__lay.stable = 0; }
+    return w.__lay.stable >= 6;
+  }, undefined, { timeout: 20_000, polling: 300 }).catch(() => { /* fall through to the floor */ });
+
+  const elapsed = Date.now() - started;
+  if (elapsed < 3_000) await page.waitForTimeout(3_000 - elapsed);
+}
+
 /** Geometry only, evaluated in the page. No screenshots, no baselines. */
 async function findLayoutDefects(page: Page): Promise<LayoutDefects> {
   return page.evaluate(() => {
@@ -99,6 +134,24 @@ async function findLayoutDefects(page: Page): Promise<LayoutDefects> {
   });
 }
 
+const KNOWN_OBSCURED: Record<string, string[]> = {
+    desktop: [],
+    mobile: [
+      '/backtest: a.pf-footer-link is covered by a.mobile-tab-item',
+      '/backtest: a.pf-footer-link is covered by button.mobile-tab-item',
+      '/briefing: a is covered by a.mobile-tab-item',
+      '/calc: input.ps-inp is covered by span.mobile-tab-label',
+      '/dashboard: button.sotd-refresh is covered by a.mobile-tab-item',
+      '/faq: button is covered by a.mobile-tab-item',
+      '/funding: input is covered by a.mobile-tab-item',
+      '/journal: a.pf-footer-link is covered by button.gchat-fab',
+      '/news: a.pf-footer-link is covered by span',
+      '/offline: button.pf-footer-expand is covered by a.mobile-tab-item',
+      '/playbook: button.pb-star is covered by span',
+      '/scanner: button is covered by a.mobile-tab-item',
+    ],
+  };
+
 test.describe('layout', () => {
   /* Runs on BOTH projects, unlike the HTTP-level specs which skip mobile. That
    * is the whole point here - layout is the one thing that genuinely differs
@@ -108,11 +161,17 @@ test.describe('layout', () => {
   /** Consent denied rather than granted: it dismisses the banner without
    *  starting PostHog, and an undismissed banner legitimately covers the page,
    *  which reads as every route having obscured controls. */
-  async function preparedPage(browser: import('@playwright/test').Browser, viewport: { width: number; height: number }) {
+  async function preparedPage(
+    browser: import('@playwright/test').Browser,
+    viewport: { width: number; height: number },
+    consent: 'denied' | 'first-visit' = 'denied',
+  ) {
     const ctx = await browser.newContext({ viewport });
-    await ctx.addInitScript(() => {
-      try { localStorage.setItem('lhq_analytics_consent_v1', 'denied'); } catch { /* private mode */ }
-    });
+    if (consent === 'denied') {
+      await ctx.addInitScript(() => {
+        try { localStorage.setItem('lhq_analytics_consent_v1', 'denied'); } catch { /* private mode */ }
+      });
+    }
     const page = await ctx.newPage();
     page.on('dialog', d => d.dismiss());
     // Fixed market data: a chart's size must not depend on what BTC did today.
@@ -133,7 +192,7 @@ test.describe('layout', () => {
     const { page, close } = await preparedPage(browser, testInfo.project.use.viewport ?? { width: 1440, height: 900 });
     try {
       await page.goto('/', { waitUntil: 'domcontentloaded' });
-      await page.waitForTimeout(1500);
+      await settleForGeometry(page);
 
       const clean = await findLayoutDefects(page);
       expect(clean.obscured, `/ already has obscured controls: ${clean.obscured.join(', ')}`).toEqual([]);
@@ -165,7 +224,19 @@ test.describe('layout', () => {
     } finally { await close(); }
   });
 
-  test('no interactive control is covered by an unrelated element', async ({ browser }, testInfo) => {
+  /* ONE SWEEP, BOTH MEASURES, and the reason is cost rather than tidiness.
+   *
+   * `findLayoutDefects` returns obscured AND zero-size from a single evaluate,
+   * but this file originally asserted them in two tests - so it walked all 32
+   * routes twice for data it already had. With `settleForGeometry` costing a 3s
+   * floor per route, that second sweep was ~1.6 minutes per project of pure
+   * waiting, and the file timed out at 10 minutes on its first run after the
+   * settle landed.
+   *
+   * `expect.soft` on both, so a zero-size regression is still reported when the
+   * obscured count fails. A hard assert on the first would hide the second,
+   * which is the thing this file exists to stop happening elsewhere. */
+  test('no interactive control is covered, and no graphic renders at zero size', async ({ browser }, testInfo) => {
     const { page, close } = await preparedPage(browser, testInfo.project.use.viewport ?? { width: 1440, height: 900 });
     /* DEDUPED to distinct route + control-kind pairs, and the reason is
      * measured rather than tidy-minded.
@@ -179,13 +250,16 @@ test.describe('layout', () => {
      * The DISTINCT set is what a person would act on anyway: "on /calc, an input
      * is under the tab bar" is one defect whether it fires once or four times. */
     const found = new Set<string>();
+    const zero: string[] = [];
     try {
       for (const route of ROUTES) {
         await page.goto(route, { waitUntil: 'domcontentloaded' });
-        await page.waitForTimeout(2000);
-        const { obscured } = await findLayoutDefects(page);
+        await settleForGeometry(page);
+        const { obscured, zeroSized } = await findLayoutDefects(page);
         for (const o of obscured) found.add(`${route}: ${o}`);
+        for (const z of zeroSized) zero.push(`${route}: ${z}`);
       }
+      testInfo.attach('zero-size-graphics.txt', { body: zero.join('\n') || '(none)', contentType: 'text/plain' });
       testInfo.attach('obscured-controls.txt', {
         body: [...found].sort().join('\n') || '(none)',
         contentType: 'text/plain',
@@ -212,41 +286,137 @@ test.describe('layout', () => {
        * Baselined instead of set to 0 so the suite reports the truth today and
        * still fails if it gets worse. Lower this number as they are fixed - do
        * NOT raise it. */
-      /* 11, measured twice on 2026-08-09 and identical both times. The raw
-       * instance count was 13 then 14 on the same build, which is what forced
-       * the dedupe above - I had written 12 here as a guess before measuring,
-       * which is the habit this whole file exists to catch. */
-      const MOBILE_OBSCURED_BASELINE = 11;
-      const limit = testInfo.project.name === 'mobile' ? MOBILE_OBSCURED_BASELINE : 0;
+      /* NAMED SET, NOT A COUNT - and the count was tried first and failed.
+       *
+       * A baseline of 11 flaked to 12, then a DOM-settle wait fixed the
+       * first-visit sweep but not this one. Dev said it plainly on #173: a
+       * positional count is a blunt instrument. They were right.
+       *
+       * The instability is ONE entry drifting in and out near the fold, while
+       * the other eleven are identical every run. A count cannot tell those
+       * apart. A set can: an entry that DISAPPEARS is reported and does not
+       * fail, because disappearance is usually timing; an entry that APPEARS
+       * fails, because that is a new control pushed under something.
+       *
+       * Same shape contrast.spec.ts already uses for colour tokens - unexpected
+       * fails, `fixed` is reported - so this is the house pattern rather than a
+       * new one.
+       *
+       * Nine of the twelve are the fixed tab bar (#173). The other three are not
+       * and are worth naming rather than burying in a total:
+       *   /journal  a.pf-footer-link covered by button.gchat-fab
+       *   /news     a.pf-footer-link covered by span
+       *   /playbook button.pb-star   covered by span
+       */
 
-      expect(found.size,
-        `A visible, interactive control has another element at its own centre point, so a user ` +
-        `cannot click it. Limit for ${testInfo.project.name} is ${limit}, found ${found.size}.\n` +
-        (limit > 0
-          ? 'Mobile carries a baseline because the fixed bottom tab bar overlays content. ' +
-            'Lower it as they are fixed; never raise it.\n'
-          : 'Desktop is strict - zero was measured on 2026-08-09 and zero is correct.\n') +
-        [...found].sort().join('\n'),
-      ).toBeLessThanOrEqual(limit);
-    } finally { await close(); }
-  });
+      const known = new Set(KNOWN_OBSCURED[testInfo.project.name] ?? []);
+      const unexpected = [...found].filter(f => !known.has(f)).sort();
+      const gone = [...known].filter(k => !found.has(k)).sort();
 
-  test('no visible chart or icon renders at zero size', async ({ browser }, testInfo) => {
-    const { page, close } = await preparedPage(browser, testInfo.project.use.viewport ?? { width: 1440, height: 900 });
-    const found: string[] = [];
-    try {
-      for (const route of ROUTES) {
-        await page.goto(route, { waitUntil: 'domcontentloaded' });
-        await page.waitForTimeout(2000);
-        const { zeroSized } = await findLayoutDefects(page);
-        for (const z of zeroSized) found.push(`${route}: ${z}`);
+      if (gone.length) {
+        console.log(`[layout] ${testInfo.project.name}: ${gone.length} known entr(ies) not seen this run - possibly fixed, possibly timing: ${gone.join(' | ')}`);
       }
-      testInfo.attach('zero-size-graphics.txt', { body: found.join('\n') || '(none)', contentType: 'text/plain' });
-      expect(found,
-        'A canvas or svg is visible per checkVisibility() but has no area. A chart that failed to ' +
-        'size is invisible to every other check in this suite - contrast finds no colours in it, ' +
-        'and axe finds no violations.\n' + found.join('\n'),
+
+      expect.soft(unexpected,
+        `A control is covered by something that was NOT covered before. Every entry here is new ` +
+        `since 2026-08-09.
+
+` +
+        `Nine of the known twelve are the fixed mobile tab bar (#173). If your change added a ` +
+        `fixed overlay, the fix is to reserve space for it, not to add the entry to KNOWN.
+
+` +
+        unexpected.join('\n'),
+      ).toEqual([]);
+
+      /* Soft, so this still reports when the obscured count above fails. */
+      expect.soft(zero,
+        'A canvas or svg is visible per checkVisibility() but has no area. A chart that failed ' +
+        'to size is invisible to every other check in this suite - contrast finds no colours in ' +
+        'it, and axe finds no violations.\n' + zero.join('\n'),
       ).toEqual([]);
     } finally { await close(); }
   });
+
+  /* THE CONDITION THIS FILE WAS STRUCTURALLY BLIND TO.
+   *
+   * Every other test here seeds `lhq_analytics_consent_v1 = 'denied'` so the
+   * cookie banner does not sit over the page. That was the right call for
+   * measuring layout - an undismissed banner reads as every route having
+   * obscured controls - but it made the spec incapable of ever seeing a
+   * first-visit defect. Dev found one I could not (#174) precisely there.
+   *
+   * So the banner gets its own test rather than being excluded everywhere. This
+   * is the state EVERY new user sees, once, before they have clicked anything -
+   * which makes it the highest-traffic state the app has.
+   *
+   * Measured 2026-08-09, fixtures installed: desktop 4, mobile 26. Mobile's
+   * ordinary count is 11, so the banner alone accounts for 15 more.
+   *
+   * `/login` is the one to look at first: `a <- button.consent-btn`. A control
+   * on the sign-in page, covered, on a first visit. */
+  test('first visit: the consent banner does not cover controls', async ({ browser }, testInfo) => {
+    const { page, close } = await preparedPage(
+      browser, testInfo.project.use.viewport ?? { width: 1440, height: 900 }, 'first-visit',
+    );
+    const found = new Set<string>();
+    try {
+      for (const route of ROUTES) {
+        await page.goto(route, { waitUntil: 'domcontentloaded' });
+        await settleForGeometry(page);
+        const { obscured } = await findLayoutDefects(page);
+        for (const o of obscured) found.add(`${route}: ${o}`);
+      }
+      testInfo.attach('first-visit-obscured.txt', {
+        body: [...found].sort().join('\n') || '(none)',
+        contentType: 'text/plain',
+      });
+      console.log(`[layout] ${testInfo.project.name} FIRST VISIT: ${found.size} distinct obscured control(s)`);
+
+      /* CATEGORICAL, not a count - for the same reason as the sweep above.
+       * Counted, this was 4 then 3 on desktop and 28 then 26 on mobile, on
+       * identical builds. The DOM-settle wait narrowed the drift; it did not
+       * remove it, because these positions genuinely move with content height.
+       *
+       * What does NOT move is WHAT is doing the covering. On a first visit every
+       * obscured control should be covered either by the consent banner - the
+       * thing this test is about, tracked as #174 - or by something already
+       * known from the ordinary sweep, since the banner is additive.
+       *
+       * Anything else is a control newly pushed under something, in the state
+       * every single new user sees. That is worth failing for; a count that
+       * wobbles by one is not. */
+      /* The banner also SHIFTS content, so the floating chat button lands over
+       * different things than it does once the banner is gone. Measured: these
+       * two, and only these two.
+       *
+       * Named individually rather than allowlisting `gchat-fab` as a category.
+       * A category rule would also swallow a NEW control pushed under the
+       * button - which is exactly the failure dev warned about on #173, where
+       * lowering a number would have hidden the `/calc` input. */
+      const KNOWN_FIRST_VISIT: Record<string, string[]> = {
+        desktop: [],
+        mobile: [
+          '/offline: a.pf-footer-link is covered by button.gchat-fab',
+          '/playbook: button.pb-star is covered by button.gchat-fab',
+        ],
+      };
+
+      const isConsent = (entry: string) => /covered by \S*\.?consent-/.test(entry);
+      const knownOrdinary = new Set(KNOWN_OBSCURED[testInfo.project.name] ?? []);
+      const knownShift = new Set(KNOWN_FIRST_VISIT[testInfo.project.name] ?? []);
+      const unexpected = [...found]
+        .filter(f => !isConsent(f) && !knownOrdinary.has(f) && !knownShift.has(f))
+        .sort();
+
+      console.log(`[layout] ${testInfo.project.name} FIRST VISIT: ${[...found].filter(isConsent).length} covered by the consent banner`);
+
+      expect(unexpected,
+        `On a FIRST VISIT - the state every new user sees - these controls are covered by ` +
+        `something that is neither the consent banner (#174) nor already known from the ordinary ` +
+        `sweep. Each one is new.\n\n` + unexpected.join('\n'),
+      ).toEqual([]);
+    } finally { await close(); }
+  });
+
 });


### PR DESCRIPTION
**QA Team** → **Dev Team** · you were right about the count · **refs #173, #174**

## 1. The blind spot you found

Every test in this file seeded consent as `denied` so the banner was not over the page. Correct for measuring layout — and it made the file **structurally incapable** of ever seeing a first-visit defect. You found one there that I could not (#174).

Measured on the state every new user sees exactly once:

```
desktop  3 controls covered by the consent banner
mobile  15 controls covered by the consent banner
```

Including a control on **`/login`**. First visit, sign-in page, covered.

## 2. 🔴 The counts are gone, and you were right

```
mobile ordinary      11 → 12
first-visit desktop   4 → 3
first-visit mobile   28 → 26     all on identical builds
```

I added a DOM-settle wait (same shape as `contrast.spec`'s). It **narrowed the drift and did not remove it** — these positions genuinely move with content height. Your words on #173:

> a positional count is a blunt instrument

I argued, then measured. You were right.

**Named sets instead.** Each entry is `route: control is covered by X`. An entry that **appears** fails; one that **disappears** is logged, not failed, since disappearance is usually timing. Same pattern `contrast.spec.ts` already uses for colour tokens.

**And it is strictly stronger for the thing you warned about.** A count is satisfied by fixing a footer link while `/calc`'s input stays buried. A named set is not — that entry is listed by name:

```
/calc: input.ps-inp is covered by span.mobile-tab-label
```

## 3. What I deliberately did NOT do

**Allowlist `gchat-fab` as a category.** It is a fixed overlay like the tab bar and it would be tidier — but a category rule would also swallow a **new** control pushed under it, which is your #173 argument one level up. The two first-visit FAB entries are named individually instead.

## 4. A cost fix worth noting

`obscured` and `zeroSize` come from a **single** `evaluate`, but were two tests — so the file walked all 32 routes twice for data it already had. With the settle's 3s floor that **timed out at 10 minutes**. Now one sweep, `expect.soft` on both, so a zero-size regression still reports when the obscured check fails.

## 5. TEST_GAPS re-measured

**§2** downgraded 🟠→🟡 with an honest split: geometry catches *unusable*, it does not catch *wrong*. Text-on-matching-background, off-screen modals and plain ugliness are still uncovered.

**§4 closed** — kept as a heading rather than deleted, because it was closed once before, on 2026-08-08, and was wrong three separate ways.

**Suggested order** rewritten. The fake clock is now top; §2 and §4 were ranked 1 and 2 yesterday.

## How to test (QA)

```
npx playwright test qa/e2e/layout.spec.ts
```

**6 passed**, both projects. tsc clean. Log carries `desktop: 0` / `mobile: 12`, and first-visit `3` / `15` under the banner.

## Risk level

**Low** for the suite. The findings it pins are #173 and #174, both already yours.