### PR TITLE
perf(dashboard): batch the two Binance symbol sweeps

### DIFF
--- a/app/api/market/agg-trades/route.ts
+++ b/app/api/market/agg-trades/route.ts
@@ -1,0 +1,67 @@
+/* Binance aggregate trades for every tracked symbol, in one request (#200).
+ *
+ * Replaces a client sweep of ~45 per-symbol fetches - 360 requests per visitor,
+ * the largest single line left after batch 2. Same shape as the Bybit pair:
+ * Binance has no batch parameter, so the fan-out lives here behind one cache
+ * entry rather than in every browser.
+ *
+ * PAYLOAD, measured rather than assumed: one symbol at limit=200 is ~24 KB, so
+ * all 45 is ~1.04 MB raw and ~0.26 MB gzipped. That is the SAME total bytes the
+ * client already transfers - it is the same data - so this trades 45 requests
+ * for 1 without changing what crosses the wire.
+ *
+ * WHALE-ALERT LATENCY, the one behaviour change worth knowing: the caller emits
+ * `whale-trade` events for trades newer than the last id it saw, so a shared
+ * cache means every visitor in a TTL window sees the same trade set. `fetchCVD`
+ * already runs on a FIVE MINUTE interval, so whale events are up to 5 minutes
+ * behind today; a 60s TTL adds at most 20% to a latency that already exists. It
+ * does not introduce a new class of delay.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { symbolFanout } from '@/lib/bybitFanout';
+import { rateLimit, getClientIp } from '@/lib/rateLimit';
+import { apiError } from '@/lib/apiError';
+import { reportHealth } from '@/lib/apiHealth';
+import { BINANCE_SYMS } from '@/lib/coins';
+
+/* hype is excluded to match the caller: it is not a Binance listing, so a
+   request for it is a guaranteed 400 from upstream and one wasted call per
+   fan-out. */
+const SYMBOLS = Object.entries(BINANCE_SYMS)
+  .filter(([coin]) => coin !== 'hype')
+  .map(([, sym]) => sym);
+
+const LIMITS = new Set([100, 200, 500]);
+
+export async function GET(req: NextRequest) {
+  if (!rateLimit(`agg-trades:${getClientIp(req)}`, 120, 60_000)) {
+    return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429 });
+  }
+
+  const limit = Number(req.nextUrl.searchParams.get('limit') ?? '200');
+  if (!LIMITS.has(limit)) {
+    return NextResponse.json(
+      { error: `limit must be one of ${[...LIMITS].join(', ')}` }, { status: 400 },
+    );
+  }
+
+  try {
+    const { data, ok, total } = await symbolFanout(
+      SYMBOLS,
+      `binance:agg-trades:${limit}`,
+      60_000,
+      (sym) => `https://api.binance.com/api/v3/aggTrades?symbol=${sym}&limit=${limit}`,
+      /* Verbatim. The caller walks every trade computing CVD and whale events
+         against its own last-seen id, so reshaping here would break both. */
+      (body) => (Array.isArray(body) ? body : null),
+    );
+
+    reportHealth('binance:agg-trades', 'market', true, `${ok}/${total}`, ok);
+    return NextResponse.json({ data, ok, total, ts: Date.now() }, {
+      headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300' },
+    });
+  } catch (e) {
+    reportHealth('binance:agg-trades', 'market', false, String(e));
+    return apiError('market-agg-trades', e, 502, 'Upstream unavailable');
+  }
+}

--- a/app/api/market/funding-rate/route.ts
+++ b/app/api/market/funding-rate/route.ts
@@ -1,0 +1,55 @@
+/* Binance funding-rate history for every tracked symbol, in one request (#200).
+ *
+ * 45 calls, one per symbol, all with limit=42, and only on /funding. QA measured
+ * it as the identical shape to account-ratio and revised their own advice to
+ * collect it alongside aggTrades rather than leaving it in the tail.
+ *
+ * TTL is 15 minutes, not the 60s the trade routes use: funding settles on a
+ * fixed EIGHT HOUR schedule, so a 42-point history is unchanged between
+ * settlements. A shorter TTL would re-fetch 45 symbols to receive the same
+ * numbers.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { symbolFanout } from '@/lib/bybitFanout';
+import { rateLimit, getClientIp } from '@/lib/rateLimit';
+import { apiError } from '@/lib/apiError';
+import { reportHealth } from '@/lib/apiHealth';
+import { BINANCE_SYMS } from '@/lib/coins';
+
+const SYMBOLS = Object.entries(BINANCE_SYMS)
+  .filter(([coin]) => coin !== 'hype')
+  .map(([, sym]) => sym);
+
+const MAX_LIMIT = 100;
+
+export async function GET(req: NextRequest) {
+  if (!rateLimit(`funding-rate:${getClientIp(req)}`, 120, 60_000)) {
+    return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429 });
+  }
+
+  const limit = Number(req.nextUrl.searchParams.get('limit') ?? '42');
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+    return NextResponse.json(
+      { error: `limit must be an integer between 1 and ${MAX_LIMIT}` }, { status: 400 },
+    );
+  }
+
+  try {
+    const { data, ok, total } = await symbolFanout(
+      SYMBOLS,
+      `binance:funding-rate:${limit}`,
+      900_000,
+      (sym) => `https://fapi.binance.com/fapi/v1/fundingRate?symbol=${sym}&limit=${limit}`,
+      /* Verbatim array; /funding maps and sorts it itself. */
+      (body) => (Array.isArray(body) ? body : null),
+    );
+
+    reportHealth('binance:funding-rate', 'market', true, `${ok}/${total}`, ok);
+    return NextResponse.json({ data, ok, total, ts: Date.now() }, {
+      headers: { 'Cache-Control': 'public, s-maxage=900, stale-while-revalidate=1800' },
+    });
+  } catch (e) {
+    reportHealth('binance:funding-rate', 'market', false, String(e));
+    return apiError('market-funding-rate', e, 502, 'Upstream unavailable');
+  }
+}

--- a/app/funding/page.tsx
+++ b/app/funding/page.tsx
@@ -30,14 +30,26 @@ const RANGE_LABEL_KEYS: Record<RangeKey, LabelKey> = {
 };
 
 /* ── data fetching ── */
-async function fetchBinanceFR(sym: string): Promise<FRPoint[]> {
+/* One request for every symbol (#200 batch 3), instead of one per symbol.
+ *
+ * This was 45 calls with identical params, and only on this page - QA measured
+ * it as the same sweep shape as account-ratio. The map is fetched once by the
+ * caller below and each coin reads its own entry; the parsing is unchanged. */
+async function fetchAllBinanceFR(): Promise<Record<string, FRPoint[]>> {
   try {
-    const res  = await fetch(`https://fapi.binance.com/fapi/v1/fundingRate?symbol=${sym}&limit=42`);
-    const data = await res.json();
-    return (data as Array<{ fundingRate: string; fundingTime: number }>)
-      .map(d => ({ rate: parseFloat(d.fundingRate), ts: d.fundingTime }))
-      .sort((a, b) => a.ts - b.ts);
-  } catch { return []; }
+    const res = await fetch('/api/market/funding-rate?limit=42');
+    if (!res.ok) return {};
+    const { data } = await res.json() as {
+      data: Record<string, Array<{ fundingRate: string; fundingTime: number }>>;
+    };
+    const out: Record<string, FRPoint[]> = {};
+    for (const [sym, rows] of Object.entries(data ?? {})) {
+      out[sym] = rows
+        .map(d => ({ rate: parseFloat(d.fundingRate), ts: d.fundingTime }))
+        .sort((a, b) => a.ts - b.ts);
+    }
+    return out;
+  } catch { return {}; }
 }
 
 async function fetchBybitFR(sym: string): Promise<FRPoint[]> {
@@ -326,11 +338,16 @@ export default function FundingHistory() {
     let cancelled = false;
     (async () => {
       const result: FRHistory = {};
+      /* One request covering every Binance symbol, before the per-coin loop. */
+      const binanceAll = await fetchAllBinanceFR();
       await Promise.all(COINS.map(async id => {
         const binSym = (BINANCE_SYMS as Record<string, string>)[id];
         const bbSym  = (BYBIT_SYMS  as Record<string, string>)[id];
         let pts: FRPoint[] = [];
-        if (binSym) pts = await fetchBinanceFR(binSym);
+        /* Binance comes from the one batched map; Bybit stays per-symbol because
+           it is only the fallback for coins Binance does not list - a handful,
+           not a sweep. */
+        if (binSym) pts = binanceAll[binSym] ?? [];
         if (!pts.length && bbSym) pts = await fetchBybitFR(bbSym);
         if (pts.length) result[id] = pts;
       }));

--- a/components/MarketProvider.tsx
+++ b/components/MarketProvider.tsx
@@ -584,14 +584,21 @@ export default function MarketProvider(
     // All Binance-listed coins
     const binanceCoins = (Object.keys(BINANCE_SYMS) as CoinId[]).filter(c => c !== 'hype');
     await Promise.allSettled([
-      // ── Binance aggTrades ──
-      ...binanceCoins.map(async (coin) => {
+      /* ── Binance aggTrades - ONE request for all coins (#200 batch 3) ──
+         This was a sweep of ~45 per-symbol fetches, 360 requests per visitor.
+         The map is fetched once here; each coin then reads its own entry, so the
+         per-coin CVD and whale logic below is unchanged. */
+      (async () => {
+        let aggAll: Record<string, Array<{ m: boolean; q: string; p: string; a: number }>> = {};
+        try {
+          const r = await fetch('/api/market/agg-trades?limit=200');
+          if (r.ok) aggAll = (await r.json()).data ?? {};
+        } catch { /* every coin below then sees no trades and returns early */ }
+
+        await Promise.allSettled(binanceCoins.map(async (coin) => {
         const sym = BINANCE_SYMS[coin];
         try {
-          const res = await fetch(
-            `https://api.binance.com/api/v3/aggTrades?symbol=${sym}&limit=200`
-          );
-          const trades = await res.json();
+          const trades = aggAll[sym];
           if (!Array.isArray(trades)) return;
 
           let buyVol = 0, sellVol = 0;
@@ -653,7 +660,8 @@ export default function MarketProvider(
           }
           cvdDivStateRef.current[coin] = _newDiv;
         } catch { /* */ }
-      }),
+        }));
+      })(),
       // ── HYPE via Bybit recent-trade (Bybit-only coin) ──
       (async () => {
         try {

--- a/lib/bybitFanout.ts
+++ b/lib/bybitFanout.ts
@@ -55,9 +55,30 @@ export async function bybitFanout(
   buildUrl: (symbol: string) => string,
   pick: (body: unknown) => unknown,
 ): Promise<FanoutResult> {
+  return symbolFanout(SYMBOLS, key, ttlMs, buildUrl, pick);
+}
+
+/**
+ * The same collapse for any closed symbol list, not just Bybit's.
+ *
+ * Added for the Binance sweeps in #200 batch 3 - `aggTrades` (360 calls) and
+ * `fundingRate` (45). Both are the identical shape: one request per symbol over
+ * the app's own coin list, with no batch parameter upstream.
+ *
+ * `symbols` must be a CLOSED set for the same reason the Bybit version uses one:
+ * the cache key is per (endpoint, params), and the fan-out width is the symbol
+ * count, so free-text symbols would be both a key leak and an egress amplifier.
+ */
+export async function symbolFanout(
+  symbols: string[],
+  key: string,
+  ttlMs: number,
+  buildUrl: (symbol: string) => string,
+  pick: (body: unknown) => unknown,
+): Promise<FanoutResult> {
   return cached(key, ttlMs, async () => {
     const settled = await Promise.allSettled(
-      SYMBOLS.map(async (sym) => {
+      symbols.map(async (sym) => {
         const r = await fetch(buildUrl(sym), { cache: 'no-store' });
         if (!r.ok) throw new Error(`${sym} ${r.status}`);
         return [sym, pick(await r.json())] as const;
@@ -74,9 +95,9 @@ export async function bybitFanout(
        caller instead of being pinned for the TTL - and the route turns this into
        a non-2xx rather than an empty success. */
     if (Object.keys(data).length === 0) {
-      throw new Error(`bybit fan-out returned nothing for all ${SYMBOLS.length} symbols`);
+      throw new Error(`fan-out returned nothing for all ${symbols.length} symbols`);
     }
 
-    return { data, ok: Object.keys(data).length, total: SYMBOLS.length };
+    return { data, ok: Object.keys(data).length, total: symbols.length };
   });
 }


### PR DESCRIPTION
**Dev Team** → **QA Team** · #200 batch 3 — **1306 → 92 on your eight routes**

## Summary

```
                 BASELINE   BATCH 2   BATCH 3
/funding            206       105        15
/dashboard          159        57        12
/liq                159        58        13
/arena              158        57        12
/markets            156        55        10
/scanner            156        55        10
/correlation        156        55        10
/briefing           156        55        10
TOTAL              1306       497        92    -93%, zero failed requests
```

**92, against your predicted ~120.** Took your revised advice and did
`fundingRate` alongside `aggTrades` rather than alone — you were right that it is
the same shape and nearly free once the fan-out exists.

## The payload question I checked before choosing the shape

`aggTrades` is 200 trades × 45 symbols, so "one request instead of 45" could have
meant one enormous request. Measured:

```
one symbol, limit=200   ~24 KB
all 45                  ~1.04 MB raw   ~0.26 MB gzipped
```

That is the **same total the client already transferred** — same data, same
bytes. So it trades 45 requests for 1 without changing what crosses the wire. If
it had been 10x, I would have come back to you instead of building it.

## The behaviour change, and why it is smaller than it sounds

Whale alerts fire on trades newer than the caller's last-seen id, so a shared
cache means everyone in a TTL window sees the same trade set — a latency
increase.

**But `fetchCVD` already runs on a 5-minute interval.** Those events are up to 5
minutes late today; a 60s TTL adds at most 20% to an existing latency rather than
introducing a new one. I checked the interval before picking the TTL, because
"whale alerts are now delayed" would have been a real objection if the poll had
been every 10 seconds.

`fundingRate` gets 15 minutes instead — funding settles on a fixed 8-hour
schedule, so a shorter TTL would re-fetch 45 symbols to receive identical numbers.

## Taking your "this is where I would stop"

`recent-trade` left alone, on your measurement: 6 calls across 5 distinct symbols
at two different limits is not a sweep, and a fan-out is the wrong shape for it.
`backtestEngine`'s fundingRate paginates with cursors and stays direct for the
same reason its klines call does.

Also removed the now-dead per-symbol `fetchBinanceFR` rather than leaving it
unreferenced.

## Verification — which specs I ran, since CI is dark

```
npx eslint .                                0 errors (140 warnings, unchanged)
npx tsc --noEmit                            clean
npm test                                    288 passing
npm run build                               ok
playwright smoke + klines-route             40 passed
```

Routes directly:

```
/api/market/agg-trades?limit=200     200  ok=45/45
/api/market/funding-rate?limit=42    200  ok=45/45
/api/market/agg-trades?limit=7       400  "limit must be one of 100, 200, 500"
```

## How to test (QA)

1. **/funding** — the funding-rate history chart renders for every coin. This is
   the page that changed most (206 → 15).
2. **/dashboard**, **/arena** — CVD values and whale alerts still work.
3. DevTools Network: **one** request to `/api/market/agg-trades`, and on
   `/funding` **one** to `/api/market/funding-rate`, instead of ~45 each.
4. Re-run your probe — I make it ~92 across the eight, against your ~120 estimate.

## Risk level

**Medium-High.** `MarketProvider` again, plus `/funding`'s only data path. Failure
mode is CVD/whale/funding data missing rather than an error.

**Named:** `/api/market/agg-trades` is the widest fan-out yet — 45 upstream calls
on a cache miss, in one burst, from one IP. Single-flight keeps that to one burst
per TTL, and you have now measured that property directly (49 calls for 8
concurrent requests). It is the load-bearing assumption for this whole batch.

If you agree this closes #200's substantive work, I will file the ~92-call tail as
a separate low-priority issue rather than leaving a 93%-complete issue open.
