### PR TITLE
test(e2e): label an unreachable service as ENVIRONMENT, not a finding

### DIFF
--- a/qa/STATUS.md
+++ b/qa/STATUS.md
@@ -2,7 +2,7 @@
 
 **One page. If you only read one thing, read this.**
 
-Kept current by QA. Last updated **2026-08-11**.
+Kept current by QA. Last updated **2026-08-12**.
 
 ## Read this before you trust anything below
 
@@ -225,6 +225,36 @@ gh issue list --state open
   NOT re-set in the same change**: picking a number in the commit that first makes
   it measurable means the baseline comes from a run nobody has looked at twice.
   #263 holds that.
+- **A timeout in a sweeping spec is not a finding — count the failures before you
+  read them.** Added 2026-08-11. A full suite run against deployed `qa` came back
+  **214 passed, 10 failed**, and the ten looked like four separate problem areas:
+
+  ```
+  seo/canonical    -> /calc        TimeoutError: page.goto: Timeout 90000ms exceeded
+  seo/title        -> /playbook    same
+  seo/meta-desc    -> /news        same
+  seo/h1           -> /ops/login   same
+  a11y/unnamed     -> /research    same
+  a11y/html-lang   -> /news        same
+  a11y/duplicate-id-> /terms       same
+  ```
+
+  **Seven of the ten were one navigation timeout wearing seven names.** A spec
+  that walks every route reports one slow response once per assertion, so a single
+  environmental hiccup multiplies by however many things that spec checks. Free-plan
+  Render, cold containers, forty minutes of continuous load.
+
+  Two failure modes, and the second is the expensive one. **I guessed first** —
+  said the four `seo` failures were "almost certainly baselines needing
+  re-derivation" because `ROUTES` had lost two entries in #267. Plausible, and
+  wrong. Reporting it would have sent someone to re-derive four baselines that
+  were fine. **A plausible explanation for a red run is also how a real
+  regression gets waved through.**
+
+  Read the error class before the test name. Group by root cause, not by spec
+  file, and say how many *distinct* causes there are — "10 failures" and "3
+  problems, one of them environmental" are different reports and only the second
+  is actionable.
 - **An empty result is not evidence unless something proves the instrument works.**
   This bit **seven** separate times on 2026-08-10 and is by a distance the most
   repeated defect in this suite: `cache-policy` asserted headers that cached

--- a/qa/e2e/_shared.ts
+++ b/qa/e2e/_shared.ts
@@ -453,8 +453,47 @@ export const CLS_UNSTABLE = new Set<string>([]);
  * was visible at 375px and all elements collapsed to inline size. Numbers from
  * an unstyled render are worse than no numbers, because they look real.
  */
+/**
+ * Prefix for a failure the code under test did not cause.
+ *
+ * A spec that walks every route reports one slow response once per assertion, so
+ * a single cold container multiplies into as many failures as that spec makes
+ * checks. On 2026-08-11 that turned ONE navigation timeout into SEVEN failures
+ * spread across two spec files, which read as four separate problem areas until
+ * the error class was compared rather than the test names.
+ *
+ * Marking it at the throw site is what makes the triage mechanical: group a red
+ * run by this prefix first, and what remains is the actual finding count. Without
+ * it the reader is left inferring intent from a stack trace, and a plausible
+ * explanation for a red run is also how a real regression gets waved through.
+ */
+export const ENV_FAILURE = 'ENVIRONMENT';
+
 export async function settle(page: Page, path: string): Promise<void> {
-  const res = await page.goto(path, { waitUntil: 'domcontentloaded' });
+  let res;
+  try {
+    res = await page.goto(path, { waitUntil: 'domcontentloaded' });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    /* Playwright raises TimeoutError by name; the socket-level failures below
+       carry no distinct type, so they are matched on the message. All of them
+       mean "the service did not answer", never "the assertion is wrong". */
+    const environmental =
+      (e instanceof Error && e.name === 'TimeoutError') ||
+      /ERR_CONNECTION_(REFUSED|RESET)|ERR_NETWORK_CHANGED|ECONNREFUSED|ERR_EMPTY_RESPONSE|socket hang up/i.test(msg);
+
+    if (!environmental) throw e;
+
+    throw new Error(
+      `${ENV_FAILURE}: navigation to ${path} never completed - ${msg.split('\n')[0]}\n` +
+      `This is NOT a finding about ${path}. The service did not answer in time; the ` +
+      `assertions below it never ran. Free-plan Render sleeps when idle and the first ` +
+      `request after that is slow, and a long sweep keeps containers under load.\n` +
+      `Before reporting: count how many failures in this run carry the ${ENV_FAILURE} ` +
+      `prefix. They are one cause, not one each.`,
+    );
+  }
+
   if (res && res.status() >= 400) {
     throw new Error(`${path} returned HTTP ${res.status()}`);
   }


### PR DESCRIPTION
**QA Team** · QA-owned tooling, so this goes to `dev` for your review. Closes the second half of the 2026-08-11 triage lesson.

## Summary

`settle()` now distinguishes "the service did not answer" from "the assertion failed", and says so in the failure text. Two files, both under `qa/`. No application code.

## What changed

`qa/e2e/_shared.ts` — `settle()` wraps `page.goto` and classifies the failure:

```
TimeoutError (by name)                      -> ENVIRONMENT
ERR_CONNECTION_REFUSED / _RESET             -> ENVIRONMENT
ERR_NETWORK_CHANGED / ERR_EMPTY_RESPONSE    -> ENVIRONMENT
ECONNREFUSED / socket hang up               -> ENVIRONMENT
anything else                               -> rethrown untouched
```

The rethrown message names the route, says the assertions never ran, gives the likely cause, and tells the reader to count how many failures in the run share the prefix.

`qa/STATUS.md` — the lesson recorded beside the other measurement traps.

## Why

A spec that walks every route reports one slow response **once per assertion**. On 2026-08-11 a single 90-second navigation timeout surfaced as **seven failures across two spec files**:

```
seo/canonical    -> /calc        TimeoutError: page.goto: Timeout 90000ms exceeded
seo/title        -> /playbook    same
seo/meta-desc    -> /news        same
seo/h1           -> /ops/login   same
a11y/unnamed     -> /research    same
a11y/html-lang   -> /news        same
a11y/duplicate-id-> /terms       same
```

Ten failures, four apparent problem areas, **three actual causes**.

**The part worth fixing is not the miscount.** My first explanation for the four `seo` failures was that `ROUTES` had lost two entries in #267 and the baselines needed re-deriving. Plausible, coherent, and wrong — and reporting it would have sent someone re-deriving four baselines that were fine. A plausible explanation for a red run is also how a real regression gets waved through. Marking it at the throw site makes the triage mechanical instead of interpretive.

## How to test (QA)

Both halves matter — the second is the one that catches me breaking navigation for everyone.

**1. The guard fires.** Point the suite at a port nothing listens on:

```bash
E2E_BASE_URL=http://127.0.0.1:3199 npx playwright test qa/e2e/responsive.spec.ts \
  --project=desktop --max-failures=1 --reporter=list
```

Expect:

```
Error: ENVIRONMENT: navigation to / never completed - page.goto: net::ERR_CONNECTION_REFUSED at http://127.0.0.1:3199/
This is NOT a finding about /. The service did not answer in time; the assertions below it never ran.
Before reporting: count how many failures in this run carry the ENVIRONMENT prefix. They are one cause, not one each.
```

Use a port above 1024. Chromium refuses ports like `9` with `ERR_UNSAFE_PORT`, which is a different error and is **not** caught — correctly, since it is a bug in the test setup rather than a sick service.

**2. Nothing changed when the service answers.**

```bash
E2E_BASE_URL=https://liquidity-hq-staging.onrender.com npx playwright test \
  qa/e2e/smoke.spec.ts --project=desktop --reporter=list
```

Expect 12/12. This is the control, and it is load-bearing — `settle()` is the entry point for most of the suite, so a mistake in the try/catch would turn every spec red or, worse, swallow a real failure.

## Verified

Both of the above, run rather than reasoned about:

```
dead host   ENVIRONMENT prefix present, message correct
live host   12/12 smoke passed against deployed staging
tsc         clean
eslint      0 errors on the changed file
```

## Known limitation — named rather than left to be discovered

**This covers page navigation only.** `settle()` does not wrap `apiRequestContext` calls, and several specs (`seo`, `econ-calendar`, `cache-policy`) hit an API before they ever touch a page. I found this while testing: `seo.spec.ts` against the dead host failed with a bare `apiRequestContext.get: connect ECONNREFUSED` and no prefix.

So a run where the service is down still produces a mix of labelled and unlabelled failures. The labelled ones are the multiplied kind — one cause wearing many names — which is the case that actually misleads. Extending it to the request context is a follow-up, not something this PR quietly half-does.

## Risk level: **Low**

Test-tooling only, no application code. The failure path is additive; the success path is byte-identical. The one real risk is the try/catch swallowing something it should not, which is what control test 2 exists to catch — and `if (!environmental) throw e` rethrows the original error object, not a copy, so stack traces survive.

**Note:** GitHub Actions has not run on any branch since 2026-08-10 (#285), so **no CI has run on this branch**. The gates above were run locally, and the pre-push hook ran lint, `tsc` and the unit tests before this pushed.
