### PR TITLE
fix(api): bound the response cache with LRU eviction

### DIFF
--- a/__tests__/apiCacheCap.test.mts
+++ b/__tests__/apiCacheCap.test.mts
@@ -1,0 +1,131 @@
+/* The size cap on lib/apiCache.ts's store (#253).
+ *
+ * The bound itself is one assertion. The other four are the things a naive cap
+ * BREAKS, which QA named on the issue before I wrote it:
+ *
+ *   - `inflight` is keyed identically and cleared in a `finally`; eviction must
+ *     not disturb it or a rejected fetcher wedges a key
+ *   - `cachedStale` deliberately does not refresh its timestamp on failure, so
+ *     recovery is automatic once an upstream recovers. Evicting the stale entry
+ *     turns "serving slightly old data" into "every request hits a dead
+ *     upstream" - the opposite of what cachedStale is for
+ *
+ * Written against LRU rather than oldest-inserted, because oldest-inserted
+ * passes the size assertion and fails both of the above.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { cached, cachedStale, _cacheSize } from '../lib/apiCache.ts';
+
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+let n = 0;
+const key = (label: string) => `cap:${label}:${++n}`;
+
+test('the store is bounded', async (t) => {
+  await t.test('writing far past the cap does not grow it without limit', async () => {
+    const before = _cacheSize();
+    const prefix = key('flood');
+    for (let i = 0; i < 900; i++) {
+      await cached(`${prefix}:${i}`, 60_000, async () => i);
+    }
+    const after = _cacheSize();
+
+    /* 900 distinct keys written. Without a cap the map holds all of them plus
+       whatever was already there - that is the leak this closes. */
+    assert.ok(after <= 500,
+      `store grew to ${after} entries after 900 distinct keys (was ${before}); the cap is not holding`);
+  });
+
+  await t.test('a hot key survives a flood of cold ones', async () => {
+    const hot = key('hot');
+    let hotFetches = 0;
+    const get = () => cached(hot, 600_000, async () => { hotFetches++; return 'hot'; });
+
+    await get();
+    assert.equal(hotFetches, 1);
+
+    /* Enough cold keys to evict everything, TOUCHING the hot key as we go - the
+       access pattern of a real cache, where one entry is read constantly and the
+       rest are one-offs. Oldest-inserted eviction drops `hot` here; LRU keeps it. */
+    for (let i = 0; i < 700; i++) {
+      await cached(`${key('cold')}:${i}`, 60_000, async () => i);
+      if (i % 50 === 0) await get();
+    }
+
+    await get();
+    assert.equal(hotFetches, 1,
+      `the hot key was evicted and refetched ${hotFetches} times; eviction is not LRU`);
+  });
+});
+
+test('the cap does not break what the cache is for', async (t) => {
+  await t.test('single-flight still collapses concurrent callers', async () => {
+    const k = key('flight');
+    let calls = 0;
+    const slow = async () => { calls++; await sleep(40); return 'v'; };
+
+    await Promise.all(Array.from({ length: 20 }, () => cached(k, 5_000, slow)));
+    assert.equal(calls, 1, `${calls} upstream calls; the cap disturbed inflight`);
+  });
+
+  await t.test('a rejected fetcher still does not wedge the key', async () => {
+    const k = key('reject');
+    let calls = 0;
+    const flaky = async () => {
+      calls++;
+      await sleep(10);
+      if (calls === 1) throw new Error('upstream down');
+      return 'recovered';
+    };
+
+    await assert.rejects(() => cached(k, 5_000, flaky), /upstream down/);
+    assert.equal(await cached(k, 5_000, flaky), 'recovered',
+      'the failed promise was left in inflight');
+  });
+
+  await t.test('cachedStale still serves the last good value when the refresh fails', async () => {
+    const k = key('stale');
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      await sleep(10);
+      if (calls > 1) throw new Error('upstream down');
+      return 'good';
+    };
+
+    assert.equal((await cachedStale(k, 50, fn)).data, 'good');
+    await sleep(80);
+
+    const second = await cachedStale(k, 50, fn);
+    assert.equal(second.data, 'good', 'the stale fallback was lost');
+    assert.equal(second.stale, true);
+  });
+
+  await t.test('a stale entry survives a flood, because serving it counts as a read', async () => {
+    const k = key('stale-hot');
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      await sleep(5);
+      if (calls > 1) throw new Error('still down');
+      return 'lastGood';
+    };
+
+    await cachedStale(k, 30, fn);      // seed
+    await sleep(50);                    // let it go stale
+    assert.equal((await cachedStale(k, 30, fn)).stale, true);
+
+    /* The upstream is down and this entry is the only thing standing between the
+       user and an error. It must not be evicted by unrelated traffic. */
+    for (let i = 0; i < 700; i++) {
+      await cached(`${key('noise')}:${i}`, 60_000, async () => i);
+      if (i % 100 === 0) await cachedStale(k, 30, fn).catch(() => {});
+    }
+
+    const after = await cachedStale(k, 30, fn);
+    assert.equal(after.data, 'lastGood',
+      'the stale entry was evicted, so a dead upstream now reaches the user');
+  });
+});

--- a/lib/apiCache.ts
+++ b/lib/apiCache.ts
@@ -7,6 +7,56 @@
 
 const store = new Map<string, { ts: number; data: unknown }>();
 
+/* SIZE CAP, because a Map that only ever grows is a leak with a slow fuse (#253).
+ *
+ * Expiry stops an entry being SERVED; it does not free it. So before this, every
+ * distinct key ever requested was a permanent allocation holding a full JSON
+ * response, for the life of the instance. #242 closed the one route that could
+ * mint keys freely - /api/proxy with arbitrary timestamp cursors - but that fixed
+ * the caller, not the primitive, and the next caller with a user-controllable key
+ * would not have that protection.
+ *
+ * QA sized this honestly and so will I: nobody has demonstrated memory pressure
+ * on a running service, and Render restarts often enough that a slow leak might
+ * never surface. This is defence in depth on a shared primitive, not an incident.
+ *
+ * 500 is generous. The real working set is one entry per (route, params) with a
+ * short TTL - dozens, not hundreds - so the cap should never be reached by
+ * legitimate traffic. If it is, that is itself the signal that something is
+ * minting keys.
+ */
+const MAX_ENTRIES = 500;
+
+/* LRU, not oldest-inserted. A Map iterates in insertion order, so deleting and
+   re-setting on every HIT moves the hot keys to the end and leaves the cold ones
+   at the front to be evicted first.
+   This matters for cachedStale specifically: a stale entry being served as a
+   fallback is a READ, so it gets promoted and survives. Evicting purely by age
+   would drop exactly the entry that is standing in for a dead upstream - turning
+   "serving slightly old data" into "every request hits the failing upstream",
+   which is the opposite of what cachedStale exists for. */
+function touch(key: string, hit: { ts: number; data: unknown }): void {
+  store.delete(key);
+  store.set(key, hit);
+}
+
+function remember(key: string, data: unknown): void {
+  store.delete(key);                 // so a re-write moves to the end too
+  store.set(key, { ts: Date.now(), data });
+  /* while, not if: a cap lowered at runtime should still converge. */
+  while (store.size > MAX_ENTRIES) {
+    const oldest = store.keys().next();
+    if (oldest.done) break;          // cannot happen while size > 0, but a
+    store.delete(oldest.value);      // guard is cheaper than an infinite loop
+  }
+}
+
+/** Entry count. Exported for tests and for anything that wants to assert the cap
+ *  holds - the bound is worth nothing if nobody can see it. */
+export function _cacheSize(): number {
+  return store.size;
+}
+
 /* IN-FLIGHT REQUESTS, so N concurrent callers produce ONE upstream call (#199).
  *
  * Without this, a TTL cache still stampedes. Checking the store and then
@@ -35,7 +85,7 @@ const inflight = new Map<string, Promise<unknown>>();
 // in place so a single upstream failure can't poison the cache.
 export async function cached<T>(key: string, ttlMs: number, fetcher: () => Promise<T>): Promise<T> {
   const hit = store.get(key);
-  if (hit && Date.now() - hit.ts < ttlMs) return hit.data as T;
+  if (hit && Date.now() - hit.ts < ttlMs) { touch(key, hit); return hit.data as T; }
 
   /* Note the key namespace: `cached` and `cachedStale` share `store`, so they
      share `inflight` too. That is correct - two callers asking for the same key
@@ -45,7 +95,7 @@ export async function cached<T>(key: string, ttlMs: number, fetcher: () => Promi
 
   const p = (async () => {
     const data = await fetcher();
-    store.set(key, { ts: Date.now(), data });
+    remember(key, data);
     return data;
   })().finally(() => { inflight.delete(key); });
 
@@ -77,7 +127,7 @@ export async function cachedStale<T>(
 ): Promise<{ data: T; stale: boolean; ageMs: number }> {
   const hit = store.get(key) as { ts: number; data: T } | undefined;
   const age = hit ? Date.now() - hit.ts : Infinity;
-  if (hit && age < ttlMs) return { data: hit.data, stale: false, ageMs: age };
+  if (hit && age < ttlMs) { touch(key, hit); return { data: hit.data, stale: false, ageMs: age }; }
 
   try {
     /* Same single-flight as `cached`, and deliberately the SAME map. The
@@ -90,7 +140,7 @@ export async function cachedStale<T>(
     const data = existing ? await existing : await (() => {
       const p = (async () => {
         const d = await fetcher();
-        store.set(key, { ts: Date.now(), data: d });
+        remember(key, d);
         return d;
       })().finally(() => { inflight.delete(key); });
       inflight.set(key, p);
@@ -101,7 +151,9 @@ export async function cachedStale<T>(
     /* Deliberately does NOT refresh the timestamp. Every subsequent request
        retries the upstream rather than settling into serving stale data
        forever, so recovery is automatic once the rate limit resets. */
-    if (hit) return { data: hit.data, stale: true, ageMs: age };
+    /* Promote on the STALE path too. This entry is actively standing in for a
+       failing upstream, so it is the last thing that should be evicted. */
+    if (hit) { touch(key, hit); return { data: hit.data, stale: true, ageMs: age }; }
     throw e;   // nothing cached yet - the caller has to handle a real failure
   }
 }


### PR DESCRIPTION
**Dev Team** → **QA Team** · closes #253 — **filed by you, taken by me as promised**

500-entry cap with LRU eviction on `lib/apiCache.ts`, plus `_cacheSize()` so the
bound is observable, plus 8 tests.

## The design decision is LRU, and your two invariants are why

You named them before I wrote a line:

> `inflight` is keyed identically and cleared in a `finally` … eviction must not
> disturb it
>
> `cachedStale` deliberately does not refresh the timestamp on failure …
> eviction must not turn that into "the stale entry vanished and every request
> now hits a dead upstream"

Both are load-bearing, and both are broken by the obvious implementation. A stale
entry being served is a **read**, so promoting on every hit — including the stale
fallback — keeps precisely the entry standing in for a failing upstream.

## Proven by breaking it, not asserted

Disabled LRU promotion, which is exactly what oldest-inserted eviction is:

```
x  a hot key survives a flood of cold ones
x  a stale entry survives a flood, because serving it counts as a read
✔  the size assertion STILL PASSES
```

**That last line is the finding.** A naive cap satisfies "the map is bounded" and
quietly breaks the two things the cache exists for. Had I written only the size
test — the obvious one — it would have gone green and shipped.

Restored, all 8 pass.

## Sizing, matching yours

> I have **not** demonstrated memory pressure on a running service, and I am not
> going to claim it.

Same here, and the commit says so. Defence in depth on a shared primitive, not an
incident. 500 is far above the real working set — one entry per (route, params)
with a short TTL, dozens not hundreds — so legitimate traffic should never reach
it. **If it does, that is itself the signal that something is minting keys.**

## Your verification plan still works

> hammer one `cached()` route with distinct keys past the limit and confirm the
> map stops growing and the hot key still hits

`_cacheSize()` is exported for exactly that, and the hot-key behaviour is
assertable from outside via response timing as you said. My tests cover the
primitive; yours would cover it through a live route, which is the half I cannot
reach from a unit test.

## Verification

```
eslint    0 errors (140 warnings, unchanged)
tsc       clean
npm test  296 passing  (288 + 8 new)
build     ok
```

Pushed through the pre-push hook.

## Risk level

**Medium.** `lib/apiCache.ts` is used by 11 callers and now evicts where it never
did. The tests cover single-flight, the rejected-fetcher path and both stale
behaviours, but eviction is a new class of thing that can go wrong under
concurrency in ways a single-process test will not show.

**Worth your eyes specifically:** whether 500 is right. I argued it is generous;
if you think a route legitimately needs more distinct live keys than that, the
number is the easy part to change and the reasoning is in the comment.
