### PR TITLE
fix(arena): a new analysis always brings the AI Read card back

### DIFF
--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -189,9 +189,16 @@ function ArenaContent() {
   const [readError, setReadError]     = useState('');
   const [readMode,  setReadMode]      = useState<'quick' | 'deep'>('deep');
   const [resultsCache, setResultsCache] = useState<Partial<Record<CoinId, CacheEntry>>>({});
-  // Per-coin dismiss for the AI Read card - a UI-only "hide for now", not a
-  // data delete. Cleared automatically the next time this coin gets a fresh
-  // read, so dismissing never blocks the user from seeing the next real result.
+  // Per-coin "the AI Read card is hidden" - a UI-only hide, not a data delete.
+  // Set either by the user dismissing the card OR by starting a read (the old
+  // card closes for the duration), and cleared when that read finishes,
+  // whatever the outcome.
+  //
+  // This comment used to say "cleared the next time this coin gets a fresh
+  // read", which described the intent correctly and the code incorrectly: the
+  // clear ran when the read STARTED, so a dismiss during the load survived into
+  // the result and suppressed it. The user spent a Grok call and saw nothing
+  // (#278). Clearing on finish is what makes the sentence true.
   const [dismissedResults, setDismissedResults] = useState<Set<CoinId>>(new Set());
   const [history, setHistory]         = useState<HistItem[]>([]);
   const [detailIdx, setDetailIdx]     = useState<number | null>(null);
@@ -973,6 +980,31 @@ function ArenaContent() {
       return;
     }
 
+    /* UN-HIDE FIRST, BEFORE THE CACHE CHECK (#278).
+     *
+     * Dismiss means "hide this one now", not "stop showing me results", so ANY
+     * new analysis brings the card back - including one served from cache.
+     *
+     * The position is the entire fix. This clear used to live below the cache
+     * check and below the early return, which broke it twice over:
+     *
+     *   - a CACHE HIT returned before ever reaching it, so asking for a fresh
+     *     read on a dismissed coin appeared to do nothing at all;
+     *   - a dismiss landing AFTER this point was never undone, so a result the
+     *     user was waiting for arrived and rendered nothing. They spent a Grok
+     *     call and saw no output.
+     *
+     * The early return above it is correct and stays - serving a fresh cached
+     * result without a Grok call is the right behaviour. The bug was reading
+     * "serve cache silently" as "change nothing", when exactly one thing had to
+     * change. */
+    setDismissedResults(prev => {
+      if (!prev.has(selectedCoin)) return prev;
+      const next = new Set(prev);
+      next.delete(selectedCoin);
+      return next;
+    });
+
     // ── Cache check - skip API call if result is fresh and price hasn't moved >0.5% ──
     // Quick accepts any cached result (Quick or Deep).
     // Deep only accepts a cached Deep result - clicking Deep always re-fetches if last was Quick.
@@ -992,12 +1024,6 @@ function ArenaContent() {
 
     setReadMode(mode);
     setReadLoading(true); setReadError('');
-    setDismissedResults(prev => {
-      if (!prev.has(selectedCoin)) return prev;
-      const next = new Set(prev);
-      next.delete(selectedCoin);
-      return next;
-    });
 
     try {
       // Step 1 - fetch candles (Binance preferred; fall back to Bybit for HYPE etc.)
@@ -1128,6 +1154,25 @@ function ArenaContent() {
       if (usageFromErr) setGrokUsage(usageFromErr);
     } finally {
       setReadLoading(false); setReadStep('');
+
+      /* REVEAL, on every exit path (#278).
+       *
+       * `finally`, not the success branch, and that is deliberate. On success
+       * there is a new result to show. On FAILURE there is not - and leaving the
+       * coin dismissed would hide the previous card too, so a failed read would
+       * silently cost the user the result they already had, on top of the one
+       * that did not arrive. Restoring it puts them back where they started with
+       * an error banner explaining why, which is the honest outcome.
+       *
+       * `selectedCoin` is the closure value from when the read began, so a user
+       * who switches coins mid-read un-dismisses the coin they actually ran -
+       * not whichever one they are looking at now. */
+      setDismissedResults(prev => {
+        if (!prev.has(selectedCoin)) return prev;
+        const next = new Set(prev);
+        next.delete(selectedCoin);
+        return next;
+      });
     }
   }, [selectedCoin, readTf, store, latestHeadlines, econEvents, fundingData, resultsCache]);
 
@@ -1702,7 +1747,17 @@ function ArenaContent() {
 
       {readError && <div className="arena-err">{readError}</div>}
 
-      {result && !dismissedResults.has(selectedCoin) && nowMs - result.analyzedAt < CACHE_MAX_AGE_MS && (() => {
+      {/* `!readLoading`: the card closes the moment Quick or Deep is clicked and
+          the loading indicator above takes its place (#278). Leaving the old
+          verdict on screen while its replacement computes shows a call that is
+          about to change, under an "Updated just now" label that is already
+          wrong - and it is why a user reaches for the dismiss button mid-read in
+          the first place.
+          This is deliberately the LOADING flag and not `dismissedResults`.
+          Hiding via the dismiss set would conflate "the user hid this" with "a
+          read is running", and the two have opposite endings: one persists, the
+          other must not. */}
+      {result && !readLoading && !dismissedResults.has(selectedCoin) && nowMs - result.analyzedAt < CACHE_MAX_AGE_MS && (() => {
         const sigCol = result.signal === 'LONG' ? 'var(--green-2)' : result.signal === 'LEAN LONG' ? 'var(--green-soft)' : result.signal === 'SHORT' ? 'var(--red)' : result.signal === 'LEAN SHORT' ? 'var(--red-soft)' : 'var(--txt3)';
         const verdictWord = result.signal === 'LONG' ? t('ARENA_VERDICT_LONG') : result.signal === 'LEAN LONG' ? t('ARENA_VERDICT_LEAN_LONG') : result.signal === 'SHORT' ? t('ARENA_VERDICT_SHORT') : result.signal === 'LEAN SHORT' ? t('ARENA_VERDICT_LEAN_SHORT') : t('ARENA_VERDICT_WAIT');
         const sigGrad = result.signal.includes('LONG') ? 'linear-gradient(160deg,#5ff0b0,#34d399)'


### PR DESCRIPTION
**Dev Team**

Closes #278. Built to your state table, not to my first reading of it — **I had it wrong and rewrote it.**

## Against your five assertions

| # | Assertion | How it holds |
|---|---|---|
| 1 | dismiss → Research within cache window → **card returns, no Grok call** | clear moved to the **top of `readMarket`, above the cache check**; the early return is untouched |
| 2 | dismiss during an in-flight analysis → card appears on completion | clear repeated in `finally` |
| 3 | dismiss → switch coin → back → **stays hidden** | flag is per-coin and nothing in navigation touches it |
| 4 | during loading → indicator only, no stale card | card gate now also requires `!readLoading` |
| 5 | **control:** dismiss with nothing in flight → **stays hidden** | dismiss still sets the flag; only `readMarket` clears it |

**On 5 — that control is the reason I changed approach.** My first version closed
the card by *adding* the coin to `dismissedResults` on click and clearing it on
finish. It would have passed 1, 2 and 4, and it was the wrong model: it makes
"the user hid this" and "a read is running" the same state, when the two have
opposite endings. Hiding during a read is now the **loading** flag; the dismiss
set means only what its name says.

`:987` early return kept, exactly as you said. Serving a fresh cached result
without a Grok call is correct — the defect was reading *"serve cache silently"*
as *"change nothing"*, when one thing had to change.

## ⚠️ I could not verify this locally, and the way it failed is worth reporting

I seeded a cached result into `localStorage` to put a card on screen without a
Grok call, then drove your sequence. The harness reported:

```
1. card on screen after seeding : 1
2. card closed on click         : YES
4. card restored after read     : NO - SWALLOWED
```

**All of which was meaningless.** `app/arena/page.tsx:1540` does
`if (!user) { window.location.href = '/login'; return; }` — signed out, the click
navigates away. The card "closed" because the page left, and it was "swallowed"
because there was no page. Both readings were artifacts; the read never ran.

An earlier run of the same harness was also junk for a different reason — I
seeded `analyzedAt: 1`, which `CACHE_MAX_AGE_MS` discards, so the card never
rendered and the two checks after it were measuring an empty page.

So: **this needs an authenticated session and I do not have one.** You have A and
B pinned. Four gates are green (lint 0 errors / 140 warnings unchanged, `tsc`
clean, 296/296, production build), and the logic matches your table, but
**nothing about the runtime behaviour is verified by me** — assertions 1–5 are
all yours to make.

I would rather say that than let "gates green" stand in for "it works".

## Sequencing with #277

Agreed, and it is the smaller of the two: **merge #277 first, then this.** #277
rewrites the verdict vocabulary and deletes the levels grid; this touches `:977`,
`:995` and the card's render gate. Different regions, but the gate line itself is
one #277 also edits (`result.signal === 'LONG'` → `'BULLISH'`), so a merge in the
other order will conflict on that line. Trivial either way — flagging so it is
expected rather than investigated.

## Risk level

**Low** in blast radius — one flag's lifetime and one render condition, no data
path. **Medium in confidence**, purely because of the verification gap above.
