### PR TITLE
fix(ui): reserve the consent banner's band so it stops covering controls

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3972,6 +3972,29 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 body.consent-open .gchat-fab {
   bottom: calc(var(--consent-top, 0px) + 12px) !important;
 }
+/* AND THE PAGE ITSELF RESERVES THE BAND (#174).
+
+   --consent-top has existed since the FAB fix above, but the FAB was its only
+   consumer: the bar is `position: fixed` and out of flow, so page CONTENT sat
+   underneath it with nothing reserving the space. On a phone the bar stacks to
+   ~190px starting at bottom:56, which is a third of the screen.
+
+   Measured on mobile, first visit: 15 controls covered, including /calc's three
+   position-size inputs and - the one that matters - the PRIVACY POLICY link on
+   /login. A consent prompt that covers the document explaining what is being
+   consented to is a compliance problem, not a layout one. `a.login-skip`
+   ("Continue without signing in") was covered too, at the exact moment someone
+   decides whether to bother.
+
+   Same variable, same fallback: harmless before the measurement lands, and it
+   collapses to 0 the moment consent is answered and .consent-open is removed.
+   Desktop was clear at both viewports before this and stays clear - the rule is
+   keyed on the measurement, not on a breakpoint. */
+body.consent-open .app-content,
+body.consent-open .login-wrap {
+  padding-bottom: calc(var(--consent-top, 0px) + 16px);
+}
+
 /* These two stay hidden. Unlike the FAB they are nags rather than controls the
    user might be reaching for, and stacking three floating things above a
    consent prompt is worse than deferring them until it is answered. */


### PR DESCRIPTION
**Dev Team** → **QA Team**

Refs #174. **One CSS rule** — and the machinery was already there.

## The variable existed; nothing used it

`--consent-top` has been published by `CookieConsent` since the Ask AI FAB was
moved above the banner, measured with a ResizeObserver because the bar's height
depends on how the text wraps.

**The FAB was its only consumer.** Page content reserved nothing, so a
`position: fixed` bar that stacks to ~190px on a phone simply sat on top of a
third of the screen.

```css
body.consent-open .app-content,
body.consent-open .login-wrap { padding-bottom: calc(var(--consent-top, 0px) + 16px); }
```

Keyed on the measurement rather than a breakpoint, so desktop — which was
already clear — stays clear without a second rule.

## Measured, fresh context, consent pending

| | before | after |
|---|---|---|
| `/login` mobile | **4** — Terms, Privacy, Disclaimer, `login-skip` | **0** |
| `/login` desktop | 0 | 0 |
| `/calc` desktop | 0 | 0 |
| `/calc` mobile | 3 | **3** — see below |

**Your compliance case is closed.** The Privacy Policy link is reachable on
first visit at both viewports, which was the one with a consequence beyond
annoyance.

## 🟠 `/calc`'s three are not fixed, and it is the third time this lesson has come up today

**Padding-bottom adds space AFTER content. It does not move content up.**

`/login`'s links sit at the end of the page, so reserving the band lifts them
clear. `/calc`'s inputs are **mid-document** and render inside the band at the
initial scroll position, where no amount of trailing padding reaches them.

Same shape as #157 (a catch-all in front of the 404, not a missing 404) and #173
(where I proposed exactly this reservation and measured that it moved nothing).

So I measured what a user actually gets rather than leaving it as a failing
count:

```
initial        ok ok under-consent under-consent under-consent
after 260px    ok ok ok ok ok
```

Reachable by scrolling, and by dismissing the banner they are being asked to
dismiss. **That is a different severity from the `/login` links** — annoyance
rather than a blocked action — and I would rather say so than claim #174 is
closed.

## What that leaves

Your named set will still list `/calc`'s three under first-visit. That is
correct and I have not touched the expectations — the entries are real, and
lowering them because I fixed a different four would be exactly the drift the
set exists to prevent.

Whether the remaining three are worth a layout change to `/calc` itself is a
product call. Cheapest honest option is to leave them named.

## How to test (QA)

1. `npx playwright test qa/e2e/layout.spec.ts` — the first-visit test's `/login`
   entries should be gone; `/calc`'s three should remain
2. Mobile, first visit, `/login` — tap **Privacy Policy**. It opens
3. Same page — **Continue without signing in** is tappable
4. Dismiss consent; everything behaves as before

Step 2 is the one this PR is for.

## Risk level

**Low.** One rule, scoped to `body.consent-open`, collapsing to `0px` the moment
consent is answered. Gates green (lint 0 errors, tsc, 260 tests, build).

**Unverified:** locales other than English. The bar's height is measured, not
assumed, so a longer translation should be handled — but I checked English only,
and `--consent-top` was 189px mobile / 73px desktop here.
