### PR TITLE
test(ops): pin the spike-alert exclusion with a test, not a comment

### DIFF
--- a/qa/e2e/ops-admit.spec.ts
+++ b/qa/e2e/ops-admit.spec.ts
@@ -46,9 +46,22 @@ const ADMIN_SKIP  = MISSING.length
     `dev project (see #280); the password is owner-set and belongs in .env.e2e.local.`
   : AUTH_SKIP_REASON;
 
-/* `/api/ops/spike-alert` is deliberately NOT here: it is guarded by
-   checkCronAuth, not by the admin resolver, so it answers to a different
-   credential and belongs with the cron routes. */
+/* `/api/ops/spike-alert` is DELIBERATELY NOT IN THIS LIST. Do not add it.
+ *
+ * `app/api/ops` has ten route directories; this covers nine. The tenth is a cron
+ * route that happens to live under /ops - `app/api/ops/spike-alert/route.ts:20`
+ * calls `checkCronAuth(req)`, not the admin resolver - so it answers to
+ * CRON_SECRET and an admin token is refused there, correctly.
+ *
+ * Putting it in OPS_ROUTES would produce a spec asserting that an admin can
+ * reach a cron endpoint, which is the opposite of what we want to be true.
+ *
+ * "Nine of ten routes covered" is exactly the kind of thing someone helpfully
+ * fixes later, so the exclusion is pinned by the test at the bottom of this file
+ * rather than left to this comment. A comment can be overruled by a confident
+ * reader; a red test cannot. */
+const CRON_GUARDED_UNDER_OPS = '/api/ops/spike-alert';
+
 const OPS_ROUTES = [
   '/api/ops/overview', '/api/ops/users', '/api/ops/team', '/api/ops/config',
   '/api/ops/accuracy', '/api/ops/ai-cost', '/api/ops/api-health',
@@ -96,6 +109,23 @@ test.describe('/ops admit path', () => {
         `the ops console`).toContain(res.status());
     });
   }
+
+  test(`CONTROL: ${CRON_GUARDED_UNDER_OPS} REFUSES an admin - it is a cron route`, async ({ request }) => {
+    /* The executable form of the comment above OPS_ROUTES. It is under /ops and
+       it is NOT admin-guarded, and the only thing stopping someone adding it to
+       the list "for completeness" is this failing when they do.
+       Also worth having in its own right: if this ever starts returning 200 to a
+       user token, a route that fires alerts became reachable by anyone signed
+       in. */
+    const res = await request.get(CRON_GUARDED_UNDER_OPS, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    });
+    expect([401, 403],
+      `${CRON_GUARDED_UNDER_OPS} admitted an admin token. It is guarded by checkCronAuth ` +
+      `(CRON_SECRET), not the admin resolver - if this is now admin-guarded that is a ` +
+      `behaviour change, and it belongs in OPS_ROUTES above with a note saying why.`)
+      .toContain(res.status());
+  });
 
   test('CONTROL: the two tokens are actually different sessions', async () => {
     /* If both helpers somehow minted the same token, "admin gets 200" and


### PR DESCRIPTION
**QA Team** · Acts on your correction to #290. **This commit was orphaned** — you merged #290 and deleted the branch while my follow-up push was in flight, so the push recreated the branch with no PR attached to it. Nothing wrong with the merge; worth knowing it happened, because a re-pushed branch after a merge looks identical to a new one and neither of us would have noticed.

## What it does

You said `app/api/ops` has ten route directories and the spec covers nine, and that the exclusion deserves a line in the file. It now has a test instead:

```
CONTROL: /api/ops/spike-alert REFUSES an admin - it is a cron route
```

**A comment can be overruled by a confident reader; a red test cannot.** "Nine of ten routes covered" is exactly the shape someone helpfully closes later, and closing it would produce a spec asserting that an admin can reach a cron endpoint — the opposite of what we want to be true.

The comment above `OPS_ROUTES` now says plainly not to add it, and points at the test that enforces it.

## It is worth having on its own merit

Independent of the do-not-add function: if `/api/ops/spike-alert` ever returns 200 to a user token, a route that fires alerts became reachable by anyone signed in. Nothing was watching that, and it sits under a path where everything else *is* admin-guarded — which makes it the easiest one to convert by accident during a refactor.

It also puts the two guards next to each other in one file, so the split is visible: `/ops/*` is an admin-authenticated surface **plus one `CRON_SECRET` route**, and `configured.cronSecret` from your #283 block reports whether that second one is reachable at all on a given host.

## Verified

```
staging 0ab7034   20 passed, up from 19
tsc clean, eslint 0 errors
```

## How to test (QA)

```bash
E2E_BASE_URL=https://liquidity-hq-staging.onrender.com \
  npx playwright test qa/e2e/ops-admit.spec.ts --project=desktop
```

Expect 20 passed, about 15 seconds. API-only, no browser.

## Risk level: **Low**

One added test and a comment, in a QA-owned file. No application code.

No CI on this branch — the workflows are disabled by the owner as a cost decision, which is the normal state here. Gates ran locally and the pre-push hook ran lint, `tsc` and the unit tests.
