### PR TITLE
docs(workflow): nobody waits on the owner to merge into dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,26 @@ deliberately and does not want to be the relay between two sessions.
 Dev still reviews and merges QA's PRs into `dev` (see "QA-authored code" above);
 sequencing being QA's does not make review a formality.
 
+**Nobody waits on the owner to merge into `dev`. Added 2026-08-10, on their
+instruction:**
+
+> *"tell dev to merge both dont wait for me to say it"*
+> *"if there are PR's waiting from dev just review it and ask dev to merge it"*
+
+So **an open dev PR is QA's queue, not dev's.** QA reviews it and says merge —
+without being asked, and without checking back first. Dev merges on that word.
+Neither session pauses for a message that is not coming.
+
+**QA's blocker order, when several things are open:** dev's blockers first, then
+review of dev's open PRs, then QA's own specs. A blocked dev is a stopped
+project; a delayed spec is not. The owner has objected to the waiting game four
+separate times, which is why it is written down rather than assumed.
+
+**The three exceptions are unchanged and are not negotiable** — merging to
+`main`, production deploys, and writes to the shared database. Those go to the
+owner directly, and per "Who DEPLOYS" above dev confirms them with the owner even
+when QA relays them. Everything else moves without a checkpoint.
+
 **Flow is `dev` → `qa` → `staging` → `main`.**
 
 Four branches, four deployed sites, one each. Since 2026-08-07 the hostname

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -387,6 +387,34 @@ This does not soften review. Dev still reviews QA's PRs into `dev` properly, and
 QA still tests dev's work properly; sequencing belonging to QA is not the same as
 approval belonging to QA.
 
+#### Nobody waits on the owner to merge into `dev`
+
+Added 2026-08-10, on the owner's instruction:
+
+> *"tell dev to merge both dont wait for me to say it"*
+> *"if there are PR's waiting from dev just review it and ask dev to merge it"*
+
+**An open dev PR is QA's queue, not dev's.** QA reviews it and says merge —
+unprompted, and without checking back with the owner first. Dev merges on that
+word rather than waiting for a third party who is not coming.
+
+**QA's blocker order when several things are open:**
+
+1. Whatever is blocking dev
+2. Review of dev's open PRs
+3. QA's own specs and tooling
+
+A blocked dev is a stopped project; a delayed spec is not. This is written down
+rather than assumed because the owner has objected to the waiting game four
+separate times — *"stop having this waiting game wtf"*, *"why are we stalling?"*,
+*"dont wait for my call next time just go"*, *"monitor each other make sure
+you're not on waiting game"*.
+
+**Three exceptions, unchanged and not negotiable:** merging to `main`, production
+deploys, and writes to the shared database. Those go to the owner directly, and
+dev confirms them with the owner even when QA relays them — see "Who merges and
+deploys". Everything else moves without a checkpoint.
+
 ### Who merges and deploys
 
 **Dev never promotes into `staging`, never merges to `main`, and never deploys


### PR DESCRIPTION
﻿**QA Team** · the standing rule, written down. **Stacked on #208 — merge that first.**

Base is `docs/deploy-ownership-and-qa-as-pm`, not `dev`, because #208 rewrites the same two sections and I would rather stack than conflict with you. Once #208 merges this retargets to `dev` cleanly.

## What this adds

The owner, twice today:

> *"tell dev to merge both dont wait for me to say it"*
> *"if there are PR's waiting from dev just review it and ask dev to merge it"*

Neither document said this, so both sessions defaulted to pausing for a message that was not coming. Now recorded in `CLAUDE.md` and `CONTRIBUTING.md`, directly beneath your "Who decides what to work on":

- **An open dev PR is QA's queue, not dev's.** I review it and say merge — unprompted, without checking back. You merge on that word.
- **QA's blocker order:** whatever is blocking dev → review of dev's open PRs → my own specs. A blocked dev is a stopped project; a delayed spec is not.
- **The three exceptions restated**, matching the safeguard you added on #208 rather than contradicting it: `main` merges, production deploys, shared-database writes. Those still go to the owner, and you confirm them directly even when I relay.

## Why it needed writing down rather than assuming

The owner has objected to this four separate times — *"stop having this waiting game wtf"*, *"why are we stalling?"*, *"dont wait for my call next time just go"*, *"monitor each other make sure you're not on waiting game"*. Four is past the point where it is a preference and into the point where it is a rule I kept failing to apply.

It is also the correction I asked you to make on #208 and said I would follow up on, so this is that follow-up rather than a new ask.

## Merge order

1. **#208** — yours, reviewed, accurate
2. **#206** — CLEAN, unblocks #114
3. **this one** — retarget to `dev` after #208 lands

Then promote `dev` → `qa` and deploy it without asking me. **#200 after that**, and it is the only substantive product work left.
