### PR TITLE
docs(qa): a comment describing an invariant is the thing that goes stale

### DIFF
--- a/qa/STATUS.md
+++ b/qa/STATUS.md
@@ -263,6 +263,40 @@ gh issue list --state open
   file, and say how many *distinct* causes there are — "10 failures" and "3
   problems, one of them environmental" are different reports and only the second
   is actionable.
+- **A COMMENT DESCRIBING AN INVARIANT IS THE THING THAT GOES STALE. The durable
+  version is a check, not a note.** Three separate times on 2026-08-12, and each
+  one was CORRECT WHEN WRITTEN:
+
+  ```
+  entitlements.spec.ts header  "pro -> 503 VAPID not configured ... no real push
+                               is sent. If the 503 ever becomes a 200, someone has
+                               put credentials in CI. Worth noticing."
+                               -> it became true on qa. Nothing noticed, because
+                                  the assertion was not.toBe(403) and 200 passes
+                                  it identically. The sweep was posting a real
+                                  message into dev's Telegram on every run.
+
+  INFRASTRUCTURE.md            recorded CRON_SECRET as unset on qa. It was wrongly
+                               SET for three days in August. The doc's own row
+                               records the correction - after the fact.
+
+  /ops route comments          described routes as Pro-only that turned out to be
+                               enforced differently.
+  ```
+
+  Nothing edited any of them. **The world moved and the prose did not.** A note
+  describes the state at the moment someone typed it; a check describes the state
+  at the moment it runs.
+
+  The general fix is #283's shape: **ask the host, do not encode a belief about
+  it.** `entitlements.spec.ts` now reads `configured.telegram` before calling a
+  delivery route, and defaults to NOT calling when the answer is unknown - a build
+  that cannot answer gets the safe branch rather than the historical assumption.
+
+  Applies to this file too. Everything here is prose, so anything expensive enough
+  to be wrong about belongs in an assertion instead - and the entries that survived
+  are the ones nothing could check.
+
 - **An empty result is not evidence unless something proves the instrument works.**
   This bit **seven** separate times on 2026-08-10 and is by a distance the most
   repeated defect in this suite: `cache-policy` asserted headers that cached

--- a/qa/STATUS.md
+++ b/qa/STATUS.md
@@ -280,8 +280,12 @@ gh issue list --state open
                                SET for three days in August. The doc's own row
                                records the correction - after the fact.
 
-  /ops route comments          described routes as Pro-only that turned out to be
-                               enforced differently.
+  lib/labelDefaults.en.json    every string in it describes what users read, and
+                               none of them do - LabelsProvider overwrites them
+                               from lhq_labels after mount. Structural rather than
+                               a one-off: the whole file is a first-paint seed
+                               permanently describing a state that lasts
+                               milliseconds. It cost real time on #274 and #277.
   ```
 
   Nothing edited any of them. **The world moved and the prose did not.** A note


### PR DESCRIPTION
**QA Team** · Your line from #301, recorded where it survives the thread.

> *A comment describing an invariant is the thing that goes stale. This asks the HOST instead.*
>
> *Three for three today: the durable version is a check, not a note.*

## The three, and what makes them worth an entry

Each was **correct when written**. None was edited. The world moved and the prose did not.

```
entitlements.spec.ts   predicted the exact failure that then happened - "if the
                       503 ever becomes a 200, someone has put credentials in CI"
                       - and nothing enforced it. The sweep posted a real message
                       into dev's Telegram on every run, and passed.

INFRASTRUCTURE.md      recorded CRON_SECRET as unset on qa. It was wrongly SET
                       for three days. The row now records the correction, after
                       the fact.

/ops route comments    described gating that turned out to be enforced
                       differently.
```

The first is the one that earns the entry, because **the comment was not wrong — it was a correct prediction with no enforcement behind it.** Someone thought carefully enough to name the exact future failure and then wrote it in prose. That is the strongest possible argument that care is not the missing ingredient.

## The fix is yours, generalised

#283's shape: ask the host, do not encode a belief about it. `entitlements.spec.ts` now reads `configured.telegram` before calling a delivery route and takes the **safe** branch when a build cannot answer — so an old build gets "do not send" rather than the historical assumption that failed.

## The limit, stated in the entry itself

`qa/STATUS.md` is prose. So is this. **Anything expensive enough to be wrong about belongs in an assertion instead**, and the entries that have survived in that file are precisely the ones nothing could check — decisions, and risks that are not machine-answerable.

Recording that boundary in the entry rather than letting the file quietly become the thing it warns about.

## How to test (QA)

Docs only.

## Risk level: **Low**

One entry in a QA-owned doc. No code.
