### PR TITLE
perf(api): serve one upstream call to all users on six routes

### DIFF
--- a/app/api/cmc/route.ts
+++ b/app/api/cmc/route.ts
@@ -56,6 +56,17 @@ async function attributedUser(req: NextRequest): Promise<string> {
   }
 }
 
+/* Shared edge cache (#177). CMC is CREDIT-METERED, so an uncached call is
+   not just latency, it is money - this route was calling upstream on every
+   page load.
+
+   `r.ok` gates it deliberately: CMC returns its error bodies as JSON and this
+   route forwards them verbatim, so caching unconditionally would pin a
+   "rate limit exceeded" payload at the edge for five minutes and take the
+   feature down for everyone. Errors stay uncached and retry immediately. */
+const CMC_CACHE = (ok: boolean) =>
+  ok ? { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' } : undefined;
+
 export async function GET(req: NextRequest) {
   const ip = getClientIp(req);
   if (!rateLimit(`cmc:${ip}`, 20, 60_000)) {
@@ -82,7 +93,7 @@ export async function GET(req: NextRequest) {
       clearTimeout(timer);
       const d = await r.json();
       reportCmc('cmc:global-metrics', r, d);
-      return NextResponse.json(d);
+      return NextResponse.json(d, { headers: CMC_CACHE(r.ok) });
     }
 
     if (type === 'altseason') {
@@ -96,7 +107,7 @@ export async function GET(req: NextRequest) {
       );
       const d = await r.json();
       reportCmc('cmc:listings', r, d, (d as CmcBody)?.data?.length);
-      return NextResponse.json(d);
+      return NextResponse.json(d, { headers: CMC_CACHE(r.ok) });
     }
 
     return NextResponse.json({ error: 'Unknown type' }, { status: 400 });

--- a/app/api/cycle/route.ts
+++ b/app/api/cycle/route.ts
@@ -92,12 +92,17 @@ export async function GET(req: NextRequest) {
 
   try {
     const cycle2024 = await fetchCycle2024();
+    /* Cycle position is a slow signal - `currentDay` moves once a day and the
+       2016/2020 curves are constants. Five minutes changes nobody's decision.
+       Success only; the 429 and 500 paths stay uncached (#177). */
     return NextResponse.json({
       '2016': CYCLE_2016,
       '2020': CYCLE_2020,
       '2024': cycle2024,
       currentDay,
-    } satisfies CycleData);
+    } satisfies CycleData, {
+      headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' },
+    });
   } catch (e) {
     return apiError('cycle', e, 500, 'Request failed');
   }

--- a/app/api/forex/jpy/route.ts
+++ b/app/api/forex/jpy/route.ts
@@ -21,7 +21,13 @@ export async function GET(req: NextRequest) {
       if (!rate) throw new Error('no JPY in response');
       return rate;
     }, rate => ({ detail: String(rate) }));
-    return NextResponse.json({ jpy }, { headers: { 'Cache-Control': 'public, max-age=300' } });
+    /* `s-maxage`, not `max-age`. The old header cached per-BROWSER only, so
+       every new visitor still cost an upstream call - the shared cache is the
+       whole point of #177. Kept at 300s; added swr so a slow upstream serves
+       stale rather than blocking. */
+    return NextResponse.json({ jpy }, {
+      headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' },
+    });
   } catch (e) {
     return apiError('forex/jpy', e, 502, 'Upstream fetch failed');
   }

--- a/app/api/funding/route.ts
+++ b/app/api/funding/route.ts
@@ -104,7 +104,16 @@ export async function GET(req: NextRequest) {
 
       return { data, ts: Date.now() };
     });
-    return NextResponse.json(result);
+    /* Edge cache, so upstream cost stops scaling with visitors (#177).
+       Funding settles on a fixed 8-hour schedule, so 60s is already far tighter
+       than the data moves. CACHE_TTL above is the in-process cache and only
+       collapses concurrent requests on ONE instance; this collapses them across
+       every visitor. The two are complementary, not duplicates.
+       Success only - the 429 and the 500 above must never be cached, or one
+       rate-limited request serves an error to everyone for a minute. */
+    return NextResponse.json(result, {
+      headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=600' },
+    });
   } catch (err) {
     return apiError('funding', err, 500, 'Request failed');
   }

--- a/app/api/proxy/route.ts
+++ b/app/api/proxy/route.ts
@@ -44,6 +44,17 @@ async function attributedUser(req: NextRequest): Promise<string> {
   }
 }
 
+/* Shared edge cache (#177) - this route fans out to several third-party APIs
+   and was calling them again for every visitor.
+
+   `ok` is a parameter rather than assumed because two of the paths below can
+   return a 200 that is really a failure: Coinglass forwards its error bodies
+   verbatim, and the trends path deliberately converts an upstream block into an
+   empty 200 so the page degrades quietly. Caching either would hold a dead
+   response at the edge for five minutes. Only genuine payloads get the header. */
+const PROXY_CACHE = { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' };
+const proxyCache = (ok: boolean) => (ok ? PROXY_CACHE : undefined);
+
 export async function GET(req: NextRequest) {
   const ip = getClientIp(req);
   if (!rateLimit(`proxy:${ip}`, 20, 60_000)) {
@@ -79,7 +90,7 @@ export async function GET(req: NextRequest) {
         'https://open-api.coinglass.com/public/v2/exchange_amount_chart?symbol=BTC&time_type=h24',
         { next: { revalidate: 300 }, headers: cgKey ? { 'coinglassSecret': cgKey } : {} }
       );
-      return NextResponse.json(await r.json());
+      return NextResponse.json(await r.json(), { headers: proxyCache(r.ok) });
     }
 
     /* ── Coinglass: BTC liquidation levels ── */
@@ -89,7 +100,7 @@ export async function GET(req: NextRequest) {
         'https://open-api.coinglass.com/public/v2/liquidation_chart?symbol=BTC&time_type=h4',
         { next: { revalidate: 300 }, headers: cgKey ? { 'coinglassSecret': cgKey } : {} }
       );
-      return NextResponse.json(await r.json());
+      return NextResponse.json(await r.json(), { headers: proxyCache(r.ok) });
     }
 
     /* ── Google Trends: bitcoin 7-day search score (2-step) ── */
@@ -154,7 +165,7 @@ export async function GET(req: NextRequest) {
             return { ok: n > 0, detail: n > 0 ? `${n} points` : 'no timeline data', items: n };
           },
         ));
-        return NextResponse.json(json);
+        return NextResponse.json(json, { headers: PROXY_CACHE });
       } catch {
         // Google Trends blocked / timed out - return empty, never 500, never cached
         return NextResponse.json(EMPTY);
@@ -245,7 +256,7 @@ export async function GET(req: NextRequest) {
          is undefined on a number, so the store would silently never have been
          set and the panel would have stayed exactly as broken as before, with
          the health table now green. Updated alongside this. */
-      return NextResponse.json({ btc, eth });
+      return NextResponse.json({ btc, eth }, { headers: PROXY_CACHE });
     }
 
     return NextResponse.json({ error: 'Unknown type' }, { status: 400 });

--- a/app/api/signal-accuracy/route.ts
+++ b/app/api/signal-accuracy/route.ts
@@ -188,7 +188,11 @@ export async function GET() {
       });
     }
 
-    return NextResponse.json({ stats, candles: closes.length });
+    /* Historical hit-rates. They only change when an outcome resolves, which
+       is hours apart, so an hour of edge cache is conservative (#177). */
+    return NextResponse.json({ stats, candles: closes.length }, {
+      headers: { 'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=7200' },
+    });
   } catch (e) {
     return apiError('signal-accuracy', e, 500, 'Request failed');
   }


### PR DESCRIPTION
**Dev Team** · fixes #197, applies the values from #177

## Summary

Shared edge cache on the six routes you named, **success responses only**. No
number vetoed — your table is what shipped. One I argued against and then talked
myself out of; details at the bottom.

## What changed

| Route | Header |
|---|---|
| `/api/funding` | `s-maxage=60, swr=600` |
| `/api/cycle` | `s-maxage=300, swr=600` |
| `/api/signal-accuracy` | `s-maxage=3600, swr=7200` |
| `/api/cmc` | `s-maxage=300, swr=600` |
| `/api/proxy` | `s-maxage=300, swr=600` |
| `/api/forex/jpy` | `max-age=300` → `s-maxage=300, swr=600` |

`/api/forex/jpy` is the clearest illustration of the whole issue: `max-age`
caches **per browser**, so every new visitor still cost an upstream call. The
header looked like a cache and was not one.

## The part that needs actual review: errors are not cached

This is where a cache header stops being free. Three separate hazards, all
handled:

1. **The 429 and 500 paths** return before any header is set.
2. **`/api/cmc` forwards CMC's error bodies verbatim.** Caching unconditionally
   would pin a `rate limit exceeded` payload at the edge for five minutes and
   take the feature down for every user. Gated on `r.ok`.
3. **`/api/proxy`'s trends path deliberately converts an upstream block into an
   empty `200`** — the shape that hides a dead upstream, and your own comment in
   that file says so. Left uncached; `/api/proxy`'s Coinglass paths are gated on
   `r.ok` for the same reason.

**Caching a failure is worse than not caching**: it turns one bad response into
five minutes of bad responses, and `swr` would then keep serving it while it
revalidates.

## Verification — every route, header read off the wire

Production build, not reasoning:

```
/api/funding          200  public, s-maxage=60, stale-while-revalidate=600
/api/cycle            200  public, s-maxage=300, stale-while-revalidate=600
/api/signal-accuracy  200  public, s-maxage=3600, stale-while-revalidate=7200
/api/forex/jpy        200  public, s-maxage=300, stale-while-revalidate=600
/api/proxy?type=etf   200  public, s-maxage=300, stale-while-revalidate=600
/api/cmc?type=global  200  public, s-maxage=300, stale-while-revalidate=600
/api/cmc?type=bogus   400  (no cache header — the guard working)
```

The CMC success path needs an API key, so rather than leave it as the one
unverified claim I ran it through **your #183 interceptor** in stub mode with a
fake key:

```
stubbed pro-api.coinmarketcap.com (4 stubbed / 1 passed through)
```

First real use of that tool by me, and it turned "probably fine" into a measured
line. Worth knowing it works for this as well as for egress counting.

## This will turn your #194 spec RED, and that is the designed signal

Four `KNOWN: … has no cache policy yet` tests will fail — `/api/funding`,
`/api/cycle`, `/api/signal-accuracy`, `/api/cmc` — plus the `/api/forex/jpy`
per-browser entry. That is exactly the inverting assertion you built, doing its
job: **move those five from `PROPOSED` into `SHIPPED`.**

Your file, so I have not touched it. I verified the mechanism works before
merging #194 by adding a policy to `/api/funding` and watching that test fail, so
this is the same behaviour on purpose rather than a surprise.

Sequencing is yours. Red between the two merges either way.

## The number I was going to veto, and why I did not

I said on #194 I would probably argue `/api/cmc` should be longer than 300s
because CoinMarketCap is credit-metered. Having looked, **your number is right
and my objection was half-formed**: `type=altseason` already sets
`next: { revalidate: 300 }` internally, so 300 at the edge matches the tier
underneath rather than fighting it. Raising only the edge would have produced two
caches disagreeing about freshness for no saving.

## Risk level

**Medium.** Six live API routes, and a wrong cache is invisible until someone
reports a stale number.

Gates: lint 0 errors (140 warnings, unchanged), tsc clean, 279 tests, build ok.

**Not verified, named rather than buried:**

- **Nothing here proves the edge actually caches.** Render's CDN is what honours
  `s-maxage`, and a local `next start` has no CDN — I verified the *header is
  correct and present*, not that a second request is served from cache. That
  needs `qa`, and it is the one thing I cannot check from here.
- Freshness under real load is unmeasured. If `/api/funding` at 60s turns out to
  lag visibly, the number is the easy part to change.
