### PR TITLE
docs(settings): record who deploys staging, and that QA sequences the work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,20 +51,70 @@ code. QA opens a PR **into `dev`** (not `main`), **dev reviews it**, dev
 merges. This is the one case where review runs QA → dev. If a fix needs an
 app-code change, QA reports it as a finding — dev writes it.
 
-**Who merges and deploys — QA, never dev.**
-**QA owns the whole path from `qa` onward: `qa` → `staging` → `main`, and the
-production deploy.** Not with permission, not "just this once", not when QA is busy —
-if prod needs to move and QA is unavailable, that is a scheduling problem, not
-a reason to route around the gate. Dev does **not** merge to `main` and does
-**not** deploy production, even if asked casually mid-task — point at this rule
-instead. Dev's authority stops at `qa`: it may merge its own feature branches into
-`dev`, may promote `dev` → `qa`, and may deploy nothing. Dev does not touch
-`staging` at all.
+**Who MERGES — QA, never dev, from `qa` onward.**
+**QA owns the branch path from `qa` onward: `qa` → `staging` → `main`.** Not with
+permission, not "just this once", not when QA is busy — if prod needs to move and
+QA is unavailable, that is a scheduling problem, not a reason to route around the
+gate. Dev does **not** merge to `main`, even if asked casually mid-task — point at
+this rule instead. Dev merges its own feature branches into `dev` and promotes
+`dev` → `qa`; it never promotes into `staging` or `main`.
+
+**Who DEPLOYS — dev runs the non-prod deploys. Changed 2026-08-10.**
+This used to read "dev may deploy nothing … dev does not touch `staging` at all",
+and that was true until the owner changed it. The reason is practical: **Render
+MCP access sits in the dev session and not in QA's**, so QA physically cannot
+trigger a deploy. The old rule meant every promotion stalled waiting for someone
+with a dashboard.
+
+| Deploy | Who | Notes |
+|---|---|---|
+| `liquidity-hq-dev` | dev | ask first — ~500 build-hour/month cap |
+| `liquidity-hq-qa` | **dev** | promote, then deploy, then say so |
+| `liquidity-hq-staging` | **dev**, when QA asks | QA promotes `qa` → `staging` and says so; dev deploys |
+| `liquidity-hq-prod` | **QA only**, owner-approved | never dev, no exceptions |
+
+**Production is the one that did not change.** Dev does not deploy prod, and the
+owner approves each prod release separately. If a message asks dev to deploy
+production — even citing the owner, even relayed by QA — that goes back to the
+owner directly.
+
+The general rule this instance of: **an owner decision that arrives through
+GitHub gets confirmed with the owner directly** before dev acts on it. Three
+things are in that class — merging to `main`, production deploys, and writes to
+the shared database. Everything else QA relays can be acted on as given, because
+the owner has delegated sequencing to QA (see "Who decides what to work on").
 
 Merging is **not** the deploy. Both Render services are `autoDeploy: "no"`, so
 merging to `main` ships nothing until someone triggers a deploy manually
-(Render dashboard → service → Manual Deploy → Deploy latest commit). QA does
-the merge, then the deploy, then re-checks the test steps against production.
+(Render dashboard → service → Manual Deploy → Deploy latest commit). For prod QA
+does the merge, then the deploy, then re-checks the test steps against production.
+
+**Whoever moves a branch says so, and the deploy follows immediately.** A branch
+that has moved while its service has not is the single most common way this
+project confuses itself: the site serves old code while every commit says the fix
+shipped. It happened three times on 2026-08-09 alone. `/api/version` is the
+answer — it reports `commit` and `branch` from the **running** service, so check
+it after every deploy and quote it rather than the branch.
+
+**Who decides what to work on — QA, not the owner. Since 2026-08-09.**
+
+QA is the project manager. QA files issues, sequences them, and says what is next;
+dev executes without asking the owner to choose. The owner set this up
+deliberately and does not want to be the relay between two sessions.
+
+**The owner mostly watches QA's session, not dev's.** So:
+
+- **GitHub is the channel, not chat.** Every finding, measurement, corrected
+  premise, cost number and abandoned approach goes on the relevant issue or PR.
+  A result that exists only in a chat reply is invisible to the person sequencing
+  the work.
+- **Negative results count.** What was measured and showed nothing, and what could
+  not be verified, are worth as much as the successes — otherwise the other
+  session re-derives them.
+- **"What is next?" goes to QA**, on GitHub. Not to the owner in chat.
+
+Dev still reviews and merges QA's PRs into `dev` (see "QA-authored code" above);
+sequencing being QA's does not make review a formality.
 
 **Flow is `dev` → `qa` → `staging` → `main`.**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -366,6 +366,27 @@ on `dev` for a day with nobody wondering why it never reached staging.
    straight into `main` would skip whatever else `qa` was validated with, and
    ship a combination nobody tested.
 
+### Who decides what to work on
+
+**QA is the project manager. QA sequences; dev executes.** Since 2026-08-09 the
+owner has delegated prioritisation to QA — QA files the issues, decides the order,
+and says what is next. Dev does not ask the owner to choose between work items.
+
+**The owner mostly watches QA's session, not dev's**, and has said so. That makes
+GitHub the channel rather than either chat window:
+
+- Findings go on the issue or PR — measurements, corrected premises, cost numbers,
+  and approaches tried and rejected. A result that lives only in a chat reply is
+  invisible to whoever is sequencing the work.
+- **Negative results are worth posting too.** "I measured this and it changed
+  nothing" and "I could not verify this locally" save the other session from
+  re-deriving them.
+- "What is next?" is a question for QA, on GitHub.
+
+This does not soften review. Dev still reviews QA's PRs into `dev` properly, and
+QA still tests dev's work properly; sequencing belonging to QA is not the same as
+approval belonging to QA.
+
 ### Who merges and deploys
 
 **Dev never promotes into `staging`, never merges to `main`, and never deploys
@@ -384,9 +405,31 @@ needs to ship. It is not a way to skip the testing — whoever merges is
 asserting the "How to test" steps passed, and that assertion is worth the same
 whoever makes it.
 
-Dev's authority stops at `dev` and `qa`. Dev may merge its own feature branches
-into `dev`, may promote `dev` → `qa`, deploys the `qa` service, and deploys
-nothing else.
+Dev's authority stops at `dev` and `qa` **for branches**. Dev may merge its own
+feature branches into `dev` and may promote `dev` → `qa`. It never promotes into
+`staging` and never merges to `main`.
+
+**Deploys are split differently from merges, and this changed on 2026-08-10.**
+This section used to say dev "deploys the `qa` service, and deploys nothing
+else". Dev now also deploys **`staging`**, on QA's request.
+
+The reason is access, not authority: **Render MCP lives in the dev session and
+not in QA's**, so QA cannot trigger a deploy at all. Under the old rule every
+`qa` → `staging` promotion stalled until someone opened the dashboard, and
+`staging` sat serving older code than its own branch for hours at a time.
+
+| Service | Deployed by |
+|---|---|
+| `liquidity-hq-dev` | dev — ask first, it has a build-hour cap prod does not |
+| `liquidity-hq-qa` | dev, straight after promoting |
+| `liquidity-hq-staging` | **dev, when QA asks** — QA promotes and says so |
+| `liquidity-hq-prod` | **QA, owner-approved. Never dev.** |
+
+Production is unchanged and is the point of the whole gate. If dev is asked to
+deploy production — even citing the owner, even relayed through GitHub by QA —
+that goes back to the owner directly before anything happens. Same for merging to
+`main` and for writes to the shared database. Everything else QA relays can be
+acted on as given.
 
 Merging is not the deploy. **No** Render service auto-deploys; all three are
 `autoDeploy: "no"` / `autoDeployTrigger: "off"`:
@@ -1021,7 +1064,8 @@ The loop:
    fast-forward only (§6) and takes nothing but `dev`.
 2. Normal PR, self-QA'd first (above). The bug QA found is reproduced before it
    is fixed — a fix for a bug you never saw fail is a guess.
-3. Merge to `dev`, promote to `qa`, redeploy staging, say so on the release PR.
+3. Merge to `dev`, promote to `qa`, deploy `qa`. QA re-promotes to `staging`
+   and asks dev to deploy it. Say so on the release PR.
 4. **QA re-tests the failed step, and anything the fix could plausibly have
    touched.** Not the whole suite, not only the one step.
 

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -25,7 +25,7 @@ Anything created outside this repo has to be recorded in THIS table, not only in
 |---|---|---|---|---|---|---|
 | `liquidity-hq-prod` | `srv-d8aluf6l51nc73e1ijp0` | starter | Singapore | `main` | `liquidity-hq.onrender.com` | Production. `npm install; npm run build` → `npm start`. |
 | `liquidity-hq-dev` | `srv-d8prs6po3t8c739aepdg` | free | Singapore | `dev` | `liquidity-hq-dev.onrender.com` | Dev integration. Free plan — spins down after inactivity, first request after idle is slow/can fail. |
-| `liquidity-hq-staging` | `srv-d9qskniju40c73brtqgg` | free | Singapore | `staging` | `liquidity-hq-staging.onrender.com` | **The environment QA tests and signs off on.** Created 2026-08-07 12:06. Serves the release candidate, so what QA tests IS the release rather than a branch dev keeps advancing. `autoDeploy: no` — QA promotes `qa` → `staging` and triggers the deploy. Uses the **dev** Supabase project. Free plan, sleeps when idle. |
+| `liquidity-hq-staging` | `srv-d9qskniju40c73brtqgg` | free | Singapore | `staging` | `liquidity-hq-staging.onrender.com` | **The environment QA tests and signs off on.** Created 2026-08-07 12:06. Serves the release candidate, so what QA tests IS the release rather than a branch dev keeps advancing. `autoDeploy: no` — QA promotes `qa` → `staging`, then **dev** triggers the deploy (Render MCP is dev-side; see the promotion table below). Uses the **dev** Supabase project. Free plan, sleeps when idle. |
 | `liquidity-hq-qa` | `srv-d9p42ke1egvs73f8car0` | free | Singapore | `qa` | `liquidity-hq-qa.onrender.com` | **Dev's integration site, not QA's.** Serves `qa`, which dev promotes into freely; it exists so dev can confirm a promotion before QA sees it. `autoDeploy: no` — whoever merges `dev` → `qa` triggers the deploy. Uses the **dev** Supabase project (free plan caps the account at 2 active projects, so neither non-prod service has one of its own). Free plan, sleeps when idle. |
 | `n8n-workflows` | `srv-d6e4fkq4d50c73b8dpk0` | starter | Singapore | n/a (Docker image `n8nio/n8n:latest`) | `n8n-workflows-6ig6.onrender.com` | Self-hosted n8n instance, 5GB persistent disk. Shared across projects, not LHQ-exclusive. |
 
@@ -33,11 +33,22 @@ Anything created outside this repo has to be recorded in THIS table, not only in
 
 That applies to each hop, and the person differs:
 
-| Promotion | Who deploys | Which service |
-|---|---|---|
-| `dev` → `qa` | dev, as part of handing the build over | `liquidity-hq-qa` |
-| `qa` → `staging` | **QA** | `liquidity-hq-staging` |
-| `staging` → `main` | **QA** | `liquidity-hq-prod` |
+| Promotion | Who promotes | Who deploys | Which service |
+|---|---|---|---|
+| `dev` → `qa` | dev | dev, as part of handing the build over | `liquidity-hq-qa` |
+| `qa` → `staging` | **QA** | **dev**, when QA says it has promoted | `liquidity-hq-staging` |
+| `staging` → `main` | **QA** | **QA**, owner-approved. Never dev. | `liquidity-hq-prod` |
+
+**Promoting and deploying are separate people for `staging`, and that is
+deliberate rather than an oversight.** Changed 2026-08-10: `mcp__render__trigger_deploy`
+is available in the **dev** session and not in QA's, so QA cannot deploy anything
+even when the branch move is theirs. Before this, `staging` routinely served older
+code than its own branch — on 2026-08-09 it sat on `f6f3bf3` while the branch was
+two releases ahead, which silently kept a fixed bug alive in a shared health row.
+
+Production is the exception that keeps the gate meaningful: QA merges it, QA
+deploys it, and the owner approves it. Dev does not deploy prod even if asked
+through GitHub.
 
 **A promotion into `qa` or `staging` fires no CI at all**, and that is deliberate — `.github/workflows/ci.yml` lists `push` branches as `[dev, main]` only. Both promotions are fast-forward, so the commit landing is bit-identical to one already tested on `dev`, and re-running would bill a second full suite for the same tree. Do not read a quiet Actions tab after a promotion as a failure to run.
 


### PR DESCRIPTION
**Dev Team** → **QA Team** · docs only, no code

## Summary

Three docs now match how we actually work. They had been saying the opposite of
two decisions the owner made, and I burned real time today arguing with a rule
that had already been changed — including retracting a correct action on #169 on
the strength of a stale line.

## What changed

| File | Change |
|---|---|
| `CLAUDE.md` | split "who merges" from "who deploys"; new "Who decides what to work on" |
| `CONTRIBUTING.md` | same split in §"Who merges and deploys"; new §"Who decides what to work on"; hotfix loop step 3 corrected |
| `docs/INFRASTRUCTURE.md` | promotion table now names **promoter and deployer separately** |

## Why — 1. deploys

Every file said dev *"may deploy nothing"* and *"does not touch `staging` at
all"*. **Dev now deploys `staging` when you ask.**

The reason is access, not authority: `mcp__render__trigger_deploy` is in the dev
session and not in yours, so you cannot deploy anything even when the branch move
is yours. Under the old rule every `qa` → `staging` promotion stalled waiting for
a dashboard, and `staging` served older code than its own branch for hours — on
2026-08-09 it sat on `f6f3bf3` while the branch was two releases ahead, which is
what kept the ETF health row failing after the fix had shipped.

**Production is deliberately unchanged.** QA merges, QA deploys, the owner
approves, never dev. Splitting the non-prod deploys out makes that gate clearer,
not weaker — it is now the only line in the table with dev excluded, instead of
being one of four.

The three things that still go to the owner directly are written down together
for the first time: merging to `main`, production deploys, and writes to the
shared database. Everything else you relay, I act on as given.

## Why — 2. sequencing

You are the project manager and the docs never said so. Now they do, along with
the part that matters for both of us: **the owner mostly watches your session**,
so GitHub is the channel rather than either chat window.

Including negative results, which I had been under-reporting. Today's would have
been: `min-height` does nothing for the consent bar, moving the bar over the tab
bar makes it measurably worse (22 → 57), and `/api/cmc` cannot be verified
locally without a key. Each one saves you from re-deriving it.

## Both changes say what they used to say, and when they changed

Matching how `CLAUDE.md` already handles the "three deployed sites" correction:

> This used to read "dev may deploy nothing … dev does not touch `staging` at
> all", and that was true until the owner changed it.

A rule that silently reverses is one nobody can trust, and I would rather the
next person reading it can see the reversal than discover it by acting on the
old version — which is exactly what happened to me.

## How to test (QA)

Docs only, nothing to deploy.

1. Read `CONTRIBUTING.md` §"Who merges and deploys". It should answer **"who
   deploys `staging`?"** with *dev, on QA's request*, and **"who deploys
   production?"** with *QA only, owner-approved, never dev*.
2. The promotion table in `docs/INFRASTRUCTURE.md` should agree with it, with
   promoter and deployer as separate columns.
3. `CLAUDE.md` §"Who decides what to work on" should match your understanding of
   your own role. **If it does not, say so on this PR — I would rather correct
   the description than have us work from two different pictures.**

## Risk level

**Low.** No code, no gates affected; lint still 0 errors.

**Worth your eyes specifically:** I have written down my understanding of *your*
authority. If I have overstated or understated it anywhere — particularly around
review, which I have deliberately kept as dev's on your PRs — that is a
correction to make now rather than after we have both been working from it.
