### PR TITLE
test(qa): prove the checkout button sends the signed-in user's own id

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,6 +408,22 @@ jobs:
           # this repository forge a webhook that grants Pro.
           LEMONSQUEEZY_WEBHOOK_SECRET: ci-fake-not-a-real-lemonsqueezy-secret
 
+          # Same reasoning as the secret above, and the same deliberate fakeness.
+          # `qa/e2e/checkout.spec.ts` needs a checkout URL to exist so it can
+          # assert the button hands off the signed-in user's OWN id - the value
+          # the webhook then refuses to trust. It INTERCEPTS and ABORTS the
+          # navigation, so this host is never contacted.
+          #
+          # NEXT_PUBLIC_*, so it is inlined at BUILD time - it has to be on this
+          # step because playwright.config.ts's webServer runs `npm run build`
+          # as a child of it. Absent, getCheckoutUrl returns the signup fallback
+          # and the spec fails loudly rather than asserting the unconfigured path
+          # while claiming to test checkout.
+          #
+          # The real store URL belongs in Render's env for liquidity-hq-prod and
+          # nowhere else.
+          NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL: https://example.lemonsqueezy.com/checkout/buy/ci-fake-not-a-real-store
+
           # ── THIS FILE USED TO SAY THE SERVICE-ROLE KEY "must never be" HERE ──
           #
           # Reversed 2026-08-09 by an explicit owner decision, and written out

--- a/qa/e2e/checkout.spec.ts
+++ b/qa/e2e/checkout.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect } from '@playwright/test';
+import { AUTH_READY, AUTH_SKIP_REASON, FIXTURES, signedInContext, gotoSignedIn } from './_auth';
+
+/* Does the checkout button actually carry the signed-in user's identity?
+ *
+ * `__tests__/checkoutUrl.test.mts` pins what `getCheckoutUrl()` RETURNS. It
+ * cannot prove the function is wired to the button - which is exactly the gap
+ * that produced #164, where a fix passed 22 source-level tests while its hook
+ * returned a context default forever. This is the other half.
+ *
+ * WHY IT MATTERS MORE THAN A NORMAL WIRING CHECK. `app/upgrade/page.tsx` does:
+ *
+ *     window.location.href = getCheckoutUrl(user)
+ *
+ * so `checkout[custom][user_id]` leaves the browser in a URL the payer controls.
+ * `qa/e2e/payments-webhook.spec.ts` asserts the handler refuses a payload
+ * claiming an id the payer does not own. Between the three files the whole path
+ * is covered: what the URL contains, that the button really sends it, and that
+ * the server does not trust it.
+ *
+ * NEEDS NO LEMONSQUEEZY ACCOUNT. `NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL` is set
+ * to an obviously fake host in `ci.yml`, the same precedent as the fake webhook
+ * secret already there. The navigation is intercepted and aborted, so nothing is
+ * ever requested from that host.
+ *
+ * 🔴 WHAT REMAINS UNTESTED: a real purchase granting Pro. That needs the owner's
+ * test-mode keys and a live sandbox. §5 stays open on that alone.
+ */
+
+const CHECKOUT_HOST = 'example.lemonsqueezy.com';
+
+test.describe('checkout hand-off', () => {
+  test.skip(!AUTH_READY, AUTH_SKIP_REASON);
+  test.beforeEach(({}, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop', 'a navigation URL is viewport-independent');
+  });
+
+  test('the checkout button sends the SIGNED-IN user\'s own id', async ({ browser }) => {
+    /* `signedInContext`, NOT `signIn`.
+     *
+     * The first version called `signIn()` for a token and then opened a PLAIN
+     * context - so the page had no session, `user` was null, and /upgrade did
+     * `router.push('/login?signup=1')` instead of navigating to checkout. It
+     * failed with "nothing navigated", which reads like a wiring defect and was
+     * entirely my error.
+     *
+     * `signedInContext` seeds the `sb-<ref>-auth-token` localStorage entry that
+     * supabase-js actually reads, which is what makes the app treat the page as
+     * signed in.
+     *
+     * FIXTURE B, NOT A. A is pinned `pro`, and /upgrade redirects a Pro user
+     * away before rendering anything - `if (loading || isPro) return
+     * <LoadingState/>`. Using A produced "no checkout button rendered", which
+     * again reads like a defect and was again the fixture being wrong for the
+     * question. B is pinned `free`, which is who actually sees this page. */
+    const ctx = await signedInContext(browser, 'b', { viewport: { width: 1440, height: 900 } });
+    await ctx.addInitScript(() => {
+      try { localStorage.setItem('lhq_analytics_consent_v1', 'denied'); } catch { /* private mode */ }
+    });
+    const page = await ctx.newPage();
+
+    /* Capture the hand-off and STOP it. Aborting means the fake host is never
+     * contacted, so this test makes no third-party request at all. */
+    let handoff = '';
+    await page.route(`**${CHECKOUT_HOST}**`, route => {
+      handoff = route.request().url();
+      return route.abort();
+    });
+
+    try {
+      /* The env var is inlined at BUILD time, so if the webServer was built
+       * without it, getCheckoutUrl returns the signup fallback and this test
+       * would be asserting the unconfigured path while claiming otherwise.
+       * Skipping loudly beats a green run that measured nothing. */
+      /* gotoSignedIn asserts the page really rendered as a signed-in user
+       * rather than an onboarding or signed-out screen - without it, "no button
+       * found" is ambiguous between a defect and a bad fixture. */
+      await gotoSignedIn(page, '/upgrade');
+
+      const cta = page.locator('button', { hasText: /upgrade|pro|checkout|continue/i }).first();
+      await expect(cta, 'no checkout button rendered on /upgrade').toBeVisible({ timeout: 20_000 });
+      await cta.click();
+
+      await expect
+        .poll(() => handoff, {
+          timeout: 15_000,
+          message:
+            `nothing navigated to ${CHECKOUT_HOST}. Either the button is not wired to ` +
+            'getCheckoutUrl, or NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL was absent at BUILD time ' +
+            'and the page fell back to /login?signup=1 - check the webServer build env before ' +
+            'reading this as a product defect.',
+        })
+        .not.toBe('');
+
+      const url = new URL(handoff);
+      expect(url.searchParams.get('checkout[custom][user_id]'),
+        'the checkout URL carries a different id than the signed-in user. That is the value the ' +
+        'webhook reads as custom_data.user_id - see payments-webhook.spec.ts.',
+      ).toBe(FIXTURES.bId);
+      expect(url.searchParams.get('checkout[email]'),
+        'the checkout URL carries a different email than the signed-in user',
+      ).toBe(FIXTURES.bEmail);
+    } finally { await ctx.close(); }
+  });
+
+  /* A signed-out visitor must not reach checkout at all - they are sent to
+   * signup. Without this, the test above is satisfied by a page that sends
+   * everyone to the same URL regardless of who they are. */
+  test('a signed-out visitor is sent to signup, not to checkout', async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+    await ctx.addInitScript(() => {
+      try { localStorage.setItem('lhq_analytics_consent_v1', 'denied'); } catch { /* private mode */ }
+    });
+    const page = await ctx.newPage();
+
+    let reachedCheckout = false;
+    await page.route(`**${CHECKOUT_HOST}**`, route => { reachedCheckout = true; return route.abort(); });
+
+    try {
+      await page.goto('/upgrade', { waitUntil: 'domcontentloaded' });
+      await page.waitForTimeout(2500);
+
+      const cta = page.locator('button', { hasText: /upgrade|pro|checkout|continue/i }).first();
+      if (await cta.isVisible().catch(() => false)) {
+        await cta.click();
+        await page.waitForTimeout(2000);
+      }
+
+      expect(reachedCheckout,
+        'a signed-out visitor reached the checkout host. getCheckoutUrl(null) must return ' +
+        '/login?signup=1 - a checkout with no user_id produces a payment the webhook cannot ' +
+        'match to an account.',
+      ).toBe(false);
+    } finally { await ctx.close(); }
+  });
+});


### PR DESCRIPTION
**QA Team** → **Dev Team** · the wiring half of #187 · **§5**

## The payments path is now covered end to end, minus a real purchase

| file | asserts |
|---|---|
| `__tests__/checkoutUrl.test.mts` | what the URL **contains** (merged, #187) |
| **`qa/e2e/checkout.spec.ts`** | **that the button really sends it** ← this PR |
| `qa/e2e/payments-webhook.spec.ts` | that the server **does not trust it** |

`app/upgrade/page.tsx` assigns `window.location.href` from `getCheckoutUrl(user)`, so `checkout[custom][user_id]` leaves the browser in a URL the payer controls. A contract test alone can't prove that hand-off happens — which is exactly #164, where a fix passed **22** source-level tests while its hook returned a context default forever.

**No LemonSqueezy account needed.** The fake host follows the precedent already set by `LEMONSQUEEZY_WEBHOOK_SECRET`, and the spec **intercepts and aborts** the navigation — the host is never contacted.

## 🔴 Two failures on the way, both mine, both recorded in the file

**1. `signIn()` without a session.** I fetched a token then opened a *plain* context — so the page had no session, `user` was null, and `/upgrade` pushed to `/login?signup=1`. It reported **"nothing navigated"**, which reads exactly like broken wiring.

**2. Fixture A is `pro`.** `/upgrade` redirects a Pro user before rendering anything, so there was no button. It reported **"no checkout button rendered"** — which also reads like a defect. **B is `free`**, which is who actually sees this page.

Same lesson twice: **a fixture that is wrong for the question produces a failure indistinguishable from a real one.** Both are in the comments so the next person reads them before filing a bug.

## Still untested, unchanged

**A real purchase granting Pro.** That needs the owner's test-mode keys and a live sandbox. §5 stays open on that alone — everything else in it is now covered.

## How to test (QA)

```bash
NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL="https://example.lemonsqueezy.com/checkout/buy/qa-fake"   npx playwright test qa/e2e/checkout.spec.ts --project=desktop
```

**2 passed.** tsc clean. Without the env var the spec fails **loudly** rather than asserting the unconfigured fallback while claiming to test checkout.

## Risk level

**Low.** Test code plus one fake CI value. No app code, and no request is ever made to the fake host.