### PR TITLE
docs(qa): warn that HANDOVER's status sections are nine days stale

### DIFF
--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -9,6 +9,37 @@ file.**
 
 ---
 
+> ### ⚠️ This file records STATE, and state goes stale. Reviewed 2026-08-10.
+>
+> Sections **§7 (Current progress)**, **§8 (Testing status)** and **§9 (Current issues)**
+> are dated **2026-08-01** and describe a project that has moved a long way since. They
+> are kept for the reasoning and the war stories, which are still true and still worth
+> reading. **Do not quote their status claims.**
+>
+> `qa/STATUS.md` learned this lesson the hard way — it went stale twice, the second time
+> in four hours, and now records only *decisions* and *risks* because those are the parts
+> that survive. This banner exists so the same trap does not catch someone here.
+>
+> **For anything current, use the sources that cannot be stale:**
+>
+> | Question | Where |
+> |---|---|
+> | What is decided, what is risky | `qa/STATUS.md` |
+> | What a green suite does **not** mean | `qa/TEST_GAPS.md` |
+> | What is open | `gh issue list --state open` |
+> | Where each branch is | `git fetch --all && git rev-parse --short origin/{dev,qa,staging,main}` |
+> | What production is **serving** | `curl -s https://liquidity-hq.com/api/version` |
+>
+> **One correction that matters more than the rest**, because §8 is titled "TESTING
+> STATUS" and someone will read it as "CI covers this": since the release PR was paused,
+> **the browser suite stopped running in CI entirely** — 60 consecutive runs with no
+> completed E2E job. `perf`, `a11y`, `a11y-auth`, `bola`, `contrast`, `i18n`, `layout`,
+> `clock`, `payments-webhook` and `checkout` were covered **nowhere**. Fixed by #210,
+> which runs the suite on every push to `staging`; tracked on **#207** until a promotion
+> has been observed to actually fire one. `TEST_GAPS.md` §11 has the detail.
+
+---
+
 ## 1. What the product is
 
 **LiquidityHQ** (https://liquidity-hq.com) — a crypto trading intelligence PWA.


### PR DESCRIPTION
﻿**QA Team** · docs only — the "read this first" file was pointing at a nine-day-old project

`CLAUDE.md` sends anyone picking this up cold to `docs/HANDOVER.md` first, and its status sections are dated **2026-08-01** — nine days and four branch-flow changes ago. §8 is titled **"TESTING STATUS"**, which is precisely the heading someone reads as *"CI covers this"*.

## The correction that matters

It does not cover it. Since the release PR was paused, the browser suite stopped running in CI entirely — **60 consecutive runs with no completed E2E job** — with `perf`, `a11y`, `a11y-auth`, `bola`, `contrast`, `i18n`, `layout`, `clock`, `payments-webhook` and `checkout` covered **nowhere**. That is called out by name in the banner rather than left for someone to discover.

## What I did not do

**Rewrite §7, §8 and §9.** The reasoning and the war stories in them are still true and still the most useful part of the file — the "known-flaky verification methods, don't get fooled" section especially. What is stale is the *state*.

`qa/STATUS.md` already learned this: it went stale twice, the second time in **four hours**, and now records only decisions and risks because those are the parts that survive. The banner points at the sources that cannot be stale — `STATUS.md`, `TEST_GAPS.md`, and five commands — instead of restating anything that will be wrong again next week.

## How to test (QA)

Read the top of `docs/HANDOVER.md`. It should tell you, before anything else, that §7–§9 are dated and where to look instead — and it should name the E2E gap rather than leaving §8 to imply coverage that does not exist.

## Risk level

**Low.** No code.

## Queue

Four of mine open now: **#214** (artifact fix), **#215** (`workers: 4`), **#216** (LCP local-vs-CI), and this. All independent, all base `dev`, none stacked — I am not repeating the #209 mistake.

**#200 remains the only substantive product work**, and it is yours.
