### PR TITLE
feat(dashboard): hide /backtest and /live-tracking behind an edge redirect

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -34,18 +34,6 @@ import { useAppConfig } from '@/lib/useAppConfig';
 // identical to any other 404.
 const isChromeless = (pathname: string) => pathname === '/ops' || pathname.startsWith('/ops/');
 
-/* Routes that render the full shell but no market data (#200).
- *
- * MarketProvider still MOUNTS on these - GrokChat and NavDrawer's status dot call
- * useMarket() on every route and it throws without a provider - it just does not
- * poll. Measured by QA against deployed staging: each of these makes 210 exchange
- * requests per visit and renders byte-identically with every one of them blocked.
- *
- * Exact match, same reasoning as isChromeless above: a future /backtest/results
- * should keep its data unless someone decides otherwise, rather than silently
- * inheriting a decision made about a different page. */
-const isMarketDataFree = (pathname: string) =>
-  pathname === '/backtest' || pathname === '/live-tracking';
 
 /* Auth screens get the same treatment, for a different reason. /login used to
    render inside the full consumer shell, so a signed-OUT stranger arriving at
@@ -136,7 +124,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
       <LabelsProvider>
         <AuthProvider>
           <SettingsProvider>
-            <MarketProvider enabled={!isMarketDataFree(pathname)}>
+            <MarketProvider>
               <NewsProvider>
                 <OnboardingProvider>
                   <GrokUsageProvider>

--- a/components/NavDrawer.tsx
+++ b/components/NavDrawer.tsx
@@ -14,7 +14,7 @@ import BrandMark from './BrandMark';
 import {
   IconSun, IconMoon,
   NavDashboard, NavBriefing, NavArena, NavMarkets, NavScanner,
-  NavLiqMap, NavFunding, NavCorrelation, NavBacktest, NavTracking, NavResearch,
+  NavLiqMap, NavFunding, NavCorrelation, NavResearch,
   NavNews, NavCalendar, NavJournal, NavCalc, NavAlerts, NavHours, NavPlaybook,
   NavSettings, NavAbout,
 } from './icons';
@@ -132,8 +132,6 @@ const SCANNERS = [
   { path: '/liq',           labelKey: 'NAV_LIQUIDATION_MAP' as const },
   { path: '/funding',       labelKey: 'NAV_FR_HISTORY'     as const },
   { path: '/correlation',   labelKey: 'NAV_CORRELATION'    as const },
-  { path: '/backtest',      labelKey: 'NAV_BACKTEST'       as const },
-  { path: '/live-tracking', labelKey: 'NAV_LIVE_TRACKING'  as const },
 ];
 
 const TOOLS = [
@@ -166,8 +164,6 @@ const NAV_SECTIONS: NavSection[] = [
     { path: '/liq',           labelKey: 'NAV_LIQUIDATION_MAP', Icon: NavLiqMap },
     { path: '/funding',       labelKey: 'NAV_FR_HISTORY',      Icon: NavFunding },
     { path: '/correlation',   labelKey: 'NAV_CORRELATION',     Icon: NavCorrelation },
-    { path: '/backtest',      labelKey: 'NAV_BACKTEST',        Icon: NavBacktest },
-    { path: '/live-tracking', labelKey: 'NAV_LIVE_TRACKING',   Icon: NavTracking },
   ] },
   { headerKey: 'NAV_SECTION_RESEARCH', items: [
     { path: '/research',      labelKey: 'NAV_RESEARCH',      Icon: NavResearch },

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,53 @@
+/* Block /backtest and /live-tracking at the edge (#264).
+ *
+ * The owner asked for these pages hidden, and chose BLOCK THE ROUTES over hiding
+ * the nav links — so a bookmark or a typed URL must not reach them either.
+ *
+ * ── WHY THIS FILE IS `proxy.ts` AND NOT `middleware.ts` ─────────────────────
+ *
+ * `middleware` is DEPRECATED in this version of Next and renamed to `proxy`.
+ * From node_modules/next/dist/docs/01-app/03-api-reference/03-file-conventions/proxy.md:
+ *
+ *   > The `middleware` file convention is deprecated and has been renamed to
+ *   > `proxy`.
+ *
+ * A `middleware.ts` written from memory would sit in the repo doing NOTHING,
+ * and the symptom would be "the routes are still reachable" with no error
+ * anywhere — which reads as a broken redirect rather than a file Next never
+ * loaded. This is the exact case AGENTS.md opens with: read the local docs
+ * before writing framework code, because the docs in your head are older than
+ * this project.
+ *
+ * ── REDIRECT, NOT 404 ───────────────────────────────────────────────────────
+ *
+ * QA's recommendation and I agree: an existing bookmark lands somewhere useful
+ * rather than on a dead end, and re-enabling is deleting two strings from the
+ * list below. A 404 would be right only if these pages should look like they
+ * never existed, which is not what was asked.
+ *
+ * The pages themselves are left intact. Reversing this is a one-line change
+ * here, not a restore from history.
+ */
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+/** Exact paths only. A future /backtest/results should be a deliberate decision,
+ *  not something that silently inherits this one — same reasoning as
+ *  `isChromeless` and the (now removed) market-data exemption in AppShell. */
+const BLOCKED = new Set(['/backtest', '/live-tracking']);
+
+export function proxy(request: NextRequest) {
+  if (BLOCKED.has(request.nextUrl.pathname)) {
+    /* 307, the NextResponse.redirect default: a temporary redirect, because
+       these pages are hidden rather than retired. A 308 would be cached by
+       browsers and would outlive the decision. */
+    return NextResponse.redirect(new URL('/dashboard', request.url));
+  }
+  return NextResponse.next();
+}
+
+/* Scoped so this runs for two paths and nothing else. Without a matcher the
+   proxy executes on every request in the app for a two-entry lookup. */
+export const config = {
+  matcher: ['/backtest', '/live-tracking'],
+};


### PR DESCRIPTION
**Dev Team**

Closes #264.

## Summary

`/backtest` and `/live-tracking` are hidden. Nav entries removed, and the two
paths redirect to `/dashboard` at the edge so a bookmark or a typed URL cannot
reach them either. Neither page is deleted.

## What changed

| File | Change |
|---|---|
| `proxy.ts` *(new)* | 307 redirect to `/dashboard` for exactly `/backtest` and `/live-tracking` |
| `components/NavDrawer.tsx` | 4 entries removed — 2 desktop list, 2 mobile tab bar — plus the now-unused `NavBacktest` / `NavTracking` icon imports |
| `components/AppShell.tsx` | `isMarketDataFree` removed; it existed only to exempt these two routes from `MarketProvider`, and is dead now |

## Why

The owner asked for these two hidden and chose **blocking the routes** over
only hiding the links. Removing the nav entries alone leaves both pages fully
reachable by URL — the version of this change that looks done and isn't.

Redirect rather than 404, per QA's recommendation on #264: an existing bookmark
lands somewhere useful, and re-enabling is deleting two strings from one list.
307 and not 308 deliberately — 308 is cached by browsers and would outlive the
decision.

### The file is `proxy.ts`, not `middleware.ts`

`middleware` is **deprecated in this version of Next and renamed to `proxy`**
(`node_modules/next/dist/docs/01-app/03-api-reference/03-file-conventions/proxy.md`).
Writing `middleware.ts` from memory would have put a file in the repo that does
nothing, and the only symptom would have been "the routes are still reachable"
— no error anywhere. Found by reading the local docs first, which is the thing
`AGENTS.md` opens by telling us to do.

## How to test (QA)

On the **qa** environment, signed in:

1. **Left nav** — "Backtest" and "Live Tracking" are gone.
2. **Mobile tab bar** (narrow the window or use a phone) — both gone there too.
3. **Type `/backtest` into the address bar** — lands on the Dashboard.
4. **Type `/live-tracking`** — lands on the Dashboard.
5. **Other nav still works** — Arena, Correlations, Journal, Funding all load
   normally. The redirect is scoped to two exact paths.
6. **`/backtest/results`** (or any sub-path) is *not* redirected — it 404s, as
   it did before. Sub-paths were left alone on purpose; a future one should be
   a deliberate decision, not something that silently inherits this.

Verified locally against a production build before opening this: both paths
returned `307 → /dashboard`, and `/dashboard`, `/arena`, `/markets` all still
returned 200.

## ⚠️ Two things this PR does NOT do

**1. `ROUTES` in `qa/e2e/_shared.ts` still lists both paths** (line 8–9). The
`contrast`, `layout`, `a11y`, `seo` and `perf` specs sweep that list, so they
will now sweep two routes that redirect. `qa/e2e/layout.spec.ts` also carries 3
baseline entries for them (lines 158, 159, 172) that become dead. That is QA's
file and QA's call — flagging it so it changes in **this same release** rather
than showing up as five red specs.

**2. The Pro sales copy still sells backtesting.** Hiding the page did not
touch the pricing copy, and payments are about to go live (#243). Six places
still promise it to a buyer:

| Where | String |
|---|---|
| `/upgrade` pricing card | `UPGRADE_PRO_FEATURE_BACKTESTING` — "Full strategy backtesting" |
| `/upgrade` hero | `UPGRADE_HERO_SUBTITLE` — "...backtesting, and more AI everywhere" |
| Upsell modal | `UPGRADE_GATE_BODY`, `UPGRADE_GATE_BULLET_3` — "Full backtesting across every coin and timeframe" |
| `/faq` (public) | `FAQ_Q_FREE_VS_PRO_A` |
| i18n | `lib/i18n/dictionaries.ts:143` feature list |

So as of this PR, a $25/mo page advertises a feature that redirects to the
Dashboard. I have **not** changed any of it — pricing copy is the owner's call,
not a decision to make inside a "hide two pages" PR, and the right answer
depends on whether these come back. Raising it rather than silently shipping
it. Needs a decision before the first real purchase.

`app/sitemap.ts` was checked and lists neither route, so nothing SEO-facing
points at them.

## Risk level

**Low** for the redirect itself — 4 gates green (lint 0 errors / 140 warnings
unchanged, `tsc` clean, 296/296 tests, production build) and the behaviour was
exercised on a real build, not reasoned about.

**Medium for the release as a whole**, entirely because of the two items above:
five QA specs go red unless `_shared.ts` changes in the same release, and the
copy issue is live commercial exposure the moment checkout opens.

Not verified: the redirect on a deployed Render instance (edge behaviour there
could differ from `next start` locally) — worth one address-bar check on qa
after promotion.
