### PR TITLE
fix(ci): scope the react-hooks rules to files the plugin covers

### DIFF
--- a/__tests__/eslintConfigScope.test.mts
+++ b/__tests__/eslintConfigScope.test.mts
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+/* #184. A config object that names a plugin-namespaced rule without either
+ * declaring that plugin OR restricting `files` applies to EVERY file ESLint
+ * visits — and on any file the plugin is not registered for, ESLint treats it
+ * as a configuration error:
+ *
+ *   A configuration object specifies rule "react-hooks/set-state-in-effect",
+ *   but could not find plugin "react-hooks".
+ *
+ * It exits 2, so `npm run lint` fails and the build job with it.
+ *
+ * Nothing had ever triggered it because every file in the repo happened to be
+ * .ts or .tsx. QA hit it on a PR that was `dev` plus one `.cjs` file — CI red
+ * on a branch that changed no code.
+ *
+ * This asserts the INVARIANT rather than the one object that was wrong, because
+ * the next block someone appends will be written by copying a neighbour, and
+ * the neighbour that was wrong looked exactly like the ones that were right.
+ */
+test('every namespaced rule is scoped to files the plugin covers', async () => {
+  const config = (await import('../eslint.config.mjs')).default as Array<Record<string, unknown>>;
+
+  assert.ok(Array.isArray(config) && config.length > 0, 'eslint config did not load as an array');
+
+  const offenders: string[] = [];
+
+  for (const [i, block] of config.entries()) {
+    const rules = block?.rules as Record<string, unknown> | undefined;
+    if (!rules) continue;
+
+    /* Namespaced = "plugin/rule". Core rules have no slash and are always in
+       scope, so they need neither a plugins key nor a files restriction.
+
+       SCOPED PLUGIN NAMES CONTAIN A SLASH. `@next/next/no-html-link-for-pages`
+       belongs to the plugin `@next/next`, not `@next` - splitting on the first
+       slash reports a block that correctly declares its plugin. That was this
+       test's first result, and the config was right. */
+    const nsOf = (rule: string) => {
+      const parts = rule.split('/');
+      return rule.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0];
+    };
+    const namespaces = new Set(
+      Object.keys(rules).filter(k => k.includes('/')).map(nsOf),
+    );
+    if (namespaces.size === 0) continue;
+
+    const declared = new Set(Object.keys((block?.plugins as object) ?? {}));
+    const hasFiles = Array.isArray(block?.files) && (block.files as unknown[]).length > 0;
+    if (hasFiles) continue;   // scoped: whatever registers the plugin also matches
+
+    for (const ns of namespaces) {
+      if (!declared.has(ns)) {
+        offenders.push(`config[${i}] uses "${ns}/*" rules with neither a plugins entry nor a files restriction`);
+      }
+    }
+  }
+
+  assert.deepEqual(offenders, [],
+    'These blocks apply to every file ESLint visits, including ones the plugin is ' +
+    'not registered for, where ESLint exits 2 rather than skipping the rule:\n' +
+    offenders.join('\n'));
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,6 +21,27 @@ const eslintConfig = defineConfig([
   },
 
   {
+    /* SCOPED TO THE FILES THE PLUGIN IS REGISTERED FOR (#184).
+
+       Without this `files` key the object applies to EVERY file ESLint visits.
+       `react-hooks` is only registered by eslint-config-next for js/jsx/ts/tsx,
+       so on anything else these rules reference a plugin that is not in scope -
+       and ESLint treats that as a configuration ERROR, not a skipped rule:
+
+         A configuration object specifies rule "react-hooks/set-state-in-effect",
+         but could not find plugin "react-hooks".
+
+       It exits 2, so `npm run lint` fails and takes the build job with it.
+
+       Nothing had ever triggered it because every file in the repo happened to
+       be .ts or .tsx. The first .cjs anyone adds turns the lint gate red on a
+       branch that changed no code - which is how QA found it, on a PR that was
+       `dev` plus one new file.
+
+       The block below this one already does exactly this, with both `plugins`
+       and `files`. This one was the outlier. */
+    files: ['**/*.{js,jsx,ts,tsx,mjs}'],
+
     // ── Pre-existing backlog, deliberately non-blocking ────────────────────
     // eslint-plugin-react-hooks v6 ships the React Compiler rule set, which
     // flags patterns this app has used since before the rules existed. The


### PR DESCRIPTION
**Dev Team** → **QA Team**

Refs #184. **One `files` key.** Reproduced first, verified after.

```
before   npx eslint probe.cjs  ->  "could not find plugin react-hooks", exit 2
after    npx eslint probe.cjs  ->  clean, exit 0
```

Your diagnosis was exactly right, including the cause. The block below it
already did this with both `plugins` and `files`; the react-hooks one was the
outlier.

## The rules still fire — checked, because "fixed by disabling" is the obvious wrong fix

```
before   140 warnings repo-wide, 94 react-hooks
after    140 warnings repo-wide, 94 react-hooks
```

Identical. The change removes a crash, not coverage. Scoping to a `files`
pattern that excludes `.tsx` would also have made your reproduction pass, and
would have silently switched off the backlog this repo is deliberately tracking.

## The test asserts the invariant, not the block

Any config object naming a plugin-namespaced rule must **either** declare that
plugin **or** restrict `files`. Not "this one block has a files key" — the next
block will be written by copying a neighbour, and **the neighbour that was wrong
looked exactly like the ones that were right.**

## 🟠 And it reported a second offender on its first run, wrongly

```
config[3] uses "@next/*" rules with neither a plugins entry nor a files restriction
```

The config was correct; **my test was wrong.** Scoped plugin names contain a
slash, so `@next/next/no-html-link-for-pages` belongs to the plugin `@next/next`,
not `@next`. Splitting on the first slash reported a block that declares its
plugin properly.

Fixed in the test with the reason in a comment. Worth flagging because a
config-scanning test that cries wolf gets deleted, and this one would have on
its first CI run.

## How to test (QA)

```bash
echo "// x" > probe.cjs && npx eslint probe.cjs; echo $?   # 0, no plugin error
rm probe.cjs
npm run lint    # 140 warnings, 0 errors — unchanged
npm test        # 273 pass, 1 new
```

Your original repro is the first line. If you still have that `.cjs` branch, it
is worth re-running there rather than on a fresh file.

## Risk level

**Low.** Config scoping only. Gates green (lint 0 errors, tsc, 273 tests,
build).

Mutation verified both ways: removing the `files` key fails the new test **and**
reproduces the original ESLint error on a `.cjs` file — so the test is tied to
the real behaviour rather than to the shape of the config.
