### PR TITLE
chore(ci): add a pre-push hook so the gates run locally while CI is off

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# Runs the gates before every push. ALL CI IS DISABLED (owner instruction,
+# 2026-08-10, for cost), so on most days this is the only thing standing between
+# a mistake and the `dev` branch.
+#
+# Enable once per clone - it is NOT automatic, because .git/ is not versioned:
+#
+#     git config core.hooksPath .githooks
+#
+# Both working folders need it separately. dev's clone and QA's clone are
+# different checkouts and a hook enabled in one protects nothing in the other.
+#
+# WHAT IS DELIBERATELY NOT HERE: `npm run build`. It is by far the slowest gate
+# (~90s against ~25s for all three below) and a gate people disable protects
+# nothing. Build stays manual before opening a PR - CONTRIBUTING.md - and it is
+# the one that catches the keyless-env class of defect.
+#
+# `eslint .` currently reports 0 errors and 140 warnings, and exits 0 on
+# warnings. Do NOT add --max-warnings 0 without clearing those 140 first, or
+# this becomes unusable on day one and gets bypassed by reflex.
+#
+# Bypass with `git push --no-verify` when you genuinely need to - and say so in
+# the PR, because nothing else will.
+set -e
+
+printf '[pre-push] lint\n'
+npm run lint
+
+printf '[pre-push] typecheck\n'
+npx tsc --noEmit
+
+printf '[pre-push] unit tests\n'
+npm test
+
+printf '[pre-push] all gates passed\n'


### PR DESCRIPTION
**QA Team** · closes #246. **Written rather than handed over, so you stay on #244/#245 — the owner wants both of those today.**

I asked on #246 whose job this was and then answered it myself, because waiting
for a reply would have cost more than the hook took to write. It is not app code
— nothing under `app/`, `components/` or `lib/`. Change anything you disagree
with; I will not defend the shape.

## Summary

`.githooks/pre-push` runs **lint → tsc → unit tests** before every push.

The owner asked for it directly:

> *"can Dev run a linter on the localhost before push changes back to remote?"*
> *"i want you both to have ability to run linter on your end"*

## Why it was needed — measured, not assumed

```
npm run lint      eslint .                  exists
npm test          288 tests, 14.8s          exists
npx tsc --noEmit  clean                     exists
core.hooksPath    UNSET
.husky/           does not exist
.git/hooks/       samples only
husky/lint-staged neither, in package.json
```

Four gates in `CONTRIBUTING.md`, **enforced by nothing.** Survivable while CI ran
them on every push. **CI has been disabled since 2026-08-10 for cost**, so a lint
error, a type error or a failing test could reach `dev` with nothing underneath
it — and `qa` on the next promotion.

## One line per clone, and it is not automatic

```bash
git config core.hooksPath .githooks
```

**Both working folders need it separately.** `.git/` is not versioned, so a hook
installed in `.git/hooks/` protects exactly one checkout — and this project has
two that would drift immediately. Mine is enabled; yours needs the line above.

## Four decisions, each deliberate

**`pre-push`, not `pre-commit`.** You commit far more often than you push, and a
slow commit is exactly how people learn to reach for `--no-verify` by reflex.
Push is where the code stops being yours.

**Build is excluded.** ~90s against ~25s for the other three. A gate people
disable protects nothing. **Build stays manual before opening a PR** — it is in
`CONTRIBUTING` and it is the one that catches the keyless-env defects (#221).

**No husky.** It is another dependency on a repo currently carrying **8 npm
advisories including a critical** (#241). Git does this natively.

**Fails on errors only.** `eslint .` reports `0 errors, 140 warnings` today and
exits 0 on warnings. **Do not add `--max-warnings 0` without clearing those 140
first** — it would make the hook unusable on day one, and an unusable gate gets
bypassed rather than fixed.

## How to test (QA)

Not on `qa` — it is a local developer tool, so it is tested by using it.

```bash
git config core.hooksPath .githooks
sh .githooks/pre-push
```

Expect `lint` (0 errors, 140 warnings), a silent `tsc`, 288 tests, and
`[pre-push] all gates passed`.

Then prove it actually blocks — add `const x: number = 'a'` to any file and
confirm `git push` is **refused**. A hook that has only ever been seen to pass is
in the same category as a spec that has only ever run green.

**This PR was pushed through the hook.** All three gates ran before anything left
the machine:

```
[pre-push] lint
✖ 140 problems (0 errors, 140 warnings)
[pre-push] typecheck
[pre-push] unit tests
```

## Risk level

**Low**, with the limit stated plainly rather than buried.

A local hook is a **convenience, not a guarantee**. `--no-verify` bypasses it, and
it runs on the developer's own machine with the developer's own env — so it can
**never** catch the keyless-build class of defect that CI caught three times, most
recently #221. It is a good gate. It is not a replacement for the one that was
turned off, and it should not be mistaken for one when someone asks later whether
we still need CI.
