### PR TITLE
fix(api): actually slice bucketed klines back to the requested limit

### DIFF
--- a/app/api/market/klines/route.ts
+++ b/app/api/market/klines/route.ts
@@ -92,6 +92,37 @@ function ttlFor(interval: string): number {
   return 900_000;                                      // 4h and longer
 }
 
+/* Trim a bucketed response back to what the caller actually asked for.
+ *
+ * The bucket is what gets CACHED and fetched; this is what gets RETURNED. QA
+ * caught that the previous version documented "over-fetching slightly and
+ * slicing" and only implemented the over-fetching, so a caller asking for 20
+ * candles received 25 - and anything computing over "the last N" silently used a
+ * different N than it asked for.
+ *
+ * THE TWO UPSTREAMS ORDER CANDLES OPPOSITELY, measured rather than assumed:
+ *
+ *     bybit    NEWEST-first   -> the recent end is the HEAD, slice(0, n)
+ *     binance  OLDEST-first   -> the recent end is the TAIL, slice(-n)
+ *
+ * Getting that backwards returns the OLDEST n candles instead of the newest -
+ * a chart of the wrong period, rendered confidently, which is the same class of
+ * failure as serving stale candles and is why that was rejected on #228.
+ *
+ * Shape is otherwise preserved exactly: Bybit keeps its {retCode, result:{list}}
+ * envelope, Binance its bare array, so no client has to change how it reads a
+ * response. */
+function sliceToLimit(source: Source, body: unknown, n: number): unknown {
+  if (source === 'bybit') {
+    const b = body as { result?: { list?: unknown[] } };
+    const list = b?.result?.list;
+    if (!Array.isArray(list) || list.length <= n) return body;
+    return { ...b, result: { ...b.result, list: list.slice(0, n) } };
+  }
+  if (!Array.isArray(body) || body.length <= n) return body;
+  return body.slice(-n);
+}
+
 export async function GET(req: NextRequest) {
   const ip = getClientIp(req);
   if (!rateLimit(`klines:${ip}`, 120, 60_000)) {
@@ -165,7 +196,12 @@ export async function GET(req: NextRequest) {
 
   try {
     const key = `klines:${source}:${symbol}:${interval}:${limit}`;
-    const body = isRange ? await fetchUpstream() : await cached(key, ttlFor(interval), fetchUpstream);
+    const raw = isRange ? await fetchUpstream() : await cached(key, ttlFor(interval), fetchUpstream);
+    /* Slice AFTER the cache read, using the caller's own limit. The cache holds
+       one bucket-sized copy that every caller in that bucket shares; each gets
+       back the length it asked for. Range requests are returned untouched -
+       the caller is paginating and set its own window. */
+    const body = isRange ? raw : sliceToLimit(source, raw, limitRaw);
 
     reportHealth(`${source}:klines-proxy`, 'market', true, `${symbol} ${interval}`);
     return NextResponse.json(body, {


### PR DESCRIPTION
**Dev Team** → **QA Team** · **you were right, and the fix had a trap in it worth naming**

Good catch. The route documented over-fetch-and-slice and shipped only the
over-fetch. Your table re-run against this branch:

```
limit    1    4   20   24   50  100  152  300
bybit    1    4   20   24   50  100  152  300   all OK
binance  1    4   20   24   50  100  152  300   all OK
```

## The trap: the two upstreams order candles oppositely

Measured before writing the slice, not assumed:

```
bybit    NEWEST-first   -> recent end is the HEAD, slice(0, n)
binance  OLDEST-first   -> recent end is the TAIL, slice(-n)
```

One `slice(0, n)` for both would have returned the **oldest** n candles from
Binance. Correct length, correct shape, correct-looking data, wrong period —
and a length check alone would have passed it.

So I verified the end, not just the count:

```
limit=4 timestamps vs the newest 4 of limit=100

bybit    identical
binance  identical
```

That is the assertion I would want in your spec if you write one — **`limit=N`
returns the same newest candle as `limit=N+M`**. It catches the wrong-end bug;
counting rows does not.

This is the same failure class you argued against on #228 when you rejected
`cachedStale()` for candles: *"a chart of the wrong six hours, drawn
confidently"*. Wrong-end slicing is that bug with a different cause.

## Design

Sliced **after** the cache read, using the caller's own `limitRaw`. The shared
bucket still holds one copy; each caller gets the length it asked for. So the
collapse measured on #231 is unaffected — 25 requests to one key is still one
upstream call, and 20/24/25 still share a bucket.

Range requests are returned untouched: the caller is paginating and set its own
window.

Shape preserved exactly — Bybit keeps `{retCode, result:{list}}`, Binance its
bare array — so nothing downstream changes how it reads a response.

## How to test (QA)

1. `limit=20` returns exactly 20, `limit=24` exactly 24, both from one cached
   fetch.
2. **The newest candle in a `limit=4` response equals the newest in `limit=100`**
   for the same symbol and interval, on both sources. This is the one that
   matters.
3. Bybit response still has `retCode`/`result.list`; Binance still a bare array.

## Risk level

**Low.** Still zero client callers — nothing points at this route yet.

Gates: lint 0 errors (140 warnings, unchanged), tsc clean, 288 tests, build ok.

**Worth saying:** this is the second defect you have found in my work today that
was documented-but-not-implemented — the comment described behaviour the code did
not have. That is a specific blind spot of mine and a comment is not evidence.
Reading my own comments as though they were the diff is exactly how I would miss
it again.
