### PR TITLE
fix(news): stop the econ calendar presenting invented dates as confirmed

### DIFF
--- a/app/api/econ-calendar/route.ts
+++ b/app/api/econ-calendar/route.ts
@@ -42,6 +42,15 @@ const DISPLAY_NAMES: Record<string, string> = {
 export type CalEvent = {
   name: string; type: string; isoDate: string; impact: string;
   previous?: string; estimate?: string; actual?: string;
+  /* True when the DATE was computed by computeMacroSchedule rather than read
+     from a real source (#245).
+     Nothing in this payload used to distinguish a computed entry from a real
+     one - same shape, same `impact: 'high'`, no flag - so the UI could not tell
+     them apart and neither could the user. A computed entry also carries a real
+     FRED `actual`, which makes it look MORE authoritative than a genuine entry
+     with no number yet, while being the one that is wrong.
+     Absent on entries from Finnhub, ForexFactory and the Fed. */
+  estimated?: boolean;
 };
 
 const MONTHS = ['January','February','March','April','May','June','July','August',
@@ -282,13 +291,45 @@ async function enrichWithFRED(events: CalEvent[], now: Date): Promise<void> {
 // ── Source 4: Computed schedule for key US macro releases ─────────────────────
 // Approximate release patterns - accurate within a few days. Used when no live
 // feed is available. Covers the 8 most market-moving releases.
+/* Move a computed date off a weekend (#245).
+ *
+ * The hardcoded day-of-month entries below - CPI on the 12th, PPI on the 11th,
+ * Retail on the 15th, GDP on the 25th - have no idea what a weekend is. Over the
+ * next twelve months that emitted, among others:
+ *
+ *     RETAIL 2026-08-15 = Saturday        CPI 2026-09-12 = Saturday
+ *     PPI    2026-10-11 = Sunday          GDP 2026-10-25 = Sunday
+ *
+ * Two of those were live on staging when QA reproduced this. No US statistical
+ * agency has ever released data on a Saturday, so those are not "approximate
+ * within a few days" - they are dates that cannot exist.
+ *
+ * Nearest weekday, not "next business day": these are approximations either way,
+ * and BLS moves a release earlier as often as later. Saturday goes back to
+ * Friday, Sunday forward to Monday - the smallest change that removes an
+ * impossible date. It does NOT make the date correct, which is why every entry
+ * from this function is also flagged `estimated`. */
+function offWeekend(dt: Date): Date {
+  const day = dt.getUTCDay();
+  if (day === 6) dt.setUTCDate(dt.getUTCDate() - 1);   // Sat -> Fri
+  else if (day === 0) dt.setUTCDate(dt.getUTCDate() + 1); // Sun -> Mon
+  return dt;
+}
+
 function computeMacroSchedule(now: Date): CalEvent[] {
   const events: CalEvent[] = [];
   const maxH = 90 * 24;
 
+  /* EVERY entry from this function is `estimated: true`. The dates are patterns,
+     not a schedule - the function's own header says "accurate within a few
+     days". Shipping that as indistinguishable from a real release date is the
+     defect in #245; the approximation itself is fine and clearly labelled. */
   const push = (name: string, type: string, dt: Date) => {
-    const h = (dt.getTime() - now.getTime()) / 3600000;
-    if (h >= 0 && h <= maxH) events.push({ name, type, isoDate: dt.toISOString(), impact: 'high' });
+    const when = offWeekend(dt);
+    const h = (when.getTime() - now.getTime()) / 3600000;
+    if (h >= 0 && h <= maxH) {
+      events.push({ name, type, isoDate: when.toISOString(), impact: 'high', estimated: true });
+    }
   };
 
   for (const y of [now.getUTCFullYear(), now.getUTCFullYear() + 1]) {
@@ -371,7 +412,32 @@ export async function GET(req: NextRequest) {
 
     for (const e of ffEvents)    add(e, `${e.type}|${e.isoDate.slice(0, 10)}`);
     for (const e of fomcEvents)  add(e, `FOMC|${e.isoDate.slice(0, 10)}`);
-    for (const e of macroEvents) add(e, `${e.type}|${e.isoDate.slice(0, 10)}`);
+
+    /* A COMPUTED ENTRY IS DROPPED WHEN A REAL ONE EXISTS FOR THAT MONTH (#245).
+     *
+     * The dedup key above is `type|YYYY-MM-DD`, so a real PPI on the 13th and a
+     * computed PPI on the 11th are different keys and BOTH survived. That is
+     * what the owner actually saw: PPI listed on Tuesday the 11th when the real
+     * release was Thursday the 13th. Both were in the payload, and the wrong one
+     * carried the FRED `actual` - so the fabricated row looked like the more
+     * complete of the two.
+     *
+     * Marking computed entries `estimated` was not enough on its own. A user
+     * seeing the same release twice, on two dates, cannot tell which to plan
+     * around, and the label does not resolve that - it only says one of them is
+     * a guess.
+     *
+     * MONTH, not day: these are monthly releases (GDP quarterly), so one real
+     * CPI in August means every computed CPI for August is redundant regardless
+     * of which day it landed on. Comparing by day would keep exactly the
+     * duplicate this is here to remove. */
+    const realByMonth = new Set(
+      [...ffEvents, ...fomcEvents].map(e => `${e.type}|${e.isoDate.slice(0, 7)}`),
+    );
+    for (const e of macroEvents) {
+      if (realByMonth.has(`${e.type}|${e.isoDate.slice(0, 7)}`)) continue;
+      add(e, `${e.type}|${e.isoDate.slice(0, 10)}`);
+    }
 
     await enrichWithFRED(merged, now);
 

--- a/app/econ-calendar/page.tsx
+++ b/app/econ-calendar/page.tsx
@@ -8,6 +8,8 @@ import { econImpactKey, type EconImpact } from '@/lib/classify';
 
 type CalEvent = {
   name: string; type: string; isoDate: string; impact: string;
+  /* Computed date, not a published one (#245). */
+  estimated?: boolean;
   previous?: string; estimate?: string; actual?: string;
 };
 
@@ -141,7 +143,20 @@ export default function EconCalendarPage() {
                 {released ? t('ECON_CALENDAR_LATEST_RELEASE') : t('ECON_CALENDAR_NEXT_EVENT')}
               </div>
               <div style={{ fontSize: 'var(--fs-body)', fontWeight: 700, color: 'var(--txt)' }}>{next.name}</div>
-              <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', marginTop: 2 }}>{fmtTime(next.isoDate)}</div>
+              {/* The hero date is the most prominent claim on this page, so an
+                  estimated one says so in words rather than only a tilde (#245). */}
+              <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', marginTop: 2 }}>
+                {next.estimated ? '~' : ''}{fmtTime(next.isoDate)}
+                {next.estimated && (
+                  <span
+                    title="This date is computed from a typical release pattern, not a published schedule. It can be off by several days."
+                    style={{ marginLeft: 6, fontSize: 'var(--fs-micro)', fontWeight: 700, letterSpacing: '.04em',
+                             textTransform: 'uppercase', color: 'var(--amber)' }}
+                  >
+                    estimated
+                  </span>
+                )}
+              </div>
             </div>
             <div style={{ textAlign: 'right', flexShrink: 0 }}>
               <div style={{ fontSize: '1.5rem', fontWeight: 800, color: ic.color, lineHeight: 1, letterSpacing: '-0.5px' }}>{ct}</div>
@@ -212,8 +227,11 @@ export default function EconCalendarPage() {
                     }}
                   >
                     {/* TIME */}
-                    <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt2)', fontVariantNumeric: 'tabular-nums', fontWeight: 500 }}>
-                      {fmtTime(e.isoDate)}
+                    <div
+                      title={e.estimated ? 'Estimated date - computed from a typical release pattern, not a published schedule' : undefined}
+                      style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt2)', fontVariantNumeric: 'tabular-nums', fontWeight: 500 }}
+                    >
+                      {e.estimated ? '~' : ''}{fmtTime(e.isoDate)}
                       {!isPast && !ctObj.released && (
                         <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', marginTop: 1 }}>{t('ECON_CALENDAR_IN_COUNTDOWN', { countdown: ct })}</div>
                       )}

--- a/components/EconCalendarWidget.tsx
+++ b/components/EconCalendarWidget.tsx
@@ -9,6 +9,8 @@ import { econImpactKey, type EconImpact } from '@/lib/classify';
 
 type CalEvent = {
   name: string; type: string; isoDate: string; impact: string;
+  /* Computed date, not a published one (#245). */
+  estimated?: boolean;
   previous?: string; estimate?: string; actual?: string;
 };
 
@@ -120,8 +122,16 @@ export default function EconCalendarWidget() {
               display: 'flex', alignItems: 'center', gap: 8,
               padding: '6px 0', borderTop: i === 0 || showDateHeader ? 'none' : '0.5px solid var(--bdr)',
             }}>
-              <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', fontVariantNumeric: 'tabular-nums', flexShrink: 0, width: 42 }}>
-                {fmtTime(e.isoDate)}
+              {/* A leading ~ on an estimated row (#245). The date came from a
+                  pattern, not a published schedule, and until now nothing on
+                  screen said so - a computed entry looked identical to a real
+                  one, and carried a real FRED `actual` besides. The tooltip
+                  says it in words for anyone who does not read the tilde. */}
+              <span
+                title={e.estimated ? 'Estimated date - approximate, not a published release schedule' : undefined}
+                style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', fontVariantNumeric: 'tabular-nums', flexShrink: 0, width: 42 }}
+              >
+                {e.estimated ? '~' : ''}{fmtTime(e.isoDate)}
               </span>
               <span style={{ width: 6, height: 6, borderRadius: '50%', background: col, flexShrink: 0 }} />
               <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt)', fontWeight: 500, flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>

--- a/components/NewsProvider.tsx
+++ b/components/NewsProvider.tsx
@@ -34,6 +34,10 @@ export interface EconEvent {
   previous?: string;
   estimate?: string;
   actual?: string;
+  /* The DATE is a computed approximation, not a published release date (#245).
+     Distinct from `estimate`, which is a forecast VALUE - these two are easy to
+     confuse and mean opposite things. */
+  estimated?: boolean;
 }
 
 export interface GeoEvent {
@@ -74,6 +78,8 @@ interface NewsRow {
 export interface CalEvent {
   name: string; type: string; isoDate: string; impact: string;
   previous?: string; estimate?: string; actual?: string;
+  /* Mirrors the API type (#245). A computed date, not a published one. */
+  estimated?: boolean;
 }
 
 interface NewsCtx {
@@ -235,7 +241,7 @@ export default function NewsProvider({ children }: { children: React.ReactNode }
         const h = (dt.getTime() - now.getTime()) / 3600000;
         if (h < -24) return [];
         seen.add(key);
-        return [{ name: e.name, type: e.type, impact: e.impact, dt, h, dateStr: toLocalTime(dt), previous: e.previous, estimate: e.estimate, actual: e.actual }];
+        return [{ name: e.name, type: e.type, impact: e.impact, dt, h, dateStr: toLocalTime(dt), previous: e.previous, estimate: e.estimate, actual: e.actual, estimated: e.estimated }];
       })
       .sort((a, b) => a.dt.getTime() - b.dt.getTime());
     setEconRaw(raw);


### PR DESCRIPTION
**Dev Team** → **QA Team** · fixes #245 — **and the duplicate is what the owner actually saw**

Your three fixes, all in. Plus a fourth I found while verifying, which turns out
to be the actual complaint.

## 🔴 The one not in the issue: the same release, twice, on two dates

```
before   PPI 2026-08-11 Tue   estimated, actual=-1.3%    <- fabricated
         PPI 2026-08-13 Thu   real                        <- correct
```

**Both were in the payload.** The dedup key was `type|YYYY-MM-DD`, so a real PPI
on the 13th and a computed PPI on the 11th are different keys and both survived.

That is precisely the owner's report — *"PPI shown as today, Tuesday. The real
release is Thursday."* The real Thursday entry was there all along, sitting
underneath a fabricated Tuesday one that carried the FRED `actual` and therefore
looked like the more complete of the two.

**Marking entries `estimated` does not fix this.** A user seeing one release on
two dates still cannot tell which to plan around; the label only says one of them
is a guess. Computed entries now yield to a real one for the same type in the
same month — month, not day, because comparing by day keeps exactly the duplicate
it is meant to remove.

## Your three, measured

```
                              before    after
weekend dates                   2         0
duplicate type-in-month         1         0
entries flagged estimated       0        15 of 19
```

The 4 unflagged are ForexFactory's real CPI and PPI plus two Fed FOMC dates —
correctly unflagged, and I checked each rather than trusting the count.

**Weekend fix is nearest-weekday, not next-business-day.** BLS moves a release
earlier as often as later, so Saturday goes back to Friday and Sunday forward to
Monday — the smallest change that removes an impossible date. It does not make
the date *correct*, which is why the flag matters more than the shift, exactly as
you argued.

## Where `estimated` shows

| surface | |
|---|---|
| `/econ-calendar` hero | `~` plus an amber **ESTIMATED** label, tooltip explains |
| `/econ-calendar` rows | `~` plus tooltip |
| `EconCalendarWidget` | `~` plus tooltip |

The flag rides through `econ_snapshot` without a migration — `events` is a JSON
column, so the ingest path carries it unchanged. I checked that before designing
around it.

## Your point 3 — why live feeds are not used

Partly answered by this run: **ForexFactory IS being used** (`source:
forexfactory+fed+computed`) and supplies the near-term CPI and PPI correctly. The
computed schedule fills beyond its window, which is the intended design. Finnhub
is absent because `FINNHUB_KEY` is unset on that service.

So the sources are working as designed. The bug was never that the computed
schedule ran — it was that its output was indistinguishable from, and duplicated,
the real thing.

## Verification — which specs I ran, CI being off

```
npx eslint .        0 errors (140 warnings, unchanged)
npx tsc --noEmit    clean
npm test            288 passing
npm run build       ok
```

Plus the payload inspected directly before and after, on a production build.

**Not run:** the browser suite. This changes rendering on two surfaces, so
`smoke` at minimum is worth your time on `qa` — I would rather say I skipped it
than imply coverage I did not run.

## Risk level

**Medium.** No schema change and the payload shape is additive, but it removes
entries that were previously shown — if the month-level dedup is too aggressive
somewhere, a real release could vanish rather than merely be relabelled. Worth
checking a few months out on `qa`, not just the current one.
