### PR TITLE
test(payments): skip the signed tests when the target holds a different secret

### DIFF
--- a/qa/e2e/payments-webhook.spec.ts
+++ b/qa/e2e/payments-webhook.spec.ts
@@ -51,6 +51,53 @@ function sign(body: string, secret = SECRET): string {
   return crypto.createHmac('sha256', secret).update(body).digest('hex');
 }
 
+/* DOES THE TARGET HOLD THE SAME SECRET WE ARE SIGNING WITH?
+ *
+ * Having a secret locally means nothing when `E2E_BASE_URL` points at a deployed
+ * service — that service has its own `LEMONSQUEEZY_WEBHOOK_SECRET`, and if the
+ * two differ every signed test gets a 401 and fails.
+ *
+ * That is exactly what happened on 2026-08-11, the first time these ran against
+ * `liquidity-hq-qa`: three red tests, none of them about the app. A spec that
+ * fails for a reason outside the change under test is worse than one that skips,
+ * because it teaches everyone to read red as noise — which is the one habit this
+ * suite cannot afford.
+ *
+ * So: probe once with a throwaway payload. A 401 means the secrets differ and the
+ * signed tests CANNOT be meaningful here. Anything else means the handler
+ * accepted our signature and the tests below are measuring real behaviour.
+ *
+ * Deliberately NOT treating 401 as a failure. A mismatched secret is a fact about
+ * two environments, not a defect — and the "is a forged signature rejected" test
+ * above already covers the case that actually matters. */
+async function targetSharesOurSecret(
+  request: import('@playwright/test').APIRequestContext,
+): Promise<boolean> {
+  if (!SECRET) return false;
+  const body = JSON.stringify({
+    meta: { event_name: 'qa_secret_probe', custom_data: { qa_nonce: crypto.randomUUID() } },
+    data: { id: 'qa_secret_probe', attributes: {} },
+  });
+  const r = await request.post(ENDPOINT, {
+    headers: { 'Content-Type': 'application/json', 'x-signature': sign(body) },
+    data: body,
+    failOnStatusCode: false,
+  });
+  /* `qa_secret_probe` is not an event patchForEvent handles and carries no
+     user_id, so a matching secret returns 200 and changes nothing. */
+  return r.status() !== 401;
+}
+
+const SECRET_MISMATCH_SKIP =
+  'The target service rejected a payload signed with our LEMONSQUEEZY_WEBHOOK_SECRET (401), ' +
+  'so it holds a DIFFERENT secret - or none. Every signed test below would fail on that ' +
+  'rather than on the handler. Set the same value locally as the target service holds, or ' +
+  'run against a service that shares it.\n\n' +
+  'This is a skip and not a failure on purpose: a mismatched secret is a fact about two ' +
+  'environments, not a defect. But it IS a real gap - the signed branches are verified by ' +
+  'nothing in this run, and "a forged signature is rejected" above is the only payments ' +
+  'assertion still standing.';
+
 /* EVERY PAYLOAD CARRIES A NONCE, and that is load-bearing.
  *
  * The route hashes the raw body and inserts it into `ls_webhook_events` BEFORE
@@ -170,6 +217,10 @@ test.describe('LemonSqueezy webhook', () => {
       'Skipping rather than passing: this asserts a REASON string, and a test that never ' +
       'reaches the handler cannot tell a missing reason from a wrong one.');
 
+    test.beforeAll(async ({ request }) => {
+      test.skip(!(await targetSharesOurSecret(request)), SECRET_MISMATCH_SKIP);
+    });
+
     test('is refused with a reason, not a bare 200', async ({ request }) => {
       /* Deliberately no `custom_data.user_id`, and a nonce so the replay guard
          does not answer first on a re-run. The guard is downstream of this
@@ -201,6 +252,10 @@ test.describe('LemonSqueezy webhook', () => {
     test.skip(!SECRET,
       'LEMONSQUEEZY_WEBHOOK_SECRET is not set, so no correctly-signed payload can be built. ' +
       'Skipping rather than passing: a signed-payload test that never signs anything proves nothing.');
+
+    test.beforeAll(async ({ request }) => {
+      test.skip(!(await targetSharesOurSecret(request)), SECRET_MISMATCH_SKIP);
+    });
 
     /* AND the handler needs SUPABASE_SERVICE_ROLE_KEY.
      *


### PR DESCRIPTION
**QA Team** · **found by running my own spec against a deployed service for the first time. Three red tests, none of them about the app.**

## What happened

`payments-webhook.spec.ts` ran against `liquidity-hq-qa` at `ff9704d` — the first
time those signed tests have executed anywhere except a local build:

```
✘ signed, but no user attached: is refused with a reason, not a bare 200
✘ a payer cannot grant Pro to an account they do not own
✘ a replayed payload is recognised and not re-applied
```

Confirmed the cause directly rather than inferring it:

```
POST /api/lemonsqueezy/webhook  (signed with the LOCAL secret)
-> 401 {"error":"Invalid signature"}
```

**`qa` holds a different `LEMONSQUEEZY_WEBHOOK_SECRET` than my machine.** Not a
defect — two environments, two secrets, exactly as they should be.

## The flaw was in my guard

```ts
test.skip(!SECRET, 'LEMONSQUEEZY_WEBHOOK_SECRET is not set...')
```

That checks the secret is set **locally**. Which means nothing once
`E2E_BASE_URL` points somewhere else — the target has its own, and if they differ
every signed test 401s.

**A spec that fails for a reason outside the change under test is worse than one
that skips**, because it teaches everyone to read red as noise. That is the one
habit this suite genuinely cannot afford, and I built it.

## The fix

Probe once with a throwaway payload before the signed groups run. A 401 means the
secrets differ and those tests cannot be meaningful, so they skip with a reason
that says so.

`qa_secret_probe` is not an event `patchForEvent` handles and carries no
`user_id`, so against a matching secret it returns 200 and changes nothing.

**Deliberately a skip, not a failure.** A mismatched secret is a fact about two
environments. And the skip message says plainly what it costs:

> the signed branches are verified by nothing in this run, and "a forged
> signature is rejected" above is the only payments assertion still standing

## Verified BOTH ways, and the second is the one that matters

```
secret differs   (qa)      3 passed · 3 skipped · 0 failed
secret matches   (local)   6 passed · 0 skipped
```

**A guard that skipped everywhere would be worse than the failures it replaces** —
it would silently retire the BOLA-of-payments test while looking tidy. That is
the same shape as the bug #255 fixed this morning, where a missing import skipped
those tests for months. I am not shipping the second version of it.

## How to test (QA)

```bash
# skips cleanly
E2E_BASE_URL=https://liquidity-hq-qa.onrender.com \
  npx playwright test qa/e2e/payments-webhook.spec.ts --project=desktop

# still runs
npx playwright test qa/e2e/payments-webhook.spec.ts --project=desktop
```

`3 passed, 3 skipped` and `6 passed, 0 skipped` respectively.

## Worth doing separately

**Set the same `LEMONSQUEEZY_WEBHOOK_SECRET` on `qa` as on `staging`** when the
owner sets staging's for #243. Any string; it just has to match what QA signs
with. Then these run everywhere instead of skipping on two services out of three.

Not blocking — noting it so the skip does not become permanent by default.

## Risk level

**Low.** Test-only, no app code. One added network round-trip per signed group.
