### PR TITLE
fix(api): name the parts that came back empty instead of claiming success

### DIFF
--- a/app/api/market/snapshot/route.ts
+++ b/app/api/market/snapshot/route.ts
@@ -248,10 +248,52 @@ export async function GET(req: NextRequest) {
       return apiError('market-snapshot', t.reason, 502, 'Upstream unavailable');
     }
 
+    /* NAME THE PARTS THAT CAME BACK EMPTY (#228).
+     *
+     * `allSettled` above is right and stays: one dead upstream must not take the
+     * other two down. What was wrong is what the caller was told afterwards - a
+     * failed part became `{}` alongside HTTP 200, so the response asserted
+     * success while the health table recorded failure, and nothing reconciled
+     * them.
+     *
+     * Found when `klines` was empty on qa and staging for hours while prod served
+     * 45. The cause was upstream: `binance:klines` health read
+     * `418/429 after 0/45` - 418 is Binance's IP-ban code, so those two services
+     * were banned for that endpoint while ticker and lsr on the same host kept
+     * working. Nothing about the response said so.
+     *
+     * EMPTY COUNTS AS FAILED, not just rejected. `buildKlines` returns `{}`
+     * rather than throwing when no host is reachable, so a rejection check alone
+     * would still have missed this exact incident.
+     *
+     * SPECIFIC, NOT BOOLEAN: `['klines']` tells a caller what to hide. `true`
+     * only tells it that something is wrong, which leaves it guessing or hiding
+     * everything.
+     *
+     * AND DELIBERATELY NOT `cachedStale()`. That was my first instinct and QA
+     * talked me out of it, correctly: an all-time high six hours old is right to
+     * several decimals, but candles six hours old are a chart of the wrong six
+     * hours, drawn confidently. lib/apiCache.ts already draws this line - "only
+     * use this where stale is genuinely better than absent". An empty chart is
+     * visibly empty; a stale one is silently wrong, and people draw trendlines on
+     * these. */
+    const ticker = t.status === 'fulfilled' ? t.value : {};
+    const klines = k.status === 'fulfilled' ? k.value : {};
+    const lsr    = l.status === 'fulfilled' ? l.value : {};
+
+    const partial = [
+      ['ticker', ticker] as const,
+      ['klines', klines] as const,
+      ['lsr',    lsr]    as const,
+    ].filter(([, v]) => Object.keys(v).length === 0).map(([name]) => name);
+
     return NextResponse.json({
-      ticker: t.status === 'fulfilled' ? t.value : {},
-      klines: k.status === 'fulfilled' ? k.value : {},
-      lsr:    l.status === 'fulfilled' ? l.value : {},
+      ticker,
+      klines,
+      lsr,
+      /* Omitted entirely when everything is healthy, so the common response is
+         unchanged and `'partial' in body` is a valid check. */
+      ...(partial.length ? { partial } : {}),
       ts: Date.now(),
     }, {
       /* Public and visitor-independent, and already only as fresh as the


### PR DESCRIPTION
**Dev Team** → **QA Team** · fixes #228 — built to your spec, including the part where you overruled me

## Summary

`/api/market/snapshot` now returns `partial: ['klines']` when a sub-object comes
back empty. Still HTTP 200. Omitted entirely when all three are healthy, so the
healthy response is byte-identical and `'partial' in body` is a valid check.

## Your three calls, all taken

| Your call | Shipped |
|---|---|
| field, not header | `partial` in the body |
| specific, not boolean | `['klines']`, never `true` |
| not `cachedStale()` | not used |

**The stale one is the one I would have got wrong.** I was leaning stale-serving
and your reasoning beat mine:

> an all-time high six hours old is right to several decimals, but candles six
> hours old are a chart of the wrong six hours

And `lib/apiCache.ts` already drew that line in its own comment — *"only use this
where stale is genuinely better than absent"* — which I wrote and then argued
against without noticing. An empty chart is visibly empty; a stale one is
confidently wrong, and people draw trendlines on these.

## One implementation detail worth your attention

**Empty counts as failed, not just rejected.** `buildKlines` returns `{}` rather
than throwing when no host is reachable, so a rejected-promise check alone would
have missed **this exact incident** — the promise fulfilled, with nothing in it.

```ts
].filter(([, v]) => Object.keys(v).length === 0).map(([name]) => name);
```

That is the difference between a fix and a fix-shaped change.

## Verified both directions on a production build

```
real upstreams   ticker=45 klines=45 lsr=45   partial absent               200
all stubbed      ticker=0  klines=0  lsr=0    partial=[ticker,klines,lsr]  200
```

The failure case used **your `qa/server-intercept.mjs`** rather than waiting for a
ban to reproduce. Second time that tool has turned an unverifiable claim into a
measured one today.

**Not yet verified: the `['klines']`-only case**, which is the actual #228 state.
I cannot produce a klines-only failure locally — the stub is per-host, not
per-path, and my IP is not banned. **That one gets confirmed on `qa` after
deploy**, where the ban is live. If it does not read `partial: ["klines"]` there,
the fix is wrong and I would rather find out from that check than from you.

## How to test (QA)

1. **`qa`** — `GET /api/market/snapshot`. While the Binance kline ban lasts:
   `200`, `partial: ["klines"]`, `ticker` and `lsr` populated.
2. **prod** — same request, **no `partial` key at all**. This is the control you
   asked for: without it, "no partial failures" and "the probe is broken" are
   indistinguishable.
3. **Nothing user-visible changes.** `MarketProvider` already types all three
   parts as optional and merges what arrives, so an extra key is inert.

Your assertion 1 — *never an empty sub-object with a clean 200* — is now
expressible against the public contract, which was your point about not asserting
the admin-guarded health table.

## Risk level

**Low.** Additive field on one route; no consumer reads it yet.

Gates: lint 0 errors (140 warnings, unchanged), tsc clean, 288 tests, build ok.

**Named:** this does not fix the ban, and nothing here can. It makes the ban
visible to anyone holding the response instead of only to someone with database
access. That was the gap — `/api/ath` already had this property, which is why you
could measure its recovery this afternoon while `qa` was still refused.
