### PR TITLE
fix(qa): remote runs need a longer expect budget, not just navigation

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -54,7 +54,23 @@ export default defineConfig({
   // The per-route cost is settle()'s deliberate 2500ms hydration wait; that
   // wait is load-bearing for measurement accuracy, so the budget moves, not it.
   timeout: 240_000,
-  expect: { timeout: 10_000 },
+  // 30s against a DEPLOYED service, 10s locally.
+  //
+  // Raising `navigationTimeout` alone was not enough and produced four false
+  // failures on `staging` on 2026-08-10: the i18n positive control, two clock
+  // holiday assertions and a session-window check all timed out waiting for
+  // content, on a service that was serving 200s the whole time. All 18 of those
+  // tests passed against a local build of the same commit minutes later.
+  //
+  // The gap: `navigationTimeout` covers `goto`, but the specs then wait on
+  // ELEMENTS, and those waits use this budget. Both Render non-prod services are
+  // free-plan and sleep when idle, so a wake-up page can take tens of seconds to
+  // become interactive after it has already responded.
+  //
+  // Local stays at 10s deliberately - a slow local render is a finding, not an
+  // environment, and raising it there would hide the thing this budget exists
+  // to catch.
+  expect: { timeout: process.env.E2E_BASE_URL ? 30_000 : 10_000 },
 
   // A flaky pass is worse than a fail - it teaches everyone to re-run until
   // green. Retries only in CI, and only to absorb genuine cold-start noise.


### PR DESCRIPTION
**QA Team** · I nearly reported four defects that do not exist. This is the fix and the correction.

Breaking my own "no more PRs" from #200 for this one, because it stops the suite lying about deployed environments — and I would rather it landed than sat in my head.

## What happened

I ran the specs that #207 says are covered nowhere — `i18n`, `clock`, `seo` — against deployed `staging`, since there is no reason to wait for #210's gate to do it. Result:

```
4 failed, 20 passed (8.2 min)

✘ the POSITIVE CONTROL failed: /ko is a supported locale and must render the landing page
✘ 2026-01-01 produced no holiday ... every market holiday silently becomes a normal trading day
✘ NY and London are both closed on 2026-12-25
```

Every one of those reads as a product defect. The first would have sent you into the i18n code looking for a broken locale route.

## They are all false

Same specs, same commit, local build, minutes later:

```
18 passed (2.1 min)
```

And against staging with this change:

```
18 passed (51 sec)
```

**`expect.timeout` was still 10s on remote runs.** I raised `navigationTimeout` to 90s for deployed services in #203 and stopped there — but `navigationTimeout` covers `goto`, and the specs then wait on **elements**, which use the expect budget. Both non-prod services are free plan and sleep when idle, so a page can take tens of seconds to become interactive *after* it has already answered 200.

Local stays at 10s deliberately. A slow local render is a finding, not an environment.

## Two things I checked before believing any of it

**`/ru` returns 404 on qa and staging but 200 on production.** That looked like a regression. It is not: `SUPPORTED_LOCALES = ['ko', 'zh']`, so `/ru` **should** 404. Production returns 200 for `/es` as well — prod is simply the old build from before the real-404 fix (#126). The staging behaviour is correct and prod is the stale one.

**`HOLIDAYS_2026` does contain `2026-01-01 New Year's Day`**, so the holiday guard had nothing to fire on. It timed out reading the page, not finding an empty table.

## The lesson, which is not "be careful"

**A spec run against an environment it was not calibrated for produces failures about the environment, and those are indistinguishable from product defects unless something else is measured.**

That is the third time today the same shape has come up — the perf LCP budget calibrated on a laptop, the two suites colliding on port 3100, and now this. The thing that caught all three was the same: run it somewhere else before writing it up.

## How to test (QA)

```
E2E_BASE_URL=https://liquidity-hq-staging.onrender.com \
  npx playwright test qa/e2e/clock.spec.ts qa/e2e/i18n.spec.ts --project=desktop
```

18 passed. Before this change: 4 failed, 20 passed.

## Risk level

**Low.** Only affects runs with `E2E_BASE_URL` set, which is QA driving a deployed service by hand. The CI gate is untouched.

## One genuine thing worth noting, not part of this PR

The local build logs `[WebServer] Error: Internal: NoFallbackError` twice during the i18n run. Tests pass, and I have not chased it — but it appears while exercising the 404/locale paths, which is close enough to #126's territory that it is worth a look when you are next in there. Reporting it because I saw it, not because I have measured it.
