### PR TITLE
docs(onboarding): record the three measured dead ends on the consent bar

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3995,6 +3995,51 @@ body.consent-open .login-wrap {
   padding-bottom: calc(var(--consent-top, 0px) + 16px);
 }
 
+/* WHAT IS LEFT OF #174 IS NOT FIXABLE BY RESERVING SPACE, AND THE MEASUREMENT
+   SAYS SO. Recorded here because the obvious next patch is to shrink the box
+   that `.login-wrap` centres in, and that provably does nothing.
+
+   Measured at 390x664 - Playwright's iPhone 13 viewport, and the only one where
+   this reproduces; at 390x844 /login is clear either way:
+
+     .login-wrap   height 877px    <- content-driven
+                   min-height 478px (72vh)   <- never the binding constraint
+     viewport      664px
+
+   The login content is already TALLER than the screen, so `justify-content:
+   center` is not centring anything and reducing min-height moves nothing. Tried
+   it, measured it, count did not change.
+
+   The rule above is still the fix that mattered. With it, /login scrolls 213px
+   against a 189px bar and all three legal links can be brought into the clear.
+   Without it, /login scrolls 24px and those three are UNREACHABLE AT EVERY
+   SCROLL POSITION - measured both ways.
+
+   What remains is that they START under the bar on first visit. Three ways to
+   fix that were tried and measured against a stable baseline of 22 controls
+   covered across 10 routes. All three are recorded because each one is the
+   obvious next idea:
+
+     1. Shrink the box `.login-wrap` centres in.  NO CHANGE.
+        min-height is not the binding constraint - see above.
+
+     2. Move the bar over the tab bar (`bottom: 0`, saving its 56px).
+        22 -> 57, and the four `.mobile-tab-item` links become UNREACHABLE AT
+        EVERY SCROLL POSITION. A fixed element cannot be scrolled out from under
+        another fixed element, so this trades a first-visit annoyance for losing
+        the whole nav until consent is answered. Strictly worse.
+
+     3. Shorten the consent copy. ~18px at best - the text is 54px over 3 lines
+        at 178 characters, and 12px padding + 44px buttons are a touch-target
+        floor, not a style choice. Moves the bar top 475 -> 493 while the
+        contested band is 477..524, so the count does not move.
+
+   So the bar occupies the bottom 189px of a 664px viewport and content in that
+   band starts covered. That is what a bottom sheet does. It is one tap to
+   dismiss, permanently, and the banner carries its own Privacy Policy link
+   (`components/CookieConsent.tsx`) - so the covered legal links are duplicates
+   of one that is not covered. */
+
 /* These two stay hidden. Unlike the FAB they are nags rather than controls the
    user might be reaching for, and stacking three floating things above a
    consent prompt is worse than deferring them until it is answered. */


### PR DESCRIPTION
**Dev Team** · closes the investigation half of #174

## Summary

Comment-only change. **No CSS rule is added, removed or altered** — the file's
behaviour is byte-identical. The deliverable is the measurements.

The owner asked for #174 to be fixed. It turns out the half that mattered was
already fixed by #180, and the remaining half is not fixable by layout. Rather
than ship a cosmetic change to look busy, this records what was tried and what
each attempt measured, next to the rule it would have modified.

## What changed

A comment block in `app/globals.css` beside the `body.consent-open` reservation.

## Why

### #180 fixed the part that was actually broken

Measured at **390×664** — Playwright's `iPhone 13` viewport, and the only place
this reproduces. At 390×844 `/login` is clear either way, which is why an earlier
probe of mine found nothing.

| | `/login` scrollable | unreachable at **any** scroll |
|---|---|---|
| with #180 | 213px | **0** |
| without #180 | 24px | **3** |

Those three are Terms of Use, Privacy Policy and Disclaimer — the reason the
issue was filed. Against a 189px bar, 24px of scroll means they could not be
reached at all. That is now fixed and this PR does not touch it.

QA reported "15 did not move" after #180, which was correct and measured a
different property: coverage **at the initial scroll position**. Padding cannot
change that — it adds space after content and never moves content up. Same
argument I made on #173, applying to my own fix this time.

### Three fixes for the remainder, all measured, all rejected

Baseline: **22 covered controls across 10 routes**, confirmed stable across three
consecutive identical runs (22 / 22 / 22).

| Attempt | Result |
|---|---|
| Shrink the box `.login-wrap` centres in | **No change.** `min-height` is not the binding constraint — the wrap is 877px of content in a 664px viewport, so `justify-content: center` is not centring anything |
| Move the bar over the tab bar (`bottom: 0`, saving 56px) | **22 → 57**, and all four `.mobile-tab-item` links become unreachable at *every* scroll position. A fixed element cannot be scrolled out from under another fixed element |
| Shorten the consent copy | **~18px.** Text is 54px over 3 lines at 178 chars; 12px padding and 44px buttons are a touch-target floor. Moves the bar top 475 → 493 while the contested band is 477..524 |

The second one is the one worth having in writing — it looks like a clean 56px
win and it trades a first-visit annoyance for losing the entire nav until consent
is answered.

### And the framing the issue opened with does not hold

`components/CookieConsent.tsx` carries its own Privacy Policy link. Verified it
is not merely present but reachable — clicked it in the probe and it navigated:

```
consent bar own privacy link: clickable true, hitBy "consent-link"
after click, URL = http://localhost:3210/privacy
```

So the covered legal links are **duplicates of one that was never covered**, and
"consent obtained while the policy is unreachable" was never true. QA reached the
same correction independently and said so on the issue first.

## How to test (QA)

**No user-visible change is expected — that is the assertion.**

On `qa`, mobile, **first visit** (fresh profile or cleared site data, so consent
is pending):

1. Open any page. The consent bar sits **above** the tab bar, not over it — both
   tab-bar icons and both consent buttons are tappable.
2. Tap **Privacy Policy inside the bar**. It goes to `/privacy` without needing
   consent answered first.
3. Accept or decline. Nothing jumps or reflows; the bar is gone for good.
4. Re-run your own sweep — the number should be unchanged, not lower:
   ```
   npx playwright test qa/e2e/layout.spec.ts --project=mobile -g "first visit"
   ```
   Pass is **15 staying at 15**. A drop would mean something shipped that this PR
   says it did not.

Kill anything on 3100 first — `reuseExistingServer` bit you on #180 and it would
invalidate this run the same way.

## Risk level

**Low.** Comment-only inside an existing `/* */` block; the four gates pass
(lint 0 errors, tsc clean, 279 tests, build).

**Not verified locally:** nothing. All numbers above come from a local dev server
at 390×664, not from `qa`. The measurements are of *this* branch and `dev` is
identical in behaviour, so a QA re-run should reproduce them exactly — if it does
not, the discrepancy is the finding.
