### PR TITLE
fix(qa): the egress tally artifact was excluded for starting with a dot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -565,6 +565,20 @@ jobs:
           path: qa/.intercept-tally.*.json
           retention-days: 30
           if-no-files-found: warn
+          # REQUIRED, because the filename starts with a dot.
+          #
+          # actions/upload-artifact@v4 defaults `include-hidden-files: false`,
+          # and on Linux a leading dot makes the file hidden - so it matched the
+          # glob, was excluded, and the step reported success with no artifact.
+          # Two full 38-minute runs produced no tally this way and the only
+          # symptom was an artifact that quietly was not there.
+          #
+          # `if-no-files-found: warn` is what let it stay quiet. Left as `warn`
+          # rather than `error` on purpose: the tally genuinely can be absent
+          # when a run makes no outbound call at all, and failing the job over a
+          # missing measurement would be worse than the measurement being
+          # missing. The fix is to stop excluding it, not to shout about it.
+          include-hidden-files: true
 
       # Printed as well as uploaded: #114 is answered by one number, and making
       # someone download an artifact to read it is how a measurement stops being


### PR DESCRIPTION
**QA Team** · one line, and it is the third distinct way this instrument has failed

## What

`include-hidden-files: true` on the egress tally upload.

## Why

Two full 38-minute measurement runs produced **no artifact at all**, and the step reported success both times. `actions/upload-artifact@v4` defaults `include-hidden-files: false`, and on Linux a leading dot makes a file hidden — so `qa/.intercept-tally.<pid>.json` matched the glob, was excluded, and vanished silently.

`if-no-files-found: warn` is what kept it quiet. **Left as `warn` deliberately** — a run that makes no outbound call legitimately has no tally, and failing the job over a missing measurement is worse than the measurement being missing. The fix is to stop excluding the file, not to shout when it is absent.

## The pattern, since this is now three for three

Every failure of this tool has destroyed the measurement through plumbing rather than getting it wrong:

1. `process.on('exit')` never fired, so a killed server reported nothing
2. twelve processes shared one path and overwrote each other to zero
3. the file was excluded from its own artifact for being hidden

**The number survived all three anyway**, because the per-process totals also go to stderr and land in the job log. That redundancy was not designed — it is the only reason #114 has an answer today. Worth keeping the stderr path even now the artifact works.

## Test

`ci.yml` parses; the step carries `path: qa/.intercept-tally.*.json` and `include-hidden-files: true`. Real proof is the next `count_egress` dispatch producing a downloadable artifact rather than only log lines.

## Risk

**Low.** One key on a dispatch-only step.