### PR TITLE
test(ops): assert /api/ops ADMITS an admin, not only that it refuses anonymous

### DIFF
--- a/qa/e2e/ops-admit.spec.ts
+++ b/qa/e2e/ops-admit.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from '@playwright/test';
+import { AUTH_READY, AUTH_SKIP_REASON, FIXTURES, signIn } from './_auth';
+
+/* Does `/ops` ADMIT the people it is supposed to admit? (#280)
+ *
+ * The suite already proves all nine routes REFUSE an anonymous caller
+ * (security.spec.ts). That is half a gate, and it is the half that cannot
+ * detect the worst outcome:
+ *
+ *     tested before this file:   /api/ops/* rejects anonymous      9 routes
+ *     NOT tested before this:    /api/ops/* admits an admin        0 routes
+ *
+ * A GATE THAT DENIES EVERYONE PASSES EVERY TEST WE HAD. If `resolveRole` broke
+ * so completely that nobody could reach the console - including the owner - the
+ * suite stays green and the failure is discovered by a person trying to use it.
+ * Same shape as the empty-200 responses removed last week: absence reported as
+ * correctness.
+ *
+ * Dev probed this by hand on 2026-08-12 and it passed. A one-off probe proves
+ * the state that day; it does not notice the day someone changes the resolver.
+ * This is the regression guard, and the CONTROL is what makes it one - without
+ * "account B is refused", an /ops that admitted ANYONE would pass every
+ * assertion below.
+ *
+ * IT ALSO WALKS THE BOOTSTRAP PATH. No `admin_users` row was seeded for this
+ * account, so a 200 here means `lib/admin-auth.ts` self-seeded from
+ * ADMIN_EMAILS on first request - the "so the owner is never locked out" path
+ * that had never been exercised by anything.
+ */
+
+const ADMIN_EMAIL    = process.env.E2E_USER_ADMIN_EMAIL ?? '';
+const ADMIN_PASSWORD = process.env.E2E_USER_ADMIN_PASSWORD ?? '';
+
+const MISSING = [
+  ['E2E_USER_ADMIN_EMAIL', ADMIN_EMAIL],
+  ['E2E_USER_ADMIN_PASSWORD', ADMIN_PASSWORD],
+].filter(([, v]) => !v).map(([n]) => n);
+
+/* Named, not globbed. A skip that does not say which variable is absent is a
+   silent gap with extra steps - `E2E_B_PRICE_ALERT_ID` alone once skipped all
+   twenty authenticated tests and the only symptom was "20 skipped" scrolling
+   past. */
+const ADMIN_READY = AUTH_READY && MISSING.length === 0;
+const ADMIN_SKIP  = MISSING.length
+  ? `admin fixture absent - MISSING: ${MISSING.join(', ')}. The account exists on the ` +
+    `dev project (see #280); the password is owner-set and belongs in .env.e2e.local.`
+  : AUTH_SKIP_REASON;
+
+/* `/api/ops/spike-alert` is deliberately NOT here: it is guarded by
+   checkCronAuth, not by the admin resolver, so it answers to a different
+   credential and belongs with the cron routes. */
+const OPS_ROUTES = [
+  '/api/ops/overview', '/api/ops/users', '/api/ops/team', '/api/ops/config',
+  '/api/ops/accuracy', '/api/ops/ai-cost', '/api/ops/api-health',
+  '/api/ops/crons', '/api/ops/me',
+] as const;
+
+test.describe('/ops admit path', () => {
+  test.skip(!ADMIN_READY, ADMIN_SKIP);
+
+  let adminToken = '';
+  let freeToken  = '';
+
+  test.beforeAll(async () => {
+    /* signIn throws loudly on failure by design - a silent auth failure would
+       make every assertion below trivially "pass" by turning a 200 check into a
+       test that never ran. */
+    adminToken = await signIn(ADMIN_EMAIL, ADMIN_PASSWORD);
+    freeToken  = await signIn(FIXTURES.bEmail, FIXTURES.bPassword);
+  });
+
+  for (const path of OPS_ROUTES) {
+    test(`ADMITS an authenticated admin: ${path}`, async ({ request }) => {
+      const res = await request.get(path, {
+        headers: { Authorization: `Bearer ${adminToken}` },
+      });
+      expect(res.status(),
+        `${path} refused an ADMIN_EMAILS account. Either the admin resolver broke, or ` +
+        `ADMIN_EMAILS on this host does not contain ${ADMIN_EMAIL} - check /api/version ` +
+        `'configured.adminEmails' before assuming the first.`).toBe(200);
+    });
+  }
+
+  for (const path of OPS_ROUTES) {
+    test(`CONTROL - REFUSES a signed-in non-admin: ${path}`, async ({ request }) => {
+      /* Account B: a real session, a real user, no admin claim. This is the
+         assertion that stops the file degrading into "the gate is open".
+         Anonymous refusal is already covered in security.spec.ts; a SIGNED-IN
+         non-admin is the case that distinguishes "checks the role" from
+         "checks for any token at all". */
+      const res = await request.get(path, {
+        headers: { Authorization: `Bearer ${freeToken}` },
+      });
+      expect([401, 403],
+        `${path} admitted a non-admin signed-in user - every paying account can read ` +
+        `the ops console`).toContain(res.status());
+    });
+  }
+
+  test('CONTROL: the two tokens are actually different sessions', async () => {
+    /* If both helpers somehow minted the same token, "admin gets 200" and
+       "non-admin gets 401" could not both be true, and the file would fail in a
+       confusing way rather than an obvious one. Cheap, and it names the cause. */
+    expect(adminToken.length, 'admin token missing').toBeGreaterThan(20);
+    expect(freeToken.length, 'free-account token missing').toBeGreaterThan(20);
+    expect(adminToken, 'both fixtures minted the same session').not.toBe(freeToken);
+  });
+});


### PR DESCRIPTION
**QA Team** · Closes the gap from #280. The account you seeded is now guarded by something rather than by a probe you ran once.

## Summary

`qa/e2e/ops-admit.spec.ts` — 19 tests, **19 passing against deployed staging**.

```
9   ADMITS an authenticated admin        every admin-guarded /api/ops route
9   CONTROL: REFUSES a signed-in NON-admin (account B), same nine
1   CONTROL: the two tokens are different sessions
```

## What was actually missing

```
before this file   /api/ops/* rejects anonymous     9 routes   security.spec.ts
before this file   /api/ops/* admits an admin       0 routes
```

**A gate that denies everyone passed every test we had.** If `resolveRole` broke so completely that nobody could reach the console — including the owner — the suite stays green and the failure is found by a person trying to use it. That is the same shape as the empty-200 responses we removed last week: absence reported as correctness.

## Your probe and this file do different jobs

You wrote it yourself and you were right:

> *"It proves the state today; it will not notice the day someone changes `resolveRole` and locks the owner out."*

Yours also did not cover the case that stops this degrading into *"the gate is open"*. **Anonymous refusal is not the control** — a route that merely checks for the presence of any token would pass it. The control that discriminates is a **signed-in non-admin**, which is why all nine run twice with account B's token and expect 401/403.

Measured, not assumed:

```
admin token  -> 200 on all 9
account B    -> 401/403 on all 9
```

## The bootstrap path is now tested rather than trusted

No `admin_users` row was seeded for this account, so a 200 means `lib/admin-auth.ts:36` self-seeded from `ADMIN_EMAILS` on first request. That comment — *"so the owner is never locked out"* — now has something asserting it. It is the branch most likely to be quietly broken by a refactor and least likely to be noticed, because the only person who exercises it is the one person who cannot file a bug against themselves.

## `/api/ops/spike-alert` is deliberately out

It is guarded by `checkCronAuth`, not the admin resolver, so it answers to a different credential entirely. Including it would have made a red run ambiguous between "admin auth broke" and "cron secret is unset". It belongs with the cron routes.

## The skip names its variable

```
admin fixture absent - MISSING: E2E_USER_ADMIN_PASSWORD. The account exists on
the dev project (see #280); the password is owner-set and belongs in .env.e2e.local.
```

Not a glob. `E2E_B_PRICE_ALERT_ID` alone once skipped all twenty authenticated tests and the only symptom was `20 skipped` scrolling past — a skip that does not name its cause is a silent gap with extra steps.

**Verified both paths:** 19 skipped with the reason before the variable was set, 19 passed after.

## How to test (QA)

```bash
E2E_BASE_URL=https://liquidity-hq-staging.onrender.com \
  npx playwright test qa/e2e/ops-admit.spec.ts --project=desktop
```

Expect **19 passed** in about 15 seconds — it is API-only, no browser navigation.

If the nine ADMIT tests fail, check `/api/version` `configured.adminEmails` on that host before assuming the resolver broke. The failure message says so, because "the gate is broken" and "this host has no ADMIN_EMAILS" look identical from the outside and have completely different fixes — your #283 block is what makes that distinguishable at all.

## Risk level: **Low**

Test-only, new file, nothing else touched. `tsc` clean, `eslint` 0 errors. Reads only — no `/api/ops` route here is called with anything but GET.

**No CI on this branch** — Actions is still `disabled_manually` (#285).
