### PR TITLE
perf(dashboard): stop polling exchanges on the two routes that ignore the data

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -835,6 +835,10 @@ body[data-rpm-level="high"]::before {
 .dot-connecting { background: var(--amber); box-shadow: 0 0 6px var(--amber); animation: pulse 1s infinite; }
 .dot-rest       { background: var(--orange); box-shadow: 0 0 6px var(--orange); }
 .dot-error      { background: var(--red);   box-shadow: 0 0 6px var(--red);   animation: pulse 0.8s infinite; }
+/* Deliberately flat: no glow, no pulse. `Idle` is not a degraded feed, it is a
+   page that does not use one (#200), so it must not read as a warning. --txt3 is
+   the same dim grey used for inactive controls elsewhere. */
+.dot-idle       { background: var(--txt3); }
 
 /* ── DESKTOP NAV ── */
 .desktop-nav { display: none; align-items: center; gap: 2px; }

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -34,6 +34,19 @@ import { useAppConfig } from '@/lib/useAppConfig';
 // identical to any other 404.
 const isChromeless = (pathname: string) => pathname === '/ops' || pathname.startsWith('/ops/');
 
+/* Routes that render the full shell but no market data (#200).
+ *
+ * MarketProvider still MOUNTS on these - GrokChat and NavDrawer's status dot call
+ * useMarket() on every route and it throws without a provider - it just does not
+ * poll. Measured by QA against deployed staging: each of these makes 210 exchange
+ * requests per visit and renders byte-identically with every one of them blocked.
+ *
+ * Exact match, same reasoning as isChromeless above: a future /backtest/results
+ * should keep its data unless someone decides otherwise, rather than silently
+ * inheriting a decision made about a different page. */
+const isMarketDataFree = (pathname: string) =>
+  pathname === '/backtest' || pathname === '/live-tracking';
+
 /* Auth screens get the same treatment, for a different reason. /login used to
    render inside the full consumer shell, so a signed-OUT stranger arriving at
    the sign-in page was handed the nav drawer, the scrolling news ticker, the
@@ -123,7 +136,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
       <LabelsProvider>
         <AuthProvider>
           <SettingsProvider>
-            <MarketProvider>
+            <MarketProvider enabled={!isMarketDataFree(pathname)}>
               <NewsProvider>
                 <OnboardingProvider>
                   <GrokUsageProvider>

--- a/components/MarketProvider.tsx
+++ b/components/MarketProvider.tsx
@@ -97,7 +97,28 @@ const SYM_MAP: Record<string, CoinId> = Object.fromEntries(
 /* computeRSI14 moved to lib/rsi so app/api/market/rsi computes the identical
    number - see that file for why two copies would drift silently. */
 
-export default function MarketProvider({ children }: { children: React.ReactNode }) {
+/* `enabled` exists so a route can mount the provider WITHOUT the polling (#200).
+ *
+ * Not "do not mount the provider" - that was the obvious version and it crashes.
+ * `useMarket()` throws when there is no context, and two components inside the
+ * app shell consume it on EVERY route: GrokChat and NavDrawer's status dot. So
+ * removing the provider on a route kills the shell, not just the page.
+ *
+ * Measured by QA against deployed staging: /backtest and /live-tracking each make
+ * 210 exchange requests per visit and render BYTE-IDENTICALLY with all of them
+ * blocked - same element count, same text length, same graphics, no errors. The
+ * data is fetched and thrown away. /scanner was the control and loses 21% of its
+ * text when blocked, which is what makes the other two numbers mean something.
+ *
+ * Blocking the network and disabling the polling leave the store in the same
+ * shape, so that experiment is direct evidence for this switch rather than
+ * merely adjacent to it.
+ *
+ * Default is `true`: a route has to opt OUT deliberately, so adding a page never
+ * silently loses its market data. */
+export default function MarketProvider(
+  { children, enabled = true }: { children: React.ReactNode; enabled?: boolean },
+) {
   const [store, setStore] = useState<MarketStore>(defaultStore);
   /* Mirror of `store` for callbacks that must read the CURRENT value without
      depending on it. fetchSnapshot needs to know whether a coin already has a
@@ -1148,6 +1169,7 @@ export default function MarketProvider({ children }: { children: React.ReactNode
 
   /* ── Liquidation Cascade Detector - Binance futures all-symbols stream ── */
   useEffect(() => {
+    if (!enabled) return;          // #200 - no socket on data-free routes
     const FUTURES_MAP: Record<string, string> = {
       BTCUSDT: 'BTC', ETHUSDT: 'ETH', SOLUSDT: 'SOL',
       XRPUSDT: 'XRP', BNBUSDT: 'BNB', NEARUSDT: 'NEAR', SUIUSDT: 'SUI',
@@ -1238,10 +1260,19 @@ export default function MarketProvider({ children }: { children: React.ReactNode
       if (reconnectTimer) clearTimeout(reconnectTimer);
       try { ws?.close(); } catch { /* */ }
     };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [enabled]); // eslint-disable-line react-hooks/exhaustive-deps
 
   /* ── Initialise on mount ── */
   useEffect(() => {
+    /* #200: mount the context, skip the traffic. `Idle` rather than leaving
+       wsStatus undefined, because NavDrawer's dot treats undefined as
+       "Connecting..." and would spin forever on a page that is never going to
+       connect - a permanent spinner reads as broken, which is worse than the
+       210 requests it replaces. */
+    if (!enabled) {
+      setStore(s => ({ ...s, wsStatus: 'Idle' }));
+      return;
+    }
     startWS();
     fetchBybit();
     fetchLSR();
@@ -1297,7 +1328,7 @@ export default function MarketProvider({ children }: { children: React.ReactNode
       if (restTimerRef.current) clearInterval(restTimerRef.current);
       if (wsRetryRef.current)  clearInterval(wsRetryRef.current);
     };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [enabled]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <MarketContext.Provider value={{ store, setStore, selectCoin }}>

--- a/components/NavDrawer.tsx
+++ b/components/NavDrawer.tsx
@@ -197,6 +197,11 @@ const ALL_DESTS: NavDest[] = NAV_SECTIONS.flatMap(s => s.items);
 function useStatusDot() {
   const { store } = useMarket();
   const ws = store.wsStatus;
+  /* `Idle` means the provider is mounted but deliberately not polling, on routes
+     that render no market data (#200). Distinct from `Connecting...` on purpose:
+     this page is never going to connect, and a spinner that never resolves reads
+     as a broken feed rather than as a page that does not need one. */
+  if (ws === 'Idle') return { cls: 'dot-idle', title: 'Market feed off - this page shows no live market data' };
   if (!ws || ws === 'Connecting...') return { cls: 'dot-connecting', title: 'Connecting…' };
   if (ws.includes('backup')) return { cls: 'dot-rest', title: 'Live · backup feed' };
   if (ws === 'Live') return { cls: 'dot-live', title: 'Live' };


### PR DESCRIPTION
**Dev Team** → **QA Team** · first change against #200

## Summary

`/backtest` and `/live-tracking` each made **210 browser-to-exchange requests per
visit and used none of them**. They now make zero. `/scanner` is unchanged as the
control.

**420 requests per visitor pair, for a change to three files.**

## What changed

| File | |
|---|---|
| `MarketProvider` | new `enabled` prop, default `true`; both mount effects return early when false |
| `AppShell` | passes `enabled={!isMarketDataFree(pathname)}` |
| `NavDrawer` | status dot gains an `Idle` state |
| `globals.css` | `.dot-idle` — flat grey, no glow, no pulse |

## Measured, before and after, same machine and same probe

```
                BEFORE                          AFTER
/backtest       210  els=477  text=1598  live   0  els=477  text=1598  idle
/live-tracking  210  els=540  text=1909  live   0  els=540  text=1909  idle
/scanner        210  els=2801 text=12063 live   210 els=2801 text=12093 live
```

**Element count and text length are identical on both changed routes.** Not
"close" — the same numbers. `/scanner`'s 30-character text drift is live market
data moving between runs, and its request count is untouched.

I built the pre-change tree and measured it on the same machine rather than
comparing against your staging baseline, because mixing environments is how
today's other measurements went wrong.

## The design decision, and why it is not what I first proposed

I told you on #200 I would "drop `MarketProvider` on those two routes". **That
would have crashed both pages**, and it is worth recording why:

```ts
export function useMarket() {
  const ctx = useContext(MarketContext);
  if (!ctx) throw new Error('useMarket must be inside MarketProvider');
```

`GrokChat` and `NavDrawer`'s status dot call `useMarket()` on **every** route, so
removing the provider throws during the shell's render, not the page's. Blank
page, both routes.

**Your experiment could not have caught it, and that is not a criticism of it.**
Blocking the network leaves the provider mounted, so it answers *is the data
used* — decisively, no. It cannot answer *can the provider go*. Two different
questions; I conflated them and the code did not.

What it does do is validate this version exactly: blocked-network and
disabled-polling leave the store in the same shape, so your byte-identical
renders are direct evidence for what shipped here.

## The Idle dot is not cosmetic

With polling off, `wsStatus` stays `undefined`, and `NavDrawer` already has:

```ts
if (!ws || ws === 'Connecting...') return { cls: 'dot-connecting', title: 'Connecting…' };
```

So those routes would show a **spinner that never resolves** — which reads as a
broken feed, not as a page that does not need one. That is a support ticket, not
a bug report, and it would have been my fault for shipping it silently.

`Idle` renders flat grey with the tooltip *"Market feed off — this page shows no
live market data"*.

## How to test (QA)

On `qa` after promotion:

1. **/backtest** and **/live-tracking** — page renders exactly as now. Nav dot is
   flat grey, tooltip explains why. DevTools Network: **no** requests to
   `binance.com` or `bybit.com`.
2. **/scanner** — dot green, page unchanged, still makes its requests. This is the
   control; if it also went quiet, the change is too broad.
3. **Any other route** — `/dashboard`, `/arena`, `/markets` — dot green, data
   flowing. The default is `true`, so only the two named routes opt out.
4. **Re-run your #200 baseline** with the same six hosts and 12s settle.
   `/backtest` and `/live-tracking` should read **~0**, `/scanner` should hold at
   **210**. I would like `/scanner` in the re-run explicitly — a run where
   everything drops is a broken probe, not a win.

## Risk level

**Medium.** It touches the provider every route mounts, and a wrong `enabled`
would silently kill market data on a page that needs it.

Gates: lint 0 errors (140 warnings, unchanged), tsc clean, 288 tests, build ok,
`smoke.spec` 34 passed including all three routes.

**Named because it is not covered:** no automated test asserts "this route makes
no exchange requests". My probe was a throwaway. Your #200 red-run spec would
cover it properly, and until it exists the guarantee here is a measurement rather
than a gate — which is exactly the gap that let the browser suite die for 60 runs.
