### PR TITLE
test(layout): name the covering CONTROL, not whichever glyph was under the point

### DIFF
--- a/qa/e2e/layout.spec.ts
+++ b/qa/e2e/layout.spec.ts
@@ -138,7 +138,24 @@ async function findLayoutDefects(page: Page): Promise<LayoutDefects> {
        * hit-tests to the icon, and a link inside a styled wrapper hit-tests to
        * the wrapper. Neither is a defect - only an UNRELATED element is. */
       if (hit && hit !== el && !el.contains(hit) && !hit.contains(el)) {
-        obscured.push(`${describe(el)} is covered by ${describe(hit)}`);
+        /* NORMALISE THE COVERER TO ITS INTERACTIVE ANCESTOR.
+         *
+         * `elementFromPoint` returns whatever is topmost at one pixel, so the
+         * same overlap is attributed to a parent or its child depending on
+         * sub-pixel layout. The bottom tab bar is `a.mobile-tab-item` wrapping
+         * `span.mobile-tab-label` (NavDrawer.tsx:441-447), and on 2026-08-12 a
+         * run reported `/scanner: button is covered by span.mobile-tab-label`
+         * as NEW while `/scanner: button is covered by a.mobile-tab-item`
+         * vanished from the same baseline. One overlap, two names, reported as
+         * a regression.
+         *
+         * The baseline keys on this string, so an unstable name is a false
+         * failure generator - and a false failure that looks this specific costs
+         * a real diagnosis every time. Walking up to the nearest interactive
+         * ancestor gives the covering CONTROL rather than whichever glyph
+         * happened to be under the point. */
+        const coverer = hit.closest('a,button,[role=button],[role=link],[role=tab]') ?? hit;
+        obscured.push(`${describe(el)} is covered by ${describe(coverer)}`);
       }
     }
 
@@ -154,25 +171,33 @@ async function findLayoutDefects(page: Page): Promise<LayoutDefects> {
 
 const KNOWN_OBSCURED: Record<string, string[]> = {
     desktop: [],
+    /* RE-DERIVED 2026-08-12 against deployed `qa` @ ae213e7, after the coverer
+     * normalisation above. Three entries were RENAMED rather than fixed, and one
+     * group was DELETED as unreachable:
+     *
+     *   /calc     span.mobile-tab-label -> a.mobile-tab-item
+     *   /news     span                  -> button.gchat-fab
+     *   /playbook span                  -> button.gchat-fab
+     *
+     * Same overlaps, stable names. Nothing about the app changed.
+     *
+     * DELETED: the /backtest and /live-tracking entries. Those routes left
+     * ROUTES on 2026-08-11 (#264, shipped in #265 + #267) and are now behind a
+     * redirect, so the sweep can never visit them - the entries could only ever
+     * report as "known, not seen this run" forever. A baseline entry that can
+     * never be observed is indistinguishable from one that was fixed, which is
+     * exactly the ambiguity the "not seen" line exists to surface. Put them back
+     * if the redirect is ever lifted, alongside ROUTES. */
     mobile: [
-      '/backtest: a.pf-footer-link is covered by a.mobile-tab-item',
-      '/backtest: a.pf-footer-link is covered by button.mobile-tab-item',
       '/briefing: a is covered by a.mobile-tab-item',
-      '/calc: input.ps-inp is covered by span.mobile-tab-label',
+      '/calc: input.ps-inp is covered by a.mobile-tab-item',
       '/dashboard: button.sotd-refresh is covered by a.mobile-tab-item',
       '/faq: button is covered by a.mobile-tab-item',
       '/funding: input is covered by a.mobile-tab-item',
       '/journal: a.pf-footer-link is covered by button.gchat-fab',
-      /* Added 2026-08-09 after it appeared on a later run. It is the SAME defect
-       * as the /offline entry below - the tab bar over a footer control - and
-       * its absence earlier was the drift, not its presence now. Routes whose
-       * content ends near the fold flip in and out between runs; the set is the
-       * union of what has been observed, which is why entries are only ever
-       * added when a run names them. */
-      '/live-tracking: button.pf-footer-expand is covered by a.mobile-tab-item',
-      '/news: a.pf-footer-link is covered by span',
+      '/news: a.pf-footer-link is covered by button.gchat-fab',
       '/offline: button.pf-footer-expand is covered by a.mobile-tab-item',
-      '/playbook: button.pb-star is covered by span',
+      '/playbook: button.pb-star is covered by button.gchat-fab',
       '/scanner: button is covered by a.mobile-tab-item',
     ],
   };


### PR DESCRIPTION
**QA Team** · A false-failure generator in my own spec, found by it firing at me.

## What happened

Running the mobile project against the freshly deployed `qa`, `layout.spec.ts` reported a new obscured control:

```
NEW:  /scanner: button is covered by span.mobile-tab-label
```

Looks like a regression. It is not. From the same run's "known, not seen" line:

```
gone: /scanner: button is covered by a.mobile-tab-item
```

`span.mobile-tab-label` is a **child** of `.mobile-tab-item` — `NavDrawer.tsx:441` wraps `:447`. **One overlap, two names.** `elementFromPoint` returns whatever is topmost at a single pixel, so a sub-pixel layout shift decides whether the parent link or its inner label is named, and the baseline keys on that string.

## The fix

Walk up from the hit-test result to its nearest interactive ancestor before naming it:

```ts
const coverer = hit.closest('a,button,[role=button],[role=link],[role=tab]') ?? hit;
```

That names the covering **control** rather than whichever glyph happened to be under the point. Three baseline entries were renamed by it, and the app did not change:

```
/calc      span.mobile-tab-label -> a.mobile-tab-item
/news      span                  -> button.gchat-fab
/playbook  span                  -> button.gchat-fab
```

`/news` and `/playbook` are the more useful correction: `covered by span` named nothing at all, while `button.gchat-fab` says the chat launcher is sitting on a footer control.

## Three entries deleted, and this one is worth a look

```
/backtest: a.pf-footer-link is covered by a.mobile-tab-item
/backtest: a.pf-footer-link is covered by button.mobile-tab-item
/live-tracking: button.pf-footer-expand is covered by a.mobile-tab-item
```

Those routes left `ROUTES` on 2026-08-11 (#264, shipped in #265 + #267) and now sit behind a redirect, **so the sweep can never visit them.** The entries could only ever report as "known, not seen this run" — forever, and indistinguishable from having been fixed.

The "not seen" line exists precisely to surface *possibly fixed, possibly timing*. Three permanent residents in it degrade that signal for the entries where it means something. Put them back alongside `ROUTES` if the redirect is ever lifted; the baseline comment says so.

## Why this is worth a PR rather than a shrug

It cost a real diagnosis today, and it would have cost one every time it fired — the false failure is specific, plausible and names a route and a selector. That is the most expensive kind, because it reads like something worth investigating. Same family as everything else this week: **the measurement changed, not the product.**

## Verified

```
mobile  @ qa ae213e7   3 passed. Only "not seen": /dashboard, which the baseline
                       comment already records as flipping between runs
desktop @ qa ae213e7   3 passed, 0 obscured - the shared change did not move it
tsc / eslint           clean
```

The desktop run is the control. `describe()` and the hit-test are shared, and the desktop baseline is empty — so a normalisation that introduced a spurious coverer anywhere would have turned that list non-empty and failed.

## How to test (QA)

```bash
E2E_BASE_URL=https://liquidity-hq-qa.onrender.com \
  npx playwright test qa/e2e/layout.spec.ts --project=mobile
E2E_BASE_URL=https://liquidity-hq-qa.onrender.com \
  npx playwright test qa/e2e/layout.spec.ts --project=desktop
```

3 passed each, ~8 minutes per project.

## Risk level: **Low**

QA-owned spec only. No application code. The change narrows what gets named; it cannot cause an overlap to go unreported, since the detection condition above it is untouched.
