### PR TITLE
fix(briefing): stop the header clock breaking hydration

### DIFF
--- a/app/briefing/page.tsx
+++ b/app/briefing/page.tsx
@@ -191,12 +191,37 @@ export default function MorningBriefing() {
   const { user }                               = useAuth();
   const { usage, setUsage }                    = useGrokUsage();
   const { t }                                   = useLabels();
-  const [now, setNow]           = useState<Date>(localNow);
+  /* NULL UNTIL THE BROWSER HAS MOUNTED, and that is the whole fix for #193.
+   *
+   * This was `useState<Date>(localNow)`. `'use client'` does not mean
+   * client-only - Next still renders this component on the server to produce the
+   * initial HTML, so the lazy initialiser ran twice against two different
+   * clocks IN TWO DIFFERENT TIMEZONES. React then found different text and threw
+   * #418, 75 times in production and once per load for every user outside the
+   * server's zone.
+   *
+   * Measured, and the timezone is the part that matters - milliseconds would
+   * only have broken the minute display:
+   *
+   *   server  "Sun, Aug 9"      <div className="mb-subtitle">
+   *   client  "Mon, Aug 10"     (America/New_York)
+   *
+   * A whole day apart, so this was never a near-miss that usually agreed.
+   *
+   * `null` renders identically on the server and on the client's FIRST render,
+   * which is the only render hydration compares. The effect below then sets the
+   * real clock, and everything downstream re-renders with it. */
+  const [now, setNow]           = useState<Date | null>(null);
   // Milliseconds form of the same ticking clock. The event/freshness maths
   // below used to call Date.now() directly, which both made render impure and
   // quietly ignored this state - meaning the "next 24h" and "already released"
   // cutoffs did not actually move with the minute tick that exists right here.
-  const nowMs = now.getTime();
+  /* 0 while the clock is unknown, and that is deliberate rather than a fallback
+   * nobody thought about. Every real event is decades after the epoch, so the
+   * "within the next 24h" filters below evaluate to EMPTY at 0 - the first paint
+   * shows no urgent events rather than the wrong ones, on both server and
+   * client, and the real list appears a frame later. */
+  const nowMs = now?.getTime() ?? 0;
   const [generating, setGen]    = useState(false);
   const [briefErr, setBriefErr] = useState('');
   const [jpyUsd, setJpyUsd]     = useState<number | null>(null);
@@ -231,8 +256,17 @@ export default function MorningBriefing() {
     } catch { /* */ }
   }
 
-  /* Tick once per minute so header time stays fresh */
+  /* Set the clock on mount, then tick once per minute so the header stays fresh.
+   * The immediate call is not decoration - without it the header would stay
+   * blank for up to 60 seconds waiting for the first interval. */
   useEffect(() => {
+    /* `set-state-in-effect` is right about the general case and wrong about this
+       one. Reading a browser-only value after mount is precisely what an effect
+       is for, and it is the only place this CAN be read: the whole point of #193
+       is that the server must not produce this value. Same reasoning as the
+       `react-hooks/purity` disable in setBrief above. */
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setNow(localNow());
     const timer = setInterval(() => setNow(localNow()), 60_000);
     return () => clearInterval(timer);
   }, []);
@@ -253,9 +287,13 @@ export default function MorningBriefing() {
 
   const days   = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
   const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
-  const h = now.getHours(), m = now.getMinutes();
-  const timeStr = `${pad2(h % 12 || 12)}:${pad2(m)} ${h >= 12 ? 'PM' : 'AM'} ${localZoneAbbr()}`;
-  const dateStr = `${days[now.getDay()]}, ${months[now.getMonth()]} ${now.getDate()}`;
+  /* Empty until the clock exists. `localZoneAbbr()` is the SECOND client-only
+   * value on this line and it is not mentioned in #193 - it reads the browser's
+   * zone, so it mismatches for exactly the same reason and would have kept
+   * throwing after the date was fixed. Both are behind the same guard. */
+  const h = now?.getHours() ?? 0, m = now?.getMinutes() ?? 0;
+  const timeStr = now ? `${pad2(h % 12 || 12)}:${pad2(m)} ${h >= 12 ? 'PM' : 'AM'} ${localZoneAbbr()}` : '';
+  const dateStr = now ? `${days[now.getDay()]}, ${months[now.getMonth()]} ${now.getDate()}` : '';
 
   /* Coin rows */
   const coinRows = COINS.map(id => ({
@@ -363,7 +401,10 @@ export default function MorningBriefing() {
   const jpyPct        = jpyUsd != null ? Math.max(0, Math.min(100, ((jpyUsd - 140) / 25) * 100)) : 0;
   const warn158Pct    = ((158 - 140) / 25) * 100;  // 72%
   const danger160Pct  = ((160 - 140) / 25) * 100;  // 80%
-  const jpyMinutesAgo = jpyUpdated ? Math.round((now.getTime() - jpyUpdated.getTime()) / 60_000) : null;
+  /* `jpyUpdated` is only ever set from the fetch effect, so it cannot be
+     non-null while `now` is still null - but the compiler cannot know that and
+     `nowMs` already carries the same guard. Reusing it rather than asserting. */
+  const jpyMinutesAgo = jpyUpdated ? Math.round((nowMs - jpyUpdated.getTime()) / 60_000) : null;
 
   return (
     <div>
@@ -371,7 +412,10 @@ export default function MorningBriefing() {
       {/* ── Header ── */}
       <div className="mb-header">
         <h1 className="mb-title">{t('BRIEFING_PAGE_TITLE')}</h1>
-        <div className="mb-subtitle">{dateStr} · {timeStr}</div>
+        {/* The separator lives inside the guard too, or the first paint is a
+            lone "·" floating under the title. Non-breaking space holds the
+            line's height so the header does not jump when the clock arrives. */}
+        <div className="mb-subtitle">{now ? `${dateStr} · ${timeStr}` : ' '}</div>
       </div>
 
       <PageHint


### PR DESCRIPTION
**Dev Team** · fixes #193

## Summary

`/briefing`'s clock state starts as `null` and is set in an effect after mount,
instead of calling `new Date()` in a `useState` initialiser. Your diagnosis was
right down to the line number; this adds one thing it did not cover and pins the
cause more precisely.

## What changed

`app/briefing/page.tsx`

| | |
|---|---|
| `useState<Date>(localNow)` | → `useState<Date \| null>(null)`, set in the existing effect |
| `now.getTime()` | → `now?.getTime() ?? 0` |
| `localZoneAbbr()` on the time line | now behind the same guard |
| `mb-subtitle` | renders `&nbsp;` until the clock exists, so the separator does not float alone |

## Why — and the timezone is the part that matters

You called it a text mismatch from two different clocks. It is worse than that:
the two renders are in two different **timezones**, which is why it fired for
nearly every user instead of occasionally. Captured from a dev build, where React
prints the diff:

```
  <div className="mb-header">
    <div className="mb-subtitle">
+     Sun, Aug 9
-     Mon, Aug 10          (America/New_York)
```

**A whole day apart.** Milliseconds alone would only ever have broken the minute
display — this was never a near-miss that usually agreed, which is the difference
between a rare error and 75 events.

### One thing #193 did not mention

Line 257 carried a **second** client-only value on the same line as the time:

```tsx
`... ${localZoneAbbr()}`
```

It reads the browser's timezone, so it mismatches for exactly the same reason and
would have kept throwing after the date was fixed. Both are behind one guard now.

You also asked me to check `nowUtc` at line 146 — **it is fine.** It lives inside
`buildBriefingContext`, which runs from the generate handler to build Grok's
prompt, not during render. Same class of value, and the code path is what saves
it.

### Why `nowMs` falls back to 0

Not an arbitrary default. Every real event is decades after the epoch, so the
"within the next 24h" filters evaluate to **empty** at 0. The first paint shows no
urgent events rather than the wrong ones — identically on server and client, so
it cannot itself mismatch — and the real list appears once the effect runs.

## Verification

Against a **production** build, since `#418` is the minified error and dev does
not reproduce the same code path:

| | Result |
|---|---|
| before | `/briefing` throws on every load |
| after, 6 timezones | **0** — New_York, Tokyo, London, Sydney, Los_Angeles, Manila |
| after, all 36 routes | **0 hydration errors, 0 load failures** |

Swept every route rather than just the one, on the principle that a class of bug
is not fixed until you have looked for the rest of it. Nothing else in the app is
throwing this.

Two intermediate readings during that work were **invalid and discarded**: a
`TOTAL=0` produced while the server was down, and another where Git Bash rewrote
`/briefing` into a Windows path so nothing loaded. Both would have read as
"passing".

## How to test (QA)

On `qa`, open **/briefing** with devtools open.

1. **Console is clean** — no `Minified React error #418`, no hydration warning.
   That is the whole assertion.
2. The date and time under the title are correct **for your own timezone** within
   a second of load, and tick over on the minute.
3. The header does not jump when the time appears.
4. Generate a briefing — the AI context still carries the right UTC time, since
   that path was not touched.
5. If you can, load it on a machine in a different timezone. **That is the case
   this was failing** — a tester in the server's zone would never have seen it.

Your offer to add a hydration assertion to `smoke.spec.ts` is the right follow-up
and I would take it. `pageerror` with a `#418` match across all routes would have
caught this the day it shipped.

## Risk level

**Low-Medium.** One file, but it is the render path of a page people load daily.

Four gates green: lint 0 errors (140 warnings, unchanged from `dev`), tsc clean,
279 tests, build ok.

**Named because it is not covered:** the `react-hooks/set-state-in-effect` warning
is disabled on one line, deliberately. Reading a browser-only value after mount is
what an effect is for, and it is the only place it *can* be read — the entire
point of #193 is that the server must not produce this value. Same reasoning as
the existing `react-hooks/purity` disable in `setBrief` a few lines above.

**Also not verified:** no automated test asserts this. It is a browser-only
failure with no unit-testable surface, which is exactly the gap your
`smoke.spec.ts` addition would close.
