### PR TITLE
perf(api): route every remaining browser exchange call through the proxy

### DIFF
--- a/app/api/proxy/route.ts
+++ b/app/api/proxy/route.ts
@@ -390,6 +390,27 @@ export async function GET(req: NextRequest) {
           return v != null && v !== '';
         });
         const cacheable = entry.ttlMs > 0 && !paginating;
+
+        /* AND AN UNCACHED PATH NEEDS ITS OWN, TIGHTER LIMIT.
+         *
+         * Skipping the cache to avoid unbounded keys creates the opposite
+         * problem: every cursor request reaches the upstream, so an attacker can
+         * walk arbitrary timestamps and turn this route into an amplifier
+         * pointed at Binance and Bybit FROM OUR SERVER IP. That is not
+         * hypothetical - #228 was Binance returning 418 (their ban code) to the
+         * qa and staging egress IP for exactly this kind of volume, and it took
+         * hours to clear on its own.
+         *
+         * The main 600/min limit is sized for cache READS, which cost nothing
+         * upstream. This path costs a real upstream call every time, so it gets a
+         * separate budget two orders of magnitude smaller. The only legitimate
+         * caller is backtestEngine walking a backfill, which is a handful of
+         * windows per run, not hundreds per minute. */
+        if (paginating && !rateLimit(`proxy-cursor:${ip}`, 30, 60_000)) {
+          return NextResponse.json(
+            { error: 'Rate limit exceeded for paginated requests' }, { status: 429 },
+          );
+        }
         const body = cacheable
           ? await cached(`proxy:${type}:${u.search}`, entry.ttlMs, go)
           : await go();

--- a/app/api/proxy/route.ts
+++ b/app/api/proxy/route.ts
@@ -84,6 +84,26 @@ interface PassEntry {
   fixed?: Record<string, string>;
 }
 
+/* Params whose presence makes a request UNCACHEABLE, whatever the entry says.
+ *
+ * These are cursors. QA found that /api/proxy?type=funding-history&startTime=1&
+ * endTime=2 returned 200 and was therefore cached under a key containing those
+ * timestamps - and lib/apiCache.ts holds a Map with no eviction, no cap and no
+ * TTL sweep, so every distinct pair is a permanent allocation for the life of
+ * the instance. Unbounded keys, exactly the leak #199 warns about.
+ *
+ * The comment below already promised this and no entry implemented it. Third
+ * time today a comment of mine described a defence the code did not have, so it
+ * is enforced HERE, in one place, rather than as a per-entry field somebody has
+ * to remember to set.
+ *
+ * PER-REQUEST, NOT PER-ENTRY, and that distinction matters: /funding calls
+ * funding-history with just symbol+limit and SHOULD stay cached - it is the same
+ * request for every visitor. Only the paginating caller passes cursors. Marking
+ * the whole entry uncacheable would throw away the cache for the common case to
+ * fix the rare one. */
+const CURSOR_PARAMS = ['startTime', 'endTime', 'start', 'end'] as const;
+
 const PASSTHROUGH: Record<string, PassEntry> = {
   /* Bybit. Note for anyone slicing these later: Bybit returns NEWEST-first and
      Binance OLDEST-first - the bug qa/e2e/klines-route.spec.ts now guards. */
@@ -364,10 +384,16 @@ export async function GET(req: NextRequest) {
            cannot share an entry. ttlMs 0 skips the cache, for callers paginating
            a time range - their cursors are timestamps and would make the key
            space unbounded (#199). */
-        const body = entry.ttlMs > 0
+        /* A cursor in the REQUEST disables caching for that request only. */
+        const paginating = CURSOR_PARAMS.some(k => {
+          const v = req.nextUrl.searchParams.get(k);
+          return v != null && v !== '';
+        });
+        const cacheable = entry.ttlMs > 0 && !paginating;
+        const body = cacheable
           ? await cached(`proxy:${type}:${u.search}`, entry.ttlMs, go)
           : await go();
-        return NextResponse.json(body, { headers: entry.ttlMs > 0 ? PROXY_CACHE : undefined });
+        return NextResponse.json(body, { headers: cacheable ? PROXY_CACHE : undefined });
       } catch (e) {
         const status = (e as Error & { status?: number }).status;
         return apiError('proxy', e, 502, status

--- a/app/api/proxy/route.ts
+++ b/app/api/proxy/route.ts
@@ -55,9 +55,85 @@ async function attributedUser(req: NextRequest): Promise<string> {
 const PROXY_CACHE = { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600' };
 const proxyCache = (ok: boolean) => (ok ? PROXY_CACHE : undefined);
 
+/* PASSTHROUGH TYPES (#238).
+ *
+ * #200 moved every SWEEP - one request per symbol across the whole coin list -
+ * behind cached routes, and stopped at 117 calls on the grounds that the rest
+ * were too small to be worth a route each. QA corrected that framing and was
+ * right: the titled problem is "the browser calls Binance and Bybit directly",
+ * so 117 is a smaller instance of the same problem rather than a different one.
+ * The finish line is ZERO, not a lower number.
+ *
+ * These are not sweeps. Each is one call for one thing - a single symbol, or a
+ * global figure - so a fan-out is the wrong shape. What they need is a proxy,
+ * and this route already is one: allowlisted, cached, rate-limited, and carrying
+ * the proxyCache(ok) guard that refuses to cache an upstream error as a success.
+ *
+ * A TABLE RATHER THAN FIFTEEN BRANCHES, because fifteen near-identical if-blocks
+ * is where a copy-paste error hides.
+ *
+ * PARAMS ARE ALLOWLISTED PER ENTRY, which is a cache-key decision as much as a
+ * security one: an unbounded param space means unbounded keys in a Map that
+ * never evicts (#199), and a free-text passthrough would turn this route into an
+ * open proxy to two exchanges.
+ */
+interface PassEntry {
+  url: string;
+  params: readonly string[];
+  ttlMs: number;
+  fixed?: Record<string, string>;
+}
+
+const PASSTHROUGH: Record<string, PassEntry> = {
+  /* Bybit. Note for anyone slicing these later: Bybit returns NEWEST-first and
+     Binance OLDEST-first - the bug qa/e2e/klines-route.spec.ts now guards. */
+  'recent-trade':    { url: 'https://api.bybit.com/v5/market/recent-trade',
+                       params: ['symbol', 'limit'], fixed: { category: 'linear' }, ttlMs: 30_000 },
+  'bybit-tickers':   { url: 'https://api.bybit.com/v5/market/tickers',
+                       params: [], fixed: { category: 'linear' }, ttlMs: 30_000 },
+  'account-ratio-1': { url: 'https://api.bybit.com/v5/market/account-ratio',
+                       params: ['symbol', 'period', 'limit'], fixed: { category: 'linear' }, ttlMs: 120_000 },
+  'open-interest-1': { url: 'https://api.bybit.com/v5/market/open-interest',
+                       params: ['symbol', 'intervalTime', 'limit'], fixed: { category: 'linear' }, ttlMs: 120_000 },
+  'funding-history': { url: 'https://api.bybit.com/v5/market/funding/history',
+                       params: ['symbol', 'limit', 'startTime', 'endTime'], fixed: { category: 'linear' }, ttlMs: 900_000 },
+
+  /* Binance spot and futures */
+  'binance-24hr':    { url: 'https://api.binance.com/api/v3/ticker/24hr',
+                       params: ['symbols', 'symbol'], ttlMs: 30_000 },
+  'depth':           { url: 'https://api.binance.com/api/v3/depth',
+                       params: ['symbol', 'limit'], ttlMs: 15_000 },
+  'premium-index':   { url: 'https://fapi.binance.com/fapi/v1/premiumIndex',
+                       params: ['symbol'], ttlMs: 60_000 },
+  'oi-hist':         { url: 'https://fapi.binance.com/futures/data/openInterestHist',
+                       params: ['symbol', 'period', 'limit'], ttlMs: 120_000 },
+  'lsr-global':      { url: 'https://fapi.binance.com/futures/data/globalLongShortAccountRatio',
+                       params: ['symbol', 'period', 'limit'], ttlMs: 120_000 },
+  'lsr-top':         { url: 'https://fapi.binance.com/futures/data/topLongShortPositionRatio',
+                       params: ['symbol', 'period', 'limit'], ttlMs: 120_000 },
+  'funding-rate-1':  { url: 'https://fapi.binance.com/fapi/v1/fundingRate',
+                       params: ['symbol', 'limit', 'startTime', 'endTime'], ttlMs: 900_000 },
+
+  /* Not exchanges, but the same reasoning: still the browser talking to a third
+     party on every visit, and each is one global figure the whole app shares. */
+  'fng':             { url: 'https://api.alternative.me/fng/',
+                       params: ['limit'], ttlMs: 900_000 },
+  'deribit-book':    { url: 'https://www.deribit.com/api/v2/public/get_book_summary_by_currency',
+                       params: ['currency', 'kind'], ttlMs: 60_000 },
+  'llama-stables':   { url: 'https://stablecoins.llama.fi/stablecoins',
+                       params: ['includePrices'], ttlMs: 900_000 },
+};
+
 export async function GET(req: NextRequest) {
   const ip = getClientIp(req);
-  if (!rateLimit(`proxy:${ip}`, 20, 60_000)) {
+  /* 600/min, not 20. The old figure suited a route four callers used a handful
+     of times; #238 adds fifteen passthrough types a single page load can hit many
+     times over. The same oversight on the klines route rejected 54-98 requests
+     per visit with a 429 from our OWN route, and the resulting drop in outbound
+     traffic looked exactly like the cache working - a rate limit masquerading as
+     a saving. These responses are cache reads and cost nothing upstream, so the
+     limit is there to stop a scripted flood, not to ration a normal page. */
+  if (!rateLimit(`proxy:${ip}`, 600, 60_000)) {
     return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429 });
   }
 
@@ -257,6 +333,47 @@ export async function GET(req: NextRequest) {
          set and the panel would have stayed exactly as broken as before, with
          the health table now green. Updated alongside this. */
       return NextResponse.json({ btc, eth }, { headers: PROXY_CACHE });
+    }
+
+    /* Table-driven passthrough (#238). Placed after the hand-written branches so
+       none of their behaviour changes. */
+    const entry = type ? PASSTHROUGH[type] : undefined;
+    if (entry) {
+      const u = new URL(entry.url);
+      for (const [k, v] of Object.entries(entry.fixed ?? {})) u.searchParams.set(k, v);
+      for (const k of entry.params) {
+        const v = req.nextUrl.searchParams.get(k);
+        if (v != null && v !== '') u.searchParams.set(k, v);
+      }
+
+      const go = async () => {
+        const r = await fetch(u, { cache: 'no-store' });
+        if (!r.ok) {
+          /* FAIL LOUDLY (#228). Throwing means cached() stores nothing, so a ban
+             is retried rather than pinned, and the caller gets a status instead
+             of a plausible-looking empty body. */
+          const err = new Error(`${type} upstream ${r.status}`);
+          (err as Error & { status?: number }).status = r.status;
+          throw err;
+        }
+        return r.json();
+      };
+
+      try {
+        /* Keyed on the FULL resolved query, so two callers with different params
+           cannot share an entry. ttlMs 0 skips the cache, for callers paginating
+           a time range - their cursors are timestamps and would make the key
+           space unbounded (#199). */
+        const body = entry.ttlMs > 0
+          ? await cached(`proxy:${type}:${u.search}`, entry.ttlMs, go)
+          : await go();
+        return NextResponse.json(body, { headers: entry.ttlMs > 0 ? PROXY_CACHE : undefined });
+      } catch (e) {
+        const status = (e as Error & { status?: number }).status;
+        return apiError('proxy', e, 502, status
+          ? `${type} upstream returned ${status}`
+          : 'Upstream unavailable');
+      }
     }
 
     return NextResponse.json({ error: 'Unknown type' }, { status: 400 });

--- a/app/funding/page.tsx
+++ b/app/funding/page.tsx
@@ -55,7 +55,7 @@ async function fetchAllBinanceFR(): Promise<Record<string, FRPoint[]>> {
 async function fetchBybitFR(sym: string): Promise<FRPoint[]> {
   try {
     const res  = await fetch(
-      `https://api.bybit.com/v5/market/funding/history?category=linear&symbol=${sym}&limit=42`,
+      `/api/proxy?type=funding-history&symbol=${sym}&limit=42`,
     );
     const data = await res.json();
     return ((data?.result?.list ?? []) as Array<{ fundingRate: string; fundingRateTimestamp: string }>)

--- a/app/liq/page.tsx
+++ b/app/liq/page.tsx
@@ -279,7 +279,7 @@ export default function LiqPage() {
     if (!sym) { setWhalePos(null); return; }   // Bybit-only coin (HYPE etc.)
     const period = RANGE_TO_PERIOD[range];
     let cancelled = false;
-    fetch(`https://fapi.binance.com/futures/data/topLongShortPositionRatio?symbol=${sym}&period=${period}&limit=1`)
+    fetch(`/api/proxy?type=lsr-top&symbol=${sym}&period=${period}&limit=1`)
       .then(r => r.json())
       .then((data: Array<{ longAccount: string; shortAccount: string }>) => {
         if (cancelled || !Array.isArray(data) || !data[0]) return;
@@ -297,7 +297,7 @@ export default function LiqPage() {
     if (!sym) { setRetailPos(null); return; }   // Bybit-only coin (HYPE etc.)
     const period = RANGE_TO_PERIOD[range];
     let cancelled = false;
-    fetch(`https://fapi.binance.com/futures/data/globalLongShortAccountRatio?symbol=${sym}&period=${period}&limit=1`)
+    fetch(`/api/proxy?type=lsr-global&symbol=${sym}&period=${period}&limit=1`)
       .then(r => r.json())
       .then((data: Array<{ longAccount: string; shortAccount: string }>) => {
         if (cancelled || !Array.isArray(data) || !data[0]) return;
@@ -314,7 +314,7 @@ export default function LiqPage() {
     if (!sym) { setBybitPos(null); return; }
     const period = RANGE_TO_BYBIT_PERIOD[range];
     let cancelled = false;
-    fetch(`https://api.bybit.com/v5/market/account-ratio?category=linear&symbol=${sym}&period=${period}&limit=1`)
+    fetch(`/api/proxy?type=account-ratio-1&symbol=${sym}&period=${period}&limit=1`)
       .then(r => r.json())
       .then((d: { result?: { list?: Array<{ buyRatio: string; sellRatio: string }> } }) => {
         if (cancelled) return;

--- a/components/MarketConditionsWidget.tsx
+++ b/components/MarketConditionsWidget.tsx
@@ -71,7 +71,7 @@ function useFngHistory(): number[] {
       }
     } catch {}
     let cancelled = false;
-    fetch('https://api.alternative.me/fng/?limit=30&format=json')
+    fetch('/api/proxy?type=fng&?limit=30&format=json')
       .then(r => r.json())
       .then((d: { data?: { value: string }[] }) => {
         if (cancelled || !d.data) return;
@@ -89,7 +89,7 @@ function useBtcLongShort(): { long: number; short: number } | null {
   const [ratio, setRatio] = useState<{ long: number; short: number } | null>(null);
   useEffect(() => {
     let cancelled = false;
-    fetch(`https://fapi.binance.com/futures/data/globalLongShortAccountRatio?symbol=${BINANCE_SYMS.btc}&period=1h&limit=1`)
+    fetch(`/api/proxy?type=lsr-global&symbol=${BINANCE_SYMS.btc}&period=1h&limit=1`)
       .then(r => r.json())
       .then((data: Array<{ longAccount: string; shortAccount: string }>) => {
         if (cancelled || !Array.isArray(data) || !data[0]) return;

--- a/components/MarketProvider.tsx
+++ b/components/MarketProvider.tsx
@@ -165,7 +165,7 @@ export default function MarketProvider(
     try {
       const syms = Object.values(BINANCE_SYMS).filter(s => s !== 'HYPEUSDT');
       const batch = encodeURIComponent(JSON.stringify(syms));
-      const res = await fetch(`https://api.binance.com/api/v3/ticker/24hr?symbols=${batch}`);
+      const res = await fetch(`/api/proxy?type=binance-24hr&symbols=${batch}`);
       const data = await res.json();
       if (!Array.isArray(data)) return;
       data.forEach((d: Record<string, string>) => {
@@ -275,7 +275,7 @@ export default function MarketProvider(
   /* ── Bybit: all coins - single bulk fetch instead of per-symbol calls ── */
   const fetchBybit = useCallback(async () => {
     try {
-      const res = await fetch('https://api.bybit.com/v5/market/tickers?category=linear');
+      const res = await fetch('/api/proxy?type=bybit-tickers');
       const d = await res.json();
       // Build symbol → ticker map for O(1) lookup
       const bySymbol: Record<string, Record<string, string>> = {};
@@ -522,7 +522,7 @@ export default function MarketProvider(
         // Taker buy ratio from recent trades (Bybit klines don't split maker/taker)
         try {
           const tradeRes = await fetch(
-            `https://api.bybit.com/v5/market/recent-trade?category=linear&symbol=${sym}&limit=500`
+            `/api/proxy?type=recent-trade&symbol=${sym}&limit=500`
           );
           const tradeData = await tradeRes.json();
           const trades: Array<{ side: string; size: string }> = tradeData?.result?.list ?? [];
@@ -666,7 +666,7 @@ export default function MarketProvider(
       (async () => {
         try {
           const res = await fetch(
-            'https://api.bybit.com/v5/market/recent-trade?category=linear&symbol=HYPEUSDT&limit=200',
+            '/api/proxy?type=recent-trade&symbol=HYPEUSDT&limit=200',
             { cache: 'no-store' }
           );
           const data = await res.json();
@@ -720,7 +720,7 @@ export default function MarketProvider(
         const sym = BINANCE_SYMS[coin];
         try {
           const res = await fetch(
-            `https://api.binance.com/api/v3/depth?symbol=${sym}&limit=50`
+            `/api/proxy?type=depth&symbol=${sym}&limit=50`
           );
           const data = await res.json();
           if (!data.bids || !data.asks) return;
@@ -744,7 +744,7 @@ export default function MarketProvider(
   const fetchDeribitOptions = useCallback(async () => {
     try {
       const res = await fetch(
-        'https://www.deribit.com/api/v2/public/get_book_summary_by_currency?currency=BTC&kind=option'
+        '/api/proxy?type=deribit-book&currency=BTC&kind=option'
       );
       const data = await res.json();
       const summaries: Array<{
@@ -898,7 +898,7 @@ export default function MarketProvider(
   const fetchStablecoinFlows = useCallback(async () => {
     try {
       const res = await fetch(
-        'https://stablecoins.llama.fi/stablecoins?includePrices=true',
+        '/api/proxy?type=llama-stables&includePrices=true',
         { cache: 'no-cache' }
       );
       const data = await res.json();
@@ -1025,7 +1025,7 @@ export default function MarketProvider(
   /* ── Binance premium index → next FR estimate (Binance perps) ── */
   const fetchPremiumIndex = useCallback(async () => {
     try {
-      const res = await fetch('https://fapi.binance.com/fapi/v1/premiumIndex', { cache: 'no-store' });
+      const res = await fetch('/api/proxy?type=premium-index', { cache: 'no-store' });
       if (!res.ok) return;
       const data: Array<{
         symbol: string; markPrice: string; indexPrice: string;
@@ -1074,7 +1074,7 @@ export default function MarketProvider(
   /* ── Fear & Greed ── */
   const fetchFNG = useCallback(async () => {
     try {
-      const res = await fetch('https://api.alternative.me/fng/?limit=2&format=json', { cache: 'no-cache' });
+      const res = await fetch('/api/proxy?type=fng&?limit=2&format=json', { cache: 'no-cache' });
       const d = await res.json();
       const items = d.data;
       if (!items?.[0]?.value) return;
@@ -1086,7 +1086,7 @@ export default function MarketProvider(
       }));
     } catch {
       try {
-        const res = await fetch('https://api.alternative.me/fng/?limit=2&format=json', { cache: 'no-cache' });
+        const res = await fetch('/api/proxy?type=fng&?limit=2&format=json', { cache: 'no-cache' });
         const d = await res.json();
         const items = d.data;
         if (!items?.[0]?.value) return;

--- a/lib/backtestEngine.ts
+++ b/lib/backtestEngine.ts
@@ -50,7 +50,7 @@ async function fetchBinanceFuturesKlinesRange(sym: string, interval: string, sta
   let guard = 0;
   while (cursor < endTime && guard < 500) {
     guard++;
-    const url = `https://fapi.binance.com/fapi/v1/klines?symbol=${sym}&interval=${interval}&startTime=${cursor}&endTime=${endTime}&limit=${PAGE}`;
+    const url = `/api/market/klines?source=binance-futures&symbol=${sym}&interval=${interval}&startTime=${cursor}&endTime=${endTime}&limit=${PAGE}`;
     const r = await fetch(url, { signal: AbortSignal.timeout(15_000) });
     if (!r.ok) throw new Error(`Binance futures klines ${r.status}`);
     const raw = await r.json() as (string | number)[][];
@@ -73,7 +73,7 @@ async function fetchBybitKlinesRange(sym: string, interval: string, startTime: n
   let guard = 0;
   while (cursor < endTime && guard < 500) {
     guard++;
-    const url = `https://api.bybit.com/v5/market/kline?category=linear&symbol=${sym}&interval=${interval}&start=${cursor}&end=${endTime}&limit=${PAGE}`;
+    const url = `/api/market/klines?source=bybit&symbol=${sym}&interval=${interval}&start=${cursor}&end=${endTime}&limit=${PAGE}`;
     const r = await fetch(url, { signal: AbortSignal.timeout(15_000) });
     if (!r.ok) throw new Error(`Bybit klines ${r.status}`);
     const d = await r.json() as { result?: { list?: string[][] } };
@@ -100,7 +100,7 @@ async function fetchBinanceFundingRange(sym: string, startTime: number, endTime:
   let guard = 0;
   while (cursor < endTime && guard < 100) {
     guard++;
-    const url = `https://fapi.binance.com/fapi/v1/fundingRate?symbol=${sym}&startTime=${cursor}&endTime=${endTime}&limit=${PAGE}`;
+    const url = `/api/proxy?type=funding-rate-1&symbol=${sym}&startTime=${cursor}&endTime=${endTime}&limit=${PAGE}`;
     const r = await fetch(url, { signal: AbortSignal.timeout(15_000) });
     if (!r.ok) throw new Error(`Binance funding rate ${r.status}`);
     const raw = await r.json() as Array<{ fundingTime: number; fundingRate: string }>;
@@ -122,7 +122,7 @@ async function fetchBybitFundingRange(sym: string, startTime: number, endTime: n
   let guard = 0;
   while (cursor < endTime && guard < 200) {
     guard++;
-    const url = `https://api.bybit.com/v5/market/funding/history?category=linear&symbol=${sym}&startTime=${cursor}&endTime=${endTime}&limit=${PAGE}`;
+    const url = `/api/proxy?type=funding-history&symbol=${sym}&startTime=${cursor}&endTime=${endTime}&limit=${PAGE}`;
     const r = await fetch(url, { signal: AbortSignal.timeout(15_000) });
     if (!r.ok) throw new Error(`Bybit funding rate ${r.status}`);
     const d = await r.json() as { result?: { list?: Array<{ fundingRateTimestamp: string; fundingRate: string }> } };

--- a/lib/useOI1h.ts
+++ b/lib/useOI1h.ts
@@ -37,7 +37,7 @@ export function useOI1h(coin: CoinId): OI1hData {
 
         if (binSym) {
           const r = await fetch(
-            `https://fapi.binance.com/futures/data/openInterestHist?symbol=${binSym}&period=5m&limit=13`,
+            `/api/proxy?type=oi-hist&symbol=${binSym}&period=5m&limit=13`,
             { cache: 'no-store' }
           );
           if (r.ok) {
@@ -53,7 +53,7 @@ export function useOI1h(coin: CoinId): OI1hData {
           }
         } else if (bbtSym) {
           const r = await fetch(
-            `https://api.bybit.com/v5/market/open-interest?category=linear&symbol=${bbtSym}&intervalTime=5min&limit=13`,
+            `/api/proxy?type=open-interest-1&symbol=${bbtSym}&intervalTime=5min&limit=13`,
             { cache: 'no-store' }
           );
           if (r.ok) {


### PR DESCRIPTION
**Dev Team** → **QA Team** · closes #238 — **zero, not a lower number**

```
TOTAL browser->exchange = 0     routes measured 10/10
```

All ten routes, production build, including `/backtest` and `/live-tracking`.

## You were right to correct the framing

I sized this as a tail and you overruled it:

> That reasoning was about call VOLUME, and volume is the wrong finish line here.
> 117 calls from a visitor's browser to `api.binance.com` is a smaller version of
> the same problem, not a different one.

Correct, and I had made the same error twice — once ranking by call sites instead
of call volume, once here treating a small number as a different problem. The
title said what to measure both times.

Your `/api/proxy` suggestion is what made it cheap: **15 passthrough types as a
table**, not twelve routes.

## The probe cannot report a false zero

```
/funding  0   /markets 0   /backtest       0
/dashboard 0  /scanner 0   /live-tracking  0
/liq      0   /correlation 0
/arena    0   /briefing 0
routes measured 10/10
```

Any route that fails to load, or renders under 200 elements, is **excluded and
named** rather than counted as zero — the guard your own false 48% taught both of
us. `10/10` is part of the result, not decoration.

## Three carried-over lessons, applied not just cited

**Rate limit is part of the fix.** 20/min → 600/min. That figure suited four
occasional callers; fifteen types get hit many times per page load. The identical
oversight on the klines route rejected 54–98 requests per visit with a 429 from
our own route and *looked like the cache working*.

**Params allowlisted per entry** — a cache-key decision as much as a security one.
Unbounded params mean unbounded keys in a Map that never evicts (#199), and a
free-text passthrough would make this an open proxy to two exchanges.

**Fails loudly** (#228) — a non-2xx throws, so `cached()` stores nothing and the
caller gets the upstream status instead of an empty success.

## 🔴 One live failure, pre-existing, and it proves the point

```
502 /api/proxy?type=deribit-book -> "deribit-book upstream returned 503"
```

**Deribit returns 503 to the exact URL the browser used before.** I checked
against `origin/dev`'s literal — identical. So this is not my change; it is an
upstream outage that was **already happening and was invisible**, because the
client read `data?.result ?? []` and returned early.

The panel degrades exactly as it did before. The only difference is you can now
see why. That is the whole argument of #228, arriving on its own.

## Not moved, deliberately

`lib/ribbonCandles.ts` — imported **only** by `/api/market/rsi`,
`/api/alerts/preview` and `/api/telegram/alert`, so it runs server-side. Its calls
are not browser calls, and rewriting it to a relative URL would throw at runtime
in three routes. I checked the import graph before touching it this time.

## Verification — which specs I ran, since CI is off

```
npx eslint .                              0 errors (140 warnings, unchanged)
npx tsc --noEmit                          clean
npm test                                  288 passing
npm run build                             ok
smoke + klines-route + cache-policy       50 passed
```

Plus each new type directly, and `type=nonsense` → **400**.

## How to test (QA)

1. Every page renders as now — charts, funding, long/short, depth, Fear & Greed,
   stablecoins.
2. DevTools Network: **no** requests to `api.binance.com`, `api.bybit.com`,
   `www.deribit.com`, `api.alternative.me`, `stablecoins.llama.fi`.
3. **No 429s from `/api/proxy`.** The trap that caught me on klines.
4. The Deribit options panel is empty — upstream, predates this.
5. Re-run your probe. Target is **0**, and `10/10` measured.

## Risk level

**High** — the highest of this whole sequence. 22 call sites, six files, every
market panel in the app, and the failure mode is a panel rendering empty rather
than erroring.

**Named:** `/api/proxy` now carries fifteen types with one shared rate limit and
one shared cache. If that route fails, considerably more of the app goes quiet
than before. That is the cost of the consolidation and it is worth your eyes.
