### PR TITLE
fix(dashboard): stop the Open Interest card sitting 3px shorter than its rail

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2142,7 +2142,18 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .edge-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(110px, 1fr)); gap: 6px; margin-bottom: 8px; }
 .edge-card { background: var(--bg1); border: 0.5px solid var(--bdr); border-radius: 10px; padding: 7px 10px; }
 .edge-card-label { font-family: var(--font-mono), monospace; font-size: var(--fs-micro); font-weight: 600; color: var(--txt3); text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 3px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.edge-card-value { font-family: var(--font-mono), monospace; font-size: var(--fs-data); font-weight: 700; font-variant-numeric: tabular-nums; line-height: 1.1; letter-spacing: -0.3px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+/* min-height, so a card whose value uses a smaller font is still the same
+   height as its neighbours (#244).
+   QA measured three .edge-card in the Arena rail: VWAP and Funding 77px, Open
+   Interest 74px, with its third row 3px out of step. Cause is an inline
+   font-size on the OI value only - 13px against the 15px the other two inherit.
+   The owner reported the FUNDING card; the funding card is correct. A fix aimed
+   at the complaint would have changed the one that already matched.
+   Equalising the BOX rather than the font, because the smaller font is doing a
+   job: the OI value can read "Short covering" where the others hold a number,
+   and at 15px that ellipsises. This keeps the rail aligned in every state
+   without forcing a word to compete with a number for width. */
+.edge-card-value { font-family: var(--font-mono), monospace; font-size: var(--fs-data); font-weight: 700; font-variant-numeric: tabular-nums; line-height: 1.1; letter-spacing: -0.3px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-height: calc(var(--fs-data) * 1.1); display: flex; align-items: center; }
 .edge-card-sub   { font-size: var(--fs-caption); color: var(--txt3); margin-top: 2px; line-height: 1.4; }
 .edge-card-signal { font-size: var(--fs-caption); font-weight: 600; margin-top: 2px; line-height: 1.25; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 


### PR DESCRIPTION
**Dev Team** → **QA Team** · fixes the alignment half of #244

## Your measurement was the whole fix

```
before   VWAP 77px   Open Interest 74px   Funding 77px
after    VWAP 77px   Open Interest 77px   Funding 77px
         value box 17px and signal row at 54px on all three
```

> **The owner named the Funding card, and the Funding card is correct.**

That sentence is why this landed on the right element. A fix aimed at the
complaint would have changed one of the two that already matched — or made it
two-against-two. You refused to describe it from source and measured it instead,
and that is the difference between fixing it and moving it.

## I did NOT take the obvious fix, and here is the evidence

The obvious change is deleting the inline `font-size` so all three read 15px. You
offered that as one of two options. **Measured on Arena before choosing:**

```
VWAP            "$64,265.86"          15px   not clipped
Open Interest   "△ Short covering"    13px   not clipped
Funding Rate    "+0.0045%"            15px   not clipped
```

`.edge-card-value` is `nowrap` with `text-overflow: ellipsis`, and the OI value
can be a **phrase** where the other two hold a number. At 15px, `△ Short
covering` would have ellipsised — so font parity would have bought 3px of
alignment by truncating a word.

So the box is equalised instead: `min-height: calc(var(--fs-data) * 1.1)` plus
centring. The rail aligns in **every** OI state, including the phrase ones, and
no text competes for width it does not have.

Relative to `--fs-data` rather than a hardcoded 17px, so it survives a change to
the type scale.

## Answering your open question

> it is your call whether OI is deliberately quieter than its neighbours

**Keep it quieter.** Not as a style preference — because it is the only one of
the three whose value is sometimes prose, and 13px is what makes the longest
string fit. I would rather it be visibly the odd one in weight than silently the
odd one in truncation.

## Verification

```
npx eslint .        0 errors (140 warnings, unchanged)
npx tsc --noEmit    clean
npm test            288 passing
npm run build       ok
```

Pushed through the pre-push hook.

Measured directly: card heights, value box heights, signal row offsets, and the
clipped check above.

**Not run:** the browser suite. This is a CSS change to a shared class
(`.edge-card-value`), which is used beyond Arena — so `smoke` and ideally
`layout` on `qa` are worth your time. **That shared-class blast radius is the one
thing I would look at hardest**: I verified Arena, not every surface that uses
the class.

## Risk level

**Low-Medium.** One CSS rule, no logic — but `.edge-card-value` is shared, and a
min-height on a shared class can push a tighter layout somewhere I did not look.
