### PR TITLE
fix(api): make the upstream cache collapse concurrent callers

### DIFF
--- a/__tests__/apiCache.test.mts
+++ b/__tests__/apiCache.test.mts
@@ -1,0 +1,136 @@
+/* Single-flight in lib/apiCache.ts (#199).
+ *
+ * The property under test is not "does it cache" - it did that already. It is
+ * "do N concurrent callers produce ONE upstream call". Every one of these
+ * assertions FAILS against the previous implementation, with the numbers in the
+ * failure messages below; that is the point, and it is why they are written as
+ * exact counts rather than `assert.ok(calls < 20)`.
+ *
+ * No network and no timers beyond a short sleep: the fetcher is a counter, so
+ * "upstream calls" is directly observable rather than inferred.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+/* Relative with the extension: run under `node --test`, which resolves neither
+   tsconfig paths nor Next's `@/` alias. */
+import { cached, cachedStale } from '../lib/apiCache.ts';
+
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+/** A fetcher that counts its own invocations and is slow enough to overlap. */
+function counter<T>(value: T, ms = 40) {
+  const state = { calls: 0 };
+  return {
+    state,
+    fn: async () => { state.calls++; await sleep(ms); return value; },
+  };
+}
+
+/* Keys are unique per test. `store` is module-level and shared across the whole
+   file, so a reused key would make one test depend on another's leftovers. */
+let n = 0;
+const key = (label: string) => `test:${label}:${++n}`;
+
+test('concurrent callers share one upstream request', async (t) => {
+  await t.test('cached: 20 cold callers produce exactly 1 call', async () => {
+    const k = key('cold');
+    const { state, fn } = counter('v');
+
+    const results = await Promise.all(Array.from({ length: 20 }, () => cached(k, 5_000, fn)));
+
+    assert.equal(state.calls, 1,
+      `20 concurrent callers made ${state.calls} upstream calls; the old implementation made 20`);
+    assert.deepEqual(results, Array(20).fill('v'), 'every caller gets the same value');
+  });
+
+  await t.test('cached: the stampede at EXPIRY is the one that matters', async () => {
+    const k = key('expiry');
+    const { state, fn } = counter('v');
+
+    await cached(k, 60, fn);        // warm it
+    assert.equal(state.calls, 1);
+    await sleep(90);                 // let it expire
+
+    await Promise.all(Array.from({ length: 20 }, () => cached(k, 60, fn)));
+
+    /* 2 = the warm call plus one refresh shared by all 20. The old
+       implementation made 21, which is the failure mode the cache exists to
+       prevent, happening once per TTL under exactly the load it was added for. */
+    assert.equal(state.calls, 2,
+      `expected 2 upstream calls (warm + one shared refresh), got ${state.calls}`);
+  });
+
+  await t.test('cachedStale: same guarantee', async () => {
+    const k = key('stale');
+    const { state, fn } = counter('v');
+
+    const results = await Promise.all(Array.from({ length: 20 }, () => cachedStale(k, 5_000, fn)));
+
+    assert.equal(state.calls, 1, `got ${state.calls} upstream calls`);
+    assert.ok(results.every(r => r.data === 'v' && r.stale === false));
+  });
+
+  await t.test('a hit still does not call upstream at all', async () => {
+    const k = key('hit');
+    const { state, fn } = counter('v');
+    await cached(k, 5_000, fn);
+    await cached(k, 5_000, fn);
+    assert.equal(state.calls, 1, 'second call inside the TTL must be served from the store');
+  });
+});
+
+test('failures are not cached and do not wedge the key', async (t) => {
+  await t.test('a rejected fetch is retried by the next caller', async () => {
+    const k = key('reject');
+    let calls = 0;
+    const flaky = async () => {
+      calls++;
+      await sleep(10);
+      if (calls === 1) throw new Error('upstream down');
+      return 'recovered';
+    };
+
+    await assert.rejects(() => cached(k, 5_000, flaky), /upstream down/);
+
+    /* The critical half: `inflight` is cleared in a `finally`, so the failed
+       promise is not left in the map. Without that, every later caller would
+       await an already-rejected promise and the key would be permanently
+       broken - strictly worse than having no single-flight at all. */
+    assert.equal(await cached(k, 5_000, flaky), 'recovered');
+    assert.equal(calls, 2);
+  });
+
+  await t.test('concurrent callers all see the failure, and it is called once', async () => {
+    const k = key('reject-concurrent');
+    const state = { calls: 0 };
+    const failing = async () => { state.calls++; await sleep(20); throw new Error('boom'); };
+
+    const settled = await Promise.allSettled(
+      Array.from({ length: 10 }, () => cached(k, 5_000, failing)),
+    );
+
+    assert.equal(state.calls, 1, 'a failing upstream must not be hit 10 times either');
+    assert.ok(settled.every(s => s.status === 'rejected'), 'no caller silently gets undefined');
+  });
+
+  await t.test('cachedStale serves the last good value when the refresh fails', async () => {
+    const k = key('stale-serves');
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      await sleep(10);
+      if (calls > 1) throw new Error('upstream down');
+      return 'good';
+    };
+
+    const first = await cachedStale(k, 50, fn);
+    assert.equal(first.data, 'good');
+    assert.equal(first.stale, false);
+
+    await sleep(80);
+    const second = await cachedStale(k, 50, fn);
+    assert.equal(second.data, 'good', 'stale beats a hole on the page');
+    assert.equal(second.stale, true);
+  });
+});

--- a/lib/apiCache.ts
+++ b/lib/apiCache.ts
@@ -7,6 +7,28 @@
 
 const store = new Map<string, { ts: number; data: unknown }>();
 
+/* IN-FLIGHT REQUESTS, so N concurrent callers produce ONE upstream call (#199).
+ *
+ * Without this, a TTL cache still stampedes. Checking the store and then
+ * awaiting the fetcher is not atomic, so every caller that arrives while the
+ * first fetch is in the air sees a miss and starts its own. Measured against
+ * the previous implementation:
+ *
+ *   cached()      20 concurrent cold callers -> 20 upstream calls
+ *   cachedStale() 20 concurrent cold callers -> 20 upstream calls
+ *   cached()      20 concurrent AT EXPIRY    -> 21 upstream calls
+ *
+ * Expiry is the worst moment for this: the cache exists because traffic is
+ * concentrated, and it dumps that entire concentration on the upstream once per
+ * TTL. For /api/funding at a 20s TTL that is three stampedes a minute at
+ * Binance, from a cache whose stated purpose is to prevent exactly that.
+ *
+ * The map is keyed identically to `store` and cleared in a `finally`, so a
+ * rejected fetcher does not wedge the key - the next caller retries rather than
+ * awaiting a promise that has already failed.
+ */
+const inflight = new Map<string, Promise<unknown>>();
+
 // Returns the cached value for `key` if it's younger than `ttlMs`, otherwise
 // calls `fetcher()`, caches the result, and returns it. Only successful
 // results are cached - a throwing fetcher leaves the previous entry (or none)
@@ -14,9 +36,21 @@ const store = new Map<string, { ts: number; data: unknown }>();
 export async function cached<T>(key: string, ttlMs: number, fetcher: () => Promise<T>): Promise<T> {
   const hit = store.get(key);
   if (hit && Date.now() - hit.ts < ttlMs) return hit.data as T;
-  const data = await fetcher();
-  store.set(key, { ts: Date.now(), data });
-  return data;
+
+  /* Note the key namespace: `cached` and `cachedStale` share `store`, so they
+     share `inflight` too. That is correct - two callers asking for the same key
+     want the same upstream call regardless of which helper they used. */
+  const existing = inflight.get(key) as Promise<T> | undefined;
+  if (existing) return existing;
+
+  const p = (async () => {
+    const data = await fetcher();
+    store.set(key, { ts: Date.now(), data });
+    return data;
+  })().finally(() => { inflight.delete(key); });
+
+  inflight.set(key, p);
+  return p;
 }
 
 /* Same as `cached`, but keeps serving the last good value when the fetcher
@@ -46,8 +80,22 @@ export async function cachedStale<T>(
   if (hit && age < ttlMs) return { data: hit.data, stale: false, ageMs: age };
 
   try {
-    const data = await fetcher();
-    store.set(key, { ts: Date.now(), data });
+    /* Same single-flight as `cached`, and deliberately the SAME map. The
+       in-flight promise always resolves to the raw fetcher value rather than
+       this function's `{ data, stale, ageMs }` wrapper, so either helper can
+       await a promise the other one started. Wrapping happens per caller,
+       after the shared await, because `stale` and `ageMs` are properties of
+       the CALLER's moment, not of the upstream request. */
+    const existing = inflight.get(key) as Promise<T> | undefined;
+    const data = existing ? await existing : await (() => {
+      const p = (async () => {
+        const d = await fetcher();
+        store.set(key, { ts: Date.now(), data: d });
+        return d;
+      })().finally(() => { inflight.delete(key); });
+      inflight.set(key, p);
+      return p;
+    })();
     return { data, stale: false, ageMs: 0 };
   } catch (e) {
     /* Deliberately does NOT refresh the timestamp. Every subsequent request


### PR DESCRIPTION
**Dev Team** · addresses #199 — **and corrects two of its premises, with measurements**

## Summary

Added single-flight to the **existing** `lib/apiCache.ts`. Did not create
`lib/upstreamCache.ts`. The one genuine defect #199 identifies is real, measured,
fixed and now tested; the rest of the issue describes a cache this codebase
already has.

## The part of #199 that was exactly right

> Every naive TTL-cache example omits it […] the cache would fire a thundering
> herd at Binance once per TTL.

Correct, and measured against the previous implementation:

| | before | after |
|---|---|---|
| `cached()` — 20 concurrent cold callers | **20** upstream calls | **1** |
| `cachedStale()` — 20 concurrent cold callers | **20** | **1** |
| `cached()` — 20 concurrent **at expiry** | **21** | **2** |

For `/api/funding` at its 20s TTL that was three stampedes a minute at Binance,
from a cache whose stated purpose is preventing them.

## Correction 1 — the cache already exists, with 11 consumers

`lib/apiCache.ts` has been there all along:

- `cached(key, ttlMs, fetcher)` — the TTL cache #199 specifies
- `cachedStale(...)` — **already implements the serve-stale-on-failure behaviour
  the issue raises as an open question for me to decide.** It was written for
  `/api/ath` after CoinGecko rate-limited the qa instance, and its comment
  already argues the case: *stale beats a hole on the page, except for anything
  a user acts on directly.*

Building `lib/upstreamCache.ts` alongside it would have split the key space, so
the same upstream would be fetched once per module — a cache that makes the
problem slightly worse. Single-flight went into the existing module instead, and
both helpers share one in-flight map so callers converge regardless of which one
they used.

## Correction 2 — four of the six routes already collapse upstream calls

#199 and #197 both say these routes call upstream on every page load. Measured
with **your own `count` mode from #183**, on `dev`, 30 sequential requests to
`/api/cycle`:

```
api.bybit.com: 1
```

**Thirty requests, one upstream call.** `/api/cycle`, `/api/signal-accuracy`,
`/api/cmc` and `/api/forex/jpy` all pass `next: { revalidate: N }` to `fetch`,
which is Next's Data Cache — server-side, shared across users, and working. They
were never per-request.

So the six routes on #198 break down as:

| Route | Server-side sharing before this PR |
|---|---|
| `/api/cycle`, `/api/signal-accuracy`, `/api/cmc`, `/api/forex/jpy` | yes — Next Data Cache |
| `/api/funding`, `/api/proxy` | yes — `cached()`, but stampeding at expiry |

That does not make #199 wrong to file. It narrows it from "build a cache" to
"the cache we have stampedes", which is the defect worth fixing and is what this
does.

## `inflight` is cleared in a `finally`, and that matters more than the happy path

A rejected promise left in the map would be awaited by every subsequent caller,
so one upstream blip would break the key **permanently** — strictly worse than
having no single-flight. Two tests cover it: a rejected fetch is retried by the
next caller, and 10 concurrent callers on a failing upstream all see the
rejection while the upstream is hit once.

## Test discipline

9 assertions in `__tests__/apiCache.test.mts`, counting upstream invocations
directly rather than inferring them from timing.

**Verified failing before trusting the pass** — 6 of 9 fail against the previous
implementation:

```
✖ cached: 20 cold callers produce exactly 1 call
✖ cached: the stampede at EXPIRY is the one that matters
✖ cachedStale: same guarantee
✖ concurrent callers all see the failure, and it is called once
ℹ pass 3   fail 6
```

Same rule I have been pushing at you since #196, applied here to my own work.

## How to test (QA)

Nothing user-visible changes — this is a cost and load fix.

On `qa`:

1. Load `/dashboard`, `/briefing`, `/liq`. Numbers appear as now and still
   update: funding within a minute, cycle within five.
2. Hard-refresh `/dashboard` several times quickly. Previously each burst could
   fan out to Binance; now the first request fetches and the rest wait on it.
   **Nothing observable should differ — that is the assertion.**
3. `npm test` → 288 passing, including the 9 new ones.

Worth pairing with your `count` mode if you want the direct number: run the qa
service with `QA_INTERCEPT_UPSTREAM=count` and hammer `/api/funding` past its
20s TTL. Before this, a burst at expiry produced one upstream call per request.

## Risk level

**Medium.** It changes concurrency behaviour in a module with 11 consumers.

Gates: lint 0 errors (140 warnings, unchanged), tsc clean, **288** tests, build ok.

**Not verified, named rather than buried:**

- **Only measured on a single instance.** Prod is `plan: starter`, one instance,
  so a module-level map is genuinely shared. #199 is right that a second instance
  multiplies the upstream rate by the instance count — that is a real ceiling,
  not a hypothetical, and Redis becomes necessary the day the plan changes.
- **`count` mode cannot give an exact total unless the process exits
  gracefully.** I killed the server and the `process.on('exit')` tally never
  printed, so my route numbers come from the `n === 1 || n % 25 === 0` progress
  lines. Enough to prove 30 requests made fewer than 25 calls and at least 1 —
  not enough to distinguish 1 from 24 without the 25-request threshold trick I
  used. Worth a follow-up on your side; a `SIGTERM` handler would fix it.
