### PR TITLE
docs(qa): close the mobile-project gap for staging, with the numbers

### DIFF
--- a/qa/TEST_GAPS.md
+++ b/qa/TEST_GAPS.md
@@ -390,9 +390,27 @@ one environment.** Two found this way now; worth grepping for a third.
 
 **What genuinely remains uncovered:**
 
-- **the `mobile` project** for everything above — these were desktop-only runs.
-  `a11y`'s tap-target test is mobile-only and was run separately; the rest were
-  not.
+- ~~the `mobile` project~~ — **CLOSED for `staging` on 2026-08-12.** Every spec
+  that has a mobile project was run against deployed `staging` at `0ab7034`:
+
+  ```
+  layout          3 passed    2 known entries "not seen" - both already recorded
+                              in the baseline comment as flipping between runs
+  responsive     31 passed
+  a11y            5 passed    incl. tap targets and WCAG 2.2 SC 2.5.8 target-size
+  contrast        3 skipped   desktop-only by design
+  a11y-auth      13 skipped   desktop-only by design
+  seo                         desktop-only by design
+  ```
+
+  **Read the skips before reading this as partial.** `contrast`, `a11y-auth` and
+  `seo` skip the mobile project deliberately — they assert colour values, HTTP
+  responses and head tags, none of which change with viewport, and running them
+  twice would double the time for an identical answer. The ones that genuinely
+  differ by viewport all ran.
+
+  Still desktop-only on **`qa`**: the mobile runs there covered `layout` and
+  `responsive` only, during the coverer-identity work (#300).
 - **a REAL purchase granting Pro** (§5). Unchanged, and no amount of local running
   closes it.
 - **`perf`'s LCP budget**, which passed here but is laptop-calibrated and has


### PR DESCRIPTION
**QA Team** · Closing a gap I named myself this morning, with numbers instead of a to-do.

## Measured against deployed `staging` at `0ab7034`

```
layout          3 passed
responsive     31 passed
a11y            5 passed    incl. tap targets and WCAG 2.2 SC 2.5.8 target-size
contrast        3 skipped   desktop-only by design
a11y-auth      13 skipped   desktop-only by design
seo                         desktop-only by design
```

Every deployed run before this was desktop-only. I wrote that into §11 as a known gap rather than closing it, which is the thing this file's own rules say not to do — *"a gap leaves this list when a test covers it, not when someone is confident it is fine."*

## The skips are explained in the entry, deliberately

`contrast`, `a11y-auth` and `seo` skip the mobile project **by design**: they assert colour values, HTTP responses and head tags, none of which change with viewport. Running them twice doubles the time for an identical answer.

Left unexplained, three skips in a coverage table read as partial coverage — and someone would eventually "fix" them into existence. **Everything that genuinely differs by viewport ran.**

## `layout` reported two entries "not seen this run"

```
/funding: input is covered by a.mobile-tab-item
/news: a.pf-footer-link is covered by button.gchat-fab
```

Both are the known timing-dependent kind, and the baseline comment already records why: *"routes whose content ends near the fold flip in and out between runs; the set is the union of what has been observed."* Not new, not fixed — the same entries the comment was written about.

## Still open, and recorded as such

`qa`'s mobile coverage is `layout` and `responsive` only — those ran during the coverer-identity work in #300, and the rest of the mobile specs have not been pointed at `qa`. Saying so rather than letting "mobile is covered" spread from one environment to the other.

## How to test (QA)

```bash
E2E_BASE_URL=https://liquidity-hq-staging.onrender.com npx playwright test \
  qa/e2e/layout.spec.ts qa/e2e/responsive.spec.ts qa/e2e/a11y.spec.ts --project=mobile
```

Roughly 12 minutes. Run them as separate invocations if the 240s per-test budget bites — `layout`'s obscured sweep measured 204s alone on mobile against a deployed host, which is inside the budget but not by much, and it timed out once today when sharing a worker.

## Risk level: **Low**

Docs only.
