### PR TITLE
fix(qa): the auth skip must name WHICH fixture is missing

### DIFF
--- a/qa/STATUS.md
+++ b/qa/STATUS.md
@@ -106,12 +106,33 @@ gh issue list --state open
   would not be believed if it did. Do **not** raise the number to make it green;
   decide first whether it asserts a user-facing target or catches regressions.
 - **An empty result is not evidence unless something proves the instrument works.**
-  This bit three separate times on 2026-08-10 and is the single most repeated
-  defect in this suite: `cache-policy` asserted headers that cached nothing;
-  `/api/cmc` and `/api/proxy` skipped permanently while reporting green; the
-  contrast detector parses a human-readable axe message with a regex, so an
-  upstream reword would silently return zero violations forever. Each now carries
-  a control or a named cause. **Any spec asserting "no findings" needs one.**
+  This bit **five** separate times on 2026-08-10 and is by a distance the most
+  repeated defect in this suite: `cache-policy` asserted headers that cached
+  nothing; `/api/cmc` and `/api/proxy` skipped permanently while reporting green;
+  the contrast detector parses a human-readable axe message with a regex, so an
+  upstream reword would silently return zero violations forever; the egress tally
+  reported `0` while a worker in the same run had counted 8; and — the worst one —
+  **the entire BOLA/IDOR suite ran zero tests for want of one missing variable**,
+  reporting only `20 skipped`. Each now carries a control or a named cause.
+  **Any spec asserting "no findings" needs one.**
+- **`skipped` is the same trap as `passed`, and it hides better.** A skip is
+  designed to be unremarkable, so twenty of them scroll past where twenty
+  failures would not. On 2026-08-10 `E2E_B_PRICE_ALERT_ID` was absent from
+  `.env.e2e.local` — CI supplies it as a GitHub *variable* rather than a secret,
+  so it was never copied across — and that single absence skipped every
+  authenticated test: cross-account access, RLS, forged tokens, signed-in
+  accessibility. The browser suite was not running in CI at the same time, so the
+  authenticated security surface was verified by **nothing, anywhere**, and
+  neither half raised a hand.
+  **Every skip must name the specific thing that is missing**, not a category.
+  The old message listed `E2E_USER_A_* / E2E_USER_B_* / E2E_A_*_ID / ...`, which
+  reads as "QA has no test accounts" rather than "one id is missing".
+- **Production is currently emitting an uncaught error that monitoring drops.**
+  Measured on prod 2026-08-10: `/briefing` throws React #418 and the report to
+  GlitchTip comes back `429`. Both halves in one page load. The error is #193,
+  already fixed by #195 and verified absent on `staging` — it is simply not
+  shipped. **So GlitchTip reads zero errors and that zero is false**, which is
+  worse than reading nothing because zero looks like health. See #51, #193.
 
 ---
 

--- a/qa/e2e/_auth.ts
+++ b/qa/e2e/_auth.ts
@@ -53,17 +53,49 @@ export const FIXTURES = {
 } as const;
 
 
-/** Everything the authenticated specs need, or they must skip rather than pass. */
-export const AUTH_READY =
-  !!(SUPABASE_URL && SUPABASE_ANON &&
-     FIXTURES.aEmail && FIXTURES.aPassword && FIXTURES.bEmail && FIXTURES.bPassword &&
-     FIXTURES.tradeId && FIXTURES.hypothesisId && FIXTURES.priceAlertId &&
-     FIXTURES.bPriceAlertId);
+/* Everything the authenticated specs need, or they must skip rather than pass.
+ *
+ * NAMED INDIVIDUALLY so the skip message can say WHICH one is missing. The
+ * previous version was a single boolean and a message listing every variable as
+ * a glob (`E2E_USER_A_* / E2E_USER_B_* / E2E_A_*_ID / ...`), which is accurate
+ * and useless: it cannot distinguish "no fixtures at all" from "nine of ten".
+ *
+ * That cost real time on 2026-08-10. `E2E_B_PRICE_ALERT_ID` alone was absent
+ * from `.env.e2e.local` - CI supplies it as a GitHub *variable* rather than a
+ * secret, so it never made it into the local file - and its absence silently
+ * skipped ALL TWENTY authenticated tests, including the entire BOLA/IDOR
+ * security suite. Combined with the browser suite not running in CI at the time
+ * (#207), the authenticated surface was covered by nothing anywhere, and the
+ * only symptom was `20 skipped` scrolling past.
+ *
+ * A skip that does not name its cause is a silent gap with extra steps. */
+const REQUIRED_FIXTURES: ReadonlyArray<readonly [name: string, value: string]> = [
+  ['NEXT_PUBLIC_SUPABASE_URL', SUPABASE_URL],
+  ['NEXT_PUBLIC_SUPABASE_ANON_KEY', SUPABASE_ANON],
+  ['E2E_USER_A_EMAIL', FIXTURES.aEmail],
+  ['E2E_USER_A_PASSWORD', FIXTURES.aPassword],
+  ['E2E_USER_B_EMAIL', FIXTURES.bEmail],
+  ['E2E_USER_B_PASSWORD', FIXTURES.bPassword],
+  ['E2E_A_TRADE_ID', FIXTURES.tradeId],
+  ['E2E_A_HYPOTHESIS_ID', FIXTURES.hypothesisId],
+  ['E2E_A_PRICE_ALERT_ID', FIXTURES.priceAlertId],
+  ['E2E_B_PRICE_ALERT_ID', FIXTURES.bPriceAlertId],
+];
+
+const MISSING_FIXTURES = REQUIRED_FIXTURES.filter(([, v]) => !v).map(([n]) => n);
+
+export const AUTH_READY = MISSING_FIXTURES.length === 0;
 
 export const AUTH_SKIP_REASON =
-  'authenticated fixtures absent - set E2E_USER_A_* / E2E_USER_B_* / E2E_A_*_ID / E2E_B_PRICE_ALERT_ID ' +
-  '(see the issue "QA unblocked: two seeded test accounts"). Skipping rather than ' +
-  'passing: a BOLA test that runs without fixtures proves nothing.';
+  `authenticated fixtures absent - MISSING: ${MISSING_FIXTURES.join(', ')}. ` +
+  'Set them in `.env.e2e.local` (gitignored) or as env vars. Note that CI supplies ' +
+  'E2E_A_PRICE_ALERT_ID and E2E_B_PRICE_ALERT_ID as GitHub VARIABLES rather than secrets - ' +
+  'they are row ids in the dev database, not credentials - so they are easy to miss when ' +
+  'copying a local file from the secret list. See the issue "QA unblocked: two seeded test ' +
+  'accounts".\n\n' +
+  'Skipping rather than passing: a BOLA test that runs without fixtures proves nothing. ' +
+  'But a skip is NOT a pass either - if you are seeing this, the authenticated surface ' +
+  'is being verified by nothing at all in this run.';
 
 /* ENTITLEMENT FIXTURES ARE A AND B, PINNED.
  *


### PR DESCRIPTION
**QA Team** · **the BOLA/IDOR suite was being verified by nothing, and both halves were silent**

This is the most serious thing I have found today, and it was hidden behind the word `skipped`.

## What was happening

`E2E_B_PRICE_ALERT_ID` was absent from `.env.e2e.local`. CI supplies it as a GitHub **variable** rather than a secret — it is a row id in the dev database, not a credential (#107) — so it never made it into the local file when that file was assembled from the secret list. Every other fixture was present.

One missing variable made `AUTH_READY` false, which skipped **all twenty** authenticated tests:

- cross-account read, modify, delete
- RLS direct-PostgREST refusal
- forged-token rejection
- unauthenticated rejection
- signed-in accessibility, U1–U6

The only symptom was `20 skipped` scrolling past in a run summary.

## Why that mattered more than it looks

The browser suite was **not running in CI at the time** (#207). So:

| | Covered by |
|---|---|
| CI | nothing — the gate had not run in 60 runs |
| local / deployed | nothing — silently skipped on a missing id |

**The authenticated security surface was verified by nothing, anywhere.** Both halves failed quietly, and neither would have raised a hand.

## It all passes

With the variable supplied, against **deployed staging**:

```
16 passed (29.0s)

✓ A can read its own seeded rows (guards against a vacuous pass)
✓ B listing its own collections never returns A rows
✓ B cannot modify / delete A's hypothesis by id
✓ A cannot modify or deactivate B's price alert by id
✓ a FREE account is refused by the Pro gate, not by ownership
✓ B cannot overwrite A's settings
✓ RLS refuses B direct PostgREST access to A rows
✓ the same requests without a token are rejected
✓ a forged token for A's user id is rejected
✓ U1–U6 signed-in accessibility
```

**No defects.** The security properties hold. That is the good news, and it is only knowable now.

## The fix

The old skip message listed every variable as a glob:

```
E2E_USER_A_* / E2E_USER_B_* / E2E_A_*_ID / E2E_B_PRICE_ALERT_ID
```

Accurate and useless — it cannot distinguish *"no fixtures at all"* from *"nine of ten"*, so the natural reading is "QA has no test accounts" rather than "one id is missing". I read it that way myself for weeks.

Now it names them:

```
MISSING: E2E_B_PRICE_ALERT_ID. Set them in `.env.e2e.local` (gitignored) or as env vars.
Note that CI supplies E2E_A_PRICE_ALERT_ID and E2E_B_PRICE_ALERT_ID as GitHub VARIABLES
rather than secrets — they are row ids in the dev database, not credentials — so they are
easy to miss when copying a local file from the secret list.
```

And it says outright that **a skip is not a pass**, because that is the reading which let this sit.

## Verified by removing the variable again

```
$ (hide E2E_B_PRICE_ALERT_ID) && npx playwright test qa/e2e/bola.spec.ts --reporter=json
SKIP MESSAGE NAMES: E2E_B_PRICE_ALERT_ID …
```

## How to test (QA)

1. `E2E_BASE_URL=https://liquidity-hq-staging.onrender.com npx playwright test qa/e2e/bola.spec.ts qa/e2e/a11y-auth.spec.ts --project=desktop` → 16 passed.
2. Remove `E2E_B_PRICE_ALERT_ID` and re-run → 10 skipped, and the reason names that variable.

## Risk level

**Low** as a change — a message and a derived boolean. **High as a finding**, which is why it is written up at this length rather than buried in a commit body.

## The pattern, again

Fourth time today: **an absence that reports as normal.** Headers that cached nothing, routes that skipped permanently, a detector that would return zero forever, and now a security suite that ran zero tests. Every one looked exactly like success from the outside.

`qa/STATUS.md` already carries "an empty result is not evidence unless something proves the instrument works" as a standing risk. This is the same rule applied to `skipped` rather than `passed`, and I will add it there in the next docs pass rather than opening another PR now.
