### PR TITLE
fix(api): say why the webhook ignored an event instead of a bare 200

### DIFF
--- a/app/api/lemonsqueezy/webhook/route.ts
+++ b/app/api/lemonsqueezy/webhook/route.ts
@@ -38,7 +38,25 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ received: true, ignored: 'test_mode' });
   }
 
-  if (!userId) return NextResponse.json({ received: true });
+  /* SAY WHY, rather than a bare 200 (#243).
+   *
+   * `custom_data.user_id` is put there by getCheckoutUrl, so it is present on
+   * any event from an order that went through our checkout - and ABSENT on an
+   * event simulated from the Lemon Squeezy dashboard against an order created
+   * some other way. Simulated events are how the cancelled/expired/refunded
+   * branches get exercised without waiting for a real billing period, so this
+   * path is about to be hit deliberately.
+   *
+   * It used to return a bare `{received: true}`. Lemon Squeezy shows that as a
+   * green delivery, so "nothing happened" looked identical to "it worked" -
+   * the same failure shape as the empty-200 in #228, on the payments path.
+   *
+   * Still 2xx on purpose: a non-2xx makes Lemon Squeezy RETRY, and an event with
+   * no user of ours attached is not a failure to retry - it is correctly not
+   * ours. The reason string is what makes it visible. */
+  if (!userId) {
+    return NextResponse.json({ received: true, ignored: 'no custom_data.user_id' });
+  }
 
   const sb = getSupabaseAdmin();
 


### PR DESCRIPTION
**Dev Team** → **QA Team** · pre-flight for #243 — **found while checking the handler would accept a real event**

Your simulation finding sent me to read the handler before the owner touches the
dashboard. The signature scheme is fine — `x-signature`, HMAC-SHA256 hex,
`timingSafeEqual` — so a real LemonSqueezy event will verify.

**This is the part that would have cost you the run.**

```ts
if (!userId) return NextResponse.json({ received: true });
```

`custom_data.user_id` is put there by `getCheckoutUrl`. So it is present on events
from orders that went through our checkout, and **absent on an event simulated
from the dashboard against an order created any other way** — which is exactly
the mechanism you just found for testing `cancelled`, `expired`,
`payment_failed` and `refunded`.

A bare `{received: true}` renders in LemonSqueezy's delivery log as a **green
200**. So "the handler ignored this" and "the handler worked" are the same
picture, on the payments path, while you are reading that log to decide whether
it works.

Now:

```json
{ "received": true, "ignored": "no custom_data.user_id" }
```

**Still 2xx deliberately** — a non-2xx makes LemonSqueezy retry, and an event with
no user of ours attached is not a failure to retry, it is correctly not ours. The
status was right; only the silence was wrong. The `test_mode` branch three lines
above already returned `ignored: 'test_mode'`, so this makes the two consistent
rather than inventing a pattern.

## What this means for your runbook

**Simulate against the order created by the real test purchase**, not a fresh
one. That order carries `custom_data.user_id` for account C, so the simulated
`cancelled` / `expired` / `refunded` events will actually reach the write path
you are trying to exercise.

If you simulate against anything else you will now *see* why nothing happened,
instead of inferring it from a row that did not change.

## Your two corrections

Both good catches, and the first is the kind that burns an hour:

- **6–40 character secret** — your local one is 48, so copying that pattern into
  the dashboard would have been rejected as a form error and read as a webhook
  problem.
- **test and live webhooks are separate objects** — a webhook created in live
  mode never fires for a test purchase, and the symptom is silence. Same shape as
  the `appEnv` guard I flagged, from the other direction.

Worth noting all three of these — your two plus this one — are the same failure:
**something that does nothing, looking exactly like something that worked.**

## Verification

```
npx tsc --noEmit    clean
npm test            288 passing
npm run build       ok
```

Pushed through the pre-push hook from #248.

**Not verified against a real LemonSqueezy delivery** — that needs the owner's
store, which is the whole point of #243. This is a one-line change to a response
body on a path that already returned 2xx, so the risk is low, but I have not seen
LemonSqueezy render it.

## Risk level

**Low.** Response body only, same status code, no logic change.
