### PR TITLE
test(qa): assert caching works, and let the suite run against a deployed environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,22 @@ on:
         description: Run the full browser suite
         type: boolean
         default: true
+      # DISPATCH-ONLY, and off by default. This changes what the run measures,
+      # so it must never be the thing that happens on an ordinary push.
+      #
+      # #114 wants `workers` above 2. The blocker is not the theory - a local
+      # run at 2 produced zero 429s - it is that rate limits are PER IP and the
+      # only measurement anyone has is from one developer machine. A clean local
+      # number proves the volume is low; it does not prove GitHub's shared
+      # egress is under the threshold, and that is the IP that would get banned.
+      #
+      # count mode passes every call through untouched and only tallies it, so a
+      # run with this on is exactly as valid as one without. It answers the one
+      # question #114 has been stuck on since it was filed.
+      count_egress:
+        description: 'Tally outbound third-party calls (does not change behaviour; artifact: egress-tally)'
+        type: boolean
+        default: false
 
 # Without this, every push to a PR stacked another run and the superseded one
 # carried on to completion. Nothing was ever cancelled. Costs no coverage.
@@ -311,6 +327,21 @@ jobs:
         run: npm run test:e2e
         env:
           CI: true
+
+          # ── EGRESS COUNTING, dispatch-only and off unless asked for ────────
+          #
+          # Empty on every ordinary run, so the preload is not loaded at all and
+          # this step behaves exactly as it did before.
+          #
+          # NODE_OPTIONS applies to EVERY node process in the tree, including the
+          # `npm` wrapper and the `npm run build` that playwright.config.ts's
+          # webServer runs as a child. That is intended - build-time fetches are
+          # real egress from this IP and belong in the tally - but it is also why
+          # qa/server-intercept.mjs writes exclusively to stderr: npm parses its
+          # own stdout while resolving npm-prefix.js, and one console.log there
+          # stopped the server from starting at all.
+          NODE_OPTIONS: ${{ (github.event_name == 'workflow_dispatch' && inputs.count_egress) && '--import ./qa/server-intercept.mjs' || '' }}
+          QA_INTERCEPT_UPSTREAM: ${{ (github.event_name == 'workflow_dispatch' && inputs.count_egress) && 'count' || '' }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
           NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ secrets.E2E_TURNSTILE_SITE_KEY }}
@@ -477,6 +508,50 @@ jobs:
           name: playwright-report-${{ github.run_attempt }}
           path: qa/e2e-report/
           retention-days: 14
+
+      # always(), NOT success(). The number is most interesting precisely when
+      # the run went badly - a suite that tripped a rate limit is the case #114
+      # needs to see, and that run fails.
+      #
+      # The file is written DURING the run, once a second, so it survives the
+      # webServer being killed. `process.on('exit')` does not fire on a kill,
+      # which is how the first attempt at this measurement produced a tally of
+      # zero calls to Binance while /api/funding alone was making three.
+      - name: Upload egress tally
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && inputs.count_egress }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: egress-tally-${{ github.run_attempt }}
+          path: qa/.intercept-tally.json
+          retention-days: 30
+          if-no-files-found: warn
+
+      # Printed as well as uploaded: #114 is answered by one number, and making
+      # someone download an artifact to read it is how a measurement stops being
+      # consulted.
+      - name: Summarise egress
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && inputs.count_egress }}
+        run: |
+          if [ ! -f qa/.intercept-tally.json ]; then
+            echo "No tally written. The preload did not load, or no outbound call was made." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          # grep, not require() - playwright.config.ts is TypeScript and node
+          # cannot load it here. The number is what the tally must be read
+          # against: N calls at 2 workers says nothing about 4 on its own.
+          WORKERS=$(grep -oE '^\s*workers:\s*[0-9]+' playwright.config.ts | grep -oE '[0-9]+' | head -1)
+          {
+            echo "## Outbound third-party calls"
+            echo ""
+            echo "Measured at \`workers: ${WORKERS:-unknown}\`."
+            echo ""
+            echo '```json'
+            cat qa/.intercept-tally.json
+            echo '```'
+            echo ""
+            echo "Per-IP rate limits apply to this runner's egress, not to a developer machine."
+            echo "This is the measurement #114 needs before \`workers\` goes above 2."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # ───────────────────────────────────────────────────────────────────────────
   # THE ONLY REQUIRED STATUS CHECK. Do not require `build` or `e2e` directly.

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ next-env.d.ts
 # Playwright E2E
 qa/e2e-report/
 test-results/
+# Written during a run by qa/server-intercept.mjs in count mode. A measurement
+# artefact, and it is rewritten every second while a run is in progress.
+qa/.intercept-tally.json

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,6 +12,36 @@ import { defineConfig, devices } from '@playwright/test';
 // owner already has open.
 const PORT = Number(process.env.E2E_PORT ?? 3100);
 
+// ── Running against a DEPLOYED environment ────────────────────────────────
+//
+// `E2E_BASE_URL` points the whole suite at a real service instead of a local
+// build, and suppresses the webServer so nothing is built or booted:
+//
+//   E2E_BASE_URL=https://liquidity-hq-qa.onrender.com      npx playwright test
+//   E2E_BASE_URL=https://liquidity-hq-staging.onrender.com npx playwright test
+//
+// WHY THIS EXISTS. QA signs off on what is DEPLOYED, and until now the suite
+// could only ever address localhost - so every "verified on qa" claim was in
+// fact measured against a local build of the same commit. Usually the same
+// thing; not always. Two failures this suite has already produced came from
+// exactly that gap: a stale `reuseExistingServer` build nearly reported a false
+// negative on #180, and #198's cache headers are correct locally and inert on
+// the deployed service, because the thing that was missing is infrastructure
+// that no local build has.
+//
+// WHAT DOES NOT WORK REMOTELY, and must be skipped rather than silently
+// mismeasured:
+//   - `qa/e2e/_fixtures.ts` route stubs still work (they intercept in the
+//     BROWSER), but `qa/server-intercept.mjs` does not - it is a node preload
+//     for a process we do not own here.
+//   - anything asserting build-time env inlining, since we did not do the build.
+//
+// Both Render non-prod services are on the free plan and sleep when idle, so
+// the first request after a quiet period can take ~50s. That is why the
+// navigation timeout is raised rather than the suite being called flaky.
+const BASE_URL = process.env.E2E_BASE_URL?.replace(/\/$/, '');
+const IS_REMOTE = Boolean(BASE_URL);
+
 export default defineConfig({
   testDir: './qa/e2e',
   // Each spec sweeps ~32 routes; the default 30s is not enough on a cold start.
@@ -68,10 +98,14 @@ export default defineConfig({
     : [['list'], ['html', { outputFolder: 'qa/e2e-report', open: 'never' }]],
 
   use: {
-    baseURL: `http://localhost:${PORT}`,
+    baseURL: BASE_URL ?? `http://localhost:${PORT}`,
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
     video: 'off',
+    // Free-plan Render services sleep when idle; the wake-up request is slow
+    // once and fast afterwards. Only raised for remote runs so a genuine local
+    // hang still fails fast.
+    ...(IS_REMOTE ? { navigationTimeout: 90_000, actionTimeout: 30_000 } : {}),
   },
 
   projects: [
@@ -93,7 +127,11 @@ export default defineConfig({
   // Playwright builds and boots the app itself so CI and local behave the same.
   // reuseExistingServer locally means a server you already have on 3100 is used
   // as-is; CI always starts its own.
-  webServer: {
+  //
+  // Omitted entirely when E2E_BASE_URL is set - building and booting a local app
+  // we are not going to address would waste ~4 minutes and, worse, could make a
+  // remote run look like it passed against something it never touched.
+  webServer: IS_REMOTE ? undefined : {
     command: `npm run build && npm start`,
     url: `http://localhost:${PORT}`,
     reuseExistingServer: !process.env.CI,

--- a/qa/e2e/cache-effective.spec.ts
+++ b/qa/e2e/cache-effective.spec.ts
@@ -1,0 +1,239 @@
+import { test, expect } from '@playwright/test';
+import { createHash } from 'node:crypto';
+
+/* Does the server-side cache actually SERVE repeat callers?
+ *
+ * `cache-policy.spec.ts` asserts a `Cache-Control` header is present. This
+ * asserts that a second caller costs no upstream call - which is the only reason
+ * anybody wanted the header, and a claim that file never made.
+ *
+ * ── WHAT THIS FILE COST ME, RECORDED SO IT IS NOT REPEATED ─────────────────
+ *
+ * Two wrong conclusions on the way here, both from the same habit of trusting a
+ * cheap signal that was adjacent to the real question.
+ *
+ * 1. I reported on #198 that repeat payloads VARY and called that independent
+ *    proof the cache was dead. It was not proof of anything. Both routes stamp
+ *    `ts: Date.now()` into every response, so the bytes differ on every request
+ *    no matter how well the data is cached. I was hashing a clock.
+ *
+ * 2. I filed #199 asking dev to build `lib/upstreamCache.ts`. `lib/apiCache.ts`
+ *    already existed, with `cached()` AND `cachedStale()` - including the
+ *    serve-stale-on-failure behaviour I raised as an open design question. My
+ *    grep searched for `new Map()` and the code says
+ *    `new Map<string, { ts: number; data: unknown }>()`, so the type parameters
+ *    hid it.
+ *
+ * Strip `ts` and measure again (qa, 4 requests ~800ms apart):
+ *
+ *   /api/market/snapshot  whole body  e3341fcc 7d29d12f 9d9c7fa1 82e433bf  VARIES
+ *                         minus ts    1309a683 1309a683 1309a683 1309a683  IDENTICAL
+ *   /api/market/rsi       whole body  c6240db6 7ea565ad 2bcc4aca 5835e799  VARIES
+ *                         minus ts    cdb116f4 cdb116f4 cdb116f4 cdb116f4  IDENTICAL
+ *
+ * The data is cached. It was cached the whole time.
+ *
+ * ── WHAT REMAINS TRUE FROM THE #198 INVESTIGATION ──────────────────────────
+ *
+ * The `s-maxage` finding stands, because it never rested on payloads: `age` is
+ * absent from every response, `x-render-origin-server: Render` is present on
+ * every repeat, and a `_next/static` chunk with `max-age=31536000, immutable` is
+ * `cf-cache-status: DYNAMIC` too. Nothing in front of this app caches anything.
+ *
+ * What changed is how much that matters. `s-maxage` being inert would be serious
+ * if it were the only thing collapsing upstream calls. It is not - `cached()`
+ * and Next's Data Cache already do that server-side, which is why the routes
+ * below pass. The header is redundant, not load-bearing.
+ *
+ * The real remaining cost is #200: 56 call sites still call Binance and Bybit
+ * straight from the browser, where no server-side cache can reach them.
+ *
+ * ── WHY THE ASSERTION IS SHAPED THIS WAY ───────────────────────────────────
+ *
+ * Byte-identity is NECESSARY evidence of a cache and never SUFFICIENT. An
+ * all-time high and a published calendar look identical with no cache at all. So
+ * a route is only usable here if its data provably moves when uncached, and the
+ * rest are reported honestly as inconclusive rather than counted as passes.
+ */
+
+/** ~800ms between samples: shorter than any TTL here, longer than one upstream tick. */
+const GAP_MS = 800;
+const SAMPLES = 4;
+
+/* Fields stamped per-response rather than carried from the cached data. Hashing
+ * these measures the server's clock, which is the mistake documented above. */
+const VOLATILE_FIELDS = ['ts', 'timestamp', 'generatedAt', 'fetchedAt'] as const;
+
+function stableDigest(raw: string): string {
+  let payload = raw;
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      for (const f of VOLATILE_FIELDS) delete (parsed as Record<string, unknown>)[f];
+      payload = JSON.stringify(parsed);
+    }
+  } catch {
+    /* Not JSON - hash it as-is. A non-JSON route is not one of ours below. */
+  }
+  return createHash('sha1').update(payload).digest('hex').slice(0, 10);
+}
+
+interface Probe { stable: string[]; raw: string[]; statuses: number[] }
+
+type Req = { get: (u: string) => Promise<{ status(): number; text(): Promise<string> }> };
+
+async function probe(request: Req, path: string): Promise<Probe> {
+  const stable: string[] = [];
+  const raw: string[] = [];
+  const statuses: number[] = [];
+
+  for (let i = 0; i < SAMPLES; i++) {
+    const res = await request.get(path);
+    statuses.push(res.status());
+    const body = await res.text();
+    raw.push(createHash('sha1').update(body).digest('hex').slice(0, 10));
+    stable.push(stableDigest(body));
+    if (i < SAMPLES - 1) await new Promise(r => setTimeout(r, GAP_MS));
+  }
+  return { stable, raw, statuses };
+}
+
+/* Routes whose DATA measurably moves when uncached, so identity across a window
+ * is real evidence. Each names the shortest TTL it composes, because the claim
+ * is "identical inside the shortest window this route depends on". */
+const CACHED: Array<{ path: string; shortestTtl: string; why: string }> = [
+  {
+    path: '/api/market/snapshot',
+    shortestTtl: '3 min (TICKER_TTL / KLINES_TTL)',
+    why: 'composes cached() over Bybit tickers, klines and LSR; the ticker moves every second when uncached',
+  },
+  {
+    path: '/api/market/rsi',
+    shortestTtl: '3 min (FAST_TTL)',
+    why: 'derived from live klines via cached(); recomputes on every uncached call',
+  },
+];
+
+/* Identity here proves nothing - the data barely moves either way. Asserted for
+ * liveness only, and used as the validity control below. */
+const INCONCLUSIVE: Array<{ path: string; why: string }> = [
+  { path: '/api/econ-calendar',   why: 'a published calendar is static for hours' },
+  { path: '/api/funding',         why: 'funding settles on a fixed 8-hour schedule' },
+  { path: '/api/signal-accuracy', why: 'historical stats change only when outcomes resolve' },
+  { path: '/api/forex/jpy',       why: 'quoted to few decimals; often unchanged second to second' },
+  /* DEMOTED from the group above by this file's own guard, on its first run.
+   * The audit called it "Yahoo quotes move continuously", so it looked usable.
+   * Five samples 10s apart say otherwise:
+   *   qa    aa3badbe aa3badbe aa3badbe aa3badbe 46b00156
+   *   prod  9f2f1492 d76e4589 d76e4589 d76e4589 d76e4589
+   * It ticks every ~30-40s, so at an 800ms gap it is stable by luck rather than
+   * by caching - the assertion would pass or fail on Yahoo's schedule. */
+  { path: '/api/macro',           why: 'ticks every ~30-40s, so a short sample is stable by luck, not by caching' },
+];
+
+test.describe('cache effectiveness', () => {
+  // HTTP-level; the mobile project would fetch identical bytes.
+  test.beforeEach(({}, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop', 'response bodies are viewport-independent');
+  });
+
+  for (const { path, shortestTtl, why } of CACHED) {
+    test(`${path} serves repeat callers from cache (${shortestTtl})`, async ({ request }) => {
+      const { stable, raw, statuses } = await probe(request, path);
+
+      expect(statuses.every(s => s < 400),
+        `${path} returned ${statuses.join(', ')} - cannot judge caching from a failing route`,
+      ).toBe(true);
+
+      const span = ((SAMPLES - 1) * GAP_MS) / 1000;
+
+      expect(new Set(stable).size,
+        `${path} returned ${new Set(stable).size} DIFFERENT payloads across ${SAMPLES} requests ` +
+        `spanning ~${span}s, far inside its ${shortestTtl} window.\n\n` +
+        `Volatile fields (${VOLATILE_FIELDS.join(', ')}) are already excluded, so this is the ` +
+        'DATA changing, not the response clock. Something stopped collapsing upstream calls: ' +
+        `check that this route still goes through cached() in lib/apiCache.ts (${why}).\n\n` +
+        'Cost of ignoring this: the route calls its upstream once per visitor instead of once ' +
+        'per TTL, so third-party spend scales with traffic. That is #197/#199, and the ' +
+        'CoinGecko 429s already seen on /api/ath are what it looks like when the bill lands.\n\n' +
+        `raw digests (WITH the clock, expected to differ): ${raw.join(' ')}\n` +
+        `stable digests (what is asserted):                ${stable.join(' ')}`,
+      ).toBe(1);
+
+      /* The clock SHOULD still move. If raw digests are identical too, something
+       * in front started serving a stored response - which would be new, since
+       * nothing currently caches at the edge. Not a failure, but it means the
+       * assertion above passed for a different reason than intended, and the
+       * file's premise needs re-checking. */
+      if (new Set(raw).size === 1) {
+        console.log(
+          `[cache-effective] NOTE: ${path} returned byte-identical responses INCLUDING its ` +
+          'per-request timestamp. A shared/edge cache may now be in play - re-check the ' +
+          'premise in this file\'s header before trusting it.',
+        );
+      }
+    });
+  }
+
+  /* The control that makes the group above mean something.
+   *
+   * Without it, a green run could equally mean the probe is measuring something
+   * that is constant for an uninteresting reason - an error page, a redirect, a
+   * cached 404. This asserts the probe observes stability where stability
+   * genuinely exists AND reports the routes it could not judge. */
+  test('control: the probe reports stability where data really is stable', async ({ request }) => {
+    const results: string[] = [];
+    let anyStable = false;
+
+    for (const { path, why } of INCONCLUSIVE) {
+      const { stable, statuses } = await probe(request, path);
+      if (statuses.some(s => s >= 400)) {
+        results.push(`${path}: HTTP ${statuses.join(',')} - upstream failing, skipped`);
+        continue;
+      }
+      const isStable = new Set(stable).size === 1;
+      if (isStable) anyStable = true;
+      results.push(`${path}: ${isStable ? 'stable' : 'varies'} (${why})`);
+    }
+
+    expect(anyStable,
+      'NOT ONE route returned an identical payload twice. Either every upstream is churning at ' +
+      'once, or the probe is measuring something other than the response body.\n\n' +
+      'Until this control passes, treat the results above as unproven - the probe has not ' +
+      'demonstrated it can tell stability from variation.\n\n' + results.join('\n'),
+    ).toBe(true);
+
+    console.log(`[cache-effective] inconclusive by design:\n  ${results.join('\n  ')}`);
+  });
+
+  /* /api/ath is deliberately NOT in either list.
+   *
+   * It returned `502 {"error":"Upstream unavailable"}` on qa on 2026-08-10 while
+   * production served 200 from the same commit. That is not flake - the comment
+   * in lib/apiCache.ts documents CoinGecko rate-limiting the qa instance by IP,
+   * and cachedStale() was written for this exact route because of it.
+   *
+   * Recorded as its own test because it is the live demonstration of #200's
+   * warning: one server IP asking a keyless public API on behalf of everyone is
+   * how you get refused. Right now cachedStale() has no last-good value to serve
+   * on qa, so the degradation is a 502 rather than a stale number.
+   *
+   * Asserted as KNOWN so it cannot be quietly forgotten, and so it FAILS the day
+   * qa starts succeeding - at which point delete this and put /api/ath in
+   * INCONCLUSIVE. */
+  test('KNOWN: /api/ath is rate-limited on non-prod and returns 502', async ({ request }) => {
+    const res = await request.get('/api/ath');
+
+    test.skip(
+      !(process.env.E2E_BASE_URL ?? '').includes('onrender.com'),
+      'the CoinGecko per-IP limit is specific to the deployed non-prod services',
+    );
+
+    expect(res.status(),
+      '/api/ath now succeeds on this environment. THAT IS THE GOOD OUTCOME - either the ' +
+      'CoinGecko limit reset, a key was added, or cachedStale() finally has a last-good value ' +
+      'to serve. Delete this test and move /api/ath into INCONCLUSIVE.\n\n' +
+      'If it was a key, check prod still has its own - see #200 on one IP fronting every user.',
+    ).toBe(502);
+  });
+});

--- a/qa/e2e/cache-policy.spec.ts
+++ b/qa/e2e/cache-policy.spec.ts
@@ -38,15 +38,46 @@ const SHIPPED: Array<{ path: string; expect: RegExp; note: string }> = [
   { path: '/api/macro',           expect: /s-maxage=300\b/,  note: 'Yahoo, er-api' },
   { path: '/api/econ-calendar',   expect: /s-maxage=3600\b/, note: 'ForexFactory, Fed' },
   { path: '/api/ath',             expect: /s-maxage=3600\b/, note: 'CoinGecko' },
+
+  /* ── PROMOTED FROM `PROPOSED` when #198 merged, 2026-08-10 ────────────────
+   *
+   * These five were the KNOWN group. #198 applied a policy to each, those
+   * inverting assertions failed exactly as designed, and this is the move they
+   * were written to trigger. Values read off `origin/dev` after the merge
+   * rather than copied from the PR description.
+   *
+   * READ THIS BEFORE CONCLUDING ANYTHING ABOUT COST. A policy here does NOT
+   * currently save an upstream call. Measured on prod and qa the same day:
+   * `age` is absent from every response, `x-render-origin-server: Render` is on
+   * every repeat, and a `_next/static` chunk with `max-age=31536000, immutable`
+   * is `cf-cache-status: DYNAMIC` too. Nothing in front of this app caches
+   * anything, so `s-maxage` has no consumer.
+   *
+   * What actually collapses upstream calls is server-side: `cached()` in
+   * `lib/apiCache.ts` and `next: { revalidate: N }`. That was already working
+   * before #198, which is why the real numbers never moved.
+   *
+   * So these assertions guard a header that is CORRECT and currently INERT.
+   * Worth keeping - it starts working the day a CDN appears and costs nothing -
+   * but `cache-effective.spec.ts` is the file that measures whether callers are
+   * actually served, and this one must not be mistaken for it again. */
+  { path: '/api/funding',         expect: /s-maxage=60\b/,   note: 'Binance + Bybit, #198' },
+  { path: '/api/cycle',           expect: /s-maxage=300\b/,  note: 'slow signal, #198' },
+  { path: '/api/signal-accuracy', expect: /s-maxage=3600\b/, note: 'historical stats, #198' },
+  { path: '/api/cmc',             expect: /s-maxage=300\b/,  note: 'CoinMarketCap is credit-metered, #198' },
+  { path: '/api/proxy',           expect: /s-maxage=300\b/,  note: 'Coinglass + trends, #198' },
+  /* Was the `max-age` case below - a per-browser cache that did nothing for the
+   * second visitor. #198 changed it to `s-maxage`, which is the fix. */
+  { path: '/api/forex/jpy',       expect: /s-maxage=300\b/,  note: 'was per-browser max-age, #198' },
 ];
 
-/** Uncached today. Proposed values are in the failure message, not asserted. */
-const PROPOSED: Array<{ path: string; proposed: string; why: string }> = [
-  { path: '/api/funding',         proposed: 's-maxage=60, swr=600',   why: 'funding settles on a fixed 8-hour schedule' },
-  { path: '/api/cycle',           proposed: 's-maxage=300, swr=600',  why: 'a slow signal; 5 minutes changes nobody\'s decision' },
-  { path: '/api/signal-accuracy', proposed: 's-maxage=3600, swr=7200', why: 'historical stats, change when outcomes resolve' },
-  { path: '/api/cmc',             proposed: 's-maxage=300, swr=600',  why: 'CoinMarketCap is credit-metered - longer is strictly cheaper' },
-];
+/** Uncached today. Proposed values are in the failure message, not asserted.
+ *
+ *  EMPTY since #198 - every route that was here now carries a policy and has
+ *  moved into SHIPPED above. Kept rather than deleted because the audit in
+ *  `qa/API_CACHE_AUDIT.md` covers 37 third-party routes and only 11 are
+ *  asserted here, so the next batch has somewhere to go. */
+const PROPOSED: Array<{ path: string; proposed: string; why: string }> = [];
 
 test.describe('API cache policy', () => {
   // HTTP-level; the mobile project would fetch identical headers.
@@ -113,18 +144,16 @@ test.describe('API cache policy', () => {
     });
   }
 
-  /* Not in either list: /api/forex/jpy uses `max-age`, which caches per-browser
-   * and does nothing for the second visitor. Recorded as its own case because
-   * "has a header" and "has a USEFUL header" are different claims, and the audit
-   * found this one had been mistaken for the first. */
-  test('KNOWN: /api/forex/jpy caches per-browser, not at the edge', async ({ request }) => {
-    const res = await request.get('/api/forex/jpy');
-    const cc = res.headers()['cache-control'] ?? '';
-
-    expect(cc, '/api/forex/jpy lost its Cache-Control entirely').toContain('max-age');
-    expect(cc,
-      '/api/forex/jpy now sends s-maxage - it caches at the shared edge and this KNOWN test is ' +
-      'obsolete. Move it into SHIPPED and delete this test.',
-    ).not.toContain('s-maxage');
-  });
+  /* `/api/forex/jpy` HAD ITS OWN TEST HERE UNTIL #198, and the reason is worth
+   * keeping even though the test is gone.
+   *
+   * It sent `max-age=300`, which caches in ONE browser and does nothing for the
+   * second visitor. It was in neither list because "has a header" and "has a
+   * USEFUL header" are different claims, and the audit found this route had been
+   * mistaken for the first. #198 changed it to `s-maxage` and it moved into
+   * SHIPPED above.
+   *
+   * The distinction it was written to make is the same one this whole file got
+   * wrong at a larger scale: a `Cache-Control` header being present says nothing
+   * about whether any cache honours it. See `cache-effective.spec.ts`. */
 });

--- a/qa/e2e/cache-policy.spec.ts
+++ b/qa/e2e/cache-policy.spec.ts
@@ -59,9 +59,29 @@ test.describe('API cache policy', () => {
       const res = await request.get(path);
 
       /* A 4xx/5xx can carry no cache header for reasons that have nothing to do
-       * with policy, so a failing route must not read as a missing policy. */
-      expect(res.status(), `${path} returned ${res.status()} - cannot judge its cache policy`)
-        .toBeLessThan(400);
+       * with policy, so a failing route must not read as a missing policy.
+       *
+       * SKIP, NOT FAIL, and this changed on 2026-08-10 after the first run
+       * against a DEPLOYED environment. `/api/ath` returns 502 on qa while
+       * production serves 200 from the same commit - CoinGecko rate-limits per
+       * IP and the qa instance has spent its budget, which `lib/apiCache.ts`
+       * already documents.
+       *
+       * Failing here reported that as `/api/ath returned 502 - cannot judge its
+       * cache policy` in the middle of a cache-policy run, which reads like this
+       * PR broke caching. It is an environmental limit on one non-prod service
+       * and has nothing to do with any header.
+       *
+       * The 502 is NOT swallowed - `cache-effective.spec.ts` asserts it as a
+       * KNOWN condition that fails the day qa starts succeeding. So the outage
+       * is still tracked, by a test whose subject it actually is, and this file
+       * goes back to only ever reporting on cache policy. */
+      test.skip(res.status() >= 400,
+        `${path} returned ${res.status()}, so there is nothing to judge here - a failing route ` +
+        'carries no cache policy either way. This is NOT a silent pass: the failure itself is ' +
+        'asserted in cache-effective.spec.ts, which fails when the route recovers. If you are ' +
+        'seeing this for a route other than /api/ath, that is a new upstream outage - check it ' +
+        'there rather than treating this skip as the finding.');
 
       const cc = res.headers()['cache-control'] ?? '';
       expect(cc,

--- a/qa/server-intercept.mjs
+++ b/qa/server-intercept.mjs
@@ -1,3 +1,6 @@
+import { writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
 /* Intercept the SERVER's outbound fetch, which `page.route` cannot reach.
  *
  * WHY THIS EXISTS. `qa/e2e/_fixtures.ts` intercepts what the BROWSER requests,
@@ -97,6 +100,63 @@ if (ENABLED) {
   /** host -> call count, so the report says WHERE the traffic goes. */
   const byHost = new Map();
 
+  /* The tally file is the only record that survives SIGKILL, so it is written
+   * DURING the run rather than at the end.
+   *
+   * Throttled to once a second: without that, a sweep making thousands of calls
+   * would do a synchronous write per call and change the timing of the thing it
+   * is measuring. Once a second means the worst case is losing the final <1s of
+   * counts to a hard kill, which cannot change any conclusion drawn from a run
+   * that lasts minutes.
+   *
+   * writeFileSync and not a stream: a stream buffers, and a buffer is exactly
+   * what SIGKILL discards. */
+  /* fileURLToPath, NOT `.pathname`. This repo lives under "VS code" - a path
+   * with a space - and `.pathname` percent-encodes it, so the first version
+   * wrote to `.../VS%20code/...`, which does not exist. The write threw, the
+   * catch below swallowed it exactly as designed, and the file simply never
+   * appeared. Caught by testing the SIGKILL case rather than assuming it. */
+  const TALLY_PATH = process.env.QA_INTERCEPT_OUT
+    ?? fileURLToPath(new URL('./.intercept-tally.json', import.meta.url));
+  let lastFlush = 0;
+  let trailing = null;
+
+  const flushTally = (force = false) => {
+    const now = Date.now();
+
+    /* LEADING + TRAILING, not leading only.
+     *
+     * A leading-only throttle writes the first call in each window and silently
+     * drops the rest, so the file records whatever happened to land on a window
+     * boundary. First test of this wrote `total: 1` after three calls - the two
+     * that followed within the same second were dropped and nothing ever wrote
+     * again, because the process then sat idle.
+     *
+     * The trailing timer guarantees the last state is always written once the
+     * window closes. `unref()` so an idle timer never holds the process open -
+     * this module must not change when the server is allowed to exit. */
+    if (!force && now - lastFlush < 1000) {
+      if (!trailing) {
+        trailing = setTimeout(() => { trailing = null; flushTally(true); }, 1000);
+        if (typeof trailing.unref === 'function') trailing.unref();
+      }
+      return;
+    }
+
+    lastFlush = now;
+    try {
+      writeFileSync(TALLY_PATH, JSON.stringify({
+        mode: MODE,
+        pid: process.pid,
+        updatedAt: new Date(now).toISOString(),
+        total: [...byHost.values()].reduce((n, c) => n + c, 0),
+        served,
+        passed,
+        byHost: Object.fromEntries([...byHost.entries()].sort((a, b) => b[1] - a[1])),
+      }, null, 2));
+    } catch { /* never break the app to record a measurement */ }
+  };
+
   globalThis.fetch = async function qaInterceptingFetch(input, init) {
     let url = '';
     try {
@@ -123,6 +183,8 @@ if (ENABLED) {
       const n = byHost.get(host);
       if (n === 1 || n % 25 === 0) log(`[intercept] ${host}: ${n}`);
     }
+
+    if (host) flushTally();
 
     /* count mode never stubs - it only observes. A measurement that alters the
      * thing being measured would answer a different question than #114 asks. */
@@ -151,12 +213,42 @@ if (ENABLED) {
     });
   };
 
-  process.on('exit', () => {
+  const report = (why) => {
     const rows = [...byHost.entries()].sort((a, b) => b[1] - a[1]);
     const total = rows.reduce((n, [, c]) => n + c, 0);
-    log(`[intercept] TOTAL outbound: ${total} (${served} stubbed, ${passed} passed through)`);
+    log(`[intercept] TOTAL outbound: ${total} (${served} stubbed, ${passed} passed through) [${why}]`);
     for (const [h, c] of rows) log(`[intercept]   ${String(c).padStart(5)}  ${h}`);
-  });
+  };
+
+  /* THREE WAYS OUT, because a measurement that only survives a graceful exit is
+   * not a measurement of anything that gets killed.
+   *
+   * Dev hit this on #201: they killed the server, the tally never printed, and
+   * they were left inferring the total from the `n % 25` progress lines above -
+   * enough to prove "fewer than 25", not enough to distinguish 1 from 24. My
+   * bug, reported by the person it cost time.
+   *
+   *   exit             - graceful, and the only one that fired before
+   *   SIGTERM/SIGINT   - how Playwright and Ctrl-C actually stop this process
+   *   the tally file   - the only thing that survives SIGKILL, which no handler
+   *                      can intercept by definition
+   *
+   * The signal handlers re-raise rather than calling process.exit() with a made
+   * up code: re-raising after removing the handler lets the process die of the
+   * signal it was sent, so the exit status still tells the truth about how it
+   * ended. */
+  process.on('exit', () => report('exit'));
+
+  for (const sig of ['SIGTERM', 'SIGINT', 'SIGHUP']) {
+    process.on(sig, () => {
+      report(sig);
+      flushTally();
+      process.removeAllListeners(sig);
+      process.kill(process.pid, sig);
+    });
+  }
+
+  log(`[intercept] tally file: ${TALLY_PATH} (survives SIGKILL)`);
 
   log(MODE === 'count'
     ? '[intercept] COUNT MODE - every call passes through untouched, tallied by host'


### PR DESCRIPTION
**QA Team** · QA-owned tooling only (`qa/`, `playwright.config.ts`, `.gitignore`). No app code.

## Summary

Three changes, all consequences of #198 turning out to be inert and of me getting two things wrong while investigating it.

## What changed

**1. `E2E_BASE_URL` — the suite can address a deployed service**

```
E2E_BASE_URL=https://liquidity-hq-qa.onrender.com      npx playwright test
E2E_BASE_URL=https://liquidity-hq-staging.onrender.com npx playwright test
```

Sets `baseURL` and omits the `webServer` entirely, so nothing is built or booted.

**2. `qa/e2e/cache-effective.spec.ts` — assert the cache SERVES, not that a header exists**

Repeat requests must return the same **data**, with `ts` / `timestamp` / `generatedAt` / `fetchedAt` excluded so the assertion cannot be fooled by a response clock.

**3. `qa/server-intercept.mjs` — the egress tally survives being killed**

Reports on `SIGTERM`/`SIGINT`/`SIGHUP` as well as graceful exit, and writes a running tally to `qa/.intercept-tally.json` (gitignored) during the run.

## Why

**`baseURL` was pinned to localhost.** QA signs off on what is *deployed*, and the suite could only ever address a local build — so every "verified on qa" claim to date was in fact measured against a local build of the same commit. Usually the same thing; not always, and the difference is undetectable from inside the suite. That is precisely what let #198 look finished: headers that are correct locally and inert on the deployed service, because what is missing is infrastructure no local build has.

**`cache-policy.spec.ts` passed green throughout and measured nothing of value.** Every route it guards really does send the header it claims. Not one of those headers caches anything on the deployed service. "The header is present" and "a second caller costs no upstream call" are different claims, and only the second one is why anybody wanted the header. I asserted the cheap one.

**The tally bug is dev's report from #201.** They killed the server, the tally never printed, and they were left inferring the total from the `n % 25` progress lines — enough to prove "fewer than 25", not enough to distinguish 1 from 24.

## Two things I got wrong, since the spec exists because of them

**1. I hashed a clock.** I reported on #198 that repeat payloads VARY and called it independent proof the cache was dead. Both routes do `NextResponse.json({ ..., ts: Date.now() })`, so the bytes differ regardless of caching. Excluding `ts` (qa, 4 requests ~800ms apart):

```
/api/market/snapshot   whole body   e3341fcc 7d29d12f 9d9c7fa1 82e433bf   VARIES
                       minus ts     1309a683 1309a683 1309a683 1309a683   IDENTICAL
/api/market/rsi        whole body   c6240db6 7ea565ad 2bcc4aca 5835e799   VARIES
                       minus ts     cdb116f4 cdb116f4 cdb116f4 cdb116f4   IDENTICAL
```

The data is cached. It always was.

**2. I filed #199 asking dev to build `lib/apiCache.ts`.** It already existed, with `cached()` *and* `cachedStale()` — including the serve-stale-on-failure behaviour I raised as an open question for dev to decide. My grep searched `new Map\(\)`; the code says `new Map<string, { ts: number; data: unknown }>()`, and the type parameters hid it. Retracted on #199 and #201.

**What survives:** there is no shared cache in front of either service — `age` absent from every response, `x-render-origin-server: Render` on every repeat, and a `max-age=31536000, immutable` static chunk also `DYNAMIC`. That never rested on payloads. But it matters less than I implied, because the server-side caches already collapse upstream calls. `s-maxage` is redundant, not load-bearing.

## The design point worth reviewing

**Byte-identity is necessary evidence of a cache and never sufficient.** An all-time high and a published calendar look identical with no cache at all. A spec that only checks identity would report passes on an app with no cache — the same failure one level deeper.

So the spec asserts only on routes whose data provably moves, carries a **control** proving the probe can distinguish stability from variation, and reports the rest as inconclusive rather than counting them as passes. `/api/macro` was demoted out of the conclusive set by that control on its first run — it ticks every ~30-40s, so at an 800ms sampling gap it is stable by luck rather than by caching.

## Verification

**Against the deployed `qa` service at `14c57b5`, not a local build:**

```
✓ /api/market/snapshot serves repeat callers from cache (3 min)
✓ /api/market/rsi serves repeat callers from cache (3 min)
✓ control: the probe reports stability where data really is stable
✓ KNOWN: /api/ath is rate-limited on non-prod and returns 502
4 passed (24.0s)
```

**The tally fix, tested by actually killing it** rather than assuming:

```
3 calls in → kill -9 → { "total": 3, "byHost": { "api.binance.com": 2, "api.bybit.com": 1 } }
```

That test found two bugs in my own fix: `new URL(...).pathname` percent-encodes and this repo lives under "VS code", so every write went to `.../VS%20code/...` and was swallowed by the catch; and a leading-only throttle recorded 3 calls as `total: 1`.

Gates: **lint 0 errors** (140 warnings, unchanged), **tsc clean**, **279 tests pass**.

## Finding, not part of this PR

**`/api/ath` returns `502 {"error":"Upstream unavailable"}` on qa** while production serves 200 from the same commit. The comment in `lib/apiCache.ts` already documents why — CoinGecko rate-limits per IP and the qa instance spent its budget — so `cachedStale()` is right in design but has no last-good value on qa, and the degradation is a 502 rather than a stale number.

Worth naming because **it is #200's warning already happening**: one server IP asking a keyless public API on behalf of everyone is how you get refused. Recorded as a KNOWN test that fails the day qa starts succeeding.

## How to test (QA)

This is QA's own tooling, so the reverse handoff — dev reviews, dev merges.

1. `npx playwright test qa/e2e/cache-effective.spec.ts --project=desktop` with no env var: runs against a local build exactly as before.
2. `E2E_BASE_URL=https://liquidity-hq-qa.onrender.com npx playwright test qa/e2e/cache-effective.spec.ts --project=desktop`: runs against the deployed qa service, no build step, ~24s.
3. `npm test` → 279 passing.
4. Confirm no behaviour change without `E2E_BASE_URL` set — the whole existing gate must be untouched.

## Risk level

**Low.** Test tooling only; nothing ships to users. The one behavioural risk is the `webServer` being omitted when `E2E_BASE_URL` is set — deliberate, since building an app you are not going to address wastes ~4 minutes and could make a remote run look like it passed against something it never touched.

**Not verified:** the suite has only been run end-to-end against `qa` for this one spec. Other specs assume a locally seeded state (fixture sign-in, build-time env inlining) and some will need work before they are meaningful remotely — named in the config comment rather than discovered later.
