### PR TITLE
fix(chart): reconnect the live candle stream after a network drop

### DIFF
--- a/__tests__/macroRiskStale.test.mts
+++ b/__tests__/macroRiskStale.test.mts
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { computeMacroRisk } from '../lib/confluence.ts';
+
+/* `level: 'none'` from a stale calendar is a FALSE NEGATIVE (#298).
+ *
+ * The econ snapshot is written by a cron. When that writer stops, the events
+ * still in the snapshot are handled correctly - expired ones are dropped by
+ * NewsProvider's `h < -24` filter and by the five-minute floor in
+ * computeMacroRisk. What breaks is the SET: a release scheduled or corrected
+ * since the writer stopped is simply absent, the search finds nothing, and the
+ * card reports "no macro risk" exactly as confidently as when there is none.
+ *
+ * Non-prod has no ingest schedule at all by deliberate decision (#261), so those
+ * hosts sit permanently in this state.
+ *
+ * WHAT THESE PIN, and the second one matters more than the first: that stale
+ * turns an empty result into `unknown`, and that it does NOT touch a result the
+ * calendar actually produced. A guard that downgraded every verdict would pass a
+ * test written only for the first.
+ */
+
+const HOUR = 3600_000;
+const NOW = Date.parse('2026-08-12T12:00:00Z');
+
+const at = (offsetMs: number, name = 'CPI') => ({
+  name, type: 'CPI', impact: 'high',
+  isoDate: new Date(NOW + offsetMs).toISOString(),
+});
+
+test('fresh calendar with nothing upcoming reports none, not unknown', () => {
+  const r = computeMacroRisk([at(48 * HOUR)], null, NOW, false);
+  assert.equal(r.level, 'none');
+  assert.equal(r.unknown, undefined, 'a fresh empty result must not be marked unknown');
+});
+
+test('stale calendar with nothing found reports unknown, not a clean none', () => {
+  const r = computeMacroRisk([at(48 * HOUR)], null, NOW, true);
+  assert.equal(r.level, 'none');
+  assert.equal(r.unknown, true, 'a stale set cannot support the claim that nothing is upcoming');
+  assert.match(r.reasons[0], /out of date/i, 'the reason must say WHY it cannot be checked');
+});
+
+test('CONTROL: stale does not override a real finding', () => {
+  /* The whole risk of this change is that it downgrades everything to "unknown"
+     and the card stops saying anything useful. A stale calendar that still
+     surfaced an imminent event has done its job for that event. */
+  const fresh = computeMacroRisk([at(20 * 60_000)], null, NOW, false);
+  const stale = computeMacroRisk([at(20 * 60_000)], null, NOW, true);
+  assert.equal(fresh.level, 'danger');
+  assert.equal(stale.level, 'danger', 'a found event is a found event regardless of the set is age');
+  assert.equal(stale.unknown, undefined, 'do not mark a real finding unknown');
+  assert.deepEqual(stale.reasons, fresh.reasons);
+});
+
+test('CONTROL: the USD/JPY factor is unaffected - it does not come from the calendar', () => {
+  /* This is the case that would break silently: jpyUsd raises the level without
+     any calendar involvement, so blanking on `stale` would discard a signal the
+     calendar never provided. */
+  const stale = computeMacroRisk([], 161, NOW, true);
+  assert.equal(stale.level, 'danger');
+  assert.equal(stale.unknown, undefined);
+  assert.match(stale.reasons.join(' '), /USD\/JPY/);
+});
+
+test('a stale calendar with a quiet USD/JPY still reports unknown', () => {
+  const r = computeMacroRisk([], 140, NOW, true);
+  assert.equal(r.level, 'none');
+  assert.equal(r.unknown, true);
+});
+
+test('the default is unchanged, so every existing caller behaves as before', () => {
+  const withoutArg = computeMacroRisk([at(48 * HOUR)], null, NOW);
+  const explicitFresh = computeMacroRisk([at(48 * HOUR)], null, NOW, false);
+  assert.deepEqual(withoutArg, explicitFresh);
+  assert.equal(withoutArg.unknown, undefined);
+});

--- a/components/ConfluenceScore.tsx
+++ b/components/ConfluenceScore.tsx
@@ -33,7 +33,7 @@ export default function ConfluenceScore(
   const d = store.coins[coin];
   // Reads the calendar NewsProvider already holds instead of fetching it again
   // on a 5-minute timer. Same data, one shared push-fed copy per tab.
-  const { econRaw: econEvents } = useNews();
+  const { econRaw: econEvents, econStale } = useNews();
 
   if (!d?.price) return null;
 
@@ -134,8 +134,13 @@ export default function ConfluenceScore(
 
   const result = computeConfluence(factors);
   const cfg = VERDICT_CONFIG[result.verdict];
-  const macro = computeMacroRisk(econEvents, jpyUsd);
-  const macroCol = macro.level === 'danger' ? 'var(--red)' : macro.level === 'caution' ? 'var(--amber)' : null;
+  const macro = computeMacroRisk(econEvents, jpyUsd, Date.now(), econStale);
+  /* `unknown` renders in the same amber band as `caution` on purpose (#298).
+     "We could not check for upcoming releases" is a reason to size down, which
+     is what amber already means here - and giving it a colour of its own would
+     add a fourth state to a card whose whole job is to be read in a second. */
+  const macroCol = macro.level === 'danger' ? 'var(--red)'
+    : (macro.level === 'caution' || macro.unknown) ? 'var(--amber)' : null;
 
   return (
     <div className="sms-card">

--- a/components/KLineProChart.tsx
+++ b/components/KLineProChart.tsx
@@ -1181,18 +1181,76 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
 
           if (bnSym) {
             const iv = periodToBnInterval(period);
-            const ws = new WebSocket(`wss://stream.binance.com:9443/ws/${bnSym.toLowerCase()}@kline_${iv}`);
-            ws.onopen    = () => setWsStatus('live');
-            ws.onerror   = () => setWsStatus('error');
-            ws.onclose   = (e) => { if (!e.wasClean) setWsStatus('connecting'); };
-            ws.onmessage = (e: MessageEvent) => {
-              const { k } = JSON.parse(e.data as string) as { k: Record<string, string | number> };
-              const bar = { timestamp: Number(k.t), open: Number(k.o), high: Number(k.h), low: Number(k.l), close: Number(k.c), volume: Number(k.v) };
-              lastCloseRef.current = bar.close;
-              upsertEmaBar(bar);
-              callback(bar);
+
+            /* RECONNECT (#306).
+             *
+             * This socket used to be opened once. On a network drop it closed,
+             * `onclose` set the status dot to 'connecting', and nothing ever
+             * connected - so the chart froze at the last bar and stayed there
+             * until the user reloaded. The dot was honest and permanent.
+             *
+             * Why only some things came back: the Bybit branch below polls on a
+             * setInterval, which survives an outage and simply succeeds again,
+             * and six other endpoints recover the same incidental way. The
+             * WebSocket had no such loop, which is why the owner saw the chart
+             * specifically stop while the rest of the page carried on.
+             *
+             * Backoff so a server-side rejection cannot become a reconnect
+             * storm, capped so a long outage still recovers promptly. `online`
+             * short-circuits the wait: the browser knows the network returned
+             * before any timer would have fired. */
+            let attempt = 0;
+            let timer: ReturnType<typeof setTimeout> | null = null;
+            let cancelled = false;
+            /* Declared before `connect`, which captures it. Ordering matters:
+               relying on the call happening later would break the moment someone
+               moved it. */
+            let live: WebSocket | null = null;
+
+            const connect = () => {
+              if (cancelled) return;
+              const ws = new WebSocket(`wss://stream.binance.com:9443/ws/${bnSym.toLowerCase()}@kline_${iv}`);
+              live = ws;
+              ws.onopen    = () => { attempt = 0; setWsStatus('live'); };
+              ws.onerror   = () => setWsStatus('error');
+              ws.onclose   = (e) => {
+                if (cancelled || e.wasClean) return;   // a clean close is us, not the network
+                setWsStatus('connecting');
+                attempt += 1;
+                const delay = Math.min(1000 * 2 ** (attempt - 1), 30_000);
+                if (timer) clearTimeout(timer);
+                timer = setTimeout(connect, delay);
+              };
+              ws.onmessage = (e: MessageEvent) => {
+                const { k } = JSON.parse(e.data as string) as { k: Record<string, string | number> };
+                const bar = { timestamp: Number(k.t), open: Number(k.o), high: Number(k.h), low: Number(k.l), close: Number(k.c), volume: Number(k.v) };
+                lastCloseRef.current = bar.close;
+                upsertEmaBar(bar);
+                callback(bar);
+              };
             };
-            wsRef.current = ws;
+
+            /* Nothing in this app listened for `online` before this (#306) - the
+               endpoints that recovered did so by accident of having a timer. */
+            const onOnline = () => {
+              if (cancelled) return;
+              if (live && live.readyState === WebSocket.OPEN) return;
+              attempt = 0;                       // the network is back; do not serve out a long backoff
+              if (timer) clearTimeout(timer);
+              connect();
+            };
+            window.addEventListener('online', onOnline);
+
+            connect();
+
+            wsRef.current = {
+              close: () => {
+                cancelled = true;
+                window.removeEventListener('online', onOnline);
+                if (timer) clearTimeout(timer);
+                live?.close();
+              },
+            };
           } else if (bybitSym) {
             // Bybit: 5s polling
             setWsStatus('live');

--- a/components/NewsProvider.tsx
+++ b/components/NewsProvider.tsx
@@ -82,11 +82,27 @@ export interface CalEvent {
   estimated?: boolean;
 }
 
+/* 24 HOURS (#298).
+ *
+ * Production ingests this hourly, so a day without a write means the writer has
+ * stopped rather than run late - short enough to catch a real outage, long
+ * enough that ordinary jitter never trips it. Non-prod has no ingest schedule at
+ * all by deliberate decision (#261), so those hosts sit permanently stale, which
+ * is correct and is exactly what this makes visible.
+ */
+const ECON_STALE_MS = 24 * 60 * 60 * 1000;
+
 interface NewsCtx {
   alerts: Alert[];
   dismissAlert: (id: number) => void;
   econEvents: EconEvent[];
   econRaw: CalEvent[];
+  /** True when the econ snapshot is older than ECON_STALE_MS, or its age could
+   *  not be determined. Consumers must not report "no upcoming events" from a
+   *  stale set - the events are fine, the SET is incomplete (#298). */
+  econStale: boolean;
+  /** Age of the snapshot in ms, or null if unknown. For display only. */
+  econAgeMs: number | null;
   geoEvents: GeoEvent[];
   eventsLoaded: boolean;
   alertsLoaded: boolean;  // true once the initial news read has been applied
@@ -136,6 +152,10 @@ export default function NewsProvider({ children }: { children: React.ReactNode }
   const [alerts, setAlerts] = useState<Alert[]>([]);
   const [econEvents, setEconEvents] = useState<EconEvent[]>([]);
   const [econRaw, setEconRaw] = useState<CalEvent[]>([]);
+  /* Age of the econ snapshot at read time, or null when unknown (#298).
+     null and 0 mean different things: null is "we could not tell", which is the
+     same caution state as stale. */
+  const [econStaleMs, setEconStaleMs] = useState<number | null>(null);
   const [newsRows, setNewsRows] = useState<NewsRow[]>([]);
   // Replaces a `geoTick` counter that existed only to force the relative
   // timestamps below to recompute, and which had to be referenced with a
@@ -154,6 +174,9 @@ export default function NewsProvider({ children }: { children: React.ReactNode }
   // read their current values - it is created once and would otherwise close
   // over whatever they were on first render.
   const alertsLoadedRef = useRef(false);
+  /* Unknown age is treated as stale: we cannot show that the set is complete,
+     and claiming freshness we have not established is the failure this fixes. */
+  const econStale = econStaleMs === null || econStaleMs > ECON_STALE_MS;
   const eventsLoadedRef = useRef(false);
 
   const pushAlert = useCallback((
@@ -313,13 +336,32 @@ export default function NewsProvider({ children }: { children: React.ReactNode }
     };
 
     const hydrateEcon = async () => {
+      /* `updated_at` as well as `events` (#298).
+       *
+       * The table has always recorded when the snapshot was written and this
+       * read threw it away, so a calendar the cron stopped feeding was
+       * indistinguishable from a current one.
+       *
+       * The rows themselves are not the problem - expired events are already
+       * dropped at the `h < -24` filter below, and `computeMacroRisk` ignores
+       * anything more than five minutes past. The problem is the SET: when the
+       * writer stops, events scheduled or corrected since then are simply
+       * absent, and `computeMacroRisk` then reports `level: 'none'` for a
+       * genuinely imminent release because it is not in the array to be found.
+       *
+       * A false "no macro risk" is stated exactly as confidently as a true one,
+       * which is why this needs to travel with the data rather than be inferred
+       * by each consumer. */
       const { data } = await sb
         .from(T.econ_snapshot)
-        .select('events')
+        .select('events, updated_at')
         .eq('key', 'us_high_impact')
         .maybeSingle();
       if (!live) return;
-      const events = (data as { events?: CalEvent[] } | null)?.events;
+      const snap = data as { events?: CalEvent[]; updated_at?: string } | null;
+      const writtenMs = snap?.updated_at ? new Date(snap.updated_at).getTime() : NaN;
+      setEconStaleMs(Number.isNaN(writtenMs) ? null : Date.now() - writtenMs);
+      const events = snap?.events;
       if (events?.length) applyEconSnapshot(events);
       else setEventsLoaded(true);
     };
@@ -401,7 +443,7 @@ export default function NewsProvider({ children }: { children: React.ReactNode }
   const newsActive = alerts.some(a => nowMs / 1000 - a.ts < 5 * 60);
 
   return (
-    <NewsContext.Provider value={{ alerts, dismissAlert, econEvents, econRaw, geoEvents, eventsLoaded, alertsLoaded, newsActive, latestHeadlines, whaleAlerts }}>
+    <NewsContext.Provider value={{ alerts, dismissAlert, econEvents, econRaw, econStale, econAgeMs: econStaleMs, geoEvents, eventsLoaded, alertsLoaded, newsActive, latestHeadlines, whaleAlerts }}>
       {children}
     </NewsContext.Provider>
   );

--- a/lib/confluence.ts
+++ b/lib/confluence.ts
@@ -92,12 +92,28 @@ export function multiTfRsiFactor(rsi14: number | null, rsi1h: number | null, rsi
 export interface MacroRisk {
   level: 'none' | 'caution' | 'danger';
   reasons: string[];
+  /* True when the verdict was computed from a calendar we cannot vouch for
+     (#298). `level: 'none'` then means "nothing found in an incomplete set",
+     which is not the same claim as "nothing scheduled" - and the two are
+     indistinguishable to a reader unless one of them says so. */
+  unknown?: boolean;
 }
 
 const EVENT_DANGER_MS = 30 * 60_000;
 const EVENT_CAUTION_MS = 2 * 3600_000;
 
-export function computeMacroRisk(events: CalEvent[], jpyUsd: number | null, nowMs: number = Date.now()): MacroRisk {
+/* `stale` marks the CALENDAR as untrustworthy, not the events in it (#298).
+ *
+ * When the econ snapshot's writer stops, expired events are still filtered out
+ * correctly - NewsProvider drops anything past 24h and the window below ignores
+ * anything more than five minutes old. What breaks is the SET: a release
+ * scheduled or corrected since the writer stopped is simply absent, so the
+ * `upcoming` search below finds nothing and this returns `level: 'none'`.
+ *
+ * That is a false negative delivered with the same confidence as a true one -
+ * the card says there is no macro risk, on a calendar that could not have told
+ * us there was. Defaults to false so every existing caller is unaffected. */
+export function computeMacroRisk(events: CalEvent[], jpyUsd: number | null, nowMs: number = Date.now(), stale = false): MacroRisk {
   const reasons: string[] = [];
   let level: MacroRisk['level'] = 'none';
 
@@ -127,6 +143,18 @@ export function computeMacroRisk(events: CalEvent[], jpyUsd: number | null, nowM
       level = 'caution';
       reasons.push(`USD/JPY ${jpyUsd.toFixed(1)} - approaching the 160 carry-trade danger zone`);
     }
+  }
+
+  /* Only when NOTHING was found. A stale calendar that still surfaced a real
+     event has done its job for that event, and the USD/JPY factor above does not
+     come from the calendar at all - downgrading either to "unknown" would be
+     less informative, not more. */
+  if (stale && level === 'none') {
+    return {
+      level: 'none',
+      unknown: true,
+      reasons: ['Economic calendar is out of date - upcoming releases cannot be checked'],
+    };
   }
 
   return { level, reasons };


### PR DESCRIPTION
**Dev Team**

Closes #306. Your endpoint isolation found it — the fix is where you said to look, not where the issue body pointed.

## The cause

`components/KLineProChart.tsx` opened the Binance candle socket **once**:

```ts
ws.onclose = (e) => { if (!e.wasClean) setWsStatus('connecting'); };
```

That is the whole recovery story. The dot said `connecting` and nothing ever
connected, so the chart froze at its last bar until a reload.

**Which is exactly why six endpoints came back and three did not.** The six have
their own `setInterval` — an outage makes one tick fail and the next one
succeed. The socket had no such loop. Your line stands:

> the six that recover are doing so incidentally, through their own retry or
> interval logic, not because anything noticed the network came back

Confirmed app-wide: **zero** references to `online`, `offline` or
`navigator.onLine` in `app/`, `components/` or `lib/` before this.

## The fix

- unclean close → reconnect with backoff `1s, 2s, 4s … capped at 30s`
- `online` event → reconnect immediately and reset the backoff, since the browser knows before any timer would fire
- unsubscribe → cancels the listener and any pending timer

**A clean close is deliberately not retried.** That is the app closing its own
socket on unsubscribe or a symbol switch, and reconnecting there would leak a
socket per switch. The Bybit branch already polled and is untouched — which
matches the owner naming the chart specifically.

## Verified, and one gap I could not close

**The fix works.** Instrumented `WebSocket`, opened `/arena`, then:

```
[1] connected      kline sockets: 1   open: 1
[2] socket killed  kline sockets: 1   open: 0     <- the frozen state
[3] after online   kline sockets: 2   open: 1     <- a NEW socket
```

**The before-control is void and I am not claiming it.** I stashed the fix,
rebuilt, and re-ran — the old build never opened a kline socket at all in that
run, so "still dead" proved nothing. Cause is external: `subscribeBar` only
fires after the history fetch succeeds, and Binance was not reachable from this
machine on that attempt. **Not evidence about the code**, and I would rather say
so than present a void run as a control.

Two earlier attempts were also void and are worth recording: `context.setOffline(true)`
left the sockets `OPEN`, so the disruption never happened and the run "passed"
without testing anything. **Three void measurements before one that meant
something** — the same shape you have been cataloguing all day, on my side this
time.

If you want the before-and-after cleanly, `qa` is the place: it is at `ae213e7`,
which predates this.

## How to test (QA)

1. Arena on a Binance coin (BTC), wait for the dot beside the timeframe to read **live**.
2. Kill the network. Dot goes to **connecting**.
3. Restore it. **Dot returns to `live` on its own within a few seconds and candles resume, with no reload.**
4. **Control — the one I care about:** switch coin and timeframe several times. There must be exactly one live socket afterwards. A reconnect bug that leaks a socket per switch looks identical to a working fix until the tab has been open an hour.

## Risk level

**Medium.** It changes socket lifetime management on the busiest component in the
app. The leak case in step 4 is the realistic failure mode, and it is the one
thing my instrumentation did not exercise.

4 gates green: lint 0 errors / 141 warnings unchanged, `tsc` clean, 308/308,
production build.
