### PR TITLE
test(qa): stop exempting /briefing from the uncaught-JS assertion

### DIFF
--- a/qa/e2e/smoke.spec.ts
+++ b/qa/e2e/smoke.spec.ts
@@ -13,18 +13,27 @@ test.describe('smoke', () => {
       // settle() throws on HTTP >=400 and on an unstyled render.
       await settle(page, route);
 
-      // A hydration mismatch surfaces here as React error #418/#423/#425.
-      // /briefing currently trips #418 - see audit §5.1. That one is a known
-      // bug with a known cause, so it is skipped rather than silently allowed:
-      // delete this branch the moment page.tsx:194 is fixed.
-      if (route === '/briefing') {
-        test.info().annotations.push({
-          type: 'known-issue',
-          description: 'React #418 hydration mismatch - audit §5.1, briefing/page.tsx:194',
-        });
-      } else {
-        expect(pageErrors, `uncaught JS on ${route}`).toEqual([]);
-      }
+      /* THE /briefing EXEMPTION IS GONE, and removing it is the point.
+       *
+       * This branch exempted /briefing from the uncaught-JS assertion because it
+       * trips React #418, citing briefing/page.tsx:194 - the correct line, known
+       * since the audit. The annotation was honest and the exemption was not:
+       * an annotation is invisible in a green run, so the suite reported clean
+       * while that route threw on every single load.
+       *
+       * It cost 75 events in production and was the most frequent error in
+       * GlitchTip - found by reading the dashboard, not by this suite, which had
+       * the line number written down the whole time. Filed as #193.
+       *
+       * SEQUENCING, and dev raised it before I did: this assertion only proves
+       * something if it goes RED while the bug is still present. Landing it after
+       * the fix would assert a green state it had never seen fail. So it is
+       * committed failing, deliberately, and #195 turns it green.
+       *
+       * If you are reading this because /briefing failed again: the cause is a
+       * value that differs between server render and hydration - `useState(new
+       * Date())` or equivalent - not something to exempt. */
+      expect(pageErrors, `uncaught JS on ${route}`).toEqual([]);
     });
   }
 


### PR DESCRIPTION
**QA Team** → **Dev Team** · 🔴 **this PR is expected to FAIL until #195 lands** · pairs with #193

## Your sequencing point, acted on

> it only proves anything if it fails before #195 merges. Land it after and it's asserting a green state it never saw go red.

Exactly right, so this is committed **failing on purpose**:

```
✘ /briefing loads and renders styled
  + "Minified React error #418; args[]=text&args[]="
```

The other 31 routes pass, so the assertion is specific, not blanket. **Merge this before or with #195 — never after.**

## 🔴 A correction to #193 that makes my find look worse, not better

I presented #418 as a discovery. **The suite already knew.** `smoke.spec.ts` carried:

```ts
// /briefing currently trips #418 - see audit §5.1.
// delete this branch the moment page.tsx:194 is fixed.
if (route === '/briefing') { /* annotate, skip the assertion */ }
```

The **correct line number**, written down, since the audit. The annotation was honest — the exemption was not. An annotation is invisible in a green run, so the suite reported clean while that route threw on every load.

**It took reading the GlitchTip dashboard to notice**, at 75 events and the most frequent error in production. A check that cannot fail is worse than no check, because it occupies the space where a real one would go. That is the thing this suite exists to catch, and it was sitting inside the suite.

## What replaces it

No exemption. If `/briefing` throws again, the message points at the cause class — a value differing between server render and hydration — rather than inviting another skip.

## How to test (QA)

```
npx playwright test qa/e2e/smoke.spec.ts --project=desktop
```

**Today: 1 failed, 31 passed.** After #195: 32 passed — and that green then means something, because this red is on the record.

## Risk level

**Low** as code. **The merge order is the risk** — after #195 it proves nothing.