### PR TITLE
docs: correct payment status and record the hidden routes

### DIFF
--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -53,7 +53,19 @@ Core surfaces: AI Arena (EMA ribbon signal engine + confluence scoring), backtes
 scanners, 11 Grok-powered research tools, Telegram + Web Push alerts, news/sentiment,
 calculators, trade journal, and an internal-only `/ops` admin console.
 
-**Business state:** pre-revenue. Two test accounts, no real users, payments not switched on.
+> **`/backtest` and `/live-tracking` are HIDDEN as of 2026-08-11** (#264, shipped in
+> #265). `proxy.ts` redirects both to `/dashboard`, and their nav entries are gone.
+> The pages are hidden, **not deleted** — everything under `app/backtest/` and
+> `app/live-tracking/` still exists and still builds, so the backtest engine above is
+> live code, not dead code, and `lib/backtestEngine.ts` is still what the Arena chart
+> and the signal tracker share their fill rules with. Reversing this is deleting two
+> strings from `BLOCKED` in `proxy.ts` — but the route list in `qa/e2e/_shared.ts` and
+> `HIDDEN_ROUTES` have to move with it in both directions, or the sweeping specs
+> silently measure `/dashboard` twice instead of failing.
+
+**Business state:** pre-revenue. Two test accounts, no real users, payments not switched
+on in production — a **test-mode** checkout is live on staging as of 2026-08-11 (see
+"Turning on payments" below).
 
 ---
 
@@ -436,6 +448,12 @@ Deliberately deferred while there are zero real users — nothing of value would
 today. But do it **before** flipping payments on, not after the first paying signup.
 
 ### Turning on payments — 4 steps, in this order
+
+**Status 2026-08-11: steps 1, 3 and 4 are done on STAGING in test mode; step 2 is not.
+All four are still outstanding for PRODUCTION** — test and live webhooks are separate
+objects, secrets never cross environments, and `NEXT_PUBLIC_*` is inlined per build, so
+nothing configured on staging carries over. Detail and the staging verification method
+in `pendings/LEMONSQUEEZY.md`.
 
 The code is finished and verified (webhook signature check, `custom_data.user_id` bound to
 the payer's real email, replay protection via `lhq_ls_webhook_events`, test-mode rejection

--- a/pendings/LEMONSQUEEZY.md
+++ b/pendings/LEMONSQUEEZY.md
@@ -1,12 +1,50 @@
 # LemonSqueezy — Payment Feature
 
-**Status 2026-08-01: the code is finished. What is left is dashboard and
-environment configuration, all of which needs the owner.**
+**Status 2026-08-11: a test-mode dry run is in progress on STAGING. Production
+is untouched — every step in the list below is still outstanding for prod.**
 
-Payments are not live: `NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL` is unset, so
-`/upgrade` renders "Pro payments launching soon" instead of a checkout button
-(`CHECKOUT_CONFIGURED` in `app/upgrade/page.tsx`), and `UpgradeGateModal` falls
-back the same way. Nothing is broken — there is simply no way to pay yet.
+Read that distinction carefully, because this file used to state "payments are
+not live" as a flat fact and that is now true of only one environment.
+
+### Staging — `liquidity-hq-staging`, test mode
+
+| | |
+|---|---|
+| Product/variant at $25/mo | created |
+| Checkout URL | `checkout.liquidity-hq.com/checkout/buy/0e357d1e-…`, on our own subdomain |
+| `NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL` | **set**, and confirmed inlined into the deployed build |
+| Test-mode webhook | created, all 7 events, pointed at the staging route |
+| `LEMONSQUEEZY_WEBHOOK_SECRET` | **not set yet** — staging returns 401 to every delivery, which is fail-closed working as designed |
+
+Verified on 2026-08-11 against the deployed service, not from the dashboard:
+`/upgrade` renders the real **"Get Pro - $25/mo →"** button and the "launching
+soon" copy is gone.
+
+**How to check this, because the obvious check is wrong.** The CTA is a
+`<button onClick={handleCheckout}>` that sets `window.location.href` at click
+time (`app/upgrade/page.tsx`), so the checkout URL is **never in the DOM**.
+Scanning for an `<a href>` containing the store domain reports a false failure
+every time. Assert on the button text and the absence of the fallback copy, or
+grep the served JS chunks for the URL — it is inlined into exactly one.
+
+### Production — nothing done
+
+`NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL` is unset on prod, so `/upgrade` there
+still renders "Pro payments launching soon" (`CHECKOUT_CONFIGURED` in
+`app/upgrade/page.tsx`), and `UpgradeGateModal` falls back the same way. Nothing
+is broken — there is simply no way to pay yet.
+
+**Prod needs its own everything**: its own live-mode webhook (test and live
+webhooks are separate objects in LemonSqueezy), its own secret, and its own
+build with the URL inlined. Nothing configured on staging carries over, and a
+prod secret must never be copied to a non-prod service.
+
+> ⚠️ **Before the first real purchase, someone has to decide what Pro actually
+> includes.** `/backtest` and `/live-tracking` were hidden on 2026-08-11 (#264),
+> but the Pro sales copy still advertises "Full strategy backtesting" on the
+> `/upgrade` pricing card, in the upsell modal, and on the public `/faq`. As of
+> today a buyer would be paying for a feature that redirects to the Dashboard.
+> Owner decision — raised on #265, not resolved.
 
 ## ❓ YOUR action — the only thing standing between here and revenue
 


### PR DESCRIPTION
**Dev Team**

## Summary

Two docs stated as flat fact things that are now true of production only.

## What changed

| File | Correction |
|---|---|
| `pendings/LEMONSQUEEZY.md` | "Payments are not live" split into a staging block (test-mode checkout **is** live, secret still missing) and a production block (nothing done) |
| `docs/HANDOVER.md` | same split on the "Turning on payments" steps; plus a note that `/backtest` and `/live-tracking` are hidden, not deleted |

## Why

`HANDOVER.md` is the first file a resuming session reads, so a stale claim there gets inherited rather than caught. "Payments are not live" now reads as obviously false to anyone who opens `/upgrade` on staging — which invites the *opposite* error, assuming prod is configured too. It is not, and nothing carries over: test and live webhooks are separate objects, secrets never cross environments, and `NEXT_PUBLIC_*` is inlined per build.

Also records two things that cost time today:

- **Checking the checkout button with an `<a href>` scan reports a false failure.** The CTA is a `<button onClick>` that sets `window.location.href` at click time, so the URL is never in the DOM.
- **The hidden routes must leave `qa/e2e/_shared.ts` in step with the redirect**, or the sweeps measure `/dashboard` twice and still report a clean run.

Carries the open question forward rather than burying it: the Pro copy still sells backtesting, and checkout is about to open.

## How to test (QA)

Docs only, no code, nothing deployed changes. Read the "Turning on payments" section of `docs/HANDOVER.md` and the status block at the top of `pendings/LEMONSQUEEZY.md` — both should distinguish staging from production, and neither should say payments are simply off.

## Risk level

**Low** — documentation only.