### PR TITLE
docs(workflow): nobody waits on the owner to merge into dev (re-opens #209)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,26 @@ deliberately and does not want to be the relay between two sessions.
 Dev still reviews and merges QA's PRs into `dev` (see "QA-authored code" above);
 sequencing being QA's does not make review a formality.
 
+**Nobody waits on the owner to merge into `dev`. Added 2026-08-10, on their
+instruction:**
+
+> *"tell dev to merge both dont wait for me to say it"*
+> *"if there are PR's waiting from dev just review it and ask dev to merge it"*
+
+So **an open dev PR is QA's queue, not dev's.** QA reviews it and says merge —
+without being asked, and without checking back first. Dev merges on that word.
+Neither session pauses for a message that is not coming.
+
+**QA's blocker order, when several things are open:** dev's blockers first, then
+review of dev's open PRs, then QA's own specs. A blocked dev is a stopped
+project; a delayed spec is not. The owner has objected to the waiting game four
+separate times, which is why it is written down rather than assumed.
+
+**The three exceptions are unchanged and are not negotiable** — merging to
+`main`, production deploys, and writes to the shared database. Those go to the
+owner directly, and per "Who DEPLOYS" above dev confirms them with the owner even
+when QA relays them. Everything else moves without a checkpoint.
+
 **Flow is `dev` → `qa` → `staging` → `main`.**
 
 Four branches, four deployed sites, one each. Since 2026-08-07 the hostname

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -387,6 +387,34 @@ This does not soften review. Dev still reviews QA's PRs into `dev` properly, and
 QA still tests dev's work properly; sequencing belonging to QA is not the same as
 approval belonging to QA.
 
+#### Nobody waits on the owner to merge into `dev`
+
+Added 2026-08-10, on the owner's instruction:
+
+> *"tell dev to merge both dont wait for me to say it"*
+> *"if there are PR's waiting from dev just review it and ask dev to merge it"*
+
+**An open dev PR is QA's queue, not dev's.** QA reviews it and says merge —
+unprompted, and without checking back with the owner first. Dev merges on that
+word rather than waiting for a third party who is not coming.
+
+**QA's blocker order when several things are open:**
+
+1. Whatever is blocking dev
+2. Review of dev's open PRs
+3. QA's own specs and tooling
+
+A blocked dev is a stopped project; a delayed spec is not. This is written down
+rather than assumed because the owner has objected to the waiting game four
+separate times — *"stop having this waiting game wtf"*, *"why are we stalling?"*,
+*"dont wait for my call next time just go"*, *"monitor each other make sure
+you're not on waiting game"*.
+
+**Three exceptions, unchanged and not negotiable:** merging to `main`, production
+deploys, and writes to the shared database. Those go to the owner directly, and
+dev confirms them with the owner even when QA relays them — see "Who merges and
+deploys". Everything else moves without a checkpoint.
+
 ### Who merges and deploys
 
 **Dev never promotes into `staging`, never merges to `main`, and never deploys


### PR DESCRIPTION
﻿**QA Team** · re-opening #209 — it was **closed, not merged**, and the rule never landed

Not a duplicate. #209 was stacked on `docs/deploy-ownership-and-qa-as-pm` so it would not conflict with #208, and when #208 merged and its branch was deleted, GitHub closed #209 **without merging it**. Verified rather than assumed:

```
#208  state=MERGED  merged=YES
#206  state=MERGED  merged=YES
#209  state=CLOSED  merged=NO   base=docs/deploy-ownership-and-qa-as-pm

$ git show origin/dev:CLAUDE.md | grep "Nobody waits on the owner"
(nothing)
```

Same commit, cherry-picked onto the current `dev` with #208 in place, based on `dev` this time. Applies clean — 2 files, 48 insertions.

**My mistake, and worth recording:** stacking avoided a merge conflict and created a silent loss instead. A conflict is loud and takes two minutes; this was invisible and the rule would simply not have existed. If I stack again I will say on the PR that it needs retargeting to `dev` **before** the base merges, not after.

## What it adds, unchanged from #209

The owner's instruction today, twice:

> *"tell dev to merge both dont wait for me to say it"*
> *"if there are PR's waiting from dev just review it and ask dev to merge it"*

- **An open dev PR is QA's queue, not dev's** — I review and say merge, unprompted.
- **QA's blocker order:** what is blocking dev → review of dev's open PRs → my own specs.
- **The three exceptions restated** to match the safeguard you added in #208: `main` merges, production deploys, shared-database writes.

## How to test (QA)

Docs only. `CLAUDE.md` and `CONTRIBUTING.md` should each answer "does QA wait for the owner before telling dev to merge into `dev`?" with **no**, and should still answer "who deploys production?" with **QA only, owner-approved, never dev**.

## Risk level

**Low.** No code.

Still open behind this: **#210** (E2E gate on push to `staging` — the browser suite has not run in 60 CI runs) and **#211** (TEST_GAPS refresh).
