### PR TITLE
test(e2e): every spec navigates through the guard, not just the sweeps

### DIFF
--- a/qa/e2e/_auth.ts
+++ b/qa/e2e/_auth.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { gotoGuarded } from './_shared';
 
 /**
  * Credentials + token minting for the authenticated specs.
@@ -211,7 +212,7 @@ export async function gotoSignedIn(
   page: import('@playwright/test').Page,
   path: string,
 ): Promise<void> {
-  await page.goto(path, { waitUntil: 'domcontentloaded' });
+  await gotoGuarded(page, path);
   await page.waitForTimeout(4000);
 
   const state = await page.evaluate(() => {

--- a/qa/e2e/_shared.ts
+++ b/qa/e2e/_shared.ts
@@ -444,16 +444,6 @@ export const CLS_GOOD = 0.1;
 export const CLS_UNSTABLE = new Set<string>([]);
 
 /**
- * Settle a page: wait for hydration, then assert the stylesheet actually
- * applied.
- *
- * This guard is not optional. During the audit an entire run reported 3,315
- * sub-24px tap targets (true value: 159) and a phantom horizontal overflow,
- * because a CSS chunk 404'd and every page rendered unstyled - the desktop nav
- * was visible at 375px and all elements collapsed to inline size. Numbers from
- * an unstyled render are worse than no numbers, because they look real.
- */
-/**
  * Prefix for a failure the code under test did not cause.
  *
  * A spec that walks every route reports one slow response once per assertion, so
@@ -469,10 +459,28 @@ export const CLS_UNSTABLE = new Set<string>([]);
  */
 export const ENV_FAILURE = 'ENVIRONMENT';
 
-export async function settle(page: Page, path: string): Promise<void> {
-  let res;
+/**
+ * `page.goto` that tells a dead service apart from a real finding.
+ *
+ * USE THIS INSTEAD OF `page.goto` IN EVERY SPEC. The classifier first lived
+ * inside settle(), which left the seven spec files that navigate directly still
+ * reporting a cold container as a defect - and dev pointed out that the two worst
+ * placed were `hidden-routes` and `no-selling-hidden-features`. Those gate the
+ * release, so a timeout there reads as *"/backtest did not redirect"* or
+ * *"/upgrade advertises a hidden route"*: the two conclusions most likely to stop
+ * a release, and both wrong.
+ *
+ * DELIBERATELY NOT USED IN `offline.spec.ts`. That spec navigates while the
+ * context is offline on purpose - a failed navigation there IS the assertion, and
+ * labelling it environmental would hide the one place the failure is the point.
+ */
+export async function gotoGuarded(
+  page: Page,
+  path: string,
+  opts: Parameters<Page['goto']>[1] = { waitUntil: 'domcontentloaded' },
+): Promise<Awaited<ReturnType<Page['goto']>>> {
   try {
-    res = await page.goto(path, { waitUntil: 'domcontentloaded' });
+    return await page.goto(path, opts);
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     /* Playwright raises TimeoutError by name; the socket-level failures below
@@ -493,6 +501,20 @@ export async function settle(page: Page, path: string): Promise<void> {
       `prefix. They are one cause, not one each.`,
     );
   }
+}
+
+/**
+ * Settle a page: wait for hydration, then assert the stylesheet actually
+ * applied.
+ *
+ * This guard is not optional. During the audit an entire run reported 3,315
+ * sub-24px tap targets (true value: 159) and a phantom horizontal overflow,
+ * because a CSS chunk 404'd and every page rendered unstyled - the desktop nav
+ * was visible at 375px and all elements collapsed to inline size. Numbers from
+ * an unstyled render are worse than no numbers, because they look real.
+ */
+export async function settle(page: Page, path: string): Promise<void> {
+  const res = await gotoGuarded(page, path);
 
   if (res && res.status() >= 400) {
     throw new Error(`${path} returned HTTP ${res.status()}`);

--- a/qa/e2e/a11y-auth.spec.ts
+++ b/qa/e2e/a11y-auth.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { BASELINE } from './_shared';
+import { BASELINE, gotoGuarded } from './_shared';
 import { AUTH_READY, AUTH_SKIP_REASON, signedInContext, gotoSignedIn } from './_auth';
 
 /**
@@ -159,7 +159,7 @@ test.describe('accessibility (signed in)', () => {
     const ctx = await signedInContext(browser, 'a');
     const page = await ctx.newPage();
     try {
-      await page.goto('/journal', { waitUntil: 'domcontentloaded' });
+      await gotoGuarded(page, '/journal', { waitUntil: 'domcontentloaded' });
       await page.waitForSelector('[data-testid="journal-input"]', { state: 'visible', timeout: 40_000 });
 
       const pairs = await page.evaluate(() =>
@@ -198,7 +198,7 @@ test.describe('accessibility (signed in)', () => {
     const ctx = await signedInContext(browser, 'a');
     const page = await ctx.newPage();
     try {
-      await page.goto('/journal', { waitUntil: 'domcontentloaded' });
+      await gotoGuarded(page, '/journal', { waitUntil: 'domcontentloaded' });
       await page.waitForSelector('[data-testid="journal-tab"]', { state: 'visible', timeout: 40_000 });
       await page.evaluate(() => {
         const b = [...document.querySelectorAll('[data-testid="journal-tab"]')]
@@ -228,7 +228,7 @@ test.describe('accessibility (signed in)', () => {
     const ctx = await signedInContext(browser, 'a');
     const page = await ctx.newPage();
     try {
-      await page.goto('/journal', { waitUntil: 'domcontentloaded' });
+      await gotoGuarded(page, '/journal', { waitUntil: 'domcontentloaded' });
       await page.waitForSelector('[data-testid="journal-tab"]', { state: 'visible', timeout: 40_000 });
       await page.evaluate(() => {
         const b = [...document.querySelectorAll('[data-testid="journal-tab"]')]
@@ -316,7 +316,7 @@ test.describe('accessibility (signed in)', () => {
     ];
 
     for (const { label, path, toPassword, act } of forms) {
-      await page.goto(path, { waitUntil: 'domcontentloaded' });
+      await gotoGuarded(page, path, { waitUntil: 'domcontentloaded' });
       await page.waitForSelector('[data-testid="login-email"]', { state: 'visible', timeout: 40_000 });
       if (toPassword) {
         await page.evaluate(() => {
@@ -392,7 +392,7 @@ test.describe('accessibility (signed in)', () => {
     const ctx = await signedInContext(browser, 'a');
     const page = await ctx.newPage();
     try {
-      await page.goto('/dashboard', { waitUntil: 'domcontentloaded' });
+      await gotoGuarded(page, '/dashboard', { waitUntil: 'domcontentloaded' });
       await page.waitForSelector('[data-testid="grok-launcher"]', { state: 'visible', timeout: 40_000 });
       await page.evaluate(() => (document.querySelector('[data-testid="grok-launcher"]') as HTMLElement).click());
       await page.waitForSelector('[data-testid="grok-messages"]', { state: 'visible', timeout: 20_000 });

--- a/qa/e2e/checkout.spec.ts
+++ b/qa/e2e/checkout.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { gotoGuarded } from './_shared';
 import { AUTH_READY, AUTH_SKIP_REASON, FIXTURES, signedInContext, gotoSignedIn } from './_auth';
 
 /* Does the checkout button actually carry the signed-in user's identity?
@@ -117,7 +118,7 @@ test.describe('checkout hand-off', () => {
     await page.route(`**${CHECKOUT_HOST}**`, route => { reachedCheckout = true; return route.abort(); });
 
     try {
-      await page.goto('/upgrade', { waitUntil: 'domcontentloaded' });
+      await gotoGuarded(page, '/upgrade', { waitUntil: 'domcontentloaded' });
       await page.waitForTimeout(2500);
 
       const cta = page.locator('button', { hasText: /upgrade|pro|checkout|continue/i }).first();

--- a/qa/e2e/clock.spec.ts
+++ b/qa/e2e/clock.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { gotoGuarded } from './_shared';
 import type { Browser } from '@playwright/test';
 import { installMarketFixtures } from './_fixtures';
 
@@ -47,7 +48,7 @@ async function pinnedTo(browser: Browser, iso: string, timezoneId?: string) {
 async function bodyTextOf(browser: Browser, iso: string, route = '/hours') {
   const { page, close } = await pinnedTo(browser, iso);
   try {
-    await page.goto(route, { waitUntil: 'domcontentloaded' });
+    await gotoGuarded(page, route, { waitUntil: 'domcontentloaded' });
     await page.waitForTimeout(2500);
     return (await page.evaluate(() => document.body.innerText || '')).replace(/\s+/g, ' ');
   } finally { await close(); }
@@ -68,7 +69,7 @@ test.describe('clock-dependent behaviour', () => {
   test('the fake clock is actually installed (guards against a vacuous pass)', async ({ browser }) => {
     const { page, close } = await pinnedTo(browser, '2026-08-10T02:00:00Z');
     try {
-      await page.goto('/hours', { waitUntil: 'domcontentloaded' });
+      await gotoGuarded(page, '/hours', { waitUntil: 'domcontentloaded' });
       const seen = await page.evaluate(() => new Date().toISOString());
       expect(seen.slice(0, 13),
         `the page reported ${seen} - page.clock did not take effect, so every assertion in this ` +
@@ -93,7 +94,7 @@ test.describe('clock-dependent behaviour', () => {
   async function sessionPill(browser: Browser, iso: string): Promise<string> {
     const { page, close } = await pinnedTo(browser, iso);
     try {
-      await page.goto('/hours', { waitUntil: 'domcontentloaded' });
+      await gotoGuarded(page, '/hours', { waitUntil: 'domcontentloaded' });
       const pill = page.locator('div.session-pill');
       await expect(pill, 'the session pill never rendered - nothing can be concluded from its text')
         .toBeVisible({ timeout: 20_000 });
@@ -138,7 +139,7 @@ test.describe('clock-dependent behaviour', () => {
     test(`${zone} at ${instant} renders local time, DST included`, async ({ browser }) => {
       const { page, close } = await pinnedTo(browser, instant, zone);
       try {
-        await page.goto('/hours', { waitUntil: 'domcontentloaded' });
+        await gotoGuarded(page, '/hours', { waitUntil: 'domcontentloaded' });
         const local = await page.evaluate(() =>
           new Date().toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' }));
         expect(local,

--- a/qa/e2e/contrast.spec.ts
+++ b/qa/e2e/contrast.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import type { Browser, Page } from '@playwright/test';
-import { ROUTES, BASELINE } from './_shared';
+import { ROUTES, BASELINE, gotoGuarded } from './_shared';
 import { installMarketFixtures } from './_fixtures';
 
 /**
@@ -167,7 +167,7 @@ async function measure(page: Page, theme: string, route: string): Promise<Violat
    *
    * Installed per page rather than once, because each measurement runs in its
    * own context. */
-  await page.goto(route, { waitUntil: 'domcontentloaded' });
+  await gotoGuarded(page, route, { waitUntil: 'domcontentloaded' });
   await settleForMeasurement(page);
 
   // Return null rather than [] when the theme did not take. An empty array here
@@ -518,7 +518,7 @@ Same triage as the dark test: a state that had not rendered before (add it, with
     const page = await ctx.newPage();
 
     try {
-      await page.goto('/offline', { waitUntil: 'domcontentloaded' });
+      await gotoGuarded(page, '/offline', { waitUntil: 'domcontentloaded' });
 
       /* #767676 on #808080 is ~1.1:1 - far below the 4.5:1 of SC 1.4.3, and not
        * a colour this app uses, so it cannot collide with a real token in the

--- a/qa/e2e/hidden-routes.spec.ts
+++ b/qa/e2e/hidden-routes.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { HIDDEN_ROUTES } from './_shared';
+import { HIDDEN_ROUTES, gotoGuarded } from './_shared';
 
 /* /backtest and /live-tracking are hidden (#264, shipped in #265).
  *
@@ -19,7 +19,7 @@ test.describe('hidden routes', () => {
 
   for (const route of HIDDEN_ROUTES) {
     test(`${route} does not serve its page`, async ({ page }) => {
-      const res = await page.goto(route, { waitUntil: 'domcontentloaded' });
+      const res = await gotoGuarded(page, route, { waitUntil: 'domcontentloaded' });
 
       /* A redirect, not a 404 — the owner's call, and the reason is bookmarks:
          anyone who saved the page lands somewhere useful. Asserting the
@@ -41,7 +41,7 @@ test.describe('hidden routes', () => {
    * Same shape as the snapshot control that caught a fully dead endpoint
    * reporting as a correctly-handled partial failure. */
   test('control: a route that is NOT hidden still serves itself', async ({ page }) => {
-    const res = await page.goto('/markets', { waitUntil: 'domcontentloaded' });
+    const res = await gotoGuarded(page, '/markets', { waitUntil: 'domcontentloaded' });
     expect(res?.status(), '/markets did not load').toBe(200);
     expect(page.url(), '/markets redirected - the hiding is not specific to the two routes, ' +
       'so every assertion above passes for the wrong reason').toContain('/markets');
@@ -51,7 +51,7 @@ test.describe('hidden routes', () => {
      that bounces is worse than no link: it reads as a broken feature rather than
      a removed one. */
   test('no navigation link points at a hidden route', async ({ page }) => {
-    await page.goto('/dashboard', { waitUntil: 'domcontentloaded' });
+    await gotoGuarded(page, '/dashboard', { waitUntil: 'domcontentloaded' });
     await page.waitForTimeout(3000);
 
     const offenders = await page.evaluate((hidden: readonly string[]) =>

--- a/qa/e2e/i18n.spec.ts
+++ b/qa/e2e/i18n.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { gotoGuarded } from './_shared';
 
 /* WCAG 2.2 SC 3.1.1 "Language of Page" is Level A - the lowest bar there is -
  * and this app failed it on every page until 2026-08-08.
@@ -59,13 +60,13 @@ test.describe('i18n: locale offering and page language', () => {
      * The landing page carries the language picker; the not-found page does
      * not. That difference is structural, present at the same moment for both,
      * and does not move when someone rewrites the 404 copy. */
-    await page.goto('/ko', { waitUntil: 'domcontentloaded' });
+    await gotoGuarded(page, '/ko', { waitUntil: 'domcontentloaded' });
     await expect(page.locator('button.lp-lang-btn'),
       'the POSITIVE CONTROL failed: /ko is a supported locale and must render the landing page. ' +
       'Without this, "the picker is absent on /ar" would also be satisfied by a blank page.',
     ).toBeVisible({ timeout: 20_000 });
 
-    await page.goto('/ar', { waitUntil: 'domcontentloaded' });
+    await gotoGuarded(page, '/ar', { waitUntil: 'domcontentloaded' });
     await expect(page.locator('button.lp-lang-btn'),
       '/ar rendered the LANDING page. It is serving some other language under an Arabic URL, ' +
       'which is worse than the original bug - a user who picked Arabic gets English silently.',
@@ -106,7 +107,7 @@ test.describe('i18n: locale offering and page language', () => {
 
   for (const [path, expected] of [['/', 'en'], ['/ko', 'ko'], ['/zh', 'zh']] as const) {
     test(`${path} sets documentElement.lang to "${expected}"`, async ({ page }) => {
-      const res = await page.goto(path, { waitUntil: 'domcontentloaded' });
+      const res = await gotoGuarded(page, path, { waitUntil: 'domcontentloaded' });
       expect(res!.status(), `${path} did not load`).toBeLessThan(400);
 
       /* HtmlLangSync runs on hydration, so the attribute is not correct at
@@ -150,7 +151,7 @@ test.describe('i18n: locale offering and page language', () => {
       }, stored);
       const page = await ctx.newPage();
       try {
-        await page.goto('/upgrade', { waitUntil: 'domcontentloaded' });
+        await gotoGuarded(page, '/upgrade', { waitUntil: 'domcontentloaded' });
         await expect
           .poll(() => page.evaluate(() => document.documentElement.lang), { timeout: 10_000 })
           .toBe(expected);
@@ -176,7 +177,7 @@ test.describe('i18n: locale offering and page language', () => {
     });
     const page = await ctx.newPage();
     try {
-      await page.goto('/upgrade', { waitUntil: 'domcontentloaded' });
+      await gotoGuarded(page, '/upgrade', { waitUntil: 'domcontentloaded' });
       await expect
         .poll(() => page.evaluate(() => document.documentElement.lang), { timeout: 10_000 })
         .toBe('en');
@@ -197,7 +198,7 @@ test.describe('i18n: locale offering and page language', () => {
   });
 
   test('the language picker offers exactly English, Korean and Chinese', async ({ page }) => {
-    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await gotoGuarded(page, '/', { waitUntil: 'domcontentloaded' });
 
     const btn = page.locator('button.lp-lang-btn');
     /* Positive control. Every assertion below is about what is ABSENT, and an

--- a/qa/e2e/layout.spec.ts
+++ b/qa/e2e/layout.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import type { Page } from '@playwright/test';
-import { ROUTES } from './_shared';
+import { ROUTES, gotoGuarded } from './_shared';
 import { installMarketFixtures } from './_fixtures';
 
 /* Does the page LAY OUT correctly — not "is the DOM right".
@@ -216,7 +216,7 @@ test.describe('layout', () => {
   test('the detector actually detects (guards against a vacuous pass)', async ({ browser }, testInfo) => {
     const { page, close } = await preparedPage(browser, testInfo.project.use.viewport ?? { width: 1440, height: 900 });
     try {
-      await page.goto('/', { waitUntil: 'domcontentloaded' });
+      await gotoGuarded(page, '/', { waitUntil: 'domcontentloaded' });
       await settleForGeometry(page);
 
       const clean = await findLayoutDefects(page);
@@ -278,7 +278,7 @@ test.describe('layout', () => {
     const zero: string[] = [];
     try {
       for (const route of ROUTES) {
-        await page.goto(route, { waitUntil: 'domcontentloaded' });
+        await gotoGuarded(page, route, { waitUntil: 'domcontentloaded' });
         await settleForGeometry(page);
         const { obscured, zeroSized } = await findLayoutDefects(page);
         for (const o of obscured) found.add(`${route}: ${o}`);
@@ -387,7 +387,7 @@ test.describe('layout', () => {
     const found = new Set<string>();
     try {
       for (const route of ROUTES) {
-        await page.goto(route, { waitUntil: 'domcontentloaded' });
+        await gotoGuarded(page, route, { waitUntil: 'domcontentloaded' });
         await settleForGeometry(page);
         const { obscured } = await findLayoutDefects(page);
         for (const o of obscured) found.add(`${route}: ${o}`);

--- a/qa/e2e/market-scenarios.spec.ts
+++ b/qa/e2e/market-scenarios.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { gotoGuarded } from './_shared';
 import { installMarketFixtures } from './_fixtures';
 
 /* The first tests in this suite that assert against a KNOWN market input.
@@ -24,7 +25,7 @@ test.describe('market data scenarios', () => {
 
   test('fixtures are actually served (guards against a vacuous pass)', async ({ page }) => {
     const served = await installMarketFixtures(page, 'as-recorded');
-    await page.goto('/funding', { waitUntil: 'domcontentloaded' });
+    await gotoGuarded(page, '/funding', { waitUntil: 'domcontentloaded' });
     await page.waitForTimeout(6000);
 
     /* Without this the whole file is worthless: if no route matched, every test
@@ -60,7 +61,7 @@ test.describe('market data scenarios', () => {
    * is ever true again. */
   test('funding-positive puts POSITIVE rates on screen', async ({ page }) => {
     const served = await installMarketFixtures(page, 'funding-positive');
-    await page.goto('/funding', { waitUntil: 'domcontentloaded' });
+    await gotoGuarded(page, '/funding', { waitUntil: 'domcontentloaded' });
     await page.waitForTimeout(10000);
 
     expect(served.byKey['bybit-tickers'] ?? 0,
@@ -75,7 +76,7 @@ test.describe('market data scenarios', () => {
 
   test('funding-negative puts NO positive rate on screen', async ({ page }) => {
     const served = await installMarketFixtures(page, 'funding-negative');
-    await page.goto('/funding', { waitUntil: 'domcontentloaded' });
+    await gotoGuarded(page, '/funding', { waitUntil: 'domcontentloaded' });
     await page.waitForTimeout(10000);
 
     expect(served.byKey['bybit-tickers'] ?? 0, 'bybit tickers was not intercepted').toBeGreaterThan(0);
@@ -94,7 +95,7 @@ test.describe('market data scenarios', () => {
     const pageErrors: string[] = [];
     page.on('pageerror', e => pageErrors.push(String(e).slice(0, 200)));
 
-    await page.goto('/funding', { waitUntil: 'domcontentloaded' });
+    await gotoGuarded(page, '/funding', { waitUntil: 'domcontentloaded' });
     await page.waitForTimeout(8000);
 
     expect(served.count, 'fixtures were not served').toBeGreaterThan(0);

--- a/qa/e2e/no-selling-hidden-features.spec.ts
+++ b/qa/e2e/no-selling-hidden-features.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { HIDDEN_ROUTES } from './_shared';
+import { HIDDEN_ROUTES, gotoGuarded } from './_shared';
 
 /* Do not sell what nobody can reach.
  *
@@ -40,7 +40,7 @@ test.describe('do not sell hidden features', () => {
 
   for (const surface of SALES_SURFACES) {
     test(`${surface} does not advertise a hidden route`, async ({ page }) => {
-      await page.goto(surface, { waitUntil: 'domcontentloaded' });
+      await gotoGuarded(page, surface, { waitUntil: 'domcontentloaded' });
       await page.waitForTimeout(5000);
 
       const text = (await page.evaluate(() => document.body.innerText || '')).toLowerCase();

--- a/qa/e2e/perf.spec.ts
+++ b/qa/e2e/perf.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { settle, CLS_BUDGET, CLS_GOOD, CLS_UNSTABLE } from './_shared';
+import { settle, CLS_BUDGET, CLS_GOOD, CLS_UNSTABLE, gotoGuarded } from './_shared';
 
 // Core Web Vitals + third-party request volume.
 //
@@ -199,7 +199,7 @@ test.describe('performance', () => {
       thirdParty.push(url);
     });
 
-    await page.goto('/refund', { waitUntil: 'domcontentloaded' });
+    await gotoGuarded(page, '/refund', { waitUntil: 'domcontentloaded' });
     await page.waitForTimeout(8000);
 
     const byHost = thirdParty.reduce<Record<string, number>>((acc, u) => {


### PR DESCRIPTION
**QA Team** · Follow-up to #286, acting on your review. **You were right, and the two specs you named were the ones that mattered.**

## Summary

The classifier moved out of `settle()` into a shared `gotoGuarded()` helper. All **30 direct `page.goto` call sites across 10 spec files** now go through it, plus `gotoSignedIn()` in `_auth.ts` — which navigates too and neither of us had counted.

```
spec files with direct page.goto      10   all converted
call sites                            30
helpers that navigate                  1   _auth.ts gotoSignedIn
deliberately excluded                  1   offline.spec.ts
```

## Why `offline.spec.ts` is excluded, and why that is not an oversight

That spec navigates **while the context is offline on purpose** — `page.goto('/markets').catch(() => {})` at line 88, with the assertion on what happens after. A failed navigation there *is* the measurement. Labelling it `ENVIRONMENT` would put the prefix on the one file where the failure is the point, and would make the prefix mean less everywhere else. It is documented at the helper rather than left for someone to "fix" later.

## Verified — your exact scenario, both directions

**The failure you predicted, now labelled:**

```
E2E_BASE_URL=http://127.0.0.1:3199 npx playwright test \
  qa/e2e/hidden-routes.spec.ts qa/e2e/no-selling-hidden-features.spec.ts \
  --project=desktop --max-failures=2
```

```
ENVIRONMENT: navigation to /backtest never completed - net::ERR_CONNECTION_REFUSED
ENVIRONMENT: navigation to /upgrade  never completed - net::ERR_CONNECTION_REFUSED
```

Those are precisely the two you flagged: *"/backtest did not redirect"* and *"/upgrade advertises a hidden route"*. Both now announce themselves as the environment instead of as a pricing regression.

**The control, against deployed staging at `0ab7034`:**

```
13/13 passed — no-selling-hidden-features + hidden-routes + econ-calendar
```

Same 13 as the release verification, unchanged. `tsc` clean, `eslint` 0 errors across `qa/e2e`.

## One thing worth recording, because it nearly shipped

My first pass at this rewrite used a PowerShell `Get-Content -Raw` / `Set-Content` round-trip. **It silently corrupted every non-ASCII byte in `i18n.spec.ts`** — the Arabic detection regex `/[؀-ۿ]/` came back as `/[Ø€-Û¿]/`, because PowerShell 5.1 decodes with the system ANSI codepage on read.

`tsc` caught it: `error TS1517: Range out of order in character class`. Had the range corrupted into something still *valid*, nothing would have caught it, and the i18n spec would have quietly stopped detecting Arabic while continuing to pass — a spec that reports success while measuring nothing, which is the failure mode this whole thread is about.

Redone with a node script reading and writing explicit UTF-8, which now asserts the non-ASCII character count is identical before and after per file:

```
OK  i18n.spec.ts  sites=6  non-ascii 23->23
OK  a11y-auth.spec.ts  sites=5  non-ascii 411->411
```

The diff is 12 files, and every changed line is either an import or a `goto` rewrite — checked by filtering the diff for anything else and getting nothing.

## How to test (QA)

Both commands above. The dead-host one must show `ENVIRONMENT` on both routes; the staging one must show 13/13. **The control is the load-bearing half** — `gotoGuarded` is now the entry point for essentially the whole suite, so a mistake in the try/catch either turns everything red or, worse, swallows a real failure.

## Risk level: **Low**

Test tooling only, no application code. Success path is byte-identical — `gotoGuarded` returns `page.goto`'s response untouched, and `if (!environmental) throw e` rethrows the original error object so stack traces survive. You already checked that nothing in the suite catches `TimeoutError` by name; that still holds, and this PR widens where the rename can be observed, so it is worth one more look on your side.

Still outstanding from #286 and unchanged by this: `apiRequestContext` calls remain unlabelled. Tracked, not forgotten.

**No CI has run on this branch** — Actions has been down repo-wide since 2026-08-10 (#285). Gates were run locally and the pre-push hook ran lint, `tsc` and the unit tests.
