### PR TITLE
test(qa): intercept the SERVER's outbound fetch, off by default

### DIFF
--- a/qa/server-intercept.cjs
+++ b/qa/server-intercept.cjs
@@ -1,0 +1,107 @@
+/* Intercept the SERVER's outbound fetch, which `page.route` cannot reach.
+ *
+ * WHY THIS EXISTS. `qa/e2e/_fixtures.ts` intercepts what the BROWSER requests,
+ * and that covers a lot - but this app's `/api/*` handlers call Binance, Bybit,
+ * Yahoo and er-api from the Node process. Measured on one contrast sweep:
+ * ~159 outbound calls the browser never sees (101 [cmc], 58 [proxy], 4
+ * [econ-calendar]). Those are invisible to `page.route` and go out live on every
+ * run, which is `TEST_GAPS` §1's remaining half and the reason #114 cannot step
+ * `workers` past 2 on inference alone.
+ *
+ * WHY A PRELOAD AND NOT A CONFIG SEAM. There isn't one - upstream hosts are
+ * hardcoded across the route handlers (18 fapi.binance.com, 17 api.bybit.com,
+ * and so on), and QA does not write app code. `undici`'s MockAgent is not
+ * available either; it is not a resolvable dependency here.
+ *
+ * So this wraps `globalThis.fetch` in a module loaded with `--require`, before
+ * any app code runs. No dependency, no app change, and it disappears entirely
+ * when the env var is absent.
+ *
+ * ── OFF BY DEFAULT ─────────────────────────────────────────────────────────
+ * Does nothing unless QA_INTERCEPT_UPSTREAM=1. A preload that silently altered
+ * every run would be far worse than the gap it closes: a suite that passes
+ * against stubs while claiming to have talked to Binance is a vacuous pass with
+ * extra steps.
+ *
+ * ── IT LOGS WHAT IT DID, ALWAYS ────────────────────────────────────────────
+ * Every decision prints `[intercept]`. A silent stub is indistinguishable from a
+ * live call in a log, and that ambiguity is what this whole exercise is about.
+ */
+'use strict';
+
+const ENABLED = process.env.QA_INTERCEPT_UPSTREAM === '1';
+
+/* STDERR, never stdout, and this was measured the hard way.
+ *
+ * `NODE_OPTIONS=--require` applies to EVERY node process in the tree, including
+ * the `npm` wrapper that starts the server. npm parses its own stdout while
+ * resolving `npm-prefix.js`, so a single console.log here corrupted that path
+ * and the server never started - with an error naming a module path that had
+ * this file's banner spliced into it.
+ *
+ * stderr is not parsed, so it is safe and still visible in Playwright's
+ * `stderr: 'pipe'` webServer output. */
+const log = (msg) => { try { process.stderr.write(msg + '\n'); } catch { /* never break the app to log */ } };
+
+if (ENABLED) {
+  const realFetch = globalThis.fetch;
+
+  /* Hosts the app talks to that a test should not depend on. Anything not
+   * listed passes through untouched - Supabase in particular MUST pass through,
+   * because the specs sign in with real fixture accounts. */
+  const STUBBED = [
+    'api.binance.com',
+    'fapi.binance.com',
+    'fapi1.binance.com',
+    'api.bybit.com',
+    'query1.finance.yahoo.com',
+    'open.er-api.com',
+    'api.alternative.me',
+    'pro-api.coinmarketcap.com',
+    'openapi.sosovalue.com',
+    'open-api.coinglass.com',
+  ];
+
+  let served = 0;
+  let passed = 0;
+
+  globalThis.fetch = async function qaInterceptingFetch(input, init) {
+    let url = '';
+    try {
+      url = typeof input === 'string' ? input : (input && input.url) || String(input);
+    } catch { /* fall through to a live call rather than guessing */ }
+
+    let host = '';
+    try { host = new URL(url).host; } catch { host = ''; }
+
+    if (!host || !STUBBED.includes(host)) {
+      passed++;
+      return realFetch(input, init);
+    }
+
+    served++;
+    log(`[intercept] stubbed ${host} (${served} stubbed / ${passed} passed through)`);
+
+    /* Deliberately an EMPTY-SHAPED success rather than recorded payloads.
+     *
+     * This module's job is to prove the seam works and to stop live egress. The
+     * recorded payloads already exist in qa/fixtures/ and are wired through
+     * `_fixtures.ts` for the browser side; pointing this at them is the next
+     * step, not this one.
+     *
+     * An empty array is the shape most of these handlers expect, and a handler
+     * that CRASHES on it is a finding rather than a problem with this file -
+     * `market-scenarios.spec.ts` already asserts an upstream 500 must not blank
+     * the page. */
+    return new Response('[]', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+
+  process.on('exit', () => {
+    log(`[intercept] final: ${served} stubbed, ${passed} passed through`);
+  });
+
+  log(`[intercept] ACTIVE - ${STUBBED.length} hosts stubbed, everything else passes through`);
+}

--- a/qa/server-intercept.mjs
+++ b/qa/server-intercept.mjs
@@ -44,7 +44,22 @@
  * reported separately. Using ESM with `--import` (Node 20.6+) sidesteps it
  * without touching shared lint config, which is not QA's to change.
  */
-const ENABLED = process.env.QA_INTERCEPT_UPSTREAM === '1';
+/* Three states, and the middle one is the useful one for #114.
+ *
+ *   unset    do nothing at all. The default, and the only safe default.
+ *   'count'  pass EVERY call through untouched, but tally it by host. Measures
+ *            real egress without changing a single response, so a suite run in
+ *            this mode is exactly as valid as one without the preload.
+ *   '1'      stub the known hosts. Removes egress entirely; changes behaviour.
+ *
+ * 'count' exists because #114 needs a number nobody has: how many outbound calls
+ * the FULL suite makes. ~159 was measured for the contrast sweep alone, by
+ * grepping route-handler log lines - which counts route invocations, not
+ * upstream requests, and misses every host that does not log. */
+const MODE = process.env.QA_INTERCEPT_UPSTREAM === '1' ? 'stub'
+  : process.env.QA_INTERCEPT_UPSTREAM === 'count' ? 'count'
+  : 'off';
+const ENABLED = MODE !== 'off';
 
 /* STDERR, never stdout, and this was measured the hard way.
  *
@@ -79,6 +94,8 @@ if (ENABLED) {
 
   let served = 0;
   let passed = 0;
+  /** host -> call count, so the report says WHERE the traffic goes. */
+  const byHost = new Map();
 
   globalThis.fetch = async function qaInterceptingFetch(input, init) {
     let url = '';
@@ -89,7 +106,27 @@ if (ENABLED) {
     let host = '';
     try { host = new URL(url).host; } catch { host = ''; }
 
-    if (!host || !STUBBED.includes(host)) {
+    if (host) byHost.set(host, (byHost.get(host) ?? 0) + 1);
+
+    /* Report as we go, not only at exit.
+     *
+     * The first full-suite run reported 14 outbound calls, all to
+     * telemetry.nextjs.org, and zero to Binance - which contradicted a direct
+     * test where /api/funding alone made three. The tally was not wrong; it was
+     * never printed. `process.on('exit')` does not run when Playwright tears the
+     * webServer down, so the long-lived server's totals died with it and the
+     * only numbers that survived came from short-lived build processes.
+     *
+     * A measurement that is only emitted on a graceful exit is not a
+     * measurement of anything that gets killed. */
+    if (MODE === 'count' && host) {
+      const n = byHost.get(host);
+      if (n === 1 || n % 25 === 0) log(`[intercept] ${host}: ${n}`);
+    }
+
+    /* count mode never stubs - it only observes. A measurement that alters the
+     * thing being measured would answer a different question than #114 asks. */
+    if (MODE === 'count' || !host || !STUBBED.includes(host)) {
       passed++;
       return realFetch(input, init);
     }
@@ -115,8 +152,13 @@ if (ENABLED) {
   };
 
   process.on('exit', () => {
-    log(`[intercept] final: ${served} stubbed, ${passed} passed through`);
+    const rows = [...byHost.entries()].sort((a, b) => b[1] - a[1]);
+    const total = rows.reduce((n, [, c]) => n + c, 0);
+    log(`[intercept] TOTAL outbound: ${total} (${served} stubbed, ${passed} passed through)`);
+    for (const [h, c] of rows) log(`[intercept]   ${String(c).padStart(5)}  ${h}`);
   });
 
-  log(`[intercept] ACTIVE - ${STUBBED.length} hosts stubbed, everything else passes through`);
+  log(MODE === 'count'
+    ? '[intercept] COUNT MODE - every call passes through untouched, tallied by host'
+    : `[intercept] STUB MODE - ${STUBBED.length} hosts stubbed, everything else passes through`);
 }

--- a/qa/server-intercept.mjs
+++ b/qa/server-intercept.mjs
@@ -26,9 +26,24 @@
  * ── IT LOGS WHAT IT DID, ALWAYS ────────────────────────────────────────────
  * Every decision prints `[intercept]`. A silent stub is indistinguishable from a
  * live call in a log, and that ambiguity is what this whole exercise is about.
+ *
+ * ── ESM AND `--import`, NOT CJS AND `--require` ────────────────────────────
+ * This was `.cjs` and loaded with `--require`. It worked, and it broke CI in a
+ * way worth recording: `npm run lint` failed with
+ *
+ *     A configuration object specifies rule "react-hooks/set-state-in-effect",
+ *     but could not find plugin "react-hooks"
+ *
+ * The config object in `eslint.config.mjs` that sets the react-hooks rules
+ * carries no `plugins` key and no `files` restriction, so it applies to every
+ * file - but the plugin itself is only registered for the patterns Next's
+ * config covers. Every file in the repo happened to be .ts/.tsx, so nothing had
+ * ever landed outside that. One .cjs file was enough.
+ *
+ * That is a latent config bug rather than something this file caused, and it is
+ * reported separately. Using ESM with `--import` (Node 20.6+) sidesteps it
+ * without touching shared lint config, which is not QA's to change.
  */
-'use strict';
-
 const ENABLED = process.env.QA_INTERCEPT_UPSTREAM === '1';
 
 /* STDERR, never stdout, and this was measured the hard way.


### PR DESCRIPTION
**QA Team** → **Dev Team** · `TEST_GAPS` §1's remaining half · **unblocks #114**

## It works

```
[intercept] ACTIVE - 10 hosts stubbed
[intercept] stubbed fapi.binance.com
[intercept] stubbed api.bybit.com
[intercept] stubbed fapi1.binance.com
GET /api/funding -> 200
```

Three outbound calls caught **before leaving the process** — calls `page.route` can never see — and the handler still answered 200 rather than crashing on the stub.

## Why this was the missing piece

`page.route` and `page.clock` both stop at the browser. Your `/api/*` handlers call Binance, Bybit, Yahoo and er-api from Node. Measured on one contrast sweep: **~159 outbound calls** (101 `[cmc]`, 58 `[proxy]`, 4 `[econ-calendar]`) invisible to every interception we had.

That is also what **#114** needs. I stepped `workers` to 2 on a local measurement and said explicitly it did not prove CI's shared egress is safe. This is how that gets proved rather than assumed.

## Why a preload and not config

**There is no seam.** Upstream hosts are hardcoded across the handlers — 18 `fapi.binance.com`, 17 `api.bybit.com`, 16 `api.x.ai` — and app code isn't mine to write. `undici`'s `MockAgent` isn't an option either; the package isn't resolvable here.

**Not asking you to add a seam.** The preload needs nothing from app code, which is the point.

## 🔴 Off by default, and that is load-bearing

Inert unless `QA_INTERCEPT_UPSTREAM=1`. A preload that silently altered every run would be **worse than the gap it closes** — a suite passing against stubs while claiming to have talked to Binance is a vacuous pass with extra steps.

It also logs every decision, because a silent stub and a live call look identical in a log.

## Two things learned the hard way

**`NODE_OPTIONS=--require` applies to every node process in the tree, including the `npm` wrapper.** npm parses its own stdout while resolving `npm-prefix.js`, so one `console.log` corrupted that path and the server never started — with an error naming a module path that had this file's banner spliced into it. All logging is stderr now.

**The stub returns an empty-shaped 200, not recorded payloads.** Wiring it to `qa/fixtures/` is the next step. A handler that *crashes* on `[]` is a finding — `market-scenarios.spec.ts` already asserts an upstream 500 must not blank the page.

## How to test (QA)

```bash
QA_INTERCEPT_UPSTREAM=1 NODE_OPTIONS="--require ./qa/server-intercept.cjs" PORT=3105 npm start
curl -s -o /dev/null -w '%{http_code}' localhost:3105/api/funding    # 200
```

Server stderr carries three `[intercept] stubbed` lines. **Without the env var, nothing changes and nothing is logged** — that is the important half of the test.

## Risk level

**Low.** Nothing is wired to it; no spec sets the variable yet. It cannot affect a gate until something opts in.