### PR TITLE
feat(api): /api/version declares which integrations the host has

### DIFF
--- a/__tests__/versionConfigured.test.mts
+++ b/__tests__/versionConfigured.test.mts
@@ -1,0 +1,152 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { configuredFlags } from '../lib/configured.ts';
+
+/* /api/version's `configured` block must never leak a value (#282).
+ *
+ * The block exists because staging was created missing most of its integrations
+ * and nobody noticed for eleven days - silence was the defect. Making a host
+ * declare itself is only acceptable while the answer is BOOLEANS: no value, no
+ * prefix, no length. That is a property nobody can eyeball on review forever, so
+ * it is asserted here.
+ *
+ * The sentinels below are deliberately distinctive. If the block ever grows a
+ * `...process.env` spread, a "first 4 chars" debugging hint, or a length, the
+ * serialized output contains one of them and this fails.
+ *
+ * Tests lib/configured.ts rather than the route: the route imports
+ * `next/server`, which this runner cannot resolve, and its only remaining job is
+ * to call this function - a line a reviewer can check by eye.
+ *
+ * WHAT THIS CANNOT PROVE: that a flag matches what the FEATURE does. A flag
+ * derived from a parallel read would still be a boolean and still pass. That is
+ * why the module derives from the app's own reads (isCheckoutConfigured,
+ * analyticsKey) - a property of the code, not of this test.
+ */
+
+const SENTINELS: Record<string, string> = {
+  LEMONSQUEEZY_WEBHOOK_SECRET:  'SENTINELlswh1111111111',
+  ADMIN_EMAILS:                 'SENTINELadmin@example.com',
+  VAPID_PRIVATE_KEY:            'SENTINELvapidpriv2222222222',
+  NEXT_PUBLIC_VAPID_PUBLIC_KEY: 'SENTINELvapidpub3333333333',
+  VAPID_EMAIL:                  'mailto:SENTINELvapid@example.com',
+  TELEGRAM_BOT_TOKEN:           'SENTINELtgtoken4444444444',
+  TELEGRAM_CHAT_ID:             'SENTINELtgchat5555555555',
+  TELEGRAM_WEBHOOK_SECRET:      'SENTINELtgwh6666666666',
+  BREVO_API_KEY:                'SENTINELbrevo7777777777',
+  BREVO_SENDER_EMAIL:           'SENTINELsender@example.com',
+  NEXT_PUBLIC_SENTRY_DSN:       'https://SENTINELdsn@o0.ingest.sentry.io/0',
+  COINGLASS_API_KEY:            'SENTINELcg8888888888',
+  GROK_API_KEY:                 'SENTINELgrok9999999999',
+  FINNHUB_KEY:                  'SENTINELfh1010101010',
+  CMC_API_KEY:                  'SENTINELcmc1212121212',
+  CRON_SECRET:                  'SENTINELcron1313131313',
+  NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL: 'https://SENTINELstore.example.com/checkout/buy/abc',
+  NEXT_PUBLIC_POSTHOG_KEY:      'phc_SENTINEL1414141414',
+};
+
+const flags = () => configuredFlags(process.env as Record<string, string | undefined>);
+
+test('every flag is a boolean, and no value reaches the output', () => {
+  const saved = { ...process.env };
+  try {
+    Object.assign(process.env, SENTINELS);
+    process.env.NEXT_PUBLIC_APP_ENV = 'prod';  // else analyticsKey blanks posthog
+
+    const configured = flags();
+    const serialized = JSON.stringify(configured);
+
+    for (const [key, value] of Object.entries(configured)) {
+      assert.equal(typeof value, 'boolean',
+        `configured.${key} is ${typeof value}, not boolean - only booleans may be exposed`);
+    }
+
+    for (const [name, secret] of Object.entries(SENTINELS)) {
+      assert.ok(!serialized.includes(secret),
+        `the value of ${name} appeared in the output. Booleans only.`);
+      assert.ok(!serialized.includes(secret.slice(0, 8)),
+        `a fragment of ${name} appeared in the output - a prefix is a leak too.`);
+    }
+  } finally {
+    for (const k of Object.keys(SENTINELS)) delete process.env[k];
+    Object.assign(process.env, saved);
+  }
+});
+
+test('a flag is false when unset and true when set', () => {
+  const saved = { ...process.env };
+  try {
+    delete process.env.ADMIN_EMAILS;
+    delete process.env.COINGLASS_API_KEY;
+    let c = flags();
+    assert.equal(c.adminEmails, false, 'unset ADMIN_EMAILS should read false');
+    assert.equal(c.coinglass, false, 'unset COINGLASS_API_KEY should read false');
+
+    process.env.ADMIN_EMAILS = 'someone@example.com';
+    process.env.COINGLASS_API_KEY = 'k';
+    c = flags();
+    assert.equal(c.adminEmails, true, 'set ADMIN_EMAILS should read true');
+    assert.equal(c.coinglass, true, 'set COINGLASS_API_KEY should read true');
+  } finally {
+    Object.assign(process.env, saved);
+  }
+});
+
+test('whitespace is not configuration', () => {
+  const saved = { ...process.env };
+  try {
+    // An empty string or a stray space is the commonest way a dashboard entry
+    // looks present and behaves absent.
+    process.env.ADMIN_EMAILS = '   ';
+    assert.equal(flags().adminEmails, false,
+      'a whitespace-only value must not count as configured');
+  } finally {
+    Object.assign(process.env, saved);
+  }
+});
+
+test('a partial setup reports false, not true', () => {
+  const saved = { ...process.env };
+  try {
+    // Two of three. Push fails when a notification is SENT, not at boot, so
+    // reporting true here would be the exact drift this block must not have.
+    process.env.VAPID_PRIVATE_KEY = 'priv';
+    process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY = 'pub';
+    delete process.env.VAPID_EMAIL;
+    assert.equal(flags().vapid, false, 'two of the three VAPID vars is not configured');
+
+    process.env.VAPID_EMAIL = 'mailto:a@example.com';
+    assert.equal(flags().vapid, true, 'all three should read true');
+  } finally {
+    Object.assign(process.env, saved);
+  }
+});
+
+test('posthog follows analyticsKey, not the raw variable', () => {
+  const saved = { ...process.env };
+  try {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_something';
+    process.env.NEXT_PUBLIC_APP_ENV = 'dev';
+    /* The key IS set, and analyticsKey() blanks it on any non-prod host, so no
+       event is ever sent. Reporting true would describe the variable rather than
+       the behaviour. */
+    assert.equal(flags().posthog, false,
+      'a dev host must report posthog false even with the key set');
+
+    process.env.NEXT_PUBLIC_APP_ENV = 'prod';
+    assert.equal(flags().posthog, true, 'a prod host with the key set should read true');
+  } finally {
+    Object.assign(process.env, saved);
+  }
+});
+
+test('checkout treats the "#" placeholder as unset', () => {
+  const saved = { ...process.env };
+  try {
+    process.env.NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL = '#';
+    assert.equal(flags().checkout, false,
+      '"#" is the not-live-yet placeholder and must not count as a store');
+  } finally {
+    Object.assign(process.env, saved);
+  }
+});

--- a/app/api/version/route.ts
+++ b/app/api/version/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { configuredFlags } from '@/lib/configured';
 
 export const dynamic = 'force-dynamic';
 
@@ -21,9 +22,38 @@ export const dynamic = 'force-dynamic';
  * PUBLIC ON PURPOSE, and only this much. A short commit SHA and a branch name
  * are not credentials and reveal nothing without access to a private repo -
  * they are the minimum a drift check can run on without handing CI a Render API
- * token. Nothing environment-shaped goes in here: no variable names, no
+ * token.
+ *
+ * ── THIS COMMENT USED TO FORBID THE `configured` BLOCK BELOW ────────────────
+ *
+ * It read: "Nothing environment-shaped goes in here: no variable names, no
  * versions, no dependency list. If that ever needs to grow, gate it behind
- * checkCronAuth rather than widening what is open.
+ * checkCronAuth rather than widening what is open." Owner-approved reversal on
+ * 2026-08-11 (#282), recorded rather than quietly deleted.
+ *
+ * What changed the answer: `staging` was created missing most of its
+ * integrations, that reduced what QA could verify before a release, and
+ * NOBODY NOTICED FOR ELEVEN DAYS. Silence was the defect. A dashboard answers
+ * this only for someone with access; a bundle grep answers it unreliably (it is
+ * sound for a positive and weak for a negative - a tighter pattern reported
+ * production as having no Sentry until a looser one disproved it); a table in a
+ * doc goes stale. An endpoint the environment computes about itself cannot.
+ *
+ * WHAT KEEPS IT SAFE IS THE SHAPE, NOT THE GATE. Booleans only - never a value,
+ * a prefix, a length or a variable name that is not already public. "Is a key
+ * set" is what an operator already reads off a dashboard, and every
+ * NEXT_PUBLIC_* answer is in the client bundle by definition.
+ *
+ * The one real exposure is that production tells an unauthenticated caller
+ * which protections are absent. It is small: `cronSecret: false` means those
+ * routes reject EVERYTHING (lib/cronAuth.ts fails closed), so a false is not an
+ * open door, and the rest are capability flags inferable by probing anyway. If
+ * that trade ever stops looking right, gate this block - not the whole route,
+ * which the drift check needs unauthenticated.
+ *
+ * EACH FLAG IS DERIVED FROM THE SAME READ THE APP GATES ON, not a parallel list.
+ * A boolean computed differently from the thing it describes is worse than no
+ * boolean - it would report health while the feature was broken.
  */
 export async function GET() {
   const commit = process.env.RENDER_GIT_COMMIT ?? '';
@@ -34,6 +64,10 @@ export async function GET() {
       // Which table set this host is reading - the switch that has silently
       // pointed a test environment at production data before now.
       appEnv: process.env.NEXT_PUBLIC_APP_ENV ?? 'unset',
+
+      /* Which integrations this HOST actually has (#282). Booleans only - see
+         lib/configured.ts for why each flag is derived the way it is. */
+      configured: configuredFlags(process.env as Record<string, string | undefined>),
     },
     // Must never be cached: a stale answer here would report the previous
     // build as current, which is precisely the failure it exists to catch.

--- a/app/upgrade/page.tsx
+++ b/app/upgrade/page.tsx
@@ -3,16 +3,13 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useAuth } from '@/components/AuthProvider';
-import { getCheckoutUrl } from '@/lib/checkout';
+import { getCheckoutUrl, isCheckoutConfigured } from '@/lib/checkout';
 import LoadingState from '@/components/LoadingState';
 import { AI_LIMITS } from '@/lib/limits';
 import { useLabels } from '@/lib/labels';
 import type { LabelKey } from '@/lib/labelKeys';
 
-const CHECKOUT_CONFIGURED = !!(
-  process.env.NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL &&
-  process.env.NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL !== '#'
-);
+const CHECKOUT_CONFIGURED = isCheckoutConfigured();
 
 const F = AI_LIMITS.free, P = AI_LIMITS.pro; // limit numbers derived, not hand-typed
 

--- a/components/UpgradeGateModal.tsx
+++ b/components/UpgradeGateModal.tsx
@@ -2,7 +2,7 @@
 import { useEffect } from 'react';
 import Link from 'next/link';
 import { useAuth } from '@/components/AuthProvider';
-import { getCheckoutUrl } from '@/lib/checkout';
+import { getCheckoutUrl, isCheckoutConfigured } from '@/lib/checkout';
 import { useLabels } from '@/lib/labels';
 
 interface Props {
@@ -62,10 +62,7 @@ export function LockedFeatureCard({ title, description, onUnlock }: {
 // signup with /upgrade as the destination.
 function useCheckoutHref() {
   const { user } = useAuth();
-  const checkoutConfigured = !!(
-    process.env.NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL &&
-    process.env.NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL !== '#'
-  );
+  const checkoutConfigured = isCheckoutConfigured();
   return checkoutConfigured
     ? getCheckoutUrl(user)
     : user ? '/upgrade' : '/login?signup=1&next=/upgrade';

--- a/lib/checkout.ts
+++ b/lib/checkout.ts
@@ -1,8 +1,36 @@
+/** Is a real checkout URL configured?
+ *
+ *  One definition, because there were four: this guard was written out by hand
+ *  in getCheckoutUrl below, `CHECKOUT_CONFIGURED` in app/upgrade/page.tsx,
+ *  `checkoutConfigured` in components/UpgradeGateModal.tsx and `checkoutLive` in
+ *  lib/email.ts. Four copies of "is Pro buyable" that had to agree and nothing
+ *  made them - the trial-ending email in particular decides whether to link a
+ *  checkout that may not exist.
+ *
+ *  `'#'` counts as unset: it is the placeholder the variable is given when the
+ *  store is not live yet, and treating it as a URL sends buyers to a page whose
+ *  address is a fragment.
+ *
+ *  Exported so /api/version can report `configured.checkout` from the SAME read
+ *  the app gates on (#282). A boolean computed differently from the thing it
+ *  describes is worse than no boolean. */
+export function checkoutBase(env: Record<string, string | undefined> = process.env): string | null {
+  const base = env.NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL;
+  return base && base !== '#' ? base : null;
+}
+
+/** Boolean form of the same read. Returns the URL rather than a boolean above so
+ *  callers that need the value get type narrowing from the one check, instead of
+ *  testing a helper and then re-testing the variable to satisfy the compiler. */
+export function isCheckoutConfigured(env: Record<string, string | undefined> = process.env): boolean {
+  return checkoutBase(env) !== null;
+}
+
 // Build a LemonSqueezy checkout URL with the user's email + ID pre-filled
 // so the webhook can match the payment back to the correct Supabase user.
 export function getCheckoutUrl(user: { id: string; email?: string } | null): string {
-  const base = process.env.NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL;
-  if (!base || base === '#') return '/login?signup=1';
+  const base = checkoutBase();
+  if (!base) return '/login?signup=1';
   try {
     const url = new URL(base);
     if (user?.email) url.searchParams.set('checkout[email]', user.email);

--- a/lib/configured.ts
+++ b/lib/configured.ts
@@ -1,0 +1,76 @@
+/* Explicit `.ts` extensions, unlike most of this codebase. This module is
+   imported by a node:test file, and node's ESM loader will not resolve an
+   extensionless relative import - Next's bundler will. `allowImportingTsExtensions`
+   is on in tsconfig, so both are happy. Without this the unit test cannot load
+   the module at all, and the leak invariant goes unasserted. */
+import { isCheckoutConfigured } from './checkout.ts';
+import { analyticsKey } from './analytics.ts';
+
+/* Which integrations does THIS host actually have? (#282)
+ *
+ * Lives here rather than inline in app/api/version/route.ts for one reason: the
+ * route imports `next/server`, which the unit-test runner cannot resolve, and
+ * the invariant that matters - BOOLEANS ONLY, no value ever - is exactly the
+ * kind of property that must be asserted rather than reviewed. A pure function
+ * over an env bag is testable; a route handler is not.
+ *
+ * WHY IT EXISTS. `staging` was created missing most of its integrations, that
+ * reduced what QA could verify before a release, and nobody noticed for eleven
+ * days. Silence was the defect. A dashboard answers this only for someone with
+ * access, a bundle grep answers it unreliably, and a table in a doc goes stale.
+ * A host computing it about itself cannot.
+ *
+ * EACH FLAG COMES FROM THE SAME READ THE APP GATES ON, never a parallel list.
+ * A boolean computed differently from the thing it describes is worse than no
+ * boolean: it would report health while the feature was broken.
+ */
+
+export type ConfiguredFlags = Record<string, boolean>;
+
+/** Presence of a key. Whitespace is not configuration - an empty or
+ *  space-only value is the commonest way a dashboard entry looks present and
+ *  behaves absent. */
+const set = (v: string | undefined): boolean => !!v && v.trim() !== '';
+
+export function configuredFlags(env: Record<string, string | undefined>): ConfiguredFlags {
+  return {
+    /* Payments. `checkout` goes through lib/checkout.ts so it cannot disagree
+       with /upgrade, the upsell modal or the trial-ending email - all four now
+       gate on that one function. */
+    checkout:            isCheckoutConfigured(env),
+    lemonsqueezyWebhook: set(env.LEMONSQUEEZY_WEBHOOK_SECRET),
+
+    adminEmails: set(env.ADMIN_EMAILS),
+
+    /* All three parts, because two out of three is a broken push setup that
+       reads as configured - it fails when a notification is sent, not at boot. */
+    vapid: set(env.VAPID_PRIVATE_KEY)
+        && set(env.NEXT_PUBLIC_VAPID_PUBLIC_KEY)
+        && set(env.VAPID_EMAIL),
+
+    /* Same reasoning: a bot token without a webhook secret cannot verify the
+       callbacks it is about to receive. */
+    telegram: set(env.TELEGRAM_BOT_TOKEN)
+           && set(env.TELEGRAM_CHAT_ID)
+           && set(env.TELEGRAM_WEBHOOK_SECRET),
+
+    brevo: set(env.BREVO_API_KEY) && set(env.BREVO_SENDER_EMAIL),
+
+    /* Through analyticsKey() rather than the raw variable. That function returns
+       '' whenever NEXT_PUBLIC_APP_ENV is 'dev', so a non-prod host reports false
+       even with the key set - which is the truth about whether events are sent,
+       and the whole point of deriving from the app's own read. */
+    posthog: analyticsKey(env) !== '',
+    sentry:  set(env.NEXT_PUBLIC_SENTRY_DSN),
+
+    coinglass: set(env.COINGLASS_API_KEY),
+    grok:      set(env.GROK_API_KEY),
+    finnhub:   set(env.FINNHUB_KEY),
+    cmc:       set(env.CMC_API_KEY),
+
+    /* Unlocks all nine checkCronAuth routes at once. FALSE MEANS THEY REJECT
+       EVERYTHING - lib/cronAuth.ts returns false when this is unset - so on a
+       non-prod host false is the desired state, not a gap. */
+    cronSecret: set(env.CRON_SECRET),
+  };
+}

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -33,6 +33,7 @@ interface TrialEndingArgs {
 }
 
 import { reportHealth, healthError } from '@/lib/apiHealth';
+import { isCheckoutConfigured } from './checkout';
 
 /* Every sender in this file ends in `return res.ok` inside a try/catch that
    returns false - so a bounced welcome email, an expired Brevo key or a
@@ -305,10 +306,7 @@ export async function sendTrialEndingEmail(args: TrialEndingArgs): Promise<boole
      env check /upgrade and UpgradeGateModal already use, so the three agree by
      construction. The rest of the email still sends either way: its real job is
      warning that features are about to lock, which is true regardless. */
-  const checkoutLive = !!(
-    process.env.NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL &&
-    process.env.NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL !== '#'
-  );
+  const checkoutLive = isCheckoutConfigured();
   const cta = checkoutLive
     ? `<p style="margin:0 0 12px">Keep Pro: <a href="${upgradeUrl}">${upgradeUrl}</a></p>`
     : `<p style="margin:0 0 12px">Pro is not on sale yet, so there is nothing to buy today - the features above still lock ${when}, and we will email you as soon as there is a way to keep them.</p>`;


### PR DESCRIPTION
**Dev Team**

Closes #282.

## What it returns

```json
{
  "commit": "0ab7034", "branch": "qa", "appEnv": "dev",
  "configured": {
    "checkout": false, "lemonsqueezyWebhook": false,
    "adminEmails": false, "vapid": false, "telegram": false, "brevo": false,
    "posthog": false, "sentry": false,
    "coinglass": false, "grok": true, "finnhub": false, "cmc": true,
    "cronSecret": false
  }
}
```

Thirteen booleans. **Never a value, a prefix or a length** — asserted, not
promised (below).

## Derived from the app's own reads, not a parallel list

| Flag | Comes from |
|---|---|
| `checkout` | `isCheckoutConfigured()` in `lib/checkout.ts` |
| `posthog` | `analyticsKey()` — returns `''` on any non-prod host |
| everything else | the same variable the feature reads |

**`posthog` is the one that shows why this matters.** On `qa` or `staging` the
key may be *set* and `analyticsKey()` still blanks it, so no event is ever sent.
Reporting `true` there would describe the variable rather than the behaviour —
the exact drift you warned about.

`vapid` and `telegram` require **all** their parts. Two of three reads as
configured and then fails when a notification is sent, not at boot.

### Side effect: three duplicate definitions removed

`checkout` going through `lib/checkout.ts` meant deleting hand-written copies of
the same guard in `app/upgrade/page.tsx`, `components/UpgradeGateModal.tsx` and
`lib/email.ts` — **four definitions of "is Pro buyable" that had to agree and
nothing made them.** The trial-ending email decides whether to link a checkout
that may not exist, so a drift there mails a dead link to the most interested
user we have.

## The invariant is tested, because nobody re-reads a route forever

`__tests__/versionConfigured.test.mts`, 6 tests. Every variable is set to a
distinctive sentinel and the output is searched for it — **including an 8-char
prefix**, since four characters of a token is four more than none. A future
`...process.env` spread or a "first 4 chars" debugging hint fails immediately.

Also pinned: whitespace-only is not configured, `'#'` is not a checkout URL, a
partial VAPID setup is false, and `posthog` follows `analyticsKey`.

**Flags live in `lib/configured.ts`** rather than inline: the route imports
`next/server`, which the unit runner cannot resolve, and an untestable invariant
is one nobody will notice breaking. The route's remaining job is one line.

## ⚠️ This reverses an instruction in the route's own header

It said: *"Nothing environment-shaped goes in here … If that ever needs to grow,
gate it behind checkCronAuth rather than widening what is open."*

Owner-approved on #282. The comment now **records the reversal and why**, rather
than being quietly deleted — including the one real exposure: production tells an
anonymous caller which protections are absent. Small, and named: `cronSecret:
false` means those routes reject **everything** (`lib/cronAuth.ts` fails closed),
so a false is not an open door, and the rest are capability flags inferable by
probing. If that trade stops looking right, gate **this block** — not the route,
which the drift check needs unauthenticated.

## How to test (QA)

```
curl -s https://liquidity-hq-qa.onrender.com/api/version
```

1. A `configured` object of **13 true/false values**. No strings inside it.
2. On `qa`/`staging`: **`posthog` false even though the key may be set** — analytics is off on non-prod by design.
3. On `qa`/`staging`: **`cronSecret` false is correct**, not a gap — those routes fail closed.
4. On `staging`: `checkout` and `lemonsqueezyWebhook` both **true**.
5. `/upgrade` still behaves exactly as before — the dedupe must not have changed the gate.

Verified against a production build locally: 13 booleans, `all booleans: true`.

## Risk level

**Low-medium.** The endpoint change is additive. The dedupe touches the payments
gate on three surfaces — behaviour is identical by construction (same expression,
one definition), and `checkoutUrl.test.mts` still passes, but it is the part
worth a look on qa.

4 gates green: lint 0 errors / 140 warnings unchanged, `tsc` clean, **302/302**
(6 new), production build.

This also retires your eleven-request chunk grep, and answers the same question
for every future variable.
