### PR TITLE
test(a11y): pin consent state and guard against unmeasured routes

### DIFF
--- a/qa/e2e/a11y.spec.ts
+++ b/qa/e2e/a11y.spec.ts
@@ -79,9 +79,51 @@ test.describe('accessibility', () => {
      * warns about for perf.spec. */
     await installMarketFixtures(page, 'as-recorded');
 
+    /* CONSENT IS A THIRD UNCONTROLLED INPUT, and dev measured it before this
+     * merged: a run that starts with consent already stored scores ~32 LOWER
+     * than one that does not, with zero code change. `a.consent-link` is 73x14
+     * and appears on EVERY route while the banner is up.
+     *
+     * So without pinning this, the new baseline would silently encode "the
+     * cookie banner was showing", and the first run that started with consent
+     * stored would read as a 32-element improvement.
+     *
+     * Pinned to `denied` to match `layout.spec.ts`'s ordinary sweep. The
+     * first-visit state is not ignored - it has its own dedicated test over
+     * there, which is where banner-covers-control belongs. Measuring it here as
+     * well would count one known, accepted component (#174) 32 times and drown
+     * everything else. */
+    await page.addInitScript(() => {
+      try { localStorage.setItem('lhq_analytics_consent_v1', 'denied'); } catch { /* private mode */ }
+    });
+
     const found: string[] = [];
+    const unmeasured: string[] = [];
     for (const route of ROUTES) {
       await settle(page, route);
+
+      /* A ROUTE THAT RENDERS NOTHING SCORES ZERO, and zero flatters the total.
+       * Dev hit exactly this while measuring. It is the same absence-reporting-
+       * as-normal defect this suite keeps finding, arriving inside the metric
+       * rather than the app - and it is invisible in a green run, because fewer
+       * violations always looks like good news. */
+      /* 50, CALIBRATED - not the 200 I first wrote.
+       *
+       * 200 came from the #238 exchange-call probe, where every route measured
+       * was a data-heavy dashboard. Applied here it flagged `/login` (104) and
+       * `/forgot-password` (88), which are simply small pages: a login form
+       * really does render about a hundred nodes once the shell is counted.
+       *
+       * A guard that fires on healthy pages gets deleted by the next person, so
+       * the number has to sit below the smallest LEGITIMATE page and above a
+       * blank one. Measured smallest real page: 88. A route that fails to render
+       * produces a near-empty body - single digits to low tens.
+       *
+       * 50 sits between the two with room either side. If a real page ever drops
+       * below it, that is worth knowing anyway. */
+      const rendered = await page.evaluate(() => document.querySelectorAll('*').length);
+      if (rendered < 50) { unmeasured.push(`${route} (${rendered} elements)`); continue; }
+
       const bad = await page.$$eval(INTERACTIVE_SELECTOR, els =>
         els.flatMap(el => {
           const r = el.getBoundingClientRect();
@@ -98,6 +140,16 @@ test.describe('accessibility', () => {
     }
 
     testInfo.attach('tap-targets-under-24px.txt', { body: found.join('\n'), contentType: 'text/plain' });
+
+    /* Named, and asserted BEFORE the count. A route that did not render
+     * contributes 0 violations, so an unmeasured sweep always looks better than
+     * a measured one - reporting the number first would hand over a flattering
+     * total with the caveat underneath it. */
+    expect(unmeasured,
+      'these routes rendered almost nothing, so their zero violations are about the probe ' +
+      'rather than the app. The count below is not comparable to the baseline until this is empty.')
+      .toEqual([]);
+
     expect(
       found.length,
       `Tap targets under 24px went ${found.length > BASELINE.tapTargetsUnder24 ? 'UP' : 'DOWN'} ` +


### PR DESCRIPTION
**QA Team** · follow-up to #268 — **your two points, which merged before I had them written.** Both are real and #268 alone was incomplete without them.

## Consent, the one that would have poisoned the baseline

> a run that starts with consent already recorded scores 32 lower with zero code
> change … otherwise the new baseline silently encodes "the cookie banner was
> showing"

Exactly right, and it is the more dangerous of the two because it produces a
*plausible* number. Pinned to `denied`, matching `layout.spec.ts`'s ordinary
sweep.

**First-visit is not being ignored** — `layout.spec.ts` already has a dedicated
first-visit test, which is where banner-covers-control belongs. Measuring it here
too would count one known, accepted component (#174) 32 times and drown
everything else in the metric.

## The render guard, and it caught me first

Asserted **before** the count, deliberately: a route that renders nothing scores
zero violations, and fewer violations always *looks* like good news. Reporting the
total first and the caveat second would hand over a flattering number with a
footnote.

**Your instinct that this would bite was right, and it bit me immediately.** My
first threshold was 200 elements, carried over from the #238 exchange-call probe
where every route measured was a data-heavy dashboard. Applied here it flagged:

```
/login (104 elements)
/forgot-password (88 elements)
```

Both healthy — a login form genuinely renders about a hundred nodes once the shell
is counted. **A guard that fires on good pages gets deleted by the next person**,
so the number is now 50: below the smallest measured real page (88), well above a
blank one (single digits to low tens).

Calibrated against measurements rather than picked, which is the only reason I am
comfortable with it.

## Your steps 3 and 4

> 3. Decide the environment the baseline belongs to and write it next to the number
> 4. Only then re-measure

Agreed, and **not doing either in this PR.** With consent and market data pinned
and unmeasured routes excluded, the sweep is now reproducible against itself —
which is the precondition for both. Setting a number in the same change that makes
it measurable would mean the first baseline is recorded from a run nobody has
looked at twice.

I would rather do it deliberately on a released build, with the environment
written beside it. That is #263's remaining work and it stays open for it.

## What I checked before agreeing

Your dating of `0b18831` (consent gate, 2026-08-03) against `26b2c04` (baseline,
2026-08-05) — the consent banner predates the baseline, so it was already being
counted and does **not** explain 122 to 148. That is a negative result worth as
much as the positive one; without it someone re-derives the same theory next month.

I still have no explanation for that gap either, and I am not going to invent one.

## How to test (QA)

```bash
npx playwright test qa/e2e/a11y.spec.ts --project=mobile -g "tap targets"
```

**Passes.** To see the guard work, point `ROUTES` at something that 404s — it
should be **named**, not silently counted as clean.

## Risk level

**Low**, test-only. **Named:** pinning consent to `denied` means this metric no
longer sees the first-visit surface at all. That is deliberate and covered
elsewhere, but it is a real reduction in what this one number watches, and worth
knowing before anyone treats it as total coverage.
