### PR TITLE
test(entitlements): stop the Pro sweep sending real messages

### DIFF
--- a/qa/e2e/entitlements.spec.ts
+++ b/qa/e2e/entitlements.spec.ts
@@ -73,7 +73,17 @@ const GATED: Array<{ method: 'GET' | 'POST' | 'PATCH'; path: string }> = [
   { method: 'POST',  path: '/api/token-unlock' },
 ];
 
+/* The two GATED routes that can produce a REAL external side effect, mapped to
+ * the `configured` flag on /api/version that says whether they can fire.
+ *
+ * Everything else in GATED reads or computes. These two send. */
+const DELIVERS: Record<string, string> = {
+  '/api/push/test': 'vapid',
+  '/api/telegram/test': 'telegram',
+};
+
 test.describe('Pro entitlement boundary', () => {
+  let configured: Record<string, boolean> | null = null;
   test.skip(!ENTITLEMENT_READY, ENTITLEMENT_SKIP_REASON);
   // HTTP level — running both viewport projects would just double the requests.
   test.beforeEach(({}, testInfo) => {
@@ -126,6 +136,16 @@ test.describe('Pro entitlement boundary', () => {
     ).toBe('pro');
   });
 
+  /* Ask the host which integrations are live, so the delivery routes below can
+   * refuse to fire. Absent on any build predating #283 - handled as "unknown",
+   * which skips rather than sends. */
+  test.beforeAll(async ({ request }) => {
+    try {
+      const r = await getGuarded(request, '/api/version');
+      configured = (await r.json())?.configured ?? null;
+    } catch { configured = null; }
+  });
+
   /* Guard against a vacuous pass. If the token were rejected, every route below
    * would return 401 and a naive "not 200" assertion would read as a clean run.
    * The ungated GET proves the token authenticates before anything else is
@@ -168,6 +188,38 @@ test.describe('Pro entitlement boundary', () => {
     });
 
     test(`${method} ${path} admits a PRO account`, async ({ request }) => {
+      /* DELIVERY ROUTES: prove the send is IMPOSSIBLE before calling one.
+       *
+       * Two of these fifteen do not just answer - they message a real device or
+       * chat. The old assumption, written in this file's header, was that they
+       * were inert because CI had no credentials:
+       *
+       *   "pro -> 503 VAPID not configured ... it means no real push is sent,
+       *    so this adds no side effect. If the 503 ever becomes a 200, someone
+       *    has put VAPID credentials in CI ... Worth noticing."
+       *
+       * That condition came true and nothing noticed, because the assertion is
+       * `not.toBe(403)` and a 200 satisfies it identically to a 503. Measured
+       * 2026-08-12 on deployed `qa` (#299): `telegram: true`, and
+       * `/api/telegram/test` falls back to the environment's TELEGRAM_CHAT_ID
+       * when the user has no linked chat - which on qa is a copy of dev's. So
+       * this sweep was posting a real message to dev's chat on every run.
+       *
+       * A comment describing an invariant is the thing that goes stale. This
+       * asks the HOST instead, via #283's `configured` block, and refuses to
+       * call the route unless the host says delivery cannot happen.
+       *
+       * The default is SKIP, not send: if the block is absent, or reports the
+       * integration as live, we do not know the call is safe and do not make it.
+       * The FREE direction above is unaffected - a 403 lands before any send. */
+      const flag = DELIVERS[path];
+      if (flag) {
+        test.skip(configured?.[flag] !== false,
+          `${path} can deliver on this host (configured.${flag}=${String(configured?.[flag])}). ` +
+          `Calling it messages a real device or chat, so this direction is not exercised here. ` +
+          `See #299.`);
+      }
+
       const opts = {
         headers: { Authorization: `Bearer ${proToken}`, 'Content-Type': 'application/json' },
         data: {},
@@ -182,6 +234,23 @@ test.describe('Pro entitlement boundary', () => {
        * response (400 for an empty body, 500 upstream) is not this test's
        * business; only that it was not refused for entitlement. */
       expect(r.status(), `${path} refused a PRO account — the gate is not gating, it is broken`).not.toBe(403);
+
+      /* When the host says the integration is off, the route must SAY so rather
+       * than answering 200. This is what makes the skip above meaningful: on a
+       * host where delivery is impossible we assert the not-configured path
+       * explicitly, so "no side effect" is a measurement rather than a belief.
+       *
+       * 404 and 503 are both legitimate here and mean different things - dev
+       * measured push answering 404 'No subscriptions found' before it reaches
+       * sendNotification, where the header predicted 503. The reason changed and
+       * the safety did not, which is exactly why this asserts the class of
+       * answer rather than the number. */
+      if (flag) {
+        expect([404, 503],
+          `${path} answered ${r.status()} on a host reporting configured.${flag}=false. ` +
+          `A 200 here means it found some other way to deliver, and this sweep would be ` +
+          `sending on every run - the thing #299 exists to stop.`).toContain(r.status());
+      }
     });
   }
 


### PR DESCRIPTION
**QA Team** · Acting on your #299 measurement. **The sweep no longer sends.** This is your step 2, done first as you suggested — it needs no owner decision.

## What changed

The two `GATED` routes that produce an external side effect now ask the host whether delivery is possible **before** the PRO direction calls them:

```
/api/push/test       -> configured.vapid
/api/telegram/test   -> configured.telegram

flag false   call it, and REQUIRE 404 or 503 - the not-configured path, asserted
flag true    SKIP, naming the route and its flag. Calling it would deliver.
no block     SKIP. Unknown is not permission to send.
```

The FREE direction is untouched on both — a 403 lands before any send, so that half never had a side effect and still runs.

## Why the old shape could not catch it

This file's header stated the assumption it ran under, and it was correct when written:

> *`pro -> 503 VAPID not configured` … it means **no real push is sent**, so this adds no side effect. **If the 503 ever becomes a 200**, someone has put VAPID credentials in CI and this route now messages real devices on every release run. Worth noticing.*

**Nothing was in a position to notice.** The assertion is `not.toBe(403)`, and a 200 satisfies it exactly as well as a 503 does. The comment described an invariant; nothing enforced it; the condition came true and the suite stayed green.

That is the same shape as three other things this week, and the general fix is the one you landed in #283: **ask the host rather than encode a belief about it.** This is the block being used, not just read.

## Verified on deployed `qa` at `ae213e7`

```
30 passed
 2 skipped   POST /api/push/test admits a PRO account
             GET  /api/telegram/test admits a PRO account
```

Both skips name the route and the flag. Both FREE directions still pass and still assert 403 with a `PRO_REQUIRED` body.

## Deliberately conservative on push, and I want that on the record

You showed push **cannot** deliver today — no account has a `push_subscriptions` row, so it 404s before `sendNotification`. So skipping it is stricter than necessary.

I skipped anyway. The spec can see the flag; it cannot see subscription state, and "this send will fail for a second reason I checked once" is exactly the kind of reasoning that was in the header comment and went stale. **When the host says the integration is live, the spec does not call the route.** If that costs a little coverage on a route that happens to be inert, that is the cheaper mistake.

## What this does NOT do

It does not decide whether `qa` should hold those credentials — that is the owner's, and it is still worth asking, because the credentials buy no coverage anything uses. If they are removed, `configured.telegram` goes false and **both directions run again automatically**, asserting the 404/503 path. The spec adapts either way, which is the point of keying on the host rather than on a decision.

## How to test (QA)

```bash
E2E_BASE_URL=https://liquidity-hq-qa.onrender.com \
  npx playwright test qa/e2e/entitlements.spec.ts --project=desktop
```

30 passed, 2 skipped, ~18 seconds. **The skip reasons are the output that matters** — if they ever read "configured.telegram=false" and the test still skipped, the gate logic is inverted.

## Risk level: **Low**

QA-owned spec. No application code. It strictly narrows what gets called; no assertion was weakened, and one was added.
