### PR TITLE
fix(ops): stop a known-blocked feed burying every other failure

### DIFF
--- a/__tests__/apiHealthStatus.test.mts
+++ b/__tests__/apiHealthStatus.test.mts
@@ -1,0 +1,79 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { deriveHealthStatus, knownBlockedReason, KNOWN_BLOCKED, STATUS_RANK } from '../lib/apiHealthStatus.ts';
+
+/* #176. rss:CryptoSlate has 14,234 consecutive failures and last_ok_at NULL,
+ * and /ops sorts worst-first - so it held the top row permanently and anything
+ * that broke today appeared underneath it. QA's framing, which is the right one:
+ * a signal nobody can read stops being a signal.
+ *
+ * The feed itself is kept on purpose (lib/newsFeeds.ts, 2026-07-31): 403 from
+ * Render's datacenter IP, 200 elsewhere, so it can recover with no deploy.
+ */
+
+const base = { source: 'rss:BBC', ok: true, consecutiveFailures: 0, stale: false, successRate: null };
+
+test('ordinary sources are unchanged', async (t) => {
+  await t.test('healthy is ok', () => {
+    assert.equal(deriveHealthStatus(base), 'ok');
+  });
+
+  await t.test('three consecutive failures is down, not a blip', () => {
+    assert.equal(deriveHealthStatus({ ...base, ok: false, consecutiveFailures: 3 }), 'down');
+    assert.equal(deriveHealthStatus({ ...base, ok: false, consecutiveFailures: 2 }), 'warn');
+  });
+
+  await t.test('a low success rate warns even while the last call succeeded', () => {
+    assert.equal(deriveHealthStatus({ ...base, successRate: 79 }), 'warn');
+    assert.equal(deriveHealthStatus({ ...base, successRate: 80 }), 'ok');
+  });
+});
+
+test('a known-blocked source does not bury the others', async (t) => {
+  const cs = { ...base, source: 'rss:CryptoSlate', ok: false, consecutiveFailures: 14234 };
+
+  await t.test('it is `known`, not `down`, however high the count', () => {
+    assert.equal(deriveHealthStatus(cs), 'known');
+    assert.equal(deriveHealthStatus({ ...cs, consecutiveFailures: 999999 }), 'known');
+  });
+
+  /* The whole point: it must sort BELOW anything that might need action. */
+  await t.test('it sorts under down and warn, and above ok', () => {
+    assert.ok(STATUS_RANK.down < STATUS_RANK.known);
+    assert.ok(STATUS_RANK.warn < STATUS_RANK.known);
+    assert.ok(STATUS_RANK.known < STATUS_RANK.ok);
+  });
+
+  /* If their WAF changes it starts succeeding, and that must read as recovered
+     rather than stay flagged forever. */
+  await t.test('it goes back to ok the moment it succeeds', () => {
+    assert.equal(deriveHealthStatus({ ...cs, ok: true, consecutiveFailures: 0 }), 'ok');
+  });
+
+  /* 🔴 STALE OUTRANKS KNOWN. A known-blocked source that stops reporting at all
+     means nothing is running the check - which is a real failure wearing the
+     one label that would hide it. */
+  await t.test('stale still wins over known', () => {
+    assert.equal(deriveHealthStatus({ ...cs, stale: true }), 'warn');
+    assert.equal(deriveHealthStatus({ ...base, stale: true }), 'warn');
+  });
+});
+
+test('every known entry carries its reason', async (t) => {
+  /* An entry with no reason is indistinguishable from giving up, and this list
+     is the only place the decision is visible to whoever reads /ops. */
+  await t.test('reasons are present and specific', () => {
+    const entries = Object.entries(KNOWN_BLOCKED);
+    assert.ok(entries.length > 0);
+    for (const [source, reason] of entries) {
+      assert.ok(reason.length > 40, `${source}'s reason is too thin to act on: "${reason}"`);
+      assert.match(reason, /\d{4}-\d{2}-\d{2}|because|blocked|deliberate/i,
+        `${source}'s reason should say WHY and when it was decided`);
+    }
+  });
+
+  await t.test('an unlisted source has no reason', () => {
+    assert.equal(knownBlockedReason('rss:BBC'), undefined);
+    assert.ok(knownBlockedReason('rss:CryptoSlate'));
+  });
+});

--- a/app/api/ops/api-health/route.ts
+++ b/app/api/ops/api-health/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { deriveHealthStatus, knownBlockedReason, STATUS_RANK } from '@/lib/apiHealthStatus';
 import { withAdmin } from '@/lib/admin-auth';
 import { getSupabaseAdmin } from '@/lib/supabase-admin';
 import { T } from '@/lib/tables';
@@ -48,17 +49,18 @@ export const GET = withAdmin(async () => {
     const rate = samples > 0 ? (successes / samples) * 100 : null;
     const stale = now - new Date(r.updated_at).getTime() > STALE_MS;
 
-    // Three consecutive failures is the "this is not a blip" line - a single
-    // timeout on a flaky feed should not read the same as a retired endpoint.
-    // Staleness outranks the last outcome: a source whose last write was a
-    // success but which stopped being reported half an hour ago is not
-    // healthy, it is unmonitored.
-    const status: 'ok' | 'warn' | 'down' =
-      stale                        ? 'warn'
-      : r.consecutive_failures >= 3 ? 'down'
-      : !r.ok                       ? 'warn'
-      : rate != null && rate < 80   ? 'warn'
-      :                               'ok';
+    /* Status derivation and the known-blocked registry live in
+       lib/apiHealthStatus.ts so both are testable without a database, and so
+       the REASON a source is expected to fail sits next to the list rather
+       than in a code comment three files away. See #176. */
+    const status = deriveHealthStatus({
+      source: r.source,
+      ok: r.ok,
+      consecutiveFailures: r.consecutive_failures,
+      stale,
+      successRate: rate,
+    });
+    const knownReason = knownBlockedReason(r.source);
 
     return {
       source: r.source,
@@ -66,6 +68,10 @@ export const GET = withAdmin(async () => {
       status,
       ok: r.ok,
       detail: stale ? `no report in ${Math.round((now - new Date(r.updated_at).getTime()) / 60000)}m` : r.detail,
+      /* Sent for every known source, not only failing ones - a known-blocked
+         feed that starts succeeding means their WAF changed, and the reader
+         needs the context to recognise that as news. */
+      knownReason,
       items: r.items,
       lastOkAt: r.last_ok_at,
       lastFailAt: r.last_fail_at,
@@ -78,8 +84,11 @@ export const GET = withAdmin(async () => {
 
   // Worst first - the point of opening this card is to see what is broken,
   // not to scroll a healthy list looking for the one red row.
-  const rank = { down: 0, warn: 1, ok: 2 } as const;
-  sources.sort((a, b) => rank[a.status] - rank[b.status] || a.source.localeCompare(b.source));
+  /* `known` sorts between warn and ok: visible, but never above something
+     that might need action. Before this, CryptoSlate's 14,234 failures held
+     the top row permanently and anything that broke today appeared beneath
+     it (#176). */
+  sources.sort((a, b) => STATUS_RANK[a.status] - STATUS_RANK[b.status] || a.source.localeCompare(b.source));
 
   return NextResponse.json({
     sources,
@@ -87,6 +96,7 @@ export const GET = withAdmin(async () => {
       total: sources.length,
       down: sources.filter(s => s.status === 'down').length,
       warn: sources.filter(s => s.status === 'warn').length,
+      known: sources.filter(s => s.status === 'known').length,
       ok: sources.filter(s => s.status === 'ok').length,
     },
     generatedAt: new Date(now).toISOString(),

--- a/lib/apiHealthStatus.ts
+++ b/lib/apiHealthStatus.ts
@@ -1,0 +1,69 @@
+/* Deriving a source's status for /ops, and separating "broken" from "known".
+ *
+ * `lhq_api_health` is sorted worst-first so the first thing on screen is what is
+ * wrong. That works until a source fails FOREVER for a reason someone already
+ * investigated and accepted - then it sits permanently at the top and buries
+ * whatever broke this morning.
+ *
+ * rss:CryptoSlate is the case: 14,234 consecutive failures, `last_ok_at` NULL,
+ * and a decision recorded in lib/newsFeeds.ts on 2026-07-31 to KEEP it. It
+ * returns 403 from Render's datacenter IP and 200 from an ordinary connection -
+ * re-measured 2026-08-10, still 200 and 118KB from a home network - so it is
+ * their WAF, not our code, and it can start working again without us doing
+ * anything.
+ *
+ * Removing the feed would lose that. Hiding the row would hide a real state.
+ * So it gets its own status instead: still reported, still visible, sorted
+ * BELOW anything that might need action.
+ *
+ * The bar for adding an entry here is deliberately high. It is not "this is
+ * failing"; it is "somebody diagnosed this, wrote down why, and decided to
+ * leave it". An entry with no reason is indistinguishable from giving up.
+ */
+
+export type HealthStatus = 'down' | 'warn' | 'known' | 'ok';
+
+/** source -> why it is expected to fail. The reason is the point. */
+export const KNOWN_BLOCKED: Record<string, string> = {
+  'rss:CryptoSlate':
+    'blocked at their WAF for datacenter IPs - 403 from Render, 200 elsewhere. ' +
+    'Kept deliberately (lib/newsFeeds.ts, 2026-07-31): it can recover without a ' +
+    'deploy, and 9 other crypto feeds cover the gap.',
+};
+
+export interface HealthInput {
+  source: string;
+  ok: boolean;
+  consecutiveFailures: number;
+  /** No report in the expected window - unmonitored, which outranks the last outcome. */
+  stale: boolean;
+  /** Percentage of recent samples that succeeded, or null when there are too few. */
+  successRate: number | null;
+}
+
+/**
+ * STALE STILL OUTRANKS EVERYTHING, including `known`.
+ *
+ * A known-blocked source that stops reporting at all is a different fact from
+ * one that is reporting its expected 403: the first means nothing is running
+ * the check any more. Marking it `known` there would hide exactly the failure
+ * that matters, so staleness is tested first.
+ */
+export function deriveHealthStatus(r: HealthInput): HealthStatus {
+  if (r.stale) return 'warn';
+  if (KNOWN_BLOCKED[r.source]) return r.ok ? 'ok' : 'known';
+  if (r.consecutiveFailures >= 3) return 'down';
+  if (!r.ok) return 'warn';
+  if (r.successRate != null && r.successRate < 80) return 'warn';
+  return 'ok';
+}
+
+/* Worst first, with `known` between the things that need attention and the
+   things that are fine. Above `ok` because it IS a degraded state worth seeing;
+   below `warn` because nobody needs to act on it. */
+export const STATUS_RANK: Record<HealthStatus, number> = { down: 0, warn: 1, known: 2, ok: 3 };
+
+/** A known source recovering is worth noticing - it means their WAF changed. */
+export function knownBlockedReason(source: string): string | undefined {
+  return KNOWN_BLOCKED[source];
+}


### PR DESCRIPTION
**Dev Team** → **QA Team**

Refs #176. **The feed stays. The noise goes.**

## Re-measured before touching anything

```
from an ordinary connection   HTTP 200, 118,495 bytes
from prod (Render IP)         no CryptoSlate items
```

Which confirms the decision already recorded in `lib/newsFeeds.ts` on
2026-07-31 — their WAF blocks datacenter ranges — and it is still true ten days
later. That decision ends with *"do not remove it on the strength of a 403
alone"*, and I have not.

## Your framing is the fix

> The real cost is the noise. 14,234 failures makes this table's failure column
> useless at a glance — anything genuinely new is buried under a number that
> large.

`/ops/api-health` sorts **worst-first**, so CryptoSlate held the top row
permanently. A source that has failed 14,234 times needs no attention; the one
that failed three times this morning does, and it appeared underneath.

So: a **`known`** status. Still reported, still visible, sorted between `warn`
and `ok` — above healthy because it is genuinely degraded, below anything
actionable because nobody needs to act on it.

## 🔴 The invariant I would ask you to try to break

**Stale outranks known.**

A known-blocked source that stops reporting **at all** means nothing is running
the check any more. That is a real failure, and `known` is the one label that
would hide it perfectly. So staleness is tested first, and the mutation that
swaps those two checks fails 2 assertions.

That was the trap in this change and it is the reason the derivation is a pure
function rather than three more lines in the route.

## Reasons are mandatory

`KNOWN_BLOCKED` maps source → why, and a test asserts each reason is substantial
and says when the call was made. An entry with no reason is indistinguishable
from giving up, and this list is the only place that decision is visible to
whoever opens `/ops` in six months.

Bar for adding one: not *"this is failing"* but *"somebody diagnosed this, wrote
down why, and decided to leave it."*

## It un-flags itself

If their WAF changes, the feed succeeds and the status returns to `ok`
immediately — no deploy, no list edit. `knownReason` is sent for every known
source regardless of state, so a reader seeing it green still has the context to
recognise that as news.

## How to test (QA)

1. `/ops` → API health. **CryptoSlate is no longer the first row**, and shows
   `known` with its reason rather than `down`
2. Anything genuinely failing now sorts above it
3. `npm test` — 272 pass, 12 new

Step 2 is the assertion. Step 1 without step 2 is cosmetic.

## Risk level

**Low.** Read-only ops endpoint, no change to what is recorded — only how it is
classified and ordered. Gates green (lint 0 errors, tsc, 272 tests, build).

**Unverified:** the `/ops` card's own rendering. I changed the payload — added
`knownReason` and a `known` count in the summary — and did not open the page. If
the client switches exhaustively on status, `known` may need handling there; if
it falls through to a default, it will look unstyled rather than broken.
