### PR TITLE
fix(news): stop reporting no macro risk from a calendar we cannot vouch for

### DIFF
--- a/__tests__/macroRiskStale.test.mts
+++ b/__tests__/macroRiskStale.test.mts
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { computeMacroRisk } from '../lib/confluence.ts';
+
+/* `level: 'none'` from a stale calendar is a FALSE NEGATIVE (#298).
+ *
+ * The econ snapshot is written by a cron. When that writer stops, the events
+ * still in the snapshot are handled correctly - expired ones are dropped by
+ * NewsProvider's `h < -24` filter and by the five-minute floor in
+ * computeMacroRisk. What breaks is the SET: a release scheduled or corrected
+ * since the writer stopped is simply absent, the search finds nothing, and the
+ * card reports "no macro risk" exactly as confidently as when there is none.
+ *
+ * Non-prod has no ingest schedule at all by deliberate decision (#261), so those
+ * hosts sit permanently in this state.
+ *
+ * WHAT THESE PIN, and the second one matters more than the first: that stale
+ * turns an empty result into `unknown`, and that it does NOT touch a result the
+ * calendar actually produced. A guard that downgraded every verdict would pass a
+ * test written only for the first.
+ */
+
+const HOUR = 3600_000;
+const NOW = Date.parse('2026-08-12T12:00:00Z');
+
+const at = (offsetMs: number, name = 'CPI') => ({
+  name, type: 'CPI', impact: 'high',
+  isoDate: new Date(NOW + offsetMs).toISOString(),
+});
+
+test('fresh calendar with nothing upcoming reports none, not unknown', () => {
+  const r = computeMacroRisk([at(48 * HOUR)], null, NOW, false);
+  assert.equal(r.level, 'none');
+  assert.equal(r.unknown, undefined, 'a fresh empty result must not be marked unknown');
+});
+
+test('stale calendar with nothing found reports unknown, not a clean none', () => {
+  const r = computeMacroRisk([at(48 * HOUR)], null, NOW, true);
+  assert.equal(r.level, 'none');
+  assert.equal(r.unknown, true, 'a stale set cannot support the claim that nothing is upcoming');
+  assert.match(r.reasons[0], /out of date/i, 'the reason must say WHY it cannot be checked');
+});
+
+test('CONTROL: stale does not override a real finding', () => {
+  /* The whole risk of this change is that it downgrades everything to "unknown"
+     and the card stops saying anything useful. A stale calendar that still
+     surfaced an imminent event has done its job for that event. */
+  const fresh = computeMacroRisk([at(20 * 60_000)], null, NOW, false);
+  const stale = computeMacroRisk([at(20 * 60_000)], null, NOW, true);
+  assert.equal(fresh.level, 'danger');
+  assert.equal(stale.level, 'danger', 'a found event is a found event regardless of the set is age');
+  assert.equal(stale.unknown, undefined, 'do not mark a real finding unknown');
+  assert.deepEqual(stale.reasons, fresh.reasons);
+});
+
+test('CONTROL: the USD/JPY factor is unaffected - it does not come from the calendar', () => {
+  /* This is the case that would break silently: jpyUsd raises the level without
+     any calendar involvement, so blanking on `stale` would discard a signal the
+     calendar never provided. */
+  const stale = computeMacroRisk([], 161, NOW, true);
+  assert.equal(stale.level, 'danger');
+  assert.equal(stale.unknown, undefined);
+  assert.match(stale.reasons.join(' '), /USD\/JPY/);
+});
+
+test('a stale calendar with a quiet USD/JPY still reports unknown', () => {
+  const r = computeMacroRisk([], 140, NOW, true);
+  assert.equal(r.level, 'none');
+  assert.equal(r.unknown, true);
+});
+
+test('the default is unchanged, so every existing caller behaves as before', () => {
+  const withoutArg = computeMacroRisk([at(48 * HOUR)], null, NOW);
+  const explicitFresh = computeMacroRisk([at(48 * HOUR)], null, NOW, false);
+  assert.deepEqual(withoutArg, explicitFresh);
+  assert.equal(withoutArg.unknown, undefined);
+});

--- a/components/ConfluenceScore.tsx
+++ b/components/ConfluenceScore.tsx
@@ -33,7 +33,7 @@ export default function ConfluenceScore(
   const d = store.coins[coin];
   // Reads the calendar NewsProvider already holds instead of fetching it again
   // on a 5-minute timer. Same data, one shared push-fed copy per tab.
-  const { econRaw: econEvents } = useNews();
+  const { econRaw: econEvents, econStale } = useNews();
 
   if (!d?.price) return null;
 
@@ -134,8 +134,13 @@ export default function ConfluenceScore(
 
   const result = computeConfluence(factors);
   const cfg = VERDICT_CONFIG[result.verdict];
-  const macro = computeMacroRisk(econEvents, jpyUsd);
-  const macroCol = macro.level === 'danger' ? 'var(--red)' : macro.level === 'caution' ? 'var(--amber)' : null;
+  const macro = computeMacroRisk(econEvents, jpyUsd, Date.now(), econStale);
+  /* `unknown` renders in the same amber band as `caution` on purpose (#298).
+     "We could not check for upcoming releases" is a reason to size down, which
+     is what amber already means here - and giving it a colour of its own would
+     add a fourth state to a card whose whole job is to be read in a second. */
+  const macroCol = macro.level === 'danger' ? 'var(--red)'
+    : (macro.level === 'caution' || macro.unknown) ? 'var(--amber)' : null;
 
   return (
     <div className="sms-card">

--- a/components/NewsProvider.tsx
+++ b/components/NewsProvider.tsx
@@ -82,11 +82,27 @@ export interface CalEvent {
   estimated?: boolean;
 }
 
+/* 24 HOURS (#298).
+ *
+ * Production ingests this hourly, so a day without a write means the writer has
+ * stopped rather than run late - short enough to catch a real outage, long
+ * enough that ordinary jitter never trips it. Non-prod has no ingest schedule at
+ * all by deliberate decision (#261), so those hosts sit permanently stale, which
+ * is correct and is exactly what this makes visible.
+ */
+const ECON_STALE_MS = 24 * 60 * 60 * 1000;
+
 interface NewsCtx {
   alerts: Alert[];
   dismissAlert: (id: number) => void;
   econEvents: EconEvent[];
   econRaw: CalEvent[];
+  /** True when the econ snapshot is older than ECON_STALE_MS, or its age could
+   *  not be determined. Consumers must not report "no upcoming events" from a
+   *  stale set - the events are fine, the SET is incomplete (#298). */
+  econStale: boolean;
+  /** Age of the snapshot in ms, or null if unknown. For display only. */
+  econAgeMs: number | null;
   geoEvents: GeoEvent[];
   eventsLoaded: boolean;
   alertsLoaded: boolean;  // true once the initial news read has been applied
@@ -136,6 +152,10 @@ export default function NewsProvider({ children }: { children: React.ReactNode }
   const [alerts, setAlerts] = useState<Alert[]>([]);
   const [econEvents, setEconEvents] = useState<EconEvent[]>([]);
   const [econRaw, setEconRaw] = useState<CalEvent[]>([]);
+  /* Age of the econ snapshot at read time, or null when unknown (#298).
+     null and 0 mean different things: null is "we could not tell", which is the
+     same caution state as stale. */
+  const [econStaleMs, setEconStaleMs] = useState<number | null>(null);
   const [newsRows, setNewsRows] = useState<NewsRow[]>([]);
   // Replaces a `geoTick` counter that existed only to force the relative
   // timestamps below to recompute, and which had to be referenced with a
@@ -154,6 +174,9 @@ export default function NewsProvider({ children }: { children: React.ReactNode }
   // read their current values - it is created once and would otherwise close
   // over whatever they were on first render.
   const alertsLoadedRef = useRef(false);
+  /* Unknown age is treated as stale: we cannot show that the set is complete,
+     and claiming freshness we have not established is the failure this fixes. */
+  const econStale = econStaleMs === null || econStaleMs > ECON_STALE_MS;
   const eventsLoadedRef = useRef(false);
 
   const pushAlert = useCallback((
@@ -313,13 +336,32 @@ export default function NewsProvider({ children }: { children: React.ReactNode }
     };
 
     const hydrateEcon = async () => {
+      /* `updated_at` as well as `events` (#298).
+       *
+       * The table has always recorded when the snapshot was written and this
+       * read threw it away, so a calendar the cron stopped feeding was
+       * indistinguishable from a current one.
+       *
+       * The rows themselves are not the problem - expired events are already
+       * dropped at the `h < -24` filter below, and `computeMacroRisk` ignores
+       * anything more than five minutes past. The problem is the SET: when the
+       * writer stops, events scheduled or corrected since then are simply
+       * absent, and `computeMacroRisk` then reports `level: 'none'` for a
+       * genuinely imminent release because it is not in the array to be found.
+       *
+       * A false "no macro risk" is stated exactly as confidently as a true one,
+       * which is why this needs to travel with the data rather than be inferred
+       * by each consumer. */
       const { data } = await sb
         .from(T.econ_snapshot)
-        .select('events')
+        .select('events, updated_at')
         .eq('key', 'us_high_impact')
         .maybeSingle();
       if (!live) return;
-      const events = (data as { events?: CalEvent[] } | null)?.events;
+      const snap = data as { events?: CalEvent[]; updated_at?: string } | null;
+      const writtenMs = snap?.updated_at ? new Date(snap.updated_at).getTime() : NaN;
+      setEconStaleMs(Number.isNaN(writtenMs) ? null : Date.now() - writtenMs);
+      const events = snap?.events;
       if (events?.length) applyEconSnapshot(events);
       else setEventsLoaded(true);
     };
@@ -401,7 +443,7 @@ export default function NewsProvider({ children }: { children: React.ReactNode }
   const newsActive = alerts.some(a => nowMs / 1000 - a.ts < 5 * 60);
 
   return (
-    <NewsContext.Provider value={{ alerts, dismissAlert, econEvents, econRaw, geoEvents, eventsLoaded, alertsLoaded, newsActive, latestHeadlines, whaleAlerts }}>
+    <NewsContext.Provider value={{ alerts, dismissAlert, econEvents, econRaw, econStale, econAgeMs: econStaleMs, geoEvents, eventsLoaded, alertsLoaded, newsActive, latestHeadlines, whaleAlerts }}>
       {children}
     </NewsContext.Provider>
   );

--- a/lib/confluence.ts
+++ b/lib/confluence.ts
@@ -92,12 +92,28 @@ export function multiTfRsiFactor(rsi14: number | null, rsi1h: number | null, rsi
 export interface MacroRisk {
   level: 'none' | 'caution' | 'danger';
   reasons: string[];
+  /* True when the verdict was computed from a calendar we cannot vouch for
+     (#298). `level: 'none'` then means "nothing found in an incomplete set",
+     which is not the same claim as "nothing scheduled" - and the two are
+     indistinguishable to a reader unless one of them says so. */
+  unknown?: boolean;
 }
 
 const EVENT_DANGER_MS = 30 * 60_000;
 const EVENT_CAUTION_MS = 2 * 3600_000;
 
-export function computeMacroRisk(events: CalEvent[], jpyUsd: number | null, nowMs: number = Date.now()): MacroRisk {
+/* `stale` marks the CALENDAR as untrustworthy, not the events in it (#298).
+ *
+ * When the econ snapshot's writer stops, expired events are still filtered out
+ * correctly - NewsProvider drops anything past 24h and the window below ignores
+ * anything more than five minutes old. What breaks is the SET: a release
+ * scheduled or corrected since the writer stopped is simply absent, so the
+ * `upcoming` search below finds nothing and this returns `level: 'none'`.
+ *
+ * That is a false negative delivered with the same confidence as a true one -
+ * the card says there is no macro risk, on a calendar that could not have told
+ * us there was. Defaults to false so every existing caller is unaffected. */
+export function computeMacroRisk(events: CalEvent[], jpyUsd: number | null, nowMs: number = Date.now(), stale = false): MacroRisk {
   const reasons: string[] = [];
   let level: MacroRisk['level'] = 'none';
 
@@ -127,6 +143,18 @@ export function computeMacroRisk(events: CalEvent[], jpyUsd: number | null, nowM
       level = 'caution';
       reasons.push(`USD/JPY ${jpyUsd.toFixed(1)} - approaching the 160 carry-trade danger zone`);
     }
+  }
+
+  /* Only when NOTHING was found. A stale calendar that still surfaced a real
+     event has done its job for that event, and the USD/JPY factor above does not
+     come from the calendar at all - downgrading either to "unknown" would be
+     less informative, not more. */
+  if (stale && level === 'none') {
+    return {
+      level: 'none',
+      unknown: true,
+      reasons: ['Economic calendar is out of date - upcoming releases cannot be checked'],
+    };
   }
 
   return { level, reasons };


### PR DESCRIPTION
**Dev Team**

Closes #298. Built to the **revised** shape on that issue, not my first one.

## What it does

| | |
|---|---|
| `NewsProvider` | reads `updated_at` with `events`, exposes `econStale` + `econAgeMs` |
| `computeMacroRisk` | takes a `stale` flag; when stale **and nothing found**, returns `unknown: true` with a reason |
| `ConfluenceScore` | passes it through, renders `unknown` in the existing amber band |

Threshold **24h** — prod ingests hourly, so a day means the writer stopped
rather than ran late.

**Unknown age counts as stale.** We cannot show the set is complete, and
claiming freshness we have not established is the exact failure being fixed.

## The correction this is built on

My original framing on the issue was wrong, and I would rather it stays visible
than gets quietly fixed by the PR:

```
"a released event renders as upcoming"    FALSE - NewsProvider.tsx:242  if (h < -24) return []
"a past event feeds reduce-size-or-wait"  FALSE - confluence.ts:105     x.ms >= -5 * 60_000
```

Both filters predate the issue. **The real defect is a MISSING event, not a
stale one**: when the writer stops, a release scheduled or corrected since is
absent, the search finds nothing, and the card says "no macro risk" with the same
confidence as a true negative.

## Controls, and I mutation-tested them

The risk in this change is that it downgrades everything to "unknown" and the
card stops saying anything useful. Two controls pin that it does not, and I
checked they can actually fail:

```
guard disabled (never fires)        -> 2 tests fail  (the unknown assertions)
guard fires unconditionally         -> 2 tests fail  (the CONTROL assertions)
restored                            -> 308/308
```

- a **found event still reports danger/caution** on a stale calendar, with identical reasons
- the **USD/JPY factor is untouched** — it never came from the calendar, so blanking it would discard a signal the calendar never provided
- the **default argument is unchanged**, so every existing caller behaves exactly as before

## How to test (QA)

**On `qa` or `staging`** (snapshot has not been written for days):

1. Open the Arena, look at the Confluence card's macro row.
2. It should show an amber **"Economic calendar is out of date - upcoming releases cannot be checked"** instead of silently reporting nothing.
3. **Control:** the rest of the Confluence score is unchanged — this only touches the macro row.

**On prod** (calendar is fresh, measured 30 min old today): **nothing should
change.** If anything new appears there, the threshold is wrong.

**The control that matters most:** an event that IS in the snapshot and is
imminent must still raise caution/danger normally on every host. A guard that
suppressed real findings would look like a fix and be a regression.

## Risk level

**Low-medium.** One new optional field, one new optional argument with a default,
one render condition. No data path, no route, no schema change.

4 gates green: lint 0 errors / 141 warnings (+1, the new test file), `tsc` clean,
**308/308** (6 new), production build.

**Named:** `qa` and `staging` will now show this state **permanently**, because
#261 established they have no ingest schedule by decision. That is correct and is
the point — but it will look like a new warning on every non-prod page, and I
would rather you expect it than discover it.
