### PR TITLE
docs(qa): record the three lessons from the first full remote suite run

### DIFF
--- a/qa/STATUS.md
+++ b/qa/STATUS.md
@@ -53,6 +53,7 @@ morning and done by lunchtime. They live on the issue that needs them.
 | **The suite can address a deployed service.** `E2E_BASE_URL=https://…` sets `baseURL` and drops the `webServer`. Before this, every "verified on qa" claim was measured against a *local build of the same commit* | 2026-08-10 | #203; comment in `playwright.config.ts` |
 | **A cache assertion must measure the DATA, not a header and not a clock.** Both market routes stamp `ts: Date.now()`, so whole-body diffs vary however well the data is cached | 2026-08-10 | `qa/e2e/cache-effective.spec.ts` header |
 | **A spec that reads the database asks the TARGET which table set it is using.** `lib/tables.ts` switches on `NEXT_PUBLIC_APP_ENV`, which is per Render service — so the right table is a property of the running service, not of the local machine. `/api/version` reports `appEnv` for exactly this | 2026-08-11 | `qa/e2e/payments-write-path.spec.ts`; PR #240 |
+| **`/backtest` and `/live-tracking` are hidden behind a redirect to `/dashboard`.** Owner's call — the routes are blocked, not merely dropped from the nav. They are OUT of `ROUTES` and in `HIDDEN_ROUTES`; leaving them in the sweep list would silently measure `/dashboard` twice, because `settle()` throws on 4xx but a redirect returns 200 | 2026-08-11 | #264, shipped in #265 + #267 |
 | **Account C is the sacrificial entitlement fixture.** A and B stay pinned (`pro` / `free`) and `entitlements.spec.ts` fails if either drifts, so anything that flips a role uses C | 2026-08-11 | #239, closed |
 | **`next@16.3.0` is SCHEDULED, not deferred.** Owner decision. Trigger: **#243 passes AND the current release reaches `main`.** Its own release, nothing else in it, **CI temporarily re-enabled** for the duration — a keyless build is the gate that catches upgrade breakage and is the one thing local gates cannot replace. Until then two **build-time** highs are knowingly accepted (`next`'s bundled `postcss`, `sharp`); neither is reachable by a visitor | 2026-08-11 | #257, open by design |
 
@@ -173,6 +174,57 @@ gh issue list --state open
   that the page rendered — and must *name* the routes it could not measure
   rather than counting them as zero. The corrected run matched the previous
   figure exactly, which is how the bug was confirmed rather than argued about.
+- **A render guard proves the measurement HAPPENED. It says nothing about whether
+  the measurement MEANS anything.** Added 2026-08-11 after I told the owner not to
+  start a payment run on evidence that could not exist.
+
+  I checked `/upgrade` for `a[href*="checkout"]`, found zero, and reported the
+  checkout URL had not reached the build. My probe had a render guard and it
+  passed — 118 controls, styled, not signed out — so I trusted the zero.
+
+  **The CTA is a `<button onClick>` that builds the URL at click time**
+  (`app/upgrade/page.tsx:159`). The URL is never in the DOM, so that selector
+  returns **0 on a working build and a broken one alike.** Dev measured the same
+  zero and read it correctly; the number was never the disagreement.
+
+  This is a DIFFERENT defect from the one below and the distinction is the whole
+  point: the instrument reached the page, and was then asked a question it had no
+  way to answer. Before trusting any zero, ask **what a positive result would have
+  looked like** — if you cannot describe it, the assertion is not measuring what
+  you think.
+
+  The check that worked was grepping the served JS chunks for the URL, because a
+  string cannot appear in a bundle it was not inlined into. Method-independent
+  beats DOM-shaped when the two disagree.
+- **Specs that hardcode `localhost` test nothing on a deployed service**, and one
+  of the two failure modes is silent. Found 2026-08-11 in the first full suite run
+  against deployed `qa`:
+
+  - `security.spec.ts` requested `http://localhost:3100` explicitly, so with
+    `E2E_BASE_URL` set it died `ECONNREFUSED`. **The security headers on qa,
+    staging and production had therefore been asserted by nothing.** They are
+    correct — but "correct when curled by hand" and "checked by the suite" are
+    different claims and only the first was ever true.
+  - `perf.spec.ts` treated `!url.startsWith('http://localhost')` as "third party",
+    so on a remote run **every same-origin request counted as foreign.** That one
+    does not error, it inflates — and a baseline recorded remotely would be
+    inflated to match.
+
+  Both fixed in #266. The lesson generalises: after #203 made the suite
+  addressable at a deployed service, anything holding a URL constant became a
+  spec that silently only ever tested one environment.
+- **A metric that counts rendered elements has more uncontrolled inputs than
+  market data.** `a11y.spec.ts`'s tap-target sweep moved 122 → 148 with no code
+  change. Dev measured why: browser **consent state** shifts it by ~32, because
+  `a.consent-link` is 73x14 and renders on every route while the banner is up.
+  Market fixtures alone were not enough (#268); consent had to be pinned too
+  (#270).
+
+  Pinned to `denied`, matching `layout.spec.ts`'s ordinary sweep — first-visit
+  banner coverage lives there and belongs there. **The baseline was deliberately
+  NOT re-set in the same change**: picking a number in the commit that first makes
+  it measurable means the baseline comes from a run nobody has looked at twice.
+  #263 holds that.
 - **An empty result is not evidence unless something proves the instrument works.**
   This bit **seven** separate times on 2026-08-10 and is by a distance the most
   repeated defect in this suite: `cache-policy` asserted headers that cached


### PR DESCRIPTION
**QA Team** · three standing risks and one decision, from the first full suite run against a deployed service.

## The one that is genuinely new

**A render guard proves the measurement HAPPENED. It says nothing about whether
the measurement MEANS anything.**

I told the owner not to start their payment run because `/upgrade` had no
`a[href*="checkout"]` — **with a passing render guard underneath**, so I trusted
the zero. The CTA is a `<button onClick>` that builds the URL at click time, so
that selector returns **0 for a working build and a broken one alike.**

This is distinct from *"an empty result is not evidence"*, which is about the
instrument reaching the thing. This one is about asking it a question it cannot
answer. Both guards can pass and the conclusion still be worthless.

**The test to apply: describe what a positive result would look like.** If you
cannot, the assertion is not measuring what you think it is.

Your framing is what made it click, so it is quoted in the file:

> the guard proved the page was real and the assertion underneath it could not
> answer the question being asked

## Two that generalise past the specs they were found in

**Specs holding a URL constant only ever tested one environment.** After #203 made
the suite addressable at a deployed service, `security.spec.ts` and
`perf.spec.ts` kept pointing at localhost. One died `ECONNREFUSED`; the other
**inflated silently**, counting every same-origin request as third-party. The
security headers on qa, staging and production were consequently asserted by
nothing until #266.

**A metric counting rendered elements has more uncontrolled inputs than market
data.** Your measurement — consent state alone moves the tap-target count by ~32 —
is recorded with the reason, so nobody re-derives it. As is the fact that market
fixtures alone were insufficient.

## And the hidden routes, in the decisions table

Including *why* removing them from `ROUTES` was not optional: `settle()` throws on
4xx but **a redirect returns 200**, so leaving them listed would have measured
`/dashboard` twice and reported clean.

## How to test (QA)

Docs only. Read the standing risks and confirm the render-guard entry is
**distinguishable** from the empty-result one below it. If they read as the same
lesson, the wording has failed and that is the thing to fix — they are different
failures with different remedies.

## Risk level

**Low.** No code.

**Named:** `qa/STATUS.md` has gone stale twice before by recording *state*. These
three are failure modes, not state — the category that survived a full release day
unchanged. But the file is now long enough that its own "if you only read one
thing" claim is under strain, and that is worth watching.
