### PR TITLE
perf(dashboard): fetch Bybit per-symbol metrics once for all coins

### DIFF
--- a/app/api/market/account-ratio/route.ts
+++ b/app/api/market/account-ratio/route.ts
@@ -1,0 +1,56 @@
+/* Bybit long/short account ratio for every tracked symbol, in one request (#200).
+ *
+ * Replaces a client-side loop of ~50 per-symbol fetches - 393 requests per
+ * visitor in QA's measurement, the largest single line remaining after batch 1.
+ * The browser now makes one call; the fan-out and its cache live in
+ * lib/bybitFanout.ts, with the reasoning for doing it there rather than as a
+ * per-symbol proxy.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { bybitFanout } from '@/lib/bybitFanout';
+import { rateLimit, getClientIp } from '@/lib/rateLimit';
+import { apiError } from '@/lib/apiError';
+import { reportHealth } from '@/lib/apiHealth';
+
+/* Only the periods the app actually asks for. An allowlist rather than a
+   pass-through, because each distinct value is a separate cache entry and a
+   separate fan-out of 50 upstream calls - free-text here would be both a key
+   leak and an egress amplifier. */
+const PERIODS = new Set(['5min', '15min', '30min', '1h', '4h', '1d']);
+
+export async function GET(req: NextRequest) {
+  if (!rateLimit(`acct-ratio:${getClientIp(req)}`, 120, 60_000)) {
+    return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429 });
+  }
+
+  const period = req.nextUrl.searchParams.get('period') ?? '1h';
+  if (!PERIODS.has(period)) {
+    return NextResponse.json({ error: `period '${period}' is not one this app uses` }, { status: 400 });
+  }
+
+  try {
+    const { data, ok, total } = await bybitFanout(
+      `bybit:account-ratio:${period}`,
+      120_000,
+      (sym) => `https://api.bybit.com/v5/market/account-ratio?category=linear&symbol=${sym}&period=${period}&limit=1`,
+      (body) => {
+        const item = (body as { result?: { list?: Array<Record<string, string>> } })?.result?.list?.[0];
+        if (!item) return null;
+        return {
+          longRatio:  parseFloat(item.buyRatio  || '0.5'),
+          shortRatio: parseFloat(item.sellRatio || '0.5'),
+        };
+      },
+    );
+
+    reportHealth('bybit:account-ratio', 'market', true, `${ok}/${total}`, ok);
+    /* `ok`/`total` are in the body on purpose: a caller and a probe can both see
+       a partial fan-out. An empty one cannot reach here - bybitFanout throws. */
+    return NextResponse.json({ data, ok, total, ts: Date.now() }, {
+      headers: { 'Cache-Control': 'public, s-maxage=120, stale-while-revalidate=600' },
+    });
+  } catch (e) {
+    reportHealth('bybit:account-ratio', 'market', false, String(e));
+    return apiError('market-account-ratio', e, 502, 'Upstream unavailable');
+  }
+}

--- a/app/api/market/open-interest/route.ts
+++ b/app/api/market/open-interest/route.ts
@@ -1,0 +1,54 @@
+/* Bybit open interest for every tracked symbol, in one request (#200).
+ *
+ * Replaces a client-side loop of ~50 per-symbol fetches - 392 requests per
+ * visitor. Two callers want different windows (1h/limit=3 and 5min/limit=13),
+ * so both are parameters and each combination is its own cache entry.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { bybitFanout } from '@/lib/bybitFanout';
+import { rateLimit, getClientIp } from '@/lib/rateLimit';
+import { apiError } from '@/lib/apiError';
+import { reportHealth } from '@/lib/apiHealth';
+
+const INTERVALS = new Set(['5min', '15min', '30min', '1h', '4h', '1d']);
+/* Capped, and small. Each distinct limit is another fan-out of 50 upstream
+   calls, so this is an egress control as much as a validation one. */
+const MAX_LIMIT = 50;
+
+export async function GET(req: NextRequest) {
+  if (!rateLimit(`open-interest:${getClientIp(req)}`, 120, 60_000)) {
+    return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429 });
+  }
+
+  const q = req.nextUrl.searchParams;
+  const intervalTime = q.get('intervalTime') ?? '1h';
+  const limit = Number(q.get('limit') ?? '3');
+
+  if (!INTERVALS.has(intervalTime)) {
+    return NextResponse.json({ error: `intervalTime '${intervalTime}' is not one this app uses` }, { status: 400 });
+  }
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+    return NextResponse.json({ error: `limit must be an integer between 1 and ${MAX_LIMIT}` }, { status: 400 });
+  }
+
+  try {
+    const { data, ok, total } = await bybitFanout(
+      `bybit:open-interest:${intervalTime}:${limit}`,
+      120_000,
+      (sym) => `https://api.bybit.com/v5/market/open-interest?category=linear&symbol=${sym}&intervalTime=${intervalTime}&limit=${limit}`,
+      /* The upstream `list` verbatim, newest-first as Bybit sends it. Both
+         callers do their own arithmetic over it - one reads [0], the other
+         compares [0] against the last element - so reshaping here would break
+         one of them and is not this route's business. */
+      (body) => (body as { result?: { list?: unknown[] } })?.result?.list ?? null,
+    );
+
+    reportHealth('bybit:open-interest', 'market', true, `${ok}/${total}`, ok);
+    return NextResponse.json({ data, ok, total, ts: Date.now() }, {
+      headers: { 'Cache-Control': 'public, s-maxage=120, stale-while-revalidate=600' },
+    });
+  } catch (e) {
+    reportHealth('bybit:open-interest', 'market', false, String(e));
+    return apiError('market-open-interest', e, 502, 'Upstream unavailable');
+  }
+}

--- a/components/MarketProvider.tsx
+++ b/components/MarketProvider.tsx
@@ -350,19 +350,25 @@ export default function MarketProvider(
   /* ── Bybit + Binance LSR ── */
   const fetchLSR = useCallback(async () => {
     await Promise.allSettled([
-      // Bybit account ratio (1h) - all coins
-      ...Object.entries(BYBIT_SYMS).map(async ([coin, sym]) => {
+      /* Bybit account ratio (1h) - ONE request for all coins (#200).
+         This was a loop of ~50 per-symbol fetches, 393 requests per visitor and
+         the largest single line left after batch 1. Bybit has no batch
+         parameter, so the fan-out moved server-side where one cache entry serves
+         every visitor - see lib/bybitFanout.ts. */
+      (async () => {
         try {
-          const res = await fetch(`https://api.bybit.com/v5/market/account-ratio?category=linear&symbol=${sym}&period=1h&limit=1`);
-          const d = await res.json();
-          const item = d.result?.list?.[0];
-          if (!item) return;
-          updateCoin(coin as CoinId, {
-            longRatio:  parseFloat(item.buyRatio  || '0.5'),
-            shortRatio: parseFloat(item.sellRatio || '0.5'),
-          });
+          const res = await fetch('/api/market/account-ratio?period=1h');
+          if (!res.ok) return;
+          const { data } = await res.json() as {
+            data: Record<string, { longRatio: number; shortRatio: number }>;
+          };
+          for (const [coin, sym] of Object.entries(BYBIT_SYMS)) {
+            const item = data?.[sym];
+            if (!item) continue;          // absent means not fetched, not zero
+            updateCoin(coin as CoinId, { longRatio: item.longRatio, shortRatio: item.shortRatio });
+          }
         } catch { /* */ }
-      }),
+      })(),
       // The Binance half of this - two ratio requests per coin, 91 requests
       // in total - moved to app/api/market/snapshot. Bybit stays here: it is
       // one request per coin against a different provider with its own limit,
@@ -941,18 +947,24 @@ export default function MarketProvider(
   /* ── OI Trend bootstrap - Bybit historical OI + klines ── */
   // Fires once on mount to populate OI trend without waiting for two 8-min Bybit polls
   const bootstrapOITrend = useCallback(async () => {
+    /* Open interest for every symbol in ONE request (#200), fetched before the
+       per-symbol work rather than inside it. This was ~50 fetches - 392 requests
+       per visitor. Klines stay per-symbol because they genuinely differ per
+       symbol, and they already go through the cached route from batch 1. */
+    let oiAll: Record<string, Array<{ openInterest: string }>> = {};
+    try {
+      const r = await fetch('/api/market/open-interest?intervalTime=1h&limit=3');
+      if (r.ok) oiAll = (await r.json()).data ?? {};
+    } catch { /* leave empty; the length guard below already handles no data */ }
+
     await Promise.allSettled(
       Object.entries(BYBIT_SYMS).map(async ([coin, sym]) => {
         try {
-          const [oiRes, klRes] = await Promise.all([
-            fetch(`https://api.bybit.com/v5/market/open-interest?category=linear&symbol=${sym}&intervalTime=1h&limit=3`),
-            fetch(`/api/market/klines?source=bybit&symbol=${sym}&interval=60&limit=4`),
-          ]);
-          const oiData = await oiRes.json();
+          const klRes = await fetch(`/api/market/klines?source=bybit&symbol=${sym}&interval=60&limit=4`);
           const klData = await klRes.json();
 
           // Both are newest-first - reverse to oldest-first
-          const oiList: Array<{ openInterest: string }> = [...(oiData?.result?.list ?? [])].reverse();
+          const oiList: Array<{ openInterest: string }> = [...(oiAll[sym] ?? [])].reverse();
           const klList: string[][] = [...(klData?.result?.list ?? [])].reverse();
 
           if (oiList.length < 2 || klList.length < 2) return;

--- a/lib/bybitFanout.ts
+++ b/lib/bybitFanout.ts
@@ -1,0 +1,82 @@
+/* Fan out one Bybit per-symbol endpoint across every tracked coin, once (#200).
+ *
+ * Bybit's account-ratio and open-interest endpoints take ONE symbol per request
+ * and have no batch parameter. The client currently loops over ~50 symbols, so
+ * every visitor issues ~50 requests for data that is identical for all of them -
+ * 393 and 392 calls respectively in QA's measurement, together 60% of what is
+ * left after batch 1.
+ *
+ * A per-symbol proxy route would have moved that loop onto our server without
+ * collapsing it: still 50 upstream calls per visitor, just from one IP instead
+ * of thousands. Worse, not better - that IP is the one Binance already banned
+ * once (#228).
+ *
+ * So the fan-out happens HERE, behind one cache entry per (endpoint, params).
+ * The first visitor in a TTL window pays 50 upstream calls; everyone else pays
+ * zero. #201's single-flight means a burst at expiry produces one fan-out rather
+ * than one per concurrent visitor, which is the difference between a cache and a
+ * thundering herd.
+ *
+ * The browser side goes from ~50 requests to 1.
+ */
+import { cached } from './apiCache';
+import { BYBIT_SYMS } from './coins';
+
+/** Every symbol this app tracks on Bybit. A closed set, which is what keeps the
+ *  cache key space finite - see the note in app/api/market/klines/route.ts. */
+const SYMBOLS = Object.values(BYBIT_SYMS);
+
+export interface FanoutResult {
+  /** symbol -> whatever the caller's `pick` returned. Missing symbols are absent
+   *  rather than null: a caller can then tell "we did not get it" from "it is
+   *  legitimately zero". */
+  data: Record<string, unknown>;
+  /** How many symbols came back. Exposed so the route can report health and so a
+   *  probe can tell a partial fan-out from a complete one - the #228 lesson: an
+   *  empty result must never look like a successful one. */
+  ok: number;
+  total: number;
+}
+
+/**
+ * @param key      cache key, must encode every parameter that changes the result
+ * @param ttlMs    how long one fan-out serves
+ * @param buildUrl given a symbol, the upstream URL to call
+ * @param pick     extract the bit worth keeping from one symbol's response
+ *
+ * `allSettled`, not `all`: one symbol failing must not lose the other 49. That
+ * is the same reasoning as /api/market/snapshot's three-way split, and the same
+ * trap - so the caller is told how many succeeded rather than being handed a
+ * quietly short map.
+ */
+export async function bybitFanout(
+  key: string,
+  ttlMs: number,
+  buildUrl: (symbol: string) => string,
+  pick: (body: unknown) => unknown,
+): Promise<FanoutResult> {
+  return cached(key, ttlMs, async () => {
+    const settled = await Promise.allSettled(
+      SYMBOLS.map(async (sym) => {
+        const r = await fetch(buildUrl(sym), { cache: 'no-store' });
+        if (!r.ok) throw new Error(`${sym} ${r.status}`);
+        return [sym, pick(await r.json())] as const;
+      }),
+    );
+
+    const data: Record<string, unknown> = {};
+    for (const s of settled) {
+      if (s.status === 'fulfilled' && s.value[1] != null) data[s.value[0]] = s.value[1];
+    }
+
+    /* Throwing on a total wipeout rather than caching an empty map. `cached()`
+       does not store a rejection, so a refused upstream is retried by the next
+       caller instead of being pinned for the TTL - and the route turns this into
+       a non-2xx rather than an empty success. */
+    if (Object.keys(data).length === 0) {
+      throw new Error(`bybit fan-out returned nothing for all ${SYMBOLS.length} symbols`);
+    }
+
+    return { data, ok: Object.keys(data).length, total: SYMBOLS.length };
+  });
+}


### PR DESCRIPTION
**Dev Team** → **QA Team** · #200 batch 2 — **−62% on your eight measured routes**

## Summary

Two new routes returning **all symbols in one request**, replacing two ~50-iteration
client loops.

```
                 BEFORE   AFTER
/funding           206     105
/dashboard         159      57
/liq               159      58
/arena             158      57
/markets           156      55
/scanner           156      55
/correlation       156      55
/briefing          156      55
TOTAL             1306     497     -809, -62%, zero failed requests
```

Baseline is your per-route table from today, so this is directly comparable.

## I took the all-symbols shape

You did not answer the question directly, but you wrote:

> one route fixing `account-ratio` + `open-interest` should drop all eight at once

That only works with the all-symbols shape, so I read it as the answer. **If I
read it wrong, say so** — the per-symbol version is a smaller change and I would
rather redo it than have you test the wrong thing.

The reasoning either way: a per-symbol proxy moves the loop onto our server
without collapsing it — still ~50 upstream calls per visitor, from **one IP
instead of thousands**, and that IP is the one Binance already banned once
(#228). Fanning out behind one cache entry means the first visitor in a TTL
window pays 50 and everyone else pays zero.

## #228's lesson applied where the data is assembled

`bybitFanout` **throws when every symbol fails**, so an empty map can never be
cached or returned as a success. And both routes return `ok`/`total` in the body:

```json
{ "data": { … }, "ok": 49, "total": 49, "ts": … }
```

A partial fan-out is visible rather than looking complete. That is the same
property your snapshot control just proved matters — 49/49 is a claim a probe can
check, `{}` with a 200 is not.

## Two call sites deliberately not moved

`app/liq/page.tsx` and `lib/useOI1h.ts` fetch a **single** symbol — the selected
coin — not a loop. ~1 call each, not 50. Routing them through a 50-symbol map
would make a single-coin page download 49 symbols it does not use. Named in the
commit rather than left for you to notice.

## Verification, and what I ran since CI is dark

As promised — **which specs I ran, not "gates green"**:

```
npx eslint .                                    0 errors (140 warnings, unchanged)
npx tsc --noEmit                                clean
npm test                                        288 passing
npm run build                                   ok
playwright smoke.spec + klines-route.spec       40 passed
```

Plus the eight-route egress measurement above, and the routes directly:

```
/api/market/account-ratio?period=1h              200  ok=49/49
/api/market/open-interest?intervalTime=1h&limit=3  200  ok=49/49
/api/market/account-ratio?period=bogus           400  "period 'bogus' is not one this app uses"
```

## One process note

I cut this branch from `5d08e9b` and only noticed mid-work that it predated #234
— a kline URL was still raw. Rebased onto `c59db1c` before continuing, so what is
here is on top of your merge. Worth mentioning because with no CI, a stale base
is the kind of thing that silently reverts someone else's work.

## How to test (QA)

1. `/dashboard`, `/arena`, `/liq`, `/markets` — long/short ratios and OI trend
   arrows render as before.
2. DevTools Network: **one** request to `/api/market/account-ratio` and **one** to
   `/api/market/open-interest` per page, instead of ~50 to `api.bybit.com`.
3. `/liq` — switching coin or timeframe still updates the Bybit long/short
   figure. That path is unchanged and still calls Bybit directly, by design.
4. Re-run your probe: the eight routes should land near 55, `/funding` near 105.

## Risk level

**Medium-High.** `MarketProvider` mounts on every route, and the failure mode is
ratios and OI arrows silently missing rather than an error.

**Named:** the fan-out multiplies upstream calls per cache MISS — 50 in one burst
instead of spread across visitors. `cached()` plus #201's single-flight is what
keeps that to one burst per TTL rather than one per visitor. If either regresses,
this route is the one that will show it first.
