### PR TITLE
test(payments): make the webhook spec load env, and cover the no-user-id branch

### DIFF
--- a/qa/STATUS.md
+++ b/qa/STATUS.md
@@ -129,9 +129,32 @@ gh issue list --state open
   (#221), which is not reproducible on any deployed service because the footer
   sits below the fold there.
 
-  Consequence: **the four gates in `CONTRIBUTING` are now entirely manual.** Run
-  `npm run lint && npx tsc --noEmit && npm test && npm run build` before every PR.
-  Nothing is underneath you.
+  **Three of the four gates are now enforced locally** — `.githooks/pre-push`
+  runs lint, tsc and the unit tests before every push (#246, shipped in #248).
+  One line per clone, and it is NOT automatic because `.git/` is not versioned:
+
+  ```bash
+  git config core.hooksPath .githooks
+  ```
+
+  **It is a convenience, not a replacement.** `--no-verify` bypasses it, and it
+  runs on the developer's own machine with the developer's own env — so it can
+  never catch the keyless-build class of defect above. **`npm run build` is
+  deliberately not in it** (~90s against ~25s for the other three; a gate people
+  disable protects nothing), so build stays manual before every PR.
+
+  When someone asks whether CI is still needed, the answer is yes, and the
+  paragraph above is why.
+- **`lib/apiCache.ts` holds an unbounded Map.** `store` has no eviction, no cap
+  and no TTL sweep — expiry stops an entry being *served*, it does not free it.
+  Any `cached()` caller whose key includes a user-controllable value can mint
+  permanent entries. Found via `/api/proxy` and fixed **for that route only**
+  (#242's per-request `CURSOR_PARAMS` check); the primitive is unchanged. #253.
+- **The browser now makes ZERO calls to any exchange** — measured 10/10 routes on
+  merged `dev`, 2026-08-11 (#238, from a 2,246 baseline). The consequence is that
+  `/api/proxy` carries fifteen passthrough types behind **one** shared rate limit
+  and **one** shared cache. If that route fails, far more of the app goes quiet
+  than before. That is the accepted cost of the consolidation, not an oversight.
 - **`perf.spec`'s LCP budget was calibrated on a laptop.** `< 2500ms` against a
   local 84–720ms measurement — 3× headroom over a dev machine and none over a
   GitHub runner, where the five heaviest routes land at 2740–4456ms. It fails in

--- a/qa/e2e/payments-webhook.spec.ts
+++ b/qa/e2e/payments-webhook.spec.ts
@@ -1,5 +1,21 @@
 import { test, expect } from '@playwright/test';
 import crypto from 'node:crypto';
+/* SIDE-EFFECT IMPORT, and it is load-bearing. `_auth.ts` reads `.env.e2e.local`
+ * and `.env.local` into process.env at module scope. Without it this file sees
+ * no LEMONSQUEEZY_WEBHOOK_SECRET locally, and ALL THREE signed tests skip -
+ * including the BOLA-of-payments one, which is the most important assertion in
+ * the file.
+ *
+ * That was the actual state until 2026-08-11: they passed in CI, where the job
+ * supplies env directly, and skipped everywhere else. With CI disabled for cost
+ * since 2026-08-10, "everywhere else" is the only place they run - so the
+ * payments security surface was verified by nothing, anywhere, and the only
+ * symptom was `3 skipped` scrolling past.
+ *
+ * Exactly the trap `_auth.ts` documents at length about E2E_B_PRICE_ALERT_ID
+ * skipping all twenty authenticated tests. Same shape, different file, found by
+ * adding a fourth test and noticing it skipped too. */
+import './_auth';
 
 /* The LemonSqueezy webhook — signature, replay guard, ownership check.
  *
@@ -122,6 +138,63 @@ test.describe('LemonSqueezy webhook', () => {
      * that would make the route a denial-of-service surface. */
     expect(r.status(), 'a malformed signature produced something other than 401').toBe(401);
     expect(r.status(), 'a malformed signature crashed the route').not.toBe(500);
+  });
+
+  /* ── A signed event with no user of ours attached ──────────────────────────
+   *
+   * Needs the SECRET and nothing else: `if (!userId) return` sits at
+   * route.ts:56, BEFORE `getSupabaseAdmin()`, so this never touches the
+   * database. That is why it is here rather than in `payments-write-path.spec.ts`
+   * where I first said it would go - putting it there would have made it skip
+   * whenever the service-role key was absent, for a branch that does not use it.
+   *
+   * WHY IT MATTERS, and it is about to matter for real. `custom_data.user_id` is
+   * written by `getCheckoutUrl`, so it is present on events from orders that went
+   * through our checkout and ABSENT on an event simulated from the LemonSqueezy
+   * dashboard against an order created any other way. Simulation is how the
+   * cancelled/expired/refunded branches get exercised without waiting out a real
+   * billing period (#243), so this path is about to be hit deliberately.
+   *
+   * It used to return a bare `{received: true}`, which LemonSqueezy renders as a
+   * green delivery - so "the handler ignored this" and "the handler worked" were
+   * the same picture, on the payments path, in the run whose purpose is deciding
+   * whether payments work. Fixed in #251; this is what stops it regressing.
+   *
+   * Still 2xx on purpose: a non-2xx makes LemonSqueezy RETRY, and an event with
+   * no user of ours attached is not a failure to retry - it is correctly not
+   * ours. Asserting the STATUS as well as the reason, because a later "tidy-up"
+   * to 4xx would turn every such delivery into a retry storm. */
+  test.describe('signed, but no user attached', () => {
+    test.skip(!SECRET,
+      'LEMONSQUEEZY_WEBHOOK_SECRET is not set, so no correctly-signed payload can be built. ' +
+      'Skipping rather than passing: this asserts a REASON string, and a test that never ' +
+      'reaches the handler cannot tell a missing reason from a wrong one.');
+
+    test('is refused with a reason, not a bare 200', async ({ request }) => {
+      /* Deliberately no `custom_data.user_id`, and a nonce so the replay guard
+         does not answer first on a re-run. The guard is downstream of this
+         branch, but the nonce costs nothing and the failure it prevents is the
+         confusing kind. */
+      const body = JSON.stringify({
+        meta: { event_name: 'subscription_created', custom_data: { qa_nonce: crypto.randomUUID() } },
+        data: { id: 'sub_no_user', attributes: { status: 'active', user_email: 'nobody@example.test' } },
+      });
+
+      const r = await request.post(ENDPOINT, {
+        headers: { 'Content-Type': 'application/json', 'x-signature': sign(body) },
+        data: body,
+        failOnStatusCode: false,
+      });
+
+      expect(r.status(), 'a non-2xx makes LemonSqueezy retry an event that will never succeed').toBe(200);
+
+      const text = await r.text();
+      expect(text,
+        'the handler accepted an event with no user attached and said nothing about it. ' +
+        'That renders as a green delivery in the LemonSqueezy log, so a silent no-op is ' +
+        'indistinguishable from a successful write - the #228 empty-200 on the payments path.')
+        .toContain('no custom_data.user_id');
+    });
   });
 
   test.describe('with a valid signature', () => {


### PR DESCRIPTION
**QA Team** · the assertion I owed on #251 — **and it uncovered something worse than the thing I set out to test.**

## The find: the payments security tests have not been running

`qa/e2e/payments-webhook.spec.ts` imported only `@playwright/test` and `crypto`.
**`_auth.ts` is what reads `.env.e2e.local` and `.env.local` into `process.env`**,
and this file never imported it — so `LEMONSQUEEZY_WEBHOOK_SECRET` was empty
locally and every signed test skipped:

```
before   3 passed, 3 skipped
after    6 passed, 0 skipped
```

The three that were skipping:

```
a payer cannot grant Pro to an account they do not own     <- the BOLA of payments
a replayed payload is recognised and not re-applied
is refused with a reason, not a bare 200                   <- the new one
```

**They passed in CI, where the job supplies env directly.** CI has been disabled
for cost since 2026-08-10, so locally is now the *only* place they run — which
means the payments security surface was verified by **nothing, anywhere**, and the
only symptom was `3 skipped` scrolling past.

This is the trap `_auth.ts` documents at length about `E2E_B_PRICE_ALERT_ID`
skipping all twenty authenticated tests. Same shape, different file. **I only
found it because I added a fourth test and noticed it skipped too** — the skip
message was honest, and still nobody read it.

One side-effect `import './_auth'` fixes it.

## The assertion itself

Covers #251's reason string:

```
signed payload, no custom_data.user_id  ->  200  +  ignored: "no custom_data.user_id"
```

**It asserts the 200 as well as the reason.** A later tidy-up to 4xx would turn
every such delivery into a LemonSqueezy retry storm, and the status being right
is not obvious from the body being right.

**It lives here, not in `payments-write-path.spec.ts` where I said it would.**
`if (!userId) return` runs at `route.ts:56`, *before* `getSupabaseAdmin()` — so
it needs no service-role key. Putting it in the write-path spec would have made it
skip whenever that key was absent, for a branch that never touches the database.
Correcting my own placement from the #251 review.

## Also in here

`qa/STATUS.md`, three entries that changed today:

- **the pre-push hook covers three of four gates**, with the limit stated plainly
  so "do we still need CI?" has a findable answer — it cannot catch keyless-build
  defects and `--no-verify` bypasses it
- **`lib/apiCache.ts` holds an unbounded Map** (#253) — #242 fixed one caller,
  not the primitive
- **zero browser-to-exchange calls** (#238), and the cost that came with it:
  `/api/proxy` now carries fifteen types behind one rate limit and one cache

## How to test (QA)

```bash
npx playwright test qa/e2e/payments-webhook.spec.ts --project=desktop
```

**Expect `6 passed, 0 skipped`** with `LEMONSQUEEZY_WEBHOOK_SECRET` and
`SUPABASE_SERVICE_ROLE_KEY` in `.env.local`. On `origin/dev` the same command
gives `3 passed, 3 skipped` — that difference is the finding, not the fix.

Pushed through `.githooks/pre-push`: lint 0 errors, tsc clean, 288 unit tests.

## Risk level

**Low** — test-only, no app code.

**Named:** this makes three previously-skipping tests run, so if any of them has
been wrong since it was written, this PR is where it surfaces. All three pass on
merged `dev`, so that has not happened — but it is the honest risk of turning a
skip into a run, and it is the reason to do it now rather than during a release.
