### PR TITLE
perf(dashboard): route 30 client kline calls through the cached server route

### DIFF
--- a/app/api/market/klines/route.ts
+++ b/app/api/market/klines/route.ts
@@ -124,8 +124,26 @@ function sliceToLimit(source: Source, body: unknown, n: number): unknown {
 }
 
 export async function GET(req: NextRequest) {
+  /* 1200/min, not the 120 this shipped with.
+   *
+   * 120 was copied from routes a page calls a handful of times. This one is
+   * called per symbol per panel: measured on a real page load, /markets issues
+   * ~150 kline requests and /correlation ~150, so 120 rejected 54-98 of them per
+   * visit with a 429 from OUR OWN route. The pages degraded, and the resulting
+   * drop in outbound traffic looked like the cache working - a rate limit
+   * masquerading as a saving is a worse outcome than no cache at all, because it
+   * reports success.
+   *
+   * 1200 leaves ~8x headroom over the heaviest measured page. It is deliberately
+   * generous: these responses are served from a module-level cache and cost
+   * nothing upstream, so the limit exists to stop a scripted flood, not to ration
+   * a page doing what it normally does.
+   *
+   * The real fix is fewer client calls - one request per symbol set rather than
+   * per symbol - and that is batch 2. Until then this must not be the thing that
+   * breaks a page. */
   const ip = getClientIp(req);
-  if (!rateLimit(`klines:${ip}`, 120, 60_000)) {
+  if (!rateLimit(`klines:${ip}`, 1200, 60_000)) {
     return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429 });
   }
 

--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -1004,13 +1004,13 @@ function ArenaContent() {
       setReadStep('Reading chart…');
       let raw: (string|number)[][];
       if (binanceSym) {
-        const r = await fetch(`https://api.binance.com/api/v3/klines?symbol=${binanceSym}&interval=${readTf}&limit=300`);
+        const r = await fetch(`/api/market/klines?source=binance&symbol=${binanceSym}&interval=${readTf}&limit=300`);
         if (!r.ok) throw new Error(t('ARENA_ERROR_BINANCE_API'));
         raw = await r.json();
       } else {
         // Bybit klines: interval uses numbers (1, 5, 15, 30, 60, 240) or 'D'; response is newest-first
         const bybitInterval = readTf === '1m' ? '1' : readTf === '5m' ? '5' : readTf === '30m' ? '30' : readTf === '15m' ? '15' : readTf === '1h' ? '60' : readTf === '2h' ? '120' : readTf === '4h' ? '240' : 'D';
-        const r = await fetch(`https://api.bybit.com/v5/market/kline?category=linear&symbol=${bybitSym}&interval=${bybitInterval}&limit=300`);
+        const r = await fetch(`/api/market/klines?source=bybit&symbol=${bybitSym}&interval=${bybitInterval}&limit=300`);
         if (!r.ok) throw new Error(t('ARENA_ERROR_BYBIT_API'));
         const data = await r.json();
         raw = [...(data?.result?.list ?? [])].reverse(); // oldest-first to match Binance
@@ -1045,13 +1045,13 @@ function ArenaContent() {
       let rsiDailyStr = '-';
       try {
         if (binanceSym) {
-          const dr = await fetch(`https://api.binance.com/api/v3/klines?symbol=${binanceSym}&interval=1d&limit=20`);
+          const dr = await fetch(`/api/market/klines?source=binance&symbol=${binanceSym}&interval=1d&limit=20`);
           const dd = await dr.json() as (string|number)[][];
           const dc = dd.map(k => Number(k[4]));
           const dv = calcRSI(dc, 14).at(-1);
           if (dv != null) rsiDailyStr = dv.toFixed(1) + (dv >= 70 ? ' (Overbought)' : dv <= 30 ? ' (Oversold)' : ' (Neutral)');
         } else if (bybitSym) {
-          const dr = await fetch(`https://api.bybit.com/v5/market/kline?category=linear&symbol=${bybitSym}&interval=D&limit=20`);
+          const dr = await fetch(`/api/market/klines?source=bybit&symbol=${bybitSym}&interval=D&limit=20`);
           const dd = await dr.json() as { result?: { list?: string[][] } };
           const dc = [...(dd?.result?.list ?? [])].reverse().map(k => parseFloat(k[4]));
           const dv = calcRSI(dc, 14).at(-1);

--- a/app/correlation/page.tsx
+++ b/app/correlation/page.tsx
@@ -30,7 +30,7 @@ async function fetchCloses(id: CoinId, interval: string, limit: number): Promise
   if (binSym) {
     try {
       const res  = await fetch(
-        `https://api.binance.com/api/v3/klines?symbol=${binSym}&interval=${interval}&limit=${limit}`,
+        `/api/market/klines?source=binance&symbol=${binSym}&interval=${interval}&limit=${limit}`,
       );
       const data = await res.json() as Array<unknown[]>;
       return data.map(c => parseFloat(c[4] as string));
@@ -41,7 +41,7 @@ async function fetchCloses(id: CoinId, interval: string, limit: number): Promise
     try {
       const bbInt = interval === '1h' ? '60' : '240';
       const res   = await fetch(
-        `https://api.bybit.com/v5/market/kline?category=linear&symbol=${bbSym}&interval=${bbInt}&limit=${limit}`,
+        `/api/market/klines?source=bybit&symbol=${bbSym}&interval=${bbInt}&limit=${limit}`,
       );
       const data  = await res.json();
       return ((data?.result?.list ?? []) as string[][])

--- a/components/AbsorptionDetector.tsx
+++ b/components/AbsorptionDetector.tsx
@@ -203,8 +203,8 @@ export default function AbsorptionDetector({ coin, onData }: Props) {
 
       if (binSym) {
         const [r15, r1h] = await Promise.all([
-          fetch(`https://api.binance.com/api/v3/klines?symbol=${binSym}&interval=15m&limit=50`),
-          fetch(`https://api.binance.com/api/v3/klines?symbol=${binSym}&interval=1h&limit=20`),
+          fetch(`/api/market/klines?source=binance&symbol=${binSym}&interval=15m&limit=50`),
+          fetch(`/api/market/klines?source=binance&symbol=${binSym}&interval=1h&limit=20`),
         ]);
         if (!r15.ok || !r1h.ok) throw new Error('Binance fetch failed');
         const raw15 = await r15.json() as (string | number)[][];
@@ -215,8 +215,8 @@ export default function AbsorptionDetector({ coin, onData }: Props) {
         // Bybit klines don't include per-candle taker buy - use 50/50 split (still useful for body+vol)
         const toC = (k: string[]) => ({ t: +k[0], o: +k[1], h: +k[2], l: +k[3], c: +k[4], v: +k[5], takerBuy: +k[5] * 0.5 });
         const [r15, r1h] = await Promise.all([
-          fetch(`https://api.bybit.com/v5/market/kline?category=linear&symbol=${bytSym}&interval=15&limit=50`),
-          fetch(`https://api.bybit.com/v5/market/kline?category=linear&symbol=${bytSym}&interval=60&limit=20`),
+          fetch(`/api/market/klines?source=bybit&symbol=${bytSym}&interval=15&limit=50`),
+          fetch(`/api/market/klines?source=bybit&symbol=${bytSym}&interval=60&limit=20`),
         ]);
         if (!r15.ok || !r1h.ok) throw new Error('Bybit fetch failed');
         const raw15 = await r15.json() as { result?: { list?: string[][] } };

--- a/components/GrokChat.tsx
+++ b/components/GrokChat.tsx
@@ -345,11 +345,11 @@ export default function GrokChat() {
         const by = BYBIT_SYMS[coin] as string | undefined;
         let raw: (string | number)[][];
         if (bn) {
-          const r = await fetch(`https://api.binance.com/api/v3/klines?symbol=${bn}&interval=1h&limit=300`);
+          const r = await fetch(`/api/market/klines?source=binance&symbol=${bn}&interval=1h&limit=300`);
           if (!r.ok) throw new Error('binance');
           raw = await r.json();
         } else if (by) {
-          const r = await fetch(`https://api.bybit.com/v5/market/kline?category=linear&symbol=${by}&interval=60&limit=300`);
+          const r = await fetch(`/api/market/klines?source=bybit&symbol=${by}&interval=60&limit=300`);
           if (!r.ok) throw new Error('bybit');
           raw = [...((await r.json())?.result?.list ?? [])].reverse();
         } else return;

--- a/components/HigherTfMoveBadge.tsx
+++ b/components/HigherTfMoveBadge.tsx
@@ -38,11 +38,11 @@ export default function HigherTfMoveBadge({ coin, tf, signalDir }: Props) {
         const by = BYBIT_SYMS[coin];
         let closes: number[] = [];
         if (bn) {
-          const r = await fetch(`https://fapi.binance.com/fapi/v1/klines?symbol=${bn}&interval=4h&limit=${LOOKBACK_BARS + 1}`);
+          const r = await fetch(`/api/market/klines?source=binance-futures&symbol=${bn}&interval=4h&limit=${LOOKBACK_BARS + 1}`);
           const raw = await r.json() as (string | number)[][];
           closes = raw.map(k => +k[4]);
         } else if (by) {
-          const r = await fetch(`https://api.bybit.com/v5/market/kline?category=linear&symbol=${by}&interval=240&limit=${LOOKBACK_BARS + 1}`);
+          const r = await fetch(`/api/market/klines?source=bybit&symbol=${by}&interval=240&limit=${LOOKBACK_BARS + 1}`);
           const d = await r.json() as { result?: { list?: string[][] } };
           closes = [...(d?.result?.list ?? [])].reverse().map(k => +k[4]);
         }

--- a/components/KLineProChart.tsx
+++ b/components/KLineProChart.tsx
@@ -1103,8 +1103,8 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
                 } catch { return null; }
               };
               const raw =
-                await tryFetch(`https://fapi.binance.com/fapi/v1/klines?symbol=${bnSym}&interval=${iv}&limit=1500`)
-                ?? await tryFetch(`https://api.binance.com/api/v3/klines?symbol=${bnSym}&interval=${iv}&limit=1500`)
+                await tryFetch(`/api/market/klines?source=binance-futures&symbol=${bnSym}&interval=${iv}&limit=1500`)
+                ?? await tryFetch(`/api/market/klines?source=binance&symbol=${bnSym}&interval=${iv}&limit=1500`)
                 ?? [];
               if (stale()) return; // superseded by a newer switch - drop it
               let bars = raw.map(k => ({
@@ -1116,7 +1116,7 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
               if (!bars.length && bybitSym) {
                 const bIv = periodToBybitInterval(period);
                 try {
-                  const rb = await fetch(`https://api.bybit.com/v5/market/kline?category=linear&symbol=${bybitSym}&interval=${bIv}&limit=1000`);
+                  const rb = await fetch(`/api/market/klines?source=bybit&symbol=${bybitSym}&interval=${bIv}&limit=1000`);
                   const db = await rb.json() as { result?: { list?: string[][] } };
                   if (stale()) return;
                   bars = [...(db?.result?.list ?? [])].reverse().map(k => ({
@@ -1140,7 +1140,7 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
               callback(bars, false);
             } else if (bybitSym) {
               const iv = periodToBybitInterval(period);
-              const r  = await fetch(`https://api.bybit.com/v5/market/kline?category=linear&symbol=${bybitSym}&interval=${iv}&limit=1000`);
+              const r  = await fetch(`/api/market/klines?source=bybit&symbol=${bybitSym}&interval=${iv}&limit=1000`);
               const d  = await r.json() as { result?: { list?: string[][] } };
               if (stale()) return; // superseded by a newer switch - drop it
               const list = [...(d?.result?.list ?? [])].reverse();
@@ -1199,7 +1199,7 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
             const iv = periodToBybitInterval(period);
             const timer = setInterval(async () => {
               try {
-                const r = await fetch(`https://api.bybit.com/v5/market/kline?category=linear&symbol=${bybitSym}&interval=${iv}&limit=1`);
+                const r = await fetch(`/api/market/klines?source=bybit&symbol=${bybitSym}&interval=${iv}&limit=1`);
                 const d = await r.json() as { result?: { list?: string[][] } };
                 const k = d?.result?.list?.[0];
                 if (k) {

--- a/components/MarketProvider.tsx
+++ b/components/MarketProvider.tsx
@@ -441,7 +441,7 @@ export default function MarketProvider(
       const sym = BYBIT_SYMS[coin];
       try {
         const res = await fetch(
-          `https://api.bybit.com/v5/market/kline?category=linear&symbol=${sym}&interval=15&limit=100`
+          `/api/market/klines?source=bybit&symbol=${sym}&interval=15&limit=100`
         );
         const d = await res.json();
         // Bybit returns newest-first - reverse to oldest-first
@@ -946,7 +946,7 @@ export default function MarketProvider(
         try {
           const [oiRes, klRes] = await Promise.all([
             fetch(`https://api.bybit.com/v5/market/open-interest?category=linear&symbol=${sym}&intervalTime=1h&limit=3`),
-            fetch(`https://api.bybit.com/v5/market/kline?category=linear&symbol=${sym}&interval=60&limit=4`),
+            fetch(`/api/market/klines?source=bybit&symbol=${sym}&interval=60&limit=4`),
           ]);
           const oiData = await oiRes.json();
           const klData = await klRes.json();

--- a/components/MarketStructure.tsx
+++ b/components/MarketStructure.tsx
@@ -134,12 +134,12 @@ export default function MarketStructure({ coin, onData }: Props) {
       let candles: Candle[];
 
       if (binSym) {
-        const r = await fetch(`https://api.binance.com/api/v3/klines?symbol=${binSym}&interval=4h&limit=100`);
+        const r = await fetch(`/api/market/klines?source=binance&symbol=${binSym}&interval=4h&limit=100`);
         if (!r.ok) throw new Error('Binance 4H fetch failed');
         const raw = await r.json() as (string | number)[][];
         candles = raw.map(k => ({ t: +k[0], o: +k[1], h: +k[2], l: +k[3], c: +k[4], v: +k[5] }));
       } else if (bytSym) {
-        const r = await fetch(`https://api.bybit.com/v5/market/kline?category=linear&symbol=${bytSym}&interval=240&limit=100`);
+        const r = await fetch(`/api/market/klines?source=bybit&symbol=${bytSym}&interval=240&limit=100`);
         if (!r.ok) throw new Error('Bybit 4H fetch failed');
         // Per-1000 quoting on 1000PEPEUSDT / 1000BONKUSDT. This card prints the
         // broken level and both swing levels as dollar prices, so without the

--- a/components/VolatilityRegime.tsx
+++ b/components/VolatilityRegime.tsx
@@ -22,7 +22,7 @@ const CACHE_KEY = 'lhq_vol_regime';
 const CACHE_TTL = 4 * 60 * 60 * 1000; // 4 hours - daily data barely changes
 
 function calcHV(symbol: string): Promise<HVData | null> {
-  return fetch(`https://api.binance.com/api/v3/klines?symbol=${symbol}&interval=1d&limit=152`)
+  return fetch(`/api/market/klines?source=binance&symbol=${symbol}&interval=1d&limit=152`)
     .then(r => r.ok ? r.json() : null)
     .then((data: [number, string, string, string, string][] | null) => {
       if (!data || data.length < 32) return null;

--- a/lib/sparklineData.ts
+++ b/lib/sparklineData.ts
@@ -15,7 +15,7 @@ async function fetchKlines(coin: string): Promise<number[]> {
   const bbSym = BYBIT_SYMS[coin];
   try {
     if (bnSym) {
-      const res = await fetch(`https://api.binance.com/api/v3/klines?symbol=${bnSym}&interval=1h&limit=24`, { cache: 'no-store' });
+      const res = await fetch(`/api/market/klines?source=binance&symbol=${bnSym}&interval=1h&limit=24`, { cache: 'no-store' });
       if (res.ok) {
         const raw = await res.json() as unknown[][];
         const closes = raw.map(k => parseFloat(k[4] as string)).filter(n => isFinite(n));
@@ -23,7 +23,7 @@ async function fetchKlines(coin: string): Promise<number[]> {
       }
     }
     if (bbSym) {
-      const res = await fetch(`https://api.bybit.com/v5/market/kline?category=linear&symbol=${bbSym}&interval=60&limit=24`, { cache: 'no-store' });
+      const res = await fetch(`/api/market/klines?source=bybit&symbol=${bbSym}&interval=60&limit=24`, { cache: 'no-store' });
       if (res.ok) {
         const data = await res.json() as { result?: { list?: string[][] } };
         const list = data.result?.list ?? [];

--- a/lib/useEMAStrategy.ts
+++ b/lib/useEMAStrategy.ts
@@ -77,7 +77,7 @@ interface OHLCV { time: number; open: number; high: number; low: number; close: 
 /* ── Fetch helpers ───────────────────────────────────────────────────────── */
 async function fetchBinanceFuturesKlines(sym: string, interval: string, limit: number): Promise<OHLCV[]> {
   const r = await fetch(
-    `https://fapi.binance.com/fapi/v1/klines?symbol=${sym}&interval=${interval}&limit=${limit}`,
+    `/api/market/klines?source=binance-futures&symbol=${sym}&interval=${interval}&limit=${limit}`,
     { signal: AbortSignal.timeout(12_000) }
   );
   if (!r.ok) throw new Error(`Binance futures klines ${r.status}`);
@@ -89,7 +89,7 @@ async function fetchBinanceFuturesKlines(sym: string, interval: string, limit: n
 
 async function fetchBybitKlines(sym: string, interval: string, limit: number): Promise<OHLCV[]> {
   const r = await fetch(
-    `https://api.bybit.com/v5/market/kline?category=linear&symbol=${sym}&interval=${interval}&limit=${limit}`,
+    `/api/market/klines?source=bybit&symbol=${sym}&interval=${interval}&limit=${limit}`,
     { signal: AbortSignal.timeout(12_000) }
   );
   if (!r.ok) throw new Error(`Bybit klines ${r.status}`);


### PR DESCRIPTION
**Dev Team** → **QA Team** · #200 batch 1, step 2 — **and I nearly shipped a fake win. Read the rate-limit section.**

## Summary

30 kline fetches across 11 client files now call `/api/market/klines` instead of
Binance and Bybit directly.

```
                 BEFORE   AFTER
/arena             216     155
/correlation       257     153
/scanner           207     153
/dashboard         216     155
/markets           227     153
/liq               210     156
TOTAL             1333     925      -408, -31%, zero failed requests
```

## 🔴 The near-miss, because it is the most useful thing in this PR

**The first wired build "reduced" traffic to 910 — and ~300 of that reduction was
my own route returning 429.**

```
/correlation  84 x HTTP 429      /markets  98 x 429
/dashboard    67 x 429           /scanner  54 x 429
```

I set `rateLimit('klines:ip', 120, 60_000)`, copied from routes a page calls a
handful of times. This one is called **per symbol per panel** — a real page load
issues ~150. So the pages degraded, requests were rejected, outbound traffic
dropped, and **the graph looked exactly like the cache working.**

A rate limit masquerading as a saving is worse than no cache at all, because it
reports success. I only caught it by counting **failures** alongside requests
rather than requests alone.

Raised to 1200/min — ~8x headroom over the heaviest measured page. These are
cache reads that cost nothing upstream, so the limit is there to stop a scripted
flood, not to ration a page doing its normal job.

**The real fix is fewer client calls** — one request per symbol *set* rather than
per symbol — and that is batch 2. Until then this must not be the thing that
breaks a page.

## Two files deliberately not moved

| File | Why |
|---|---|
| `lib/ribbonCandles.ts` | **imported by three API routes**, so it runs server-side where a relative URL has no base. I rewrote it, caught it before building, and reverted — it would have thrown at runtime in `/api/market/rsi`, `/api/alerts/preview` and `/api/telegram/alert` |
| `lib/backtestEngine.ts` | two paginating callers using `start`/`end` cursors — timestamps, so the unbounded-key leak from #199. A backfill reads each window once anyway |

Neither is an oversight and both are called out in the commit.

## Also worth knowing: one of my own measurements was invalid again

`/correlation` read `text=7290` after and `15030` before, which looked like a
rendering regression. It was not — the page's text **changes through its load
sequence** (skeleton, then computed rows), so a fixed 12s snapshot compares two
different moments. Verified separately: same final text, 0 page errors, 0 failed
calls, element count identical at 3158.

Third invalid reading of mine in two days, same shape each time: a measurement
that had not finished looking like a result.

## How to test (QA)

1. `/arena`, `/correlation`, `/scanner`, `/dashboard`, `/markets`, `/liq` — charts,
   sparklines and correlation tables render as before.
2. DevTools Network: kline requests go to **`/api/market/klines`**, not
   `api.binance.com` / `api.bybit.com`.
3. **None of them return 429.** This is the assertion I would most want in your
   spec — a 429 from our own route is invisible in a traffic graph and looks like
   a win.
4. The two backtest pagination paths still call exchanges directly. Expected.
5. Re-run your #200 baseline. `/backtest` and `/live-tracking` should still be 0
   from #226; these six should each drop by ~60.

## Risk level

**Medium-High** — the highest of the batch. 11 files, six user-facing pages, and
the failure mode is a chart that renders empty rather than an error.

Gates: lint 0 errors (140 warnings, unchanged), tsc clean, 288 tests, build ok.

**Named:** still no automated test asserts any of this. Element counts and
request counts came from throwaway scripts. Your red-run spec would cover items
2 and 3 above, and item 3 is now demonstrably not hypothetical.
