### PR TITLE
fix(qa): pin the two query-param routes, and prove the contrast detector still sees

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -128,6 +128,27 @@ export default defineConfig({
   // reuseExistingServer locally means a server you already have on 3100 is used
   // as-is; CI always starts its own.
   //
+  // ⚠ DO NOT RUN TWO SUITES AT ONCE LOCALLY. The port is fixed, so a second
+  // invocation attaches to the first one's server and then tears it down when it
+  // finishes - the still-running suite starts getting
+  // `net::ERR_CONNECTION_REFUSED at http://localhost:3100/` partway through.
+  //
+  // Hit on 2026-08-10 while a 19-minute contrast sweep ran in the background and
+  // I ran cache-policy tests alongside it. All three contrast tests failed, which
+  // read as a broken refactor for a few minutes and was nothing of the kind.
+  //
+  // It did not become a WRONG result, only a lost one, because contrast.spec.ts
+  // asserts every route was actually measured and said so:
+  //
+  //     These routes were NOT measured, so this run is invalid rather than clean:
+  //     /privacy, /terms, /refund, ...
+  //
+  // That guard is the reason a half-measured sweep cannot report green. Any spec
+  // that sweeps routes should have the equivalent - without it this exact
+  // accident produces a clean-looking run over a fraction of the surface.
+  //
+  // If you need concurrency, give the second run its own port: `E2E_PORT=3101`.
+  //
   // Omitted entirely when E2E_BASE_URL is set - building and booting a local app
   // we are not going to address would waste ~4 minutes and, worse, could make a
   // remote run look like it passed against something it never touched.

--- a/qa/e2e/cache-policy.spec.ts
+++ b/qa/e2e/cache-policy.spec.ts
@@ -64,8 +64,25 @@ const SHIPPED: Array<{ path: string; expect: RegExp; note: string }> = [
   { path: '/api/funding',         expect: /s-maxage=60\b/,   note: 'Binance + Bybit, #198' },
   { path: '/api/cycle',           expect: /s-maxage=300\b/,  note: 'slow signal, #198' },
   { path: '/api/signal-accuracy', expect: /s-maxage=3600\b/, note: 'historical stats, #198' },
-  { path: '/api/cmc',             expect: /s-maxage=300\b/,  note: 'CoinMarketCap is credit-metered, #198' },
-  { path: '/api/proxy',           expect: /s-maxage=300\b/,  note: 'Coinglass + trends, #198' },
+  /* THE QUERY PARAMETER IS LOAD-BEARING. Do not "tidy" it away.
+   *
+   * Both routes dispatch on `?type=` and return 400 to a bare request BY
+   * DESIGN, on every service. Measured on qa and production:
+   *
+   *   /api/proxy           400      /api/proxy?type=etf      200
+   *   /api/cmc             400      /api/cmc?type=global     200
+   *
+   * Without the parameter they hit the skip guard below on EVERY run on EVERY
+   * environment, forever - so two of the six routes #198 changed would have
+   * been pinned by nothing while the file reported ten green tests.
+   *
+   * That is the same shape as the `/briefing` exemption removed in #196:
+   * invisible in a green run, reads as covered, asserts nothing. Different
+   * cause, identical effect on the report. Caught by dev on review of #203,
+   * after I promoted these two straight from PROPOSED without noticing that a
+   * bare request had never been a valid one. */
+  { path: '/api/cmc?type=global', expect: /s-maxage=300\b/,  note: 'CoinMarketCap is credit-metered, #198' },
+  { path: '/api/proxy?type=etf',  expect: /s-maxage=300\b/,  note: 'Coinglass + trends, #198' },
   /* Was the `max-age` case below - a per-browser cache that did nothing for the
    * second visitor. #198 changed it to `s-maxage`, which is the fix. */
   { path: '/api/forex/jpy',       expect: /s-maxage=300\b/,  note: 'was per-browser max-age, #198' },
@@ -107,12 +124,48 @@ test.describe('API cache policy', () => {
        * KNOWN condition that fails the day qa starts succeeding. So the outage
        * is still tracked, by a test whose subject it actually is, and this file
        * goes back to only ever reporting on cache policy. */
+      /* A 4xx and a 5xx mean OPPOSITE things here, and conflating them is how
+       * two routes ended up permanently skipped in #203.
+       *
+       *   5xx  the upstream is down or the IP is rate-limited. Environmental,
+       *        recovers on its own, and the route itself is fine. /api/ath.
+       *   4xx  WE asked wrong. The route is healthy and rejected the request,
+       *        which almost always means the path in the table above is missing
+       *        a required query parameter. A spec bug, and one that never
+       *        recovers on its own - it skips on every run on every service
+       *        forever while the file reports green.
+       *
+       * Both still skip rather than fail, because neither says anything about a
+       * cache policy. But the message has to name which one it is, or the next
+       * person reads a permanent spec bug as a passing upstream blip. */
+      const body = await res.text().catch(() => '');
+      const unconfigured = /not configured/i.test(body);
+
       test.skip(res.status() >= 400,
         `${path} returned ${res.status()}, so there is nothing to judge here - a failing route ` +
-        'carries no cache policy either way. This is NOT a silent pass: the failure itself is ' +
-        'asserted in cache-effective.spec.ts, which fails when the route recovers. If you are ' +
-        'seeing this for a route other than /api/ath, that is a new upstream outage - check it ' +
-        'there rather than treating this skip as the finding.');
+        'carries no cache policy either way.\n\n' +
+        (res.status() < 500
+          ? `A 4xx means THIS SPEC ASKED WRONG, not that anything is broken. Check whether ${path} ` +
+            'needs a query parameter: /api/cmc and /api/proxy both dispatch on `?type=` and return ' +
+            '400 to a bare request by design, on every environment. A skip from this cause is ' +
+            'PERMANENT - it will never recover, and the route is pinned by nothing until the path ' +
+            'is fixed. Same shape as the /briefing exemption removed in #196.'
+          : unconfigured
+            ? 'A MISSING API KEY, which is permanent in this environment rather than a passing ' +
+              'outage. The route answers 500 "not configured" on every run here and will never ' +
+              'recover on its own, so this assertion is pinned by nothing LOCALLY and IN CI.\n\n' +
+              'Known and accepted: /api/cmc needs CMC_API_KEY, which CI deliberately does not ' +
+              'carry. It is not left unverified - run this spec against a deployed service, where ' +
+              'the key exists and the route answers 200:\n\n' +
+              '    E2E_BASE_URL=https://liquidity-hq-staging.onrender.com npx playwright test ' +
+              'qa/e2e/cache-policy.spec.ts --project=desktop\n\n' +
+              'If a NEW route starts skipping for this reason, it is not covered anywhere until ' +
+              'someone runs it remotely. Say so rather than letting the green count imply otherwise.'
+            : 'A 5xx with no "not configured" is environmental - the upstream is down or this IP ' +
+              'is rate-limited, and it recovers on its own. Known case: /api/ath, where CoinGecko ' +
+              'limits per IP and both non-prod services have spent their budget while production ' +
+              'is fine. Not a silent pass: cache-effective.spec.ts asserts that 502 as a KNOWN ' +
+              'condition and fails when the route recovers.'));
 
       const cc = res.headers()['cache-control'] ?? '';
       expect(cc,

--- a/qa/e2e/contrast.spec.ts
+++ b/qa/e2e/contrast.spec.ts
@@ -204,8 +204,25 @@ async function measure(page: Page, theme: string, route: string): Promise<Violat
   }));
   if (rendered.elements < 30 || rendered.color === 'rgb(0, 0, 0)') return null;
 
+  const found = await detectContrastViolations(page);
+  return found.map(f => ({ ...f, route }));
+}
+
+/* EXTRACTED so the control test below can exercise THIS code, not a copy of it.
+ *
+ * A control that re-implements the detector proves the copy works. The whole
+ * value is that the sweep's real detector is the thing being checked, so if axe
+ * stops loading, the rule name changes, or the message format shifts, the
+ * control goes red for the same reason the sweep would go quietly green.
+ *
+ * The regex is the fragile part and the reason this matters. It parses a
+ * human-readable axe message, so an upstream wording change makes every match
+ * return null - `found` becomes empty, every route reports zero violations, and
+ * the sweep passes while measuring nothing. That failure is invisible: a green
+ * contrast run looks exactly like a clean one. */
+async function detectContrastViolations(page: Page): Promise<Omit<Violation, 'route'>[]> {
   await page.addScriptTag({ path: require.resolve('axe-core/axe.min.js') });
-  const found = await page.evaluate(async () => {
+  return await page.evaluate(async () => {
     // @ts-expect-error injected at runtime
     const res = await window.axe.run(document, { runOnly: { type: 'rule', values: ['color-contrast'] } });
     return res.violations.flatMap((v: { nodes: { target: string[]; any?: { message?: string }[] }[] }) =>
@@ -217,8 +234,6 @@ async function measure(page: Page, theme: string, route: string): Promise<Violat
           : null;
       }).filter(Boolean));
   }) as Omit<Violation, 'route'>[];
-
-  return found.map(f => ({ ...f, route }));
 }
 
 test.describe('colour contrast', () => {
@@ -466,5 +481,90 @@ Same triage as the dark test: a state that had not rendered before (add it, with
       `The fix for this family belongs in the [data-theme="light"] block on the FOREGROUND ` +
       `tokens. Do not lighten the backgrounds - that breaks dark.`,
     ).toEqual([]);
+  });
+
+  /* THE CONTROL. Read this before trusting either test above.
+   *
+   * Both of them assert `unexpected` is EMPTY. An empty array is also what a
+   * broken detector returns, and the two are indistinguishable from the result:
+   * a sweep that finds nothing because everything passes and a sweep that finds
+   * nothing because it stopped looking both print "0 unexpected" and go green.
+   *
+   * That is not hypothetical here. `detectContrastViolations` parses a
+   * HUMAN-READABLE axe message with a regex:
+   *
+   *     /contrast of ([\d.]+).*foreground color: (#[0-9a-f]{3,8}), .../i
+   *
+   * An axe-core upgrade that rewords that sentence makes every match return
+   * null. `found` becomes empty for every route in both themes, the baselines
+   * stop being checked against anything, and nothing anywhere goes red. The
+   * suite would keep reporting a clean contrast sweep indefinitely.
+   *
+   * So: inject a KNOWN failure and require the detector to find it. This is the
+   * same shape as the self-test in layout.spec.ts and the control in
+   * cache-effective.spec.ts, and it exists for the same reason - an assertion
+   * that something is absent is worthless without evidence the instrument can
+   * detect it when present.
+   *
+   * TWO-SIDED ON PURPOSE. Finding the bad element proves it is not blind;
+   * ignoring the good one proves it is not simply flagging everything. A
+   * detector that reported every element would also "catch" the injected div
+   * while making the baselines meaningless noise.
+   *
+   * Cheap: one page load against a static route, no market data, no sweep.
+   */
+  test('control: the detector still finds a contrast failure when one exists', async ({ browser }) => {
+    const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+    const page = await ctx.newPage();
+
+    try {
+      await page.goto('/offline', { waitUntil: 'domcontentloaded' });
+
+      /* #767676 on #808080 is ~1.1:1 - far below the 4.5:1 of SC 1.4.3, and not
+       * a colour this app uses, so it cannot collide with a real token in the
+       * baselines. Explicit background on the element itself so the result does
+       * not depend on what the page happens to render behind it. */
+      await page.evaluate(() => {
+        const el = document.createElement('p');
+        el.id = 'qa-contrast-control';
+        el.textContent = 'contrast control probe';
+        el.setAttribute('style',
+          'color:#767676;background:#808080;font-size:14px;padding:8px;position:fixed;top:0;left:0;z-index:99999');
+        document.body.appendChild(el);
+
+        /* And a PASSING sibling, for the second half of the assertion.
+         * #000000 on #ffffff is 21:1, the maximum possible. */
+        const ok = document.createElement('p');
+        ok.id = 'qa-contrast-control-pass';
+        ok.textContent = 'contrast control passing probe';
+        ok.setAttribute('style',
+          'color:#000000;background:#ffffff;font-size:14px;padding:8px;position:fixed;top:40px;left:0;z-index:99999');
+        document.body.appendChild(ok);
+      });
+
+      const found = await detectContrastViolations(page);
+
+      const hitBad = found.some(v => v.fg === '#767676');
+      expect(hitBad,
+        'The contrast detector did not report an element at ~1.1:1 that was injected specifically ' +
+        'for it to find.\n\n' +
+        'DO NOT SUPPRESS THIS. While it fails, BOTH sweeps above are meaningless - they assert an ' +
+        'empty result, and an empty result is exactly what a blind detector returns. A green ' +
+        'contrast run and a broken one look identical from the outside.\n\n' +
+        'Most likely cause: axe-core was upgraded and reworded its violation message, so the regex ' +
+        'in detectContrastViolations no longer matches and every parse returns null. Check the raw ' +
+        'message before changing anything else.\n\n' +
+        `Detector returned ${found.length} violation(s): ` +
+        (found.length ? found.map(v => `${v.fg} on ${v.bg} at ${v.ratio}:1`).join(', ') : '(none at all)'),
+      ).toBe(true);
+
+      expect(found.some(v => v.fg === '#000000' && v.bg === '#ffffff'),
+        'The detector reported black-on-white (21:1, the maximum possible ratio) as a contrast ' +
+        'failure. It is flagging elements that pass, so the baselines above are recording noise ' +
+        'rather than real failures and their counts cannot be trusted.',
+      ).toBe(false);
+    } finally {
+      await ctx.close();
+    }
   });
 });


### PR DESCRIPTION
**QA Team** · your #203 catch, fixed — plus a control for the contrast sweep

QA-owned files only (`qa/e2e/`). No app code.

## 1. `/api/cmc` and `/api/proxy` are pinned now

You were right, and I verified it rather than taking the numbers:

```
                        qa    prod
/api/proxy             400    400
/api/proxy?type=etf    200    200
/api/cmc               400    400
/api/cmc?type=global   200    200
```

Both entries carry the parameter now. I promoted them straight out of `PROPOSED` without noticing a bare request had never been valid for either.

**Your framing is the useful part:** *"the same shape as the `/briefing` exemption we removed in #196 — invisible in a green run, reads as covered, asserts nothing."* That is the third time today the same defect has turned up wearing a different hat, and the first two were also mine.

### One correction to your diagnosis

Fixing the parameter fixes `/api/proxy?type=etf` — it asserts now. **It does not fix `/api/cmc?type=global`**, and I would rather say so than let this read as closed:

```ts
const CMC_KEY = process.env.CMC_API_KEY ?? '';
// route.ts:79
return NextResponse.json({ error: 'CMC_API_KEY not configured' }, { status: 500 });
```

CI carries no `CMC_API_KEY`, so that route answers 500 on every CI run and the assertion still skips permanently — just for a different reason than the one you found. The query parameter was necessary and not sufficient.

So the guard now names **three** causes instead of one, because conflating them is exactly what hid this:

| Status | Meaning | Recovers? |
|---|---|---|
| `4xx` | this spec asked wrong — missing query parameter | never, until the path is fixed |
| `5xx` + `"not configured"` | missing API key | never, in this environment |
| `5xx` otherwise | upstream down or IP rate-limited | on its own — `/api/ath` |

The missing-key message carries the command to actually verify it, since a deployed service *does* have the key:

```
E2E_BASE_URL=https://liquidity-hq-staging.onrender.com npx playwright test qa/e2e/cache-policy.spec.ts --project=desktop
```

That is the first thing `E2E_BASE_URL` has paid for beyond the cache work.

**Local build of `dev`: 10 passed, 1 skipped**, up from 9 passed / 2 skipped.

## 2. Contrast detector control

Unrelated to the above, same class of bug.

Both contrast tests assert `unexpected` is **empty** — and an empty array is also precisely what a broken detector returns. A sweep that finds nothing because everything passes and one that finds nothing because it stopped looking both print `0 unexpected` and go green.

Not hypothetical. The detector parses a **human-readable** axe message with a regex:

```
/contrast of ([\d.]+).*foreground color: (#[0-9a-f]{3,8}), .../i
```

An axe-core upgrade that rewords that sentence makes every match return `null`. `found` goes empty for all 32 routes in both themes, the baselines stop being compared against anything, and nothing goes red.

So: extracted the axe call into `detectContrastViolations` and pointed a control at **the real function, not a copy** — a control that re-implements the detector only proves the copy works.

**Two-sided on purpose.** Injects `#767676` on `#808080` (~1.1:1) and requires it be found; injects `#000000` on `#ffffff` (21:1, the maximum) and requires it *not* be flagged. Finding the bad one proves it is not blind; ignoring the good one proves it is not simply reporting everything, which would make the baselines noise.

**Mutation tested**, since a control that cannot fail is not a control:

```
regex -> /MUTANTNEVERMATCHES (
✘ control: the detector still finds a contrast failure when one exists
  Detector returned 0 violation(s): (none at all)
```

Reverted after. Cost is one page load against `/offline` — no market data, no sweep. The two real sweeps are untouched.

Full sweep re-running now to confirm the extraction changed nothing; the dark half already reported `13 violations across 11 tokens (baseline 11)`, unchanged. I will post the light half when it lands rather than claiming it now.

## Board

- **#197 and #199** — closing both with the evidence, not just because the PRs merged.
- **#200** — still the real remaining work, and `/api/ath` being rate-limited on *both* non-prod services is that risk already realised.
- **Promotion** — say the word and I will take `dev` → `qa` once this lands, then you deploy `qa` and `staging` together as you offered.
- **#114** — dispatch running on `dev` with `count_egress=true` right now. First real measurement of CI's own egress.
