### PR TITLE
test(qa): address baseURL, not localhost, so remote runs test the real service

### DIFF
--- a/qa/e2e/perf.spec.ts
+++ b/qa/e2e/perf.spec.ts
@@ -171,11 +171,32 @@ test.describe('performance', () => {
   //
   // Baseline is deliberately set just above today's measurement so it cannot
   // get worse, and should be driven towards ~0 for static routes.
-  test('a static legal page does not fan out to market-data APIs', async ({ page }, testInfo) => {
+  test('a static legal page does not fan out to market-data APIs', async ({ page, baseURL }, testInfo) => {
+    /* THIRD PARTY MEANS "NOT OUR ORIGIN", and that origin is not always
+     * localhost.
+     *
+     * This used to test `!url.startsWith('http://localhost')`, which is correct
+     * for a local run and silently wrong for every remote one: with
+     * E2E_BASE_URL set, EVERY same-origin request counts as third-party and the
+     * number is nonsense.
+     *
+     * The dangerous part is that it does not fail - it inflates. A baseline
+     * comparison against an inflated count either fails for the wrong reason or,
+     * worse, passes because the baseline was itself recorded remotely.
+     *
+     * Found 2026-08-11 alongside the same bug in security.spec.ts, which at
+     * least had the decency to ECONNREFUSED. */
+    /* `baseURL`, not `page.url()` - the listener is registered BEFORE the
+       navigation, so page.url() is still `about:blank` here and every request
+       would look foreign. Caught while writing this fix, which is a fair
+       indication of how easy the original mistake was to make. */
+    const ownOrigin = new URL(baseURL ?? `http://localhost:${process.env.E2E_PORT ?? 3100}`).origin;
     const thirdParty: string[] = [];
     page.on('request', r => {
       const url = r.url();
-      if (!url.startsWith('http://localhost') && !url.startsWith('data:')) thirdParty.push(url);
+      if (url.startsWith('data:') || url.startsWith('blob:')) return;
+      if (url.startsWith(ownOrigin)) return;
+      thirdParty.push(url);
     });
 
     await page.goto('/refund', { waitUntil: 'domcontentloaded' });

--- a/qa/e2e/security.spec.ts
+++ b/qa/e2e/security.spec.ts
@@ -74,11 +74,22 @@ test.describe('api security', () => {
     }
   });
 
-  test('security headers are present on the document', async () => {
+  test('security headers are present on the document', async ({ baseURL }) => {
     // A fresh context: fixture `request` shares cookie state, and we want the
     // raw document response here.
+    //
+    // ADDRESS `baseURL`, NOT localhost. This used to hardcode
+    // `http://localhost:${E2E_PORT ?? 3100}`, which meant that with
+    // E2E_BASE_URL set - the whole point of #203 - it tried to reach a local
+    // server that was never started and died with ECONNREFUSED. So the security
+    // headers on every DEPLOYED service were checked by nothing, and the failure
+    // read as a broken assertion rather than a spec addressing the wrong host.
+    //
+    // Found on 2026-08-11 in the first full remote run. The headers themselves
+    // are fine - CSP, HSTS, x-frame-options, permissions-policy and nosniff are
+    // all present on qa. This test simply was not looking at them.
     const ctx = await pwRequest.newContext();
-    const r = await ctx.get(`http://localhost:${process.env.E2E_PORT ?? 3100}/`);
+    const r = await ctx.get(baseURL ?? `http://localhost:${process.env.E2E_PORT ?? 3100}/`);
     const h = r.headers();
 
     expect(h['x-frame-options']).toBe('DENY');


### PR DESCRIPTION
**QA Team** · **two specs never addressed a deployed service, and the security headers on qa, staging and production have been verified by nothing.**

Found in the first full suite run against deployed `qa` — which is itself the
point: these could only surface once the whole suite ran remotely.

## `security.spec.ts` — loud failure, silent consequence

```ts
const r = await ctx.get(`http://localhost:${process.env.E2E_PORT ?? 3100}/`);
```

Hardcoded. With `E2E_BASE_URL` set there is no local server, so it died:

```
Error: apiRequestContext.get: connect ECONNREFUSED ::1:3100
```

**Every "verified on a deployed service" claim that included this file was wrong
about the headers.** It passed locally and only ever checked localhost.

**The headers themselves are fine.** Measured on `qa` while investigating:

```
content-security-policy: ... object-src 'none'; base-uri 'self'; frame-ancestors 'none'
strict-transport-security: max-age=63072000; includeSubDomains; preload
x-frame-options: DENY
x-content-type-options: nosniff
permissions-policy: camera=(), microphone=(), geolocation=(), payment=(), ...
referrer-policy: strict-origin-when-cross-origin
```

Nothing to fix in the app. The test was not looking.

## `perf.spec.ts` — the quieter one, and worse

```ts
if (!url.startsWith('http://localhost') && !url.startsWith('data:')) thirdParty.push(url);
```

On a remote run **every same-origin request counts as third-party**. It does not
error — it **inflates**. So a baseline comparison either fails for a reason that
has nothing to do with the app, or passes because the baseline was itself
recorded remotely and is equally inflated.

An assertion that is wrong in both directions depending on where it ran is worse
than one that crashes.

## The fix's own trap, recorded because it is instructive

My first version took the origin from `page.url()`. **That is `about:blank`** —
the request listener is registered *before* the navigation, so every request
would have looked foreign and the count would have been just as wrong in a new
way.

Caught before running it. It is a fair measure of how easy the original mistake
was to make.

## Swept for the rest

```
grep -rn "localhost" qa/e2e/*.ts
```

Only these two. `seo.spec.ts`'s `/ops/login` check uses `request.get('/robots.txt')`
— relative, so it already followed `baseURL` correctly; it showed as "did not run"
in the full suite because the run ended early, not because it was broken.

## How to test (QA)

```bash
E2E_BASE_URL=https://liquidity-hq-qa.onrender.com \
  npx playwright test qa/e2e/security.spec.ts qa/e2e/perf.spec.ts --project=desktop
```

**Both pass.** Before this commit the same command fails `ECONNREFUSED` on the
header test while passing locally — that split is the shape to watch for, and it
is what hid this.

Pushed through `.githooks/pre-push`.

## Risk level

**Low** — test-only.

**Named:** `perf`'s third-party baseline may have been recorded under the inflated
count. If that test starts failing on a remote run now, the baseline is the
suspect, not the app. I have not re-derived it in this PR because the number
should be measured on a build that is actually being released, not mid-review.
