### PR TITLE
feat(arena): blur the Pro timeframes in Multi-TF, colour stripped first

### DIFF
--- a/components/MultiTFAlignment.tsx
+++ b/components/MultiTFAlignment.tsx
@@ -2,6 +2,8 @@
 import { useMarket } from '@/lib/marketStore';
 import Tip from '@/components/Tip';
 import { useLabels } from '@/lib/labels';
+import { useAuth } from '@/components/AuthProvider';
+import { isGatedTf } from '@/lib/limits';
 
 type Bias = 'bullish' | 'bearish' | 'neutral';
 
@@ -43,7 +45,18 @@ function BiasBadge({ bias }: { bias: Bias }) {
   );
 }
 
-function RsiRow({ tf, rsi, bias, last }: { tf: string; rsi: number | null; bias: Bias; last?: boolean }) {
+/* `locked` strips the SIGNAL, then blurs what is left (#310).
+ *
+ * Order matters and it is the whole point. A blur that leaves the red/green
+ * showing still leaks the call: someone who cannot read "62" can still read
+ * bullish-or-bearish from the colour, and the badge carries it on its own. So
+ * the bias is forced to 'neutral' BEFORE render - an absent colour is a fact,
+ * whereas a blur radius is a guess about how much is unreadable.
+ *
+ * Same shape as #273, where backtesting was gated and still advertised: the
+ * feature was blocked and the information was not. */
+function RsiRow({ tf, rsi, bias, last, locked }: { tf: string; rsi: number | null; bias: Bias; last?: boolean; locked?: boolean }) {
+  if (locked) { rsi = null; bias = 'neutral'; }
   const pct = rsi != null ? Math.min(100, Math.max(0, rsi)) : 0;
   return (
     <div style={{
@@ -55,7 +68,11 @@ function RsiRow({ tf, rsi, bias, last }: { tf: string; rsi: number | null; bias:
       borderBottom: last ? 'none' : '1px solid rgba(255,255,255,0.05)',
     }}>
       <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: 'var(--txt2)' }}>{tf}</span>
-      <div style={{ position: 'relative', height: 5, borderRadius: 3, background: 'rgba(255,255,255,0.08)' }}>
+      {/* Only the SIGNAL is obscured - the timeframe label above stays sharp, so a
+          free user can see that 5m and 15m exist and are Pro rather than facing
+          an unexplained smear. aria-hidden on each blurred part keeps a screen
+          reader from reading out a value the screen is deliberately hiding. */}
+      <div aria-hidden={locked || undefined} style={{ position: 'relative', height: 5, borderRadius: 3, background: 'rgba(255,255,255,0.08)', ...(locked ? { filter: 'blur(5px)' } : {}) }}>
         <div style={{
           position: 'absolute', left: 0, top: 0, bottom: 0,
           width: `${pct}%`, borderRadius: 3,
@@ -67,14 +84,15 @@ function RsiRow({ tf, rsi, bias, last }: { tf: string; rsi: number | null; bias:
           width: 1, background: 'rgba(255,255,255,0.2)',
         }} />
       </div>
-      <span style={{
+      <span aria-hidden={locked || undefined} style={{
         fontSize: 'var(--fs-label)', fontWeight: 700, textAlign: 'right',
         color: rsi == null ? 'var(--txt3)' : valColor(bias),
         fontFamily: 'var(--font-mono), monospace',
+        ...(locked ? { filter: 'blur(5px)', userSelect: 'none' as const } : {}),
       }}>
         {rsi != null ? rsi.toFixed(0) : '-'}
       </span>
-      <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+      <div aria-hidden={locked || undefined} style={{ display: 'flex', justifyContent: 'flex-end', ...(locked ? { filter: 'blur(5px)', userSelect: 'none' as const } : {}) }}>
         <BiasBadge bias={bias} />
       </div>
     </div>
@@ -84,6 +102,15 @@ function RsiRow({ tf, rsi, bias, last }: { tf: string; rsi: number | null; bias:
 export default function MultiTFAlignment({ coin: coinProp }: { coin?: string }) {
   const { t } = useLabels();
   const { store } = useMarket();
+  /* Same `entitled` the rest of the app gates on - Pro OR active trial - so this
+     card and the timeframe switcher in Arena can never disagree about who is a
+     paying user (#310). */
+  const { entitled, loading: authLoading } = useAuth();
+  /* Locked only once we KNOW the user is not entitled. While auth resolves,
+     nothing is blurred: a Pro user briefly seeing their own paid signal smeared
+     is a worse error than a free user seeing it a moment longer, and the row is
+     re-rendered the instant the role lands. */
+  const locked = (tf: string) => !authLoading && !entitled && isGatedTf(tf);
   const coin = (coinProp ?? store.selectedCoin) as ReturnType<typeof useMarket>['store']['selectedCoin'];
   const d = store.coins[coin];
 
@@ -103,7 +130,18 @@ export default function MultiTFAlignment({ coin: coinProp }: { coin?: string }) 
   const biasWeekly = getBias(rsiWeekly);
   const biasMonthly = getBias(rsiMonthly);
 
-  const biases = [bias5m, bias14, bias1h, bias4h, biasDaily, biasWeekly, biasMonthly];
+  /* GATED ROWS ARE EXCLUDED FROM THE VERDICT (#310).
+   *
+   * Blurring 5m and 15m while still counting them would leak them straight back
+   * out: the headline verdict is derived from the same biases, so a free user
+   * could read the hidden signal off the aggregate. The majority threshold below
+   * already scales to however many timeframes are wired in, so dropping two
+   * needs no other change - it becomes a 5-timeframe majority instead of 7. */
+  const biases = [
+    ...(locked('5m')  ? [] : [bias5m]),
+    ...(locked('15m') ? [] : [bias14]),
+    bias1h, bias4h, biasDaily, biasWeekly, biasMonthly,
+  ];
   const bullCount = biases.filter(b => b === 'bullish').length;
   const bearCount = biases.filter(b => b === 'bearish').length;
   // Majority of however many timeframes are wired in - scales automatically
@@ -165,8 +203,8 @@ export default function MultiTFAlignment({ coin: coinProp }: { coin?: string }) 
         <span style={{ fontSize: 'var(--fs-micro)', color: 'var(--txt3)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', textAlign: 'right' }}>{t('MULTI_TF_ALIGNMENT_COL_BIAS')}</span>
       </div>
 
-      <RsiRow tf="5m"  rsi={rsi5m} bias={bias5m} />
-      <RsiRow tf="15m" rsi={rsi14} bias={bias14} />
+      <RsiRow tf="5m"  rsi={rsi5m} bias={bias5m} locked={locked('5m')} />
+      <RsiRow tf="15m" rsi={rsi14} bias={bias14} locked={locked('15m')} />
       <RsiRow tf="1h"  rsi={rsi1h} bias={bias1h} />
       <RsiRow tf="4h"  rsi={rsi4h} bias={bias4h} />
       <RsiRow tf="1D"  rsi={rsiDaily} bias={biasDaily} />


### PR DESCRIPTION
**Dev Team**

Closes #310. Built as **strip the colour, then blur** — your framing, and it is the right one.

## What changed

`components/MultiTFAlignment.tsx`. For accounts without Pro or an active trial:

| | |
|---|---|
| `5m` / `15m` value + bar + badge | **blurred**, and `bias` forced to `neutral` **before** render |
| `5m` / `15m` timeframe label | left sharp |
| everything else | untouched |
| **the headline verdict** | **gated rows excluded from the count** |

## The verdict exclusion is the part you did not ask for

Blurring two rows while still counting them leaks the signal one level up: the
headline is derived from the same biases, so a free user could read the hidden
call off the aggregate. The majority threshold already scales to however many
timeframes are wired in, so it becomes a 5-timeframe majority with no other
change.

Same category as the colour — **the feature was blocked and the information was
not.**

## Measured on a production build, signed out

```
tf    blur         value colour
5m    blur(5px)    rgb(123,130,151)   <- --txt3, the neutral grey
15m   blur(5px)    rgb(123,130,151)   <- --txt3
1h    none         rgb(52,211,153)    green
4h    none         rgb(248,113,113)   red
1D    none         rgb(122,126,148)
1W    none         rgb(248,113,113)   red
1M    none         rgb(248,113,113)   red
```

**Computed colour, not a class name** — which is the check you specified, and it
confirms the colour is gone rather than hidden under the blur.

## What I could NOT verify, and it is your control

**The Pro direction.** I have no Pro session locally: account A's password is the
owner's, and the admin fixture I seeded is `role: free`. So "blur everything for
everyone" would pass everything I ran.

That is precisely the failure you named on the issue, and I am handing it over
unverified rather than implying otherwise. `entitlements.spec.ts` already pins
both fixtures.

## Two decisions worth naming

**No lock icon or upgrade prompt.** The owner asked for blur specifically. A
blurred cell with no explanation does read as broken rather than gated, and you
flagged that on the issue — but inventing product copy on top of a precise
instruction seemed the wrong call. Easy to add if the owner wants it.

**There is no `1m` row on this card.** It renders 5m, 15m, 1h, 4h, 1D, 1W, 1M,
so `1m` from the owner's list has nothing to blur here. The chart's own
`1m/5m/15m` buttons are already gated by `handleTfChange` and carry no colour, so
there is no signal to strip there. If the owner meant something else by "1m",
that is the gap.

## Risk level

**Low.** One component, presentation only, no data path. 4 gates green — lint 0
errors / 141 warnings unchanged, `tsc` clean, 308/308, production build.

**Unverified:** the Pro direction, as above.
