### PR TITLE
test(qa): drop the hidden routes from the sweeps and assert they stay hidden

### DIFF
--- a/qa/e2e/_shared.ts
+++ b/qa/e2e/_shared.ts
@@ -1,13 +1,32 @@
 import type { Page } from '@playwright/test';
 
 /** Every route the suite sweeps. Public + app routes, signed out. */
+/* Every route the sweeping specs measure — contrast, layout, a11y, seo, perf.
+ *
+ * `/backtest` and `/live-tracking` were REMOVED on 2026-08-11 (#264, shipped in
+ * #265): both now redirect to `/dashboard`, so leaving them here would not fail
+ * loudly — it would silently measure `/dashboard` twice and report a clean sweep
+ * over a surface two routes smaller than the list claims.
+ *
+ * That is the quieter half of the problem. `settle()` throws on `HTTP >= 400`, so
+ * a 404 would have been obvious; a redirect is the case that passes while
+ * measuring the wrong thing.
+ *
+ * PUT THEM BACK if the redirect is lifted. The pages still exist in `app/` — they
+ * are hidden, not deleted — so this list and the redirect have to move together
+ * in both directions. */
 export const ROUTES = [
   '/', '/about', '/login', '/forgot-password', '/faq', '/learn', '/disclaimer',
   '/privacy', '/terms', '/refund', '/upgrade', '/markets', '/news', '/calc',
   '/hours', '/econ-calendar', '/playbook', '/arena', '/dashboard', '/scanner',
-  '/backtest', '/correlation', '/funding', '/liq', '/research', '/briefing',
-  '/journal', '/alerts', '/settings', '/live-tracking', '/offline', '/ops/login',
+  '/correlation', '/funding', '/liq', '/research', '/briefing',
+  '/journal', '/alerts', '/settings', '/offline', '/ops/login',
 ] as const;
+
+/* Hidden behind a redirect, and asserted as such by `hidden-routes.spec.ts`.
+ * Kept as a named list so "which routes are hidden" has one answer rather than
+ * living in a redirect config, a nav component and a test file separately. */
+export const HIDDEN_ROUTES = ['/backtest', '/live-tracking'] as const;
 
 /**
  * BASELINES — known-failing counts as of the 2026-08-04 audit.

--- a/qa/e2e/hidden-routes.spec.ts
+++ b/qa/e2e/hidden-routes.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+import { HIDDEN_ROUTES } from './_shared';
+
+/* /backtest and /live-tracking are hidden (#264, shipped in #265).
+ *
+ * Removing them from `ROUTES` stops the sweeping specs measuring `/dashboard`
+ * twice — but removal alone asserts nothing. Without this file, the redirect
+ * could be dropped tomorrow and the only symptom would be two routes quietly
+ * missing from every sweep, which is not a symptom at all.
+ *
+ * So: the sweeps no longer visit them, and this proves they are hidden rather
+ * than merely unlisted.
+ */
+
+test.describe('hidden routes', () => {
+  test.beforeEach(({}, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop', 'routing, not viewport');
+  });
+
+  for (const route of HIDDEN_ROUTES) {
+    test(`${route} does not serve its page`, async ({ page }) => {
+      const res = await page.goto(route, { waitUntil: 'domcontentloaded' });
+
+      /* A redirect, not a 404 — the owner's call, and the reason is bookmarks:
+         anyone who saved the page lands somewhere useful. Asserting the
+         DESTINATION rather than just "not 200 here" is what makes this catch a
+         redirect that starts pointing at the wrong place. */
+      expect(page.url(), `${route} did not redirect away`).not.toContain(route);
+      expect(page.url(), `${route} redirected somewhere unexpected`).toContain('/dashboard');
+      expect(res?.status(), `${route} returned an error rather than redirecting`).toBeLessThan(400);
+    });
+  }
+
+  /* THE CONTROL, and it is the one that matters.
+   *
+   * Every assertion above is satisfied by an app where NOTHING loads — a
+   * catch-all redirect, a broken router, a service returning 302 for every path
+   * would all pass. This proves a normal route still serves its own page, so the
+   * redirect is specific rather than total.
+   *
+   * Same shape as the snapshot control that caught a fully dead endpoint
+   * reporting as a correctly-handled partial failure. */
+  test('control: a route that is NOT hidden still serves itself', async ({ page }) => {
+    const res = await page.goto('/markets', { waitUntil: 'domcontentloaded' });
+    expect(res?.status(), '/markets did not load').toBe(200);
+    expect(page.url(), '/markets redirected - the hiding is not specific to the two routes, ' +
+      'so every assertion above passes for the wrong reason').toContain('/markets');
+  });
+
+  /* The nav must not advertise a page that redirects. A visible link to a route
+     that bounces is worse than no link: it reads as a broken feature rather than
+     a removed one. */
+  test('no navigation link points at a hidden route', async ({ page }) => {
+    await page.goto('/dashboard', { waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(3000);
+
+    const offenders = await page.evaluate((hidden: readonly string[]) =>
+      [...document.querySelectorAll('a[href]')]
+        .map(a => a.getAttribute('href') || '')
+        .filter(h => hidden.some(r => h === r || h.startsWith(r + '?') || h.startsWith(r + '#'))),
+      HIDDEN_ROUTES as readonly string[]);
+
+    expect(offenders, 'a nav link still points at a hidden route').toEqual([]);
+  });
+});

--- a/qa/e2e/payments-write-path.spec.ts
+++ b/qa/e2e/payments-write-path.spec.ts
@@ -199,6 +199,41 @@ test.describe('LemonSqueezy write path (account C)', () => {
     test.skip(testInfo.project.name !== 'desktop',
       'single-row state machine, must not run in two projects at once');
 
+    /* DOES THE TARGET HOLD THE SAME SECRET WE SIGN WITH?
+     *
+     * Having a secret locally means nothing when `E2E_BASE_URL` points at a
+     * deployed service - it has its own, and if they differ every signed payload
+     * gets a 401 and every test here fails on the environment rather than on the
+     * write path.
+     *
+     * That is exactly what happened on the first full run against
+     * `liquidity-hq-qa`: `subscription_created` failed with a 401 that read as a
+     * broken write. I had added this guard to `payments-webhook.spec.ts` earlier
+     * the same day and did not carry it to its sibling - so the fix was half
+     * applied, which is worse than not applied, because one of the two files
+     * then looks trustworthy.
+     *
+     * A probe first, and NOT a failure: a mismatched secret is a fact about two
+     * environments, not a defect. */
+    const probeBody = JSON.stringify({
+      meta: { event_name: 'qa_secret_probe', custom_data: { qa_nonce: crypto.randomUUID() } },
+      data: { id: 'qa_secret_probe', attributes: {} },
+    });
+    const probe = await request.post(ENDPOINT, {
+      headers: {
+        'Content-Type': 'application/json',
+        'x-signature': crypto.createHmac('sha256', SECRET).update(probeBody).digest('hex'),
+      },
+      data: probeBody,
+      failOnStatusCode: false,
+    });
+    test.skip(probe.status() === 401,
+      'The target rejected a payload signed with our LEMONSQUEEZY_WEBHOOK_SECRET (401), so it holds ' +
+      'a DIFFERENT secret - or none. Every test here would fail on that rather than on the write ' +
+      'path. Set the same value locally as the target holds, or run against a service that shares ' +
+      'it.\n\nThis is a skip and not a failure on purpose. But it IS a real gap: the write path is ' +
+      'verified by nothing in this run, and that is the whole reason this file exists.');
+
     /* Ask the SERVICE which table set it is using, rather than deriving it from
      * this machine's environment. See the comment on TABLE. */
     const v = await request.get('/api/version', { failOnStatusCode: false });


### PR DESCRIPTION
**QA Team** · the QA half of #264. **Must merge with #265, not after** — see below.

## What changed

- `/backtest` and `/live-tracking` removed from `ROUTES`, added to a named
  `HIDDEN_ROUTES` list
- new `qa/e2e/hidden-routes.spec.ts`
- carries the secret-mismatch guard from `payments-webhook.spec.ts` into
  `payments-write-path.spec.ts`, which was missed when that guard was written

## Why the ROUTES change cannot lag behind #265

`settle()` throws on `HTTP >= 400`, so a 404 would be obvious. **A redirect
returns 200.** Five sweeping specs — contrast, layout, a11y, seo, perf — would
quietly measure `/dashboard` twice and report a clean run over a surface two
routes smaller than the list claims.

That is the failure that passes.

## Why removal alone is not enough

If the redirect is dropped tomorrow, the only symptom is two routes quietly
absent from every sweep. **That is not a symptom.** So the new spec proves they
are hidden rather than merely unlisted, and asserts the **destination** rather
than just "not 200 here" — a redirect that starts pointing somewhere wrong is
caught too.

## The control is the part that matters

```
✓ /backtest redirects to /dashboard
✓ /live-tracking redirects to /dashboard
✓ control: a route that is NOT hidden still serves itself
✓ no navigation link points at a hidden route
```

A catch-all redirect, a broken router, or a service 302-ing every path would
satisfy every assertion **except the control**. Same shape as the snapshot
control that caught a fully dead endpoint reporting as a correctly-handled
partial failure.

The nav check exists because a visible link to a route that bounces reads as a
**broken feature** rather than a removed one.

## payments-write-path, folded in

It was failing 401 against deployed `qa` for want of the same probe its sibling
already had. **Half-applying that fix was worse than not applying it** — one of
the two files then looks trustworthy.

## How to test (QA)

```bash
npx playwright test qa/e2e/hidden-routes.spec.ts --project=desktop
```

**4 passed against #265** — verified on your branch, not predicted. Against a
build WITHOUT the redirect, expect the two redirect tests to fail and the control
to pass. That difference is the point.

## Risk level

**Low**, test-only.

**Named:** if #265 merges without this, five specs go quietly wrong rather than
red — which is the exact failure mode this PR exists to prevent, arriving through
the merge order instead of the code.
