### PR TITLE
test(checkout): match the checkout path, not a hostname CI invents

### DIFF
--- a/qa/TEST_GAPS.md
+++ b/qa/TEST_GAPS.md
@@ -337,22 +337,79 @@ deployed `qa` and `staging` services directly:
 | `smoke` | deployed `qa` + `staging`, all 32 routes |
 | `cache-policy`, `cache-effective` | deployed `qa` + `staging`, 11 routes pinned |
 
-**What is covered nowhere:** `perf`, `a11y`, `a11y-auth`, `bola`, `contrast`,
-`i18n`, `layout`, `clock`, `payments-webhook`, `checkout`. The authenticated and
-accessibility surfaces have no recent evidence of any kind.
+### UPDATED 2026-08-12 — the premise changed, and the gap narrowed by hand
 
-**This is why the "250 passed / 41 minutes" figure at the top of this file is a
-historical measurement rather than a current one.** It has not been re-measured
-by CI since the pause.
+**CI is not coming back for this.** All three workflows are now
+`disabled_manually` and `RELEASE_PR_PAUSED = 1`, and both are the owner's
+deliberate cost control on a private repo where every Actions minute is billed to
+them personally. PR #210's mechanism exists and is switched off. Treat "no CI ran"
+as the normal state, not as a defect — it was filed as one (#285) on a wrong guess
+about billing quota and closed as not-a-defect.
 
-**Fix in flight:** PR #210 runs the suite on every push to `staging` — the release
-candidate, a few times a week, ~190 min/month. Not on `qa`, which was QA's first
-proposal and would have cost ~760 min/month and re-created the original overspend.
+**What replaced it:** QA runs the suite locally against the **deployed** `qa` and
+`staging` services with `E2E_BASE_URL`, which costs nothing and is stronger
+evidence than CI's own ephemeral build. Measured against `0ab7034` on both hosts
+on 2026-08-12:
 
-**Closing this needs:** #210 merged, then one `qa` → `staging` promotion observed
-to fire a full run. Expect the five §9 perf LCP failures on that first run — they
-are a laptop-calibrated budget, not a regression, and they are exactly the kind of
-thing that has been invisible while this gap was open.
+| Spec | Result | Host |
+|---|---|---|
+| `smoke` | 12/12 | staging |
+| `econ-calendar` | 7/7 | qa + staging |
+| `hidden-routes` | 4/4 | qa + staging |
+| `no-selling-hidden-features` | 3/3 | qa + staging |
+| `ops-admit` | 20/20 | staging |
+| `version-configured` | 2 passed, 2 skipped (host predates #283) | staging + **production** |
+| `arena-read-card` | 5/5 | staging |
+| `arena-legacy-signals` | 5 skipped (host predates #277) | staging |
+| `a11y` tap targets | 3 consecutive passes | staging, **mobile project only** |
+| `a11y-auth` U5 | 3 passes across both hosts | qa + staging |
+| `cache-policy`, `cache-effective` | as before | qa + staging |
+
+**The rest were then run rather than listed as a gap** — same session, same host,
+`--project=desktop`:
+
+| Spec | Result |
+|---|---|
+| `bola` + `payments-webhook` + `i18n` + `clock` | 32 passed, 3 skipped |
+| `checkout` | 2/2 — **after a fix, see below** |
+| `layout` + `perf` | 11 passed |
+| `a11y` + `a11y-auth` | 10 passed, 2 skipped |
+| `contrast` | 3 passed, both themes |
+
+**`checkout` had never once run against a deployed host, and nobody knew.** It
+intercepted `example.lemonsqueezy.com` — the deliberately fake value `ci.yml`
+inlines at build time. Against a real store URL the interception never fired, and
+the failure read *"nothing navigated … either the button is not wired to
+getCheckoutUrl, or the env var was absent at BUILD time"*. That message sends the
+reader hunting a product defect or a build problem. Now matched on LemonSqueezy's
+`/checkout/buy/` path shape, which the CI fake and every real store share.
+
+Same family as the hardcoded `localhost` in `security.spec` and `perf.spec`
+(#266): **anything holding a URL constant is a spec that silently only ever tests
+one environment.** Two found this way now; worth grepping for a third.
+
+**What genuinely remains uncovered:**
+
+- **the `mobile` project** for everything above — these were desktop-only runs.
+  `a11y`'s tap-target test is mobile-only and was run separately; the rest were
+  not.
+- **a REAL purchase granting Pro** (§5). Unchanged, and no amount of local running
+  closes it.
+- **`perf`'s LCP budget**, which passed here but is laptop-calibrated and has
+  never been meaningful on a slower machine — see §9.
+
+**The "250 passed / 41 minutes" figure at the top of this file remains a
+historical measurement.** The table above is a set of targeted runs, not a sweep,
+and it does not add up to one.
+
+**A targeted run is preferred over a sweep even though both are free.** A
+40-minute suite wakes the free-plan Render services and, more importantly,
+produces the failure volume that caused the #284 misfile — ten failures where
+eight shared one cause. `qa/triage-reporter.mjs` now prints the distinct cause
+count on every run for exactly that reason.
+
+**Closing this gap now means** running the uncovered specs against a deployed host
+and recording the result here — not waiting for a pipeline that is off on purpose.
 
 ---
 

--- a/qa/e2e/checkout.spec.ts
+++ b/qa/e2e/checkout.spec.ts
@@ -28,7 +28,24 @@ import { AUTH_READY, AUTH_SKIP_REASON, FIXTURES, signedInContext, gotoSignedIn }
  * test-mode keys and a live sandbox. §5 stays open on that alone.
  */
 
-const CHECKOUT_HOST = 'example.lemonsqueezy.com';
+/* Matched on the PATH SHAPE, not on a hostname.
+ *
+ * This was `example.lemonsqueezy.com` - the deliberately fake value `ci.yml`
+ * inlines at build time. That works for a local build and silently breaks on a
+ * DEPLOYED host, where the store URL is real and different, so the interception
+ * never fires and the failure reads "nothing navigated to
+ * example.lemonsqueezy.com. Either the button is not wired to getCheckoutUrl,
+ * or the env var was absent at BUILD time" - a message that sends the reader
+ * looking for a product defect or a build problem, when the spec was aimed at a
+ * host that was never going to be contacted.
+ *
+ * Found 2026-08-12 running this against deployed `staging`. Same family as the
+ * hardcoded `localhost` in security.spec and perf.spec (#266): anything holding
+ * a URL constant is a spec that silently only ever tests one environment.
+ *
+ * `/checkout/buy/<id>` is LemonSqueezy's own path shape and is shared by the CI
+ * fake and every real store, so this matches both without knowing the host. */
+const CHECKOUT_PATH = '**/checkout/buy/**';
 
 test.describe('checkout hand-off', () => {
   test.skip(!AUTH_READY, AUTH_SKIP_REASON);
@@ -63,7 +80,7 @@ test.describe('checkout hand-off', () => {
     /* Capture the hand-off and STOP it. Aborting means the fake host is never
      * contacted, so this test makes no third-party request at all. */
     let handoff = '';
-    await page.route(`**${CHECKOUT_HOST}**`, route => {
+    await page.route(CHECKOUT_PATH, route => {
       handoff = route.request().url();
       return route.abort();
     });
@@ -86,7 +103,7 @@ test.describe('checkout hand-off', () => {
         .poll(() => handoff, {
           timeout: 15_000,
           message:
-            `nothing navigated to ${CHECKOUT_HOST}. Either the button is not wired to ` +
+            'nothing navigated to a /checkout/buy/ URL. Either the button is not wired to ' +
             'getCheckoutUrl, or NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL was absent at BUILD time ' +
             'and the page fell back to /login?signup=1 - check the webServer build env before ' +
             'reading this as a product defect.',
@@ -115,7 +132,7 @@ test.describe('checkout hand-off', () => {
     const page = await ctx.newPage();
 
     let reachedCheckout = false;
-    await page.route(`**${CHECKOUT_HOST}**`, route => { reachedCheckout = true; return route.abort(); });
+    await page.route(CHECKOUT_PATH, route => { reachedCheckout = true; return route.abort(); });
 
     try {
       await gotoGuarded(page, '/upgrade', { waitUntil: 'domcontentloaded' });


### PR DESCRIPTION
**QA Team** · A spec that had **never once run against a deployed host**, and nobody knew — including me, and I wrote the fix for the last two of these.

## The bug

`checkout.spec.ts` intercepted `example.lemonsqueezy.com`, the deliberately fake host `ci.yml` inlines at build time. On a deployed service the store URL is real and different, so the route never matched, nothing was captured, and it failed with:

> *"nothing navigated to example.lemonsqueezy.com. Either the button is not wired to `getCheckoutUrl`, or `NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL` was absent at BUILD time and the page fell back to `/login?signup=1`"*

**That message is the worst part.** It offers two plausible causes, both wrong, and both expensive: one sends the reader looking for a wiring defect in `app/upgrade/page.tsx`, the other into Render's build environment. The actual cause — the spec was aimed at a host that was never going to be contacted — is not on the list.

Now matched on `**/checkout/buy/**`, LemonSqueezy's own path shape, which the CI fake and every real store share. Works on both without knowing the host.

```
before   deployed staging: 1 failed   local build: passed
after    deployed staging: 2 passed
```

## This is the third one

```
security.spec   requested http://localhost:3100 explicitly       ECONNREFUSED, loud
perf.spec       treated !startsWith('http://localhost') as 3P    silent, inflated
checkout.spec   intercepted a hostname CI invents                misleading message
```

**Anything holding a URL constant is a spec that silently only ever tests one environment.** #266 fixed the first two and I described the lesson then; I did not go looking for the third. Worth a grep for a fourth — I have not done one yet.

The three fail differently, which is why one sweep never surfaced them together: loud, silent-and-inflating, and misleading. Only the middle one is genuinely undetectable; this one announced itself and blamed the wrong thing.

## What it means for coverage

`staging` has a **real** checkout URL, so this now verifies on a deployed host that the button carries the signed-in user's own `checkout[custom][user_id]` and email — the value `payments-webhook.spec.ts` proves the server refuses to trust. Previously that was only ever asserted against a local build with a fake store.

It does **not** move #243. A real purchase granting Pro still needs the owner's test-mode store, and no amount of local running closes it.

## TEST_GAPS §11 rewritten

It said the browser suite was covered nowhere and was waiting on CI. **CI is off deliberately and is not coming back for this**, so waiting was the wrong plan. I ran them instead — all against deployed `staging` at `0ab7034`, `--project=desktop`:

```
bola + payments-webhook + i18n + clock   32 passed, 3 skipped
checkout                                  2/2 after this fix
layout + perf                            11 passed
a11y + a11y-auth                         10 passed, 2 skipped
contrast                                  3 passed, both themes
```

The section now records results with hosts and dates instead of a to-do list, and names what genuinely remains: **the `mobile` project for all of the above** (these were desktop-only), the real-purchase half of §5, and `perf`'s laptop-calibrated LCP budget which passes here and has never been meaningful on slower hardware.

## How to test (QA)

```bash
E2E_BASE_URL=https://liquidity-hq-staging.onrender.com \
  npx playwright test qa/e2e/checkout.spec.ts --project=desktop
```

Expect 2 passed. **The asymmetry is the thing to watch**: before this change it failed on a deployed host and passed on a local build of the same commit. A spec that passes locally and fails remotely is far more often the spec's fault than the environment's.

## Risk level: **Low**

QA-owned spec plus a doc. No application code. `tsc` clean, `eslint` 0 errors.
