### PR TITLE
test(qa): intercept the proxy and the funding-rate route, not just exchanges

### DIFF
--- a/qa/e2e/_fixtures.ts
+++ b/qa/e2e/_fixtures.ts
@@ -155,6 +155,40 @@ export async function installMarketFixtures(page: Page, scenario: Scenario = 'as
   await page.route('**/api/funding**', r =>
     fulfil(r, 'lhq-funding', sign ? (b) => fundingSigned(b as FundingBody, sign) : undefined));
   await page.route('**/api/market/rsi**', r => fulfil(r, 'lhq-market-rsi'));
+
+  /* `/api/market/funding-rate` — the source /funding actually charts, and the
+   * one this file missed entirely until 2026-08-11.
+   *
+   * `app/funding/page.tsx:40` fetches it on mount and charts the result. It was
+   * invisible while the page ALSO called Bybit directly and that call dominated
+   * what rendered; #242 moved the direct call behind the proxy, and the moment it
+   * stopped competing, this route's LIVE data showed through untouched. The
+   * `funding-negative` scenario then rendered 39 positive rates and said so.
+   *
+   * The header of this file says our own `/api` shapes are ours to refactor and
+   * pinning to them turns internal changes into test failures. That still holds -
+   * which is why this does NOT serve a recorded fixture. It fetches the real
+   * response and negates every `fundingRate` in place, so the shape stays
+   * whatever the route currently returns and cannot drift.
+   *
+   * Only intercepted when a sign scenario is active. `as-recorded` wants real
+   * data and `upstream-500` is about third-party failure, not ours. */
+  if (sign) {
+    await page.route('**/api/market/funding-rate**', async (route) => {
+      const res = await route.fetch();
+      const json = await res.json() as { data?: Record<string, Array<{ fundingRate: string; fundingTime: number }>> };
+      const data: Record<string, Array<{ fundingRate: string; fundingTime: number }>> = {};
+      for (const [sym, rows] of Object.entries(json.data ?? {})) {
+        data[sym] = rows.map(r => {
+          const mag = Math.abs(parseFloat(r.fundingRate)) || 0.0001;  // never 0: the sign must be observable
+          return { ...r, fundingRate: (sign * mag).toFixed(8) };
+        });
+      }
+      served.count++;
+      served.byKey['lhq-market-funding-rate'] = (served.byKey['lhq-market-funding-rate'] ?? 0) + 1;
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ...json, data }) });
+    });
+  }
   await page.route('**/api/market/snapshot**', r => fulfil(r, 'lhq-market-snapshot'));
   await page.route('**fapi.binance.com/fapi/v1/fundingRate**', r =>
     fulfil(r, 'binance-fundingRate', sign ? (b) => binanceFundingSigned(b as BinanceFundingRow[], sign) : undefined));
@@ -187,6 +221,56 @@ export async function installMarketFixtures(page: Page, scenario: Scenario = 'as
   await page.route('**futures/data/topLongShortPositionRatio**', r => fulfil(r, 'binance-top-lsr'));
   await page.route('**alternative.me/fng**', r => fulfil(r, 'alternative-fng'));
   await page.route('**deribit.com/api/v2/public/get_book_summary_by_currency**', r => fulfil(r, 'deribit-book-summary'));
+
+  /* ── EVERY PATTERN ABOVE MATCHES A CALL THE BROWSER NO LONGER MAKES ─────────
+   *
+   * #238/#242 moved all of it behind `/api/proxy?type=...`, and the upstream
+   * fetch now happens SERVER-SIDE where `page.route` cannot reach. So the
+   * browser requests `/api/proxy?type=bybit-tickers`, nothing above matches, and
+   * the fixture never fires.
+   *
+   * That is how it surfaced: `market-scenarios` failed with
+   *
+   *     bybit tickers was not intercepted - the rates on screen are live data
+   *     served.byKey['bybit-tickers'] = 0
+   *
+   * The spec's own control caught it. Without that guard these would have gone
+   * on "passing" against whatever the live market happened to be doing, which is
+   * the failure this file exists to prevent.
+   *
+   * The patterns above are KEPT rather than replaced. They are now a tripwire: if
+   * any of them ever fires again, a direct browser->exchange call has come back
+   * and #238 has regressed. `byKey` names which one, so the regression arrives
+   * labelled.
+   *
+   * Fixture bodies need no change. `/api/proxy` is a passthrough - it returns
+   * `r.json()` from the upstream verbatim - so the recorded exchange payload is
+   * exactly what the proxy would have served. */
+  const PROXY_FIXTURES: Array<[type: string, key: string, transform?: (b: unknown) => unknown]> = [
+    ['bybit-tickers',   'bybit-tickers',         sign ? (b) => bybitTickersSigned(b as BybitTickersBody, sign) : undefined],
+    ['funding-history', 'bybit-funding-history', sign ? (b) => bybitFundingSigned(b as BybitFundingBody, sign) : undefined],
+    ['funding-rate-1',  'binance-fundingRate',   sign ? (b) => binanceFundingSigned(b as BinanceFundingRow[], sign) : undefined],
+    ['premium-index',   'binance-premiumIndex',  sign ? (b) => premiumIndexSigned(b as PremiumIndexRow[], sign) : undefined],
+    ['open-interest-1', 'bybit-open-interest'],
+    ['account-ratio-1', 'bybit-account-ratio'],
+    ['recent-trade',    'bybit-recent-trade'],
+    ['depth',           'binance-depth'],
+    ['oi-hist',         'binance-oi-hist'],
+    ['lsr-global',      'binance-global-lsr'],
+    ['lsr-top',         'binance-top-lsr'],
+    ['fng',             'alternative-fng'],
+    ['deribit-book',    'deribit-book-summary'],
+  ];
+
+  for (const [type, key, transform] of PROXY_FIXTURES) {
+    /* Anchored on a `&` or end-of-string so `type=funding-history` cannot be
+       satisfied by `type=funding-rate-1` or vice versa - the two share a prefix
+       and a loose pattern would silently serve the wrong fixture. */
+    await page.route(
+      new RegExp(`/api/proxy\\?(?:[^#]*&)?type=${type}(?:&|$)`),
+      r => fulfil(r, key, transform),
+    );
+  }
 
   return served;
 }


### PR DESCRIPTION
**QA Team** · **#242 broke my fixtures, and the breakage exposed an older hole underneath. Both fixed.**

```
before   funding-positive ✘   funding-negative ✘
after    4 passed
```

## Hole 1 — every pattern in this file matched a request the browser stopped making

#242 moved all browser→exchange traffic behind `/api/proxy`, where the upstream
fetch happens **server-side** and `page.route` cannot reach it. So the browser now
asks for `/api/proxy?type=bybit-tickers`, nothing matched, and the fixtures
stopped firing.

**The spec's own control caught it**, which is the whole reason that guard exists:

```
bybit tickers was not intercepted - the rates on screen are live data
served.byKey['bybit-tickers'] = 0
```

Without it, `market-scenarios` would have gone on green against whatever the live
market happened to be doing.

Thirteen `type=` mappings added, anchored on `(?:&|$)` so `type=funding-history`
cannot be satisfied by `type=funding-rate-1` — they share a prefix and a loose
pattern would silently serve the wrong fixture.

**Fixture bodies unchanged.** `/api/proxy` returns `r.json()` from the upstream
verbatim, so the recorded exchange payload is exactly what it would serve.

## Hole 2 — the one that predates today

Fixing hole 1 made `funding-positive` pass and left `funding-negative` failing
with **39 positive rates**. That is the asymmetry worth noticing: a positive
scenario passes trivially on live data, so **only the negative one proves
anything.**

`app/funding/page.tsx:40` fetches **`/api/market/funding-rate?limit=42`** on mount
and charts it. This file never intercepted it — and it stayed invisible because
the page *also* called Bybit directly, and that call dominated what rendered.
Remove the competition and the gap appears immediately.

**Transformed from the real response, not a recorded fixture.** This file's header
says our own `/api` shapes are ours to refactor and pinning to them turns internal
changes into test failures. So it fetches the live response and negates each
`fundingRate` in place — the shape stays whatever the route returns and cannot
drift.

## The exchange patterns are kept, deliberately

They now serve as a **tripwire**. If any fires again, a direct browser→exchange
call has come back and #238 has regressed — and `byKey` names which one, so the
regression arrives labelled instead of as a mystery.

## 🟡 A correction to #238 that belongs on the record

`app/funding/page.tsx:57` **still calls `api.bybit.com` directly from the
browser**:

```ts
if (!pts.length && bbSym) pts = await fetchBybitFR(bbSym);
```

It is a documented fallback — *"only the fallback for coins Binance does not list
- a handful, not a sweep"* — and it did not fire during my #238 sweep, which is
why that measured a genuine zero.

**But the zero is conditional, not unqualified.** If `/api/market/funding-rate`
returns nothing for a symbol, the browser calls Bybit directly. I will note that
on #238 rather than let "zero browser-to-exchange calls" stand as unqualified when
it holds only on the happy path.

## How to test (QA)

```bash
npx playwright test qa/e2e/market-scenarios.spec.ts --project=desktop
```

**4 passed.** `funding-negative` is the one to watch — it cannot pass on live data,
and it is the failure that exposed both holes.

Pushed through `.githooks/pre-push`.

## Risk level

**Low.** Test-only, no app code.

**Named:** any other spec relying on browser-level interception of an exchange has
the same staleness. `market-scenarios` is the only one that asserts on the
*values*, so it is the only one that failed loudly — `contrast` and `layout` use
fixtures for stability rather than assertions, so they went quiet instead. Worth a
sweep, not worth blocking this.
