### PR TITLE
test(a11y): pin market data in the tap-target sweep so the count is reproducible

### DIFF
--- a/qa/e2e/a11y.spec.ts
+++ b/qa/e2e/a11y.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { ROUTES, BASELINE, settle, runAxe, INTERACTIVE_SELECTOR } from './_shared';
+import { installMarketFixtures } from './_fixtures';
 
 // Accessibility. Mixed strategy on purpose:
 //   - things that currently pass (alt text, duplicate ids, lang) -> hard assert
@@ -49,6 +50,34 @@ test.describe('accessibility', () => {
   // (.pf-footer-bottom-link at 15px tall, .pf-footer-expand at 18px).
   test('tap targets below 24px do not increase', async ({ page }, testInfo) => {
     test.skip(testInfo.project.name !== 'mobile', 'touch target sizing is a mobile concern');
+
+    /* FIXED MARKET DATA, and this is the whole point of #263.
+     *
+     * This sweep counts CONTROLS, and how many controls render depends on how
+     * much data arrives. Without fixtures the number moves with the live market,
+     * so the baseline was a snapshot of one afternoon and any comparison against
+     * it measures the market as much as the code.
+     *
+     * Measured on 2026-08-11 against two builds, minutes apart:
+     *
+     *     24e8c3b  (pre-release)   148
+     *     ff9704d  (the release)   149
+     *     BASELINE                 122
+     *
+     * The pre-release build failed identically, so the 26-count gap was drift
+     * that nothing caught - and the 1-count difference between the builds is
+     * inside the noise this fixes. A ratcheting baseline over an uncontrolled
+     * input cannot distinguish "someone added a small control" from "more rows
+     * rendered today", which is the only question it exists to answer.
+     *
+     * `contrast.spec.ts` and `layout.spec.ts` already do this for the same
+     * reason. This one was missed.
+     *
+     * The baseline is NOT raised here. A controlled number has to be measured
+     * first, and raising it in the same change would convert "we cannot measure
+     * this reliably" into "this is the new normal" - the thing qa/STATUS.md
+     * warns about for perf.spec. */
+    await installMarketFixtures(page, 'as-recorded');
 
     const found: string[] = [];
     for (const route of ROUTES) {


### PR DESCRIPTION
**QA Team** · closes #263. **The baseline is deliberately NOT changed.**

## The measurement that settled it

```
BASELINE.tapTargetsUnder24                 122
24e8c3b  the build staging was already on  148
ff9704d  the release                       149
```

Two builds, minutes apart, same market. **The pre-release build failed
identically**, so this was never a regression from the eleven merges — the
baseline drifted earlier and CI being off meant nothing caught it.

## The cause

`a11y.spec.ts` did not call `installMarketFixtures`. It sweeps 32 routes counting
**controls**, and how many controls render depends on how much data arrives — so
the number moved with the live market and the baseline was a snapshot of one
afternoon.

`contrast.spec.ts` and `layout.spec.ts` already pin their data for exactly this
reason. This one was missed.

## The result

With fixtures installed the test **passes**, twice consecutively. So the 26-count
gap was live-data variance, not accumulated WCAG violations.

**That is why the baseline stays at 122.** Raising it to 149 would have retired a
WCAG 2.2 AA check by accident — the thing `qa/STATUS.md` warns about for
`perf.spec`:

> Do not raise the number to make it green; decide first whether it asserts a
> user-facing target or catches regressions.

## How to test (QA)

```bash
npx playwright test qa/e2e/a11y.spec.ts --project=mobile -g "tap targets"
```

Expect a pass — and expect the **same result on a re-run**. Reproducibility is the
point, not the number. Two consecutive controlled runs both passed.

## Risk level

**Low**, test-only.

**Named:** the sibling `axe target-size` check is a hard assert at 0 and is
unaffected — only the ratcheting count needed pinning. If the ratchet now sits far
below 122, that is worth re-deriving on a released build rather than mid-review,
because a baseline set from a controlled run is the first one worth trusting.
