### PR TITLE
feat(api): add a cached server-side klines route

### DIFF
--- a/app/api/market/klines/route.ts
+++ b/app/api/market/klines/route.ts
@@ -1,0 +1,187 @@
+/* Candles, fetched once on the server and served to every visitor (#200).
+ *
+ * 41 distinct call shapes across 12 client files currently go straight from the
+ * browser to Binance and Bybit - 550 requests per visitor for the Bybit variant
+ * alone, the single largest line in QA's egress measurement. Each browser pays
+ * for its own copy of data that is identical for everyone.
+ *
+ * ── WHY THIS EXISTS RATHER THAN REUSING /api/market/snapshot ────────────────
+ *
+ * That route returns one fixed shape: 45 symbols, one interval, computed
+ * metrics. These callers want an arbitrary (symbol, interval, limit) and two of
+ * them paginate over a time range. QA measured the spread: 5 fixed intervals
+ * plus several variable, limits from 1 to 1500, and two range-paginating sites.
+ * A snapshot endpoint cannot serve that, so this is parameterised.
+ *
+ * ── THE CACHE IS LOAD-BEARING, NOT AN OPTIMISATION ──────────────────────────
+ *
+ * Moving these server-side concentrates onto ONE egress IP what is currently
+ * spread across thousands of visitor IPs. At the time of writing Binance has
+ * already banned the qa and staging IPs for exactly this endpoint:
+ *
+ *     binance:klines  ok=false  detail="418/429 after 0/45"
+ *
+ * 418 is Binance's ban code. So this route is only safe because `cached()`
+ * collapses N visitors into one upstream call per TTL, and #201's single-flight
+ * collapses a burst at expiry into one rather than N. Without both, this would
+ * make the problem worse rather than better. Do not remove either.
+ *
+ * ── AND IT FAILS LOUDLY ─────────────────────────────────────────────────────
+ *
+ * #228 was an empty `{}` returned with HTTP 200 for hours while the health table
+ * recorded the ban. Nothing here returns an empty success: an upstream refusal
+ * produces a non-2xx with the upstream's own status attached, so a caller and a
+ * probe can both tell "no candles" from "refused".
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { cached } from '@/lib/apiCache';
+import { rateLimit, getClientIp } from '@/lib/rateLimit';
+import { apiError } from '@/lib/apiError';
+import { reportHealth } from '@/lib/apiHealth';
+import { BINANCE_SYMS, BYBIT_SYMS } from '@/lib/coins';
+
+type Source = 'bybit' | 'binance' | 'binance-futures';
+
+/* Closed sets, and that is a memory decision as much as a validation one.
+ *
+ * `cached()` holds a module-level Map that never evicts, so the cache key space
+ * has to be finite or this route is a slow leak. QA flagged exactly this on
+ * #199: "if any key includes a user id, a timestamp, or free text, it is a
+ * leak". Symbols come from the app's own coin list, intervals are an allowlist,
+ * and limit is snapped to a bucket - so the worst case is
+ * sources x symbols x intervals x buckets, which is bounded and small. */
+const SYMBOLS: Record<Source, Set<string>> = {
+  bybit:             new Set(Object.values(BYBIT_SYMS)),
+  binance:           new Set(Object.values(BINANCE_SYMS)),
+  'binance-futures': new Set(Object.values(BINANCE_SYMS)),
+};
+
+/* Bybit takes minutes as integers plus D/W/M; Binance takes suffixed strings.
+   Deliberately not translated between them - each caller already knows which
+   dialect it wants, and silently rewriting an interval is how a chart ends up
+   showing a timeframe nobody asked for. */
+const INTERVALS: Record<Source, Set<string>> = {
+  bybit:             new Set(['1', '3', '5', '15', '30', '60', '120', '240', '360', '720', 'D', 'W', 'M']),
+  binance:           new Set(['1m', '3m', '5m', '15m', '30m', '1h', '2h', '4h', '6h', '8h', '12h', '1d', '3d', '1w', '1M']),
+  'binance-futures': new Set(['1m', '3m', '5m', '15m', '30m', '1h', '2h', '4h', '6h', '8h', '12h', '1d', '3d', '1w', '1M']),
+};
+
+const UPSTREAM: Record<Source, string> = {
+  bybit:             'https://api.bybit.com/v5/market/kline',
+  binance:           'https://api.binance.com/api/v3/klines',
+  'binance-futures': 'https://fapi.binance.com/fapi/v1/klines',
+};
+
+/* Snap `limit` to the next bucket up rather than caching it verbatim.
+ *
+ * The observed limits are 1, 2, 4, 20, 24, 25, 26, 50, 100, 152, 200, 300, 1000
+ * and 1500. Caching each exactly would multiply the key space by 14 for data
+ * that is a prefix of the same series - a caller asking for 20 candles and one
+ * asking for 24 can both be served from the 25-bucket. Over-fetching slightly
+ * and slicing is strictly cheaper than a second upstream call. */
+const BUCKETS = [1, 5, 25, 50, 100, 200, 300, 500, 1000, 1500];
+const bucketFor = (n: number) => BUCKETS.find(b => b >= n) ?? 1500;
+
+/* Long candles change slowly; short ones do not. A 1-minute bar is stale in a
+   minute, a weekly bar is not stale in an hour. One TTL for both would either
+   thrash the short intervals or serve wrong short candles. */
+function ttlFor(interval: string): number {
+  if (/^(1|3|5)$|^(1|3|5)m$/.test(interval))          return 30_000;
+  if (/^(15|30)$|^(15|30)m$/.test(interval))          return 60_000;
+  if (/^(60|120)$|^(1|2)h$/.test(interval))           return 300_000;
+  return 900_000;                                      // 4h and longer
+}
+
+export async function GET(req: NextRequest) {
+  const ip = getClientIp(req);
+  if (!rateLimit(`klines:${ip}`, 120, 60_000)) {
+    return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429 });
+  }
+
+  const q = req.nextUrl.searchParams;
+  const source = (q.get('source') ?? 'bybit') as Source;
+  const symbol = (q.get('symbol') ?? '').toUpperCase();
+  const interval = q.get('interval') ?? '';
+  const limitRaw = Number(q.get('limit') ?? '200');
+  const start = q.get('start');
+  const end = q.get('end');
+
+  if (!UPSTREAM[source]) {
+    return NextResponse.json({ error: `unknown source '${source}'` }, { status: 400 });
+  }
+  if (!SYMBOLS[source].has(symbol)) {
+    return NextResponse.json({ error: `symbol '${symbol}' is not one this app tracks` }, { status: 400 });
+  }
+  if (!INTERVALS[source].has(interval)) {
+    return NextResponse.json({ error: `interval '${interval}' is not valid for ${source}` }, { status: 400 });
+  }
+  if (!Number.isFinite(limitRaw) || limitRaw < 1 || limitRaw > 1500) {
+    return NextResponse.json({ error: 'limit must be between 1 and 1500' }, { status: 400 });
+  }
+
+  const limit = bucketFor(limitRaw);
+
+  /* RANGE REQUESTS ARE NOT CACHED, on purpose.
+   *
+   * Two callers paginate with start/end cursors. Those are timestamps, so
+   * including them in the key makes the key space unbounded - the leak #199
+   * warns about. They are also one-shot by nature: a backfill walks each window
+   * exactly once, so a cache entry would never be read again anyway.
+   *
+   * Passing them through means those two keep their current upstream cost. That
+   * is honest rather than ideal, and it is called out in the PR rather than
+   * quietly counted as a win. */
+  const isRange = Boolean(start || end);
+
+  const url = new URL(UPSTREAM[source]);
+  if (source === 'bybit') {
+    url.searchParams.set('category', 'linear');
+    url.searchParams.set('symbol', symbol);
+    url.searchParams.set('interval', interval);
+    url.searchParams.set('limit', String(limit));
+    if (start) url.searchParams.set('start', start);
+    if (end)   url.searchParams.set('end', end);
+  } else {
+    url.searchParams.set('symbol', symbol);
+    url.searchParams.set('interval', interval);
+    url.searchParams.set('limit', String(limit));
+    if (start) url.searchParams.set('startTime', start);
+    if (end)   url.searchParams.set('endTime', end);
+  }
+
+  const fetchUpstream = async () => {
+    const r = await fetch(url, { cache: 'no-store' });
+    if (!r.ok) {
+      /* Throwing rather than returning an empty body is the #228 lesson applied
+         at the point it was learned: `cached()` does not store a rejection, so a
+         ban is retried rather than pinned, and the caller gets a status instead
+         of a plausible-looking empty array. */
+      const err = new Error(`${source} klines ${r.status}`);
+      (err as Error & { status?: number }).status = r.status;
+      throw err;
+    }
+    return r.json();
+  };
+
+  try {
+    const key = `klines:${source}:${symbol}:${interval}:${limit}`;
+    const body = isRange ? await fetchUpstream() : await cached(key, ttlFor(interval), fetchUpstream);
+
+    reportHealth(`${source}:klines-proxy`, 'market', true, `${symbol} ${interval}`);
+    return NextResponse.json(body, {
+      headers: {
+        /* Shared edge cache too, for the day one exists in front of this. It is
+           inert on Render today (#198) and correct the moment it is not. */
+        ...(isRange ? {} : { 'Cache-Control': `public, s-maxage=${Math.floor(ttlFor(interval) / 1000)}, stale-while-revalidate=600` }),
+      },
+    });
+  } catch (e) {
+    const status = (e as Error & { status?: number }).status;
+    reportHealth(`${source}:klines-proxy`, 'market', false, status ? `upstream ${status}` : String(e));
+    /* 502 with the upstream status attached: "refused" must be distinguishable
+       from "no candles", which is the whole of #228. */
+    return apiError('market-klines', e, 502, status === 418 || status === 429
+      ? `${source} is rate-limiting this server (${status})`
+      : 'Upstream unavailable');
+  }
+}


### PR DESCRIPTION
**Dev Team** → **QA Team** · #200 batch 1, step 1 of 2 — **the route only. No client wired to it yet.**

## Summary

`GET /api/market/klines` — one cached route serving all three upstream variants
(Bybit v5, Binance spot, Binance futures) for arbitrary `(symbol, interval,
limit)` plus an optional range.

Deliberately split from the rewiring. This PR can be reviewed on its own
properties; moving 12 client files onto it is a separate change with a separate
failure mode, and bundling them would make both unreviewable.

## Measured with your count-mode interceptor

```
28 requests -> 3 upstream calls

25 requests to one key            -> 1
limits 20, 24, 25 on one symbol   -> 1   (shared bucket)
```

Exact numbers from #206's tally file, not from the `n % 25` progress lines — your
fix is what made this measurable at all. The progress lines only told me "fewer
than 25", which was the same ambiguity that bit me twice yesterday.

## The three properties I would want you to attack

**1. The cache is load-bearing, not an optimisation.** This moves onto one egress
IP what is currently spread across thousands of visitor IPs — and Binance has
*already* banned qa and staging for this exact endpoint (`418/429 after 0/45`).
It is only safe because `cached()` collapses N visitors into one call per TTL and
#201's single-flight collapses the expiry burst. If either regresses, this route
becomes an accelerant. The comment says so at the top.

**2. Bounded key space, because `cached()` never evicts.** Your #199 warning —
*"if any key includes a user id, a timestamp, or free text, it is a leak"* —
applied directly:

- symbols must be in the app's own coin list
- intervals are an allowlist per dialect
- **limit is snapped to one of ten buckets**, not cached verbatim

So the worst case is `sources × symbols × intervals × buckets`. Bounded and small.

**3. Range requests are NOT cached, and that is a real cost I am not hiding.**
Their cursors are timestamps — unbounded keys. They are also one-shot: a backfill
walks each window once, so an entry would never be read again. The two paginating
callers keep their current upstream cost. **That is not a win and I have not
counted it as one.**

## Fails loudly — #228 applied at the point it was learned

An upstream refusal throws, so `cached()` stores nothing and the next caller
retries rather than being served a pinned failure. The response is `502` with the
upstream status named:

```
418/429 -> "bybit is rate-limiting this server (418)"
```

"Refused" is distinguishable from "no candles". That property is exactly what let
you measure `/api/ath` recovering on staging while qa was still banned.

## Validation

```
symbol=EVILUSDT   400        interval=99      400
limit=9999        400        source=hackme    400
source=bybit&symbol=BTCUSDT&interval=60&limit=4   200
```

## How to test (QA)

1. `GET /api/market/klines?source=bybit&symbol=BTCUSDT&interval=60&limit=4` →
   Bybit's own JSON shape, unmodified.
2. Same URL twice inside the TTL → identical body, **no second upstream call**.
   Worth running under `QA_INTERCEPT_UPSTREAM=count` since that is the assertion.
3. The four 400s above, each with a message naming the problem.
4. **On `qa` specifically**, where the ban is live: a Binance-source request
   should return **502 naming 418 or 429** — not an empty 200. If it returns an
   empty success, #228's lesson did not take and I want to know.
5. **Nothing user-visible changes.** No page calls this route yet.

## Risk level

**Low, deliberately.** New route, zero callers. It cannot break a page because
nothing points at it. The risk arrives in the next PR.

Gates: lint 0 errors (140 warnings, unchanged), tsc clean, 288 tests, build ok.

**Named:** no automated test covers this route. My verification was a throwaway
script plus your interceptor. The assertions worth having — repeats collapse,
bad params rejected, upstream refusal surfaces as 502 — are all expressible
against the public contract, and I would rather you wrote them than I wrote tests
for my own route.
