### PR TITLE
fix(qa): one egress tally file per process, or they destroy each other

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -522,7 +522,12 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: egress-tally-${{ github.run_attempt }}
-          path: qa/.intercept-tally.json
+          # A GLOB. Every node process in the tree loads the preload and writes
+          # its own pid-suffixed file - the npm wrapper, the build, the Next
+          # server, each Playwright worker. A single shared path made them
+          # overwrite each other and the last writer won, which in the first real
+          # run was a short-lived process reporting nothing.
+          path: qa/.intercept-tally.*.json
           retention-days: 30
           if-no-files-found: warn
 
@@ -532,21 +537,46 @@ jobs:
       - name: Summarise egress
         if: ${{ always() && github.event_name == 'workflow_dispatch' && inputs.count_egress }}
         run: |
-          if [ ! -f qa/.intercept-tally.json ]; then
+          shopt -s nullglob
+          FILES=(qa/.intercept-tally.*.json)
+          if [ ${#FILES[@]} -eq 0 ]; then
             echo "No tally written. The preload did not load, or no outbound call was made." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
+
           # grep, not require() - playwright.config.ts is TypeScript and node
           # cannot load it here. The number is what the tally must be read
           # against: N calls at 2 workers says nothing about 4 on its own.
           WORKERS=$(grep -oE '^\s*workers:\s*[0-9]+' playwright.config.ts | grep -oE '[0-9]+' | head -1)
+
+          # Sum across processes. The process COUNT is reported too, because it
+          # is the signal that aggregation is working at all - a single file
+          # would mean we are back to one process clobbering the rest.
+          node -e '
+            const fs = require("fs");
+            const files = process.argv.slice(1);
+            const byHost = {};
+            let total = 0;
+            for (const f of files) {
+              try {
+                const t = JSON.parse(fs.readFileSync(f, "utf8"));
+                for (const [h, n] of Object.entries(t.byHost || {})) {
+                  byHost[h] = (byHost[h] || 0) + n;
+                  total += n;
+                }
+              } catch { /* a half-written file is not worth failing the summary over */ }
+            }
+            const rows = Object.entries(byHost).sort((a, b) => b[1] - a[1]);
+            console.log(JSON.stringify({ processes: files.length, total, byHost: Object.fromEntries(rows) }, null, 2));
+          ' "${FILES[@]}" > /tmp/egress-summary.json
+
           {
             echo "## Outbound third-party calls"
             echo ""
-            echo "Measured at \`workers: ${WORKERS:-unknown}\`."
+            echo "Measured at \`workers: ${WORKERS:-unknown}\`, aggregated across ${#FILES[@]} node process(es)."
             echo ""
             echo '```json'
-            cat qa/.intercept-tally.json
+            cat /tmp/egress-summary.json
             echo '```'
             echo ""
             echo "Per-IP rate limits apply to this runner's egress, not to a developer machine."

--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,4 @@ qa/e2e-report/
 test-results/
 # Written during a run by qa/server-intercept.mjs in count mode. A measurement
 # artefact, and it is rewritten every second while a run is in progress.
-qa/.intercept-tally.json
+qa/.intercept-tally.*.json

--- a/qa/STATUS.md
+++ b/qa/STATUS.md
@@ -2,7 +2,7 @@
 
 **One page. If you only read one thing, read this.**
 
-Kept current by QA. Last updated **2026-08-09**.
+Kept current by QA. Last updated **2026-08-10**.
 
 ## Read this before you trust anything below
 
@@ -49,6 +49,9 @@ morning and done by lunchtime. They live on the issue that needs them.
 | **`staging` exists so a signed-off release stops growing.** Only QA promotes into it, and never while a release PR is open | 2026-08-07 | `CONTRIBUTING.md` §6 |
 | **Never require PR approvals.** Dev and QA share one GitHub account, so `Can not approve your own pull request` would deadlock every release permanently | 2026-08-08 | `CONTRIBUTING.md` §3a |
 | **The signup trial trigger is fine.** Measured, not assumed — the three rowless accounts predate it and every signup since 2026-08-01 has a row | 2026-08-09 | #127, closed |
+| **`s-maxage` caches nothing here.** No shared cache fronts either service: `age` absent on every response, `x-render-origin-server` present on every repeat, and an `immutable` static chunk is `cf-cache-status: DYNAMIC` too. What collapses upstream calls is server-side — `cached()` in `lib/apiCache.ts` and `next: { revalidate }` | 2026-08-10 | #198, #197 closed with the measurement |
+| **The suite can address a deployed service.** `E2E_BASE_URL=https://…` sets `baseURL` and drops the `webServer`. Before this, every "verified on qa" claim was measured against a *local build of the same commit* | 2026-08-10 | #203; comment in `playwright.config.ts` |
+| **A cache assertion must measure the DATA, not a header and not a clock.** Both market routes stamp `ts: Date.now()`, so whole-body diffs vary however well the data is cached | 2026-08-10 | `qa/e2e/cache-effective.spec.ts` header |
 
 ---
 
@@ -90,6 +93,25 @@ gh issue list --state open
   decisions table.
 - **A skip is not a pass, and this suite has several.** Every one names its reason
   in the skip message. Read them; some are accepted limits and some are findings.
+- **The E2E gate is not currently running** — #207. E2E fires only on release PRs,
+  and `RELEASE_PR_PAUSED` stops those being opened, so across 60 CI runs the only
+  completed browser suites were two manual dispatches. `smoke`, `cache-policy` and
+  `cache-effective` are covered by QA running them against the deployed services;
+  **`perf`, `a11y`, `a11y-auth`, `bola`, `contrast`, `i18n`, `layout`, `clock`,
+  `payments-webhook` and `checkout` are covered nowhere** until this is fixed.
+- **`perf.spec`'s LCP budget was calibrated on a laptop.** `< 2500ms` against a
+  local 84–720ms measurement — 3× headroom over a dev machine and none over a
+  GitHub runner, where the five heaviest routes land at 2740–4456ms. It fails in
+  CI and passes locally on the same commit, so it currently gates nothing and
+  would not be believed if it did. Do **not** raise the number to make it green;
+  decide first whether it asserts a user-facing target or catches regressions.
+- **An empty result is not evidence unless something proves the instrument works.**
+  This bit three separate times on 2026-08-10 and is the single most repeated
+  defect in this suite: `cache-policy` asserted headers that cached nothing;
+  `/api/cmc` and `/api/proxy` skipped permanently while reporting green; the
+  contrast detector parses a human-readable axe message with a regex, so an
+  upstream reword would silently return zero violations forever. Each now carries
+  a control or a named cause. **Any spec asserting "no findings" needs one.**
 
 ---
 

--- a/qa/server-intercept.mjs
+++ b/qa/server-intercept.mjs
@@ -111,13 +111,34 @@ if (ENABLED) {
    *
    * writeFileSync and not a stream: a stream buffers, and a buffer is exactly
    * what SIGKILL discards. */
-  /* fileURLToPath, NOT `.pathname`. This repo lives under "VS code" - a path
-   * with a space - and `.pathname` percent-encodes it, so the first version
-   * wrote to `.../VS%20code/...`, which does not exist. The write threw, the
-   * catch below swallowed it exactly as designed, and the file simply never
-   * appeared. Caught by testing the SIGKILL case rather than assuming it. */
+  /* ONE FILE PER PROCESS, and the pid in the name is the whole point.
+   *
+   * `NODE_OPTIONS` applies to EVERY node process in the tree - the npm wrapper,
+   * the build, the Next server, each Playwright worker. Every one of them loads
+   * this module and gets its OWN `byHost` map.
+   *
+   * The first version wrote them all to a single path, so they overwrote each
+   * other and the last writer won. In CI that was a short-lived process with
+   * nothing to report, and the run ended with:
+   *
+   *     [intercept] TOTAL outbound: 0 (0 stubbed, 0 passed through) [exit]
+   *
+   * while a worker in the same run had already logged
+   * `TOTAL outbound: 8 ... 8 wdtjhrilakoitfcezxpx.supabase.co`. The tally was
+   * never wrong, it was destroyed - which is the same failure as the original
+   * `process.on('exit')` bug wearing a different hat, and I shipped it in the
+   * fix for that bug.
+   *
+   * Per-pid files cannot collide. The reader sums them; ci.yml aggregates the
+   * glob and reports both the total and the process count, because "12 processes
+   * reported" is itself the signal that this is working.
+   *
+   * fileURLToPath, NOT `.pathname`: this repo lives under "VS code" and
+   * `.pathname` percent-encodes the space, so the first version wrote to
+   * `.../VS%20code/...`, threw, and was swallowed by the catch exactly as
+   * designed. Caught by testing the SIGKILL case rather than assuming it. */
   const TALLY_PATH = process.env.QA_INTERCEPT_OUT
-    ?? fileURLToPath(new URL('./.intercept-tally.json', import.meta.url));
+    ?? fileURLToPath(new URL(`./.intercept-tally.${process.pid}.json`, import.meta.url));
   let lastFlush = 0;
   let trailing = null;
 


### PR DESCRIPTION
﻿**QA Team** · the first real egress measurement returned zero, and zero was wrong

QA-owned files only (`qa/server-intercept.mjs`, `.github/workflows/ci.yml`, `.gitignore`). No app code.

## What happened

Run `31340919561`, the first `count_egress` dispatch, ended with:

```
[intercept] TOTAL outbound: 0 (0 stubbed, 0 passed through) [exit]
```

A worker in that same run had already logged:

```
[intercept] TOTAL outbound: 8 (0 stubbed, 8 passed through) [exit]
[intercept]       8  wdtjhrilakoitfcezxpx.supabase.co
```

**The tally was never wrong — it was destroyed.** `NODE_OPTIONS` applies to every node process in the tree (the npm wrapper, the build, the Next server, each Playwright worker) and each one loads the preload and gets its own `byHost` map. They all wrote the same path, so the last writer won. In CI that was a short-lived process with nothing to report.

## Why this one stings

This is the same failure mode as the `process.on('exit')` bug you reported on #201 — *a measurement that does not survive how the process actually ends* — and **I shipped it inside the fix for that bug.**

The signal was even in the log the whole time: `[intercept] tally file: ...` printed once per process, over and over. I read those lines as "the preload is loading" and not as "there are twelve of these and they all point at one file."

## The fix

- **Pid-suffixed files** — `qa/.intercept-tally.<pid>.json`. Two processes cannot collide.
- **ci.yml uploads the glob** and sums across files.
- **The summary reports the process COUNT next to the total.** That is deliberate: one file means we are back to clobbering, so the count is the signal that aggregation is working at all. A total with no denominator is what made this invisible.

## Verified against the case that broke it

Three concurrent processes making 2, 3 and 4 calls, all `SIGKILL`ed:

```
processes: 3, total: 9, byHost: { "api.binance.com": 9 }
```

Under the previous code these produced one file containing whichever process wrote last.

## Still open, and not mine to close alone

The same run had **5 perf failures** — `/arena LCP 3232ms`, plus `/dashboard`, `/markets`, `/briefing`, `/scanner`, all failing on retry. Detail on #114. A clean A/B without the preload is running as `31342723007`; if perf passes there, my instrumentation caused it and the `ci.yml` comment claiming count mode is measurement-neutral is wrong and gets corrected in this PR.

I would rather hold that claim open than merge a comment asserting something I am currently testing.
