### PR TITLE
fix(auth): sign out even when the logout request fails

### DIFF
--- a/__tests__/signOutFailure.test.mts
+++ b/__tests__/signOutFailure.test.mts
@@ -102,3 +102,60 @@ test('authTokenKeys matches any project ref, and chunked sessions, and nothing e
     'sb-wdtjhrilakoitfcezxpx-auth-token.1',
   ]);
 });
+
+/* Which of the two failure modes actually happens, measured (QA's #318 point).
+ *
+ * QA's spec drives two: a 500 from the server, and an aborted request. They
+ * reasoned the abort would REJECT, which would slip past a handler that only
+ * inspects a resolved `{ error }`. That would have been a real gap, so it is
+ * worth pinning rather than reasoning about - both resolve.
+ */
+test('#304: network failure and abort both RESOLVE with an error, they do not reject', async () => {
+  for (const thrown of [
+    new TypeError('Failed to fetch'),
+    Object.assign(new Error('The user aborted a request.'), { name: 'AbortError' }),
+  ]) {
+    const { sb, storage, key } = seededClient();
+    const realFetch = global.fetch;
+    global.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).includes('/logout')) throw thrown;
+      return realFetch(input, init);
+    }) as typeof fetch;
+
+    try {
+      const settled = await sb.auth.signOut().then(
+        r => ({ rejected: false as const, error: r.error }),
+        e => ({ rejected: true as const, error: e }),
+      );
+      assert.equal(settled.rejected, false, `${thrown.name} rejected instead of resolving`);
+      assert.ok(settled.error, `${thrown.name} resolved with no error`);
+      assert.equal((settled.error as Error).constructor.name, 'AuthRetryableFetchError');
+      assert.ok(storage.store.has(key), `${thrown.name}: session should have survived`);
+    } finally {
+      global.fetch = realFetch;
+    }
+  }
+});
+
+test('#304: a 500 from the logout endpoint also leaves the session behind', async () => {
+  // The other half of QA's spec. 401/403/404 are treated as "already gone" and
+  // DO clear; 500 is not in that list, so it takes the early return.
+  const { sb, storage, key } = seededClient();
+  const realFetch = global.fetch;
+  global.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    if (String(input).includes('/logout')) {
+      return new Response(JSON.stringify({ message: 'boom' }), {
+        status: 500, headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    return realFetch(input, init);
+  }) as typeof fetch;
+
+  try {
+    const { error } = await sb.auth.signOut();
+    assert.ok(error, '500 must surface as an error');
+    assert.ok(storage.store.has(key), '500: session should have survived');
+  } finally {
+    global.fetch = realFetch;
+  }
+});

--- a/__tests__/signOutFailure.test.mts
+++ b/__tests__/signOutFailure.test.mts
@@ -1,0 +1,104 @@
+/* #304 - "after sign out the UI still same".
+ *
+ * The owner reported this on liquidity-hq.com. Our sign-out handler is
+ * byte-identical to the one verified working on qa, so the defect is not in
+ * the click path - it is in what supabase-js does when the network misbehaves,
+ * plus the fact that we threw away the error that said so.
+ *
+ * The first test is the load-bearing one: it drives the REAL GoTrueClient, not
+ * a mock of it, so it fails if a future supabase-js bump changes the behaviour
+ * this fix compensates for. That is the point - if upstream starts clearing
+ * the session itself, we want to be told, not to keep carrying the workaround.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createClient } from '@supabase/supabase-js';
+import { authTokenKeys } from '../lib/authSession.ts';
+
+const URL = 'https://abcdefghijklmnop.supabase.co';
+const ANON = 'test-anon-key';
+
+/** A structurally valid unsigned JWT - auth-js decodes the payload for expiry. */
+function jwt(expSeconds: number): string {
+  const b64 = (o: unknown) => Buffer.from(JSON.stringify(o)).toString('base64url');
+  return `${b64({ alg: 'HS256', typ: 'JWT' })}.${b64({ sub: 'user-1', exp: expSeconds })}.sig`;
+}
+
+function memoryStorage(seed: Record<string, string> = {}) {
+  const map = new Map<string, string>(Object.entries(seed));
+  return {
+    store: map,
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => { map.set(k, v); },
+    removeItem: (k: string) => { map.delete(k); },
+  };
+}
+
+function seededClient() {
+  const future = Math.floor(Date.now() / 1000) + 3600;
+  const session = {
+    access_token: jwt(future),
+    refresh_token: 'refresh-1',
+    expires_at: future,
+    expires_in: 3600,
+    token_type: 'bearer',
+    user: { id: 'user-1', aud: 'authenticated', app_metadata: {}, user_metadata: {}, created_at: '' },
+  };
+  // The default storageKey is derived from the project ref in the URL.
+  const key = `sb-${new global.URL(URL).hostname.split('.')[0]}-auth-token`;
+  const storage = memoryStorage({ [key]: JSON.stringify(session) });
+  const sb = createClient(URL, ANON, {
+    auth: { storage, persistSession: true, autoRefreshToken: false, detectSessionInUrl: false },
+  });
+  return { sb, storage, key };
+}
+
+test('#304: a failed POST /logout leaves the session in storage and returns an error', async () => {
+  const { sb, storage, key } = seededClient();
+  const realFetch = global.fetch;
+  // Exactly the condition a dropped connection produces: the logout call never
+  // completes. Everything else is left alone.
+  global.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    if (String(input).includes('/logout')) throw new TypeError('Failed to fetch');
+    return realFetch(input, init);
+  }) as typeof fetch;
+
+  try {
+    const { error } = await sb.auth.signOut();
+
+    // Both halves of the defect, asserted separately so a partial upstream fix
+    // is legible rather than silently flipping the whole test.
+    assert.ok(error, 'signOut must report the failure - discarding this was the bug');
+    assert.ok(
+      storage.store.has(key),
+      'session should still be in storage: GoTrueClient skips _removeSession() when the ' +
+      'logout call fails with anything other than 401/403/404',
+    );
+  } finally {
+    global.fetch = realFetch;
+  }
+});
+
+test('#304: authTokenKeys finds the session key the fix has to clear', () => {
+  const { storage, key } = seededClient();
+  const found = authTokenKeys([...storage.store.keys()]);
+  assert.deepEqual(found, [key]);
+});
+
+test('authTokenKeys matches any project ref, and chunked sessions, and nothing else', () => {
+  const keys = [
+    'sb-wdtjhrilakoitfcezxpx-auth-token',      // dev
+    'sb-qdpwhnvmhqgzijuwopso-auth-token',      // prod - a different ref
+    'sb-wdtjhrilakoitfcezxpx-auth-token.0',    // chunked
+    'sb-wdtjhrilakoitfcezxpx-auth-token.1',
+    'sb-wdtjhrilakoitfcezxpx-code-verifier',   // not the session
+    'lhq_last_active',                          // ours
+    'theme',
+  ];
+  assert.deepEqual(authTokenKeys(keys), [
+    'sb-wdtjhrilakoitfcezxpx-auth-token',
+    'sb-qdpwhnvmhqgzijuwopso-auth-token',
+    'sb-wdtjhrilakoitfcezxpx-auth-token.0',
+    'sb-wdtjhrilakoitfcezxpx-auth-token.1',
+  ]);
+});

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 import { useAuth } from '@/components/AuthProvider';
 import { isGatedTf } from '@/lib/limits';
 import { useSettings } from '@/lib/settings';
@@ -106,7 +105,6 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 
 
 export default function SettingsPage() {
-  const router = useRouter();
   const { t } = useLabels();
   const { user, loading: authLoading, signOut, entitled } = useAuth();
   const { settings, saveStatus, update } = useSettings();
@@ -338,7 +336,19 @@ export default function SettingsPage() {
           onClick={async () => {
             track.signOut();
             await signOut();
-            router.push('/login');
+            /* HARD navigation, not router.push (#304).
+             *
+             * The owner reported signing out on liquidity-hq.com and seeing "the
+             * UI still same". The handler already pushed to /login and the code
+             * is byte-identical on production, so the soft navigation is
+             * reaching a client that has not fully torn down: router.push keeps
+             * the React tree, every provider and every cached fetch alive, so
+             * anything holding a stale user renders on regardless of the URL.
+             *
+             * assign() discards the document. There is no state left to be
+             * stale, which is the one guarantee worth having on a sign-out -
+             * and the cost is a page load the user is expecting anyway. */
+            window.location.assign('/login');
           }}
         >
           {t('SETTINGS_SIGN_OUT_BUTTON')}

--- a/components/AuthProvider.tsx
+++ b/components/AuthProvider.tsx
@@ -154,7 +154,25 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
   const signOut = async () => {
     const sb = getSupabase();
     localStorage.removeItem(LAST_ACTIVE_KEY);
-    const { error } = (await sb?.auth.signOut()) ?? { error: null };
+    /* Two ways this call can report failure, and it must survive both.
+     *
+     * Measured against auth-js 2.106.2 rather than assumed: a network
+     * TypeError and an AbortError both RESOLVE with an AuthRetryableFetchError
+     * in `error` - they do not reject. So the `if (error)` branch below is the
+     * live path for the reported bug, and QA's spec exercises it.
+     *
+     * The catch is still here. GoTrueAdminApi.signOut only converts what
+     * passes isAuthError() into a returned error and rethrows anything else,
+     * so a non-AuthError escaping the client rejects instead. Nothing fetch
+     * throws today lands there - but if one ever does, an uncaught rejection
+     * here would skip the local cleanup AND the caller's navigation, which is
+     * the original bug wearing a different hat. Cheap to make impossible. */
+    let error: unknown = null;
+    try {
+      ({ error } = (await sb?.auth.signOut()) ?? { error: null });
+    } catch (e) {
+      error = e ?? new Error('signOut rejected');
+    }
 
     /* A FAILED SIGN-OUT LOOKED EXACTLY LIKE A SUCCESSFUL ONE (#304).
      *

--- a/components/AuthProvider.tsx
+++ b/components/AuthProvider.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { createContext, useContext, useState, useEffect } from 'react';
 import { getSupabase } from '@/lib/supabase';
+import { authTokenKeys } from '@/lib/authSession';
 import type { User } from '@supabase/supabase-js';
 import posthog from 'posthog-js';
 import { T } from '@/lib/tables';
@@ -153,7 +154,35 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
   const signOut = async () => {
     const sb = getSupabase();
     localStorage.removeItem(LAST_ACTIVE_KEY);
-    await sb?.auth.signOut();
+    const { error } = (await sb?.auth.signOut()) ?? { error: null };
+
+    /* A FAILED SIGN-OUT LOOKED EXACTLY LIKE A SUCCESSFUL ONE (#304).
+     *
+     * GoTrueClient._signOut only drops the stored session after its POST
+     * /logout returns. It treats 401/403/404 as "already gone" and clears
+     * anyway - but on a network error, timeout or 5xx it returns the error and
+     * never reaches _removeSession(). The token stays in localStorage, no
+     * SIGNED_OUT event fires, `user` stays set, and the app carries on fully
+     * signed in. We discarded that return value, so the two outcomes were
+     * indistinguishable: the button ran, nothing happened, nothing was said.
+     * That is the reported symptom - "after sign out the UI still same".
+     *
+     * Navigating harder does not fix it, because /login bounces a signed-in
+     * user straight back (app/login/page.tsx). The session has to actually go.
+     * It is ours to drop whatever the server says, so clear it locally and let
+     * the next document load start signed out.
+     *
+     * Matched by prefix: we never set a custom storageKey, so the name is
+     * `sb-<project-ref>-auth-token` and the ref differs per environment. */
+    if (error) {
+      try {
+        authTokenKeys(Object.keys(localStorage)).forEach(k => localStorage.removeItem(k));
+      } catch {
+        // Storage can throw (private mode, quota). The hard navigation that
+        // follows is still worth attempting - do not let this abort it.
+      }
+      setUser(null);
+    }
   };
 
   // Trial expiry is compared against a clock held in state rather than a

--- a/components/NavDrawer.tsx
+++ b/components/NavDrawer.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
-import { usePathname, useRouter } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import { useMarket } from '@/lib/marketStore';
 import { useAuth } from './AuthProvider';
 import { track } from '@/lib/analytics';
@@ -252,7 +252,6 @@ export default function NavDrawer() {
   const [usageOpen, setUsageOpen] = useState(false);
   const { theme, toggleTheme }          = useTheme();
   const pathname = usePathname();
-  const router   = useRouter();
   const dot      = useStatusDot();
   const { user, loading: authLoading, signOut } = useAuth();
   const authRef  = useRef<HTMLDivElement>(null);
@@ -395,7 +394,8 @@ export default function NavDrawer() {
                           setAuthOpen(false);
                           track.signOut();
                           await signOut();
-                          router.push('/login');
+                          // Hard navigation - see the note on the Settings control (#304).
+                          window.location.assign('/login');
                         }}
                       >
                         {t('NAV_SIGN_OUT_MENU')}
@@ -556,7 +556,8 @@ export default function NavDrawer() {
                   setDrawerOpen(false);
                   track.signOut();
                   await signOut();
-                  router.push('/login');
+                  // Hard navigation - see the note on the Settings control (#304).
+                  window.location.assign('/login');
                 }}
               >
                 {t('NAV_SIGN_OUT_DRAWER')}

--- a/lib/authSession.ts
+++ b/lib/authSession.ts
@@ -1,0 +1,16 @@
+/* Locating the stored Supabase session, so a failed sign-out can still drop it.
+ *
+ * We never pass a custom `storageKey` to createClient (lib/supabase.ts), so
+ * supabase-js uses its default: `sb-<project-ref>-auth-token`. The project ref
+ * differs per environment - dev, qa and prod are three different Supabase
+ * projects - so the name cannot be hardcoded, and matching by shape is what is
+ * left. Chunked sessions (`...-auth-token.0`, `.1`) match too, which is the
+ * reason for `includes` rather than `endsWith`.
+ *
+ * Why this exists at all: see the note on signOut() in AuthProvider (#304).
+ * GoTrueClient only clears the session once its POST /logout returns, so a
+ * network failure leaves the user signed in with no error surfaced.
+ */
+export function authTokenKeys(keys: readonly string[]): string[] {
+  return keys.filter(k => k.startsWith('sb-') && k.includes('-auth-token'));
+}


### PR DESCRIPTION
**Dev Team**

Closes #304.

## Summary

The owner reported signing out on liquidity-hq.com and seeing "the UI still same". The sign-out handler is byte-identical to the one I verified working on `qa`, so the cause was never in our click path — `supabase-js` was leaving the session in place, and we were discarding the error that said so.

## What changed

| File | Change |
|---|---|
| `components/AuthProvider.tsx` | `signOut()` reads the returned `{ error }` and, on failure, clears the stored session locally and drops `user` |
| `lib/authSession.ts` | new — `authTokenKeys()`, matches `sb-<project-ref>-auth-token` (and chunked `.0`/`.1`) by shape, since the ref differs per environment |
| `app/settings/page.tsx`, `components/NavDrawer.tsx` | all three sign-out controls do a full page load to `/login` instead of `router.push` |
| `__tests__/signOutFailure.test.mts` | new — 3 tests |

## Why

`GoTrueClient._signOut` only drops the stored session **after** its `POST /logout` returns:

```js
const { error } = await this.admin.signOut(accessToken, scope);
if (error) {
  // ignore 404s ... ignore 401s ...
  if (!((isAuthApiError(error) && (error.status === 404 || error.status === 401 || error.status === 403))
        || isAuthSessionMissingError(error))) {
    return this._returnResult({ error });   // <-- returns WITHOUT _removeSession()
  }
}
if (scope !== 'others') { await this._removeSession(); ... }
```

401/403/404 are treated as "already gone" and clear anyway. A **network error, timeout or 5xx** hits the early return: the token stays in `localStorage`, no `SIGNED_OUT` event fires, `user` stays set, and the app carries on fully signed in.

Our handler was `await sb?.auth.signOut();` — the error went in the bin. So a failed sign-out and a successful one were indistinguishable: the button ran, nothing happened, nothing was said. Same shape as the recurring one in this project — **an absence reporting as a result**.

**Navigating harder would not have fixed this on its own.** `/login` redirects a signed-in user straight back (`app/login/page.tsx:57`), and renders the spinner rather than the form while `user` is set (`:208`). A surviving session lands you exactly where you started — which is precisely the "UI still same" being reported. The session has to actually go. The hard navigation is kept because it guarantees no stale provider state survives, but it is the second half of the fix, not the first.

## Correcting myself

Earlier on #304 I wrote *"The only difference on the entire auth surface since production is a test attribute."* I had diffed `AuthProvider.tsx`, `AuthGate.tsx`, `app/login/page.tsx`, `app/ops/layout.tsx` and `NavDrawer.tsx` — **but not `app/settings/page.tsx`**, the file holding the exact button the owner pressed. I have now diffed it: 5 added lines, all `data-testid` plus a comment. The conclusion held, but it was stated more confidently than the evidence supported at the time.

## How to test (QA)

On **liquidity-hq-qa.onrender.com**, signed in:

1. **Settings → Sign out.** You land on the login page with the email field visible. Not the dashboard, not a spinner.
2. **Nav drawer → Sign out** (open the menu, bottom of the list). Same result.
3. **Same two on a phone.**
4. **The actual bug.** DevTools → Network → throttling **Offline** → click Sign out → set throttling back to **No throttling** → reload. You should still be signed out and on the login page. *Before this change this left you signed in, silently.*
5. **Regression check:** sign back in normally and confirm nothing about the login flow changed.

Step 4 is the one that matters — 1–3 passed before this change too.

## Risk level

**Low.**

- Verified: the failure mode itself, against the real `GoTrueClient` (not a mock) in `__tests__/signOutFailure.test.mts` — `signOut()` returns an error *and* leaves the session in storage. All four gates green (lint 0 errors, tsc clean, 311 tests, build ✓).
- **Not verified:** the end-to-end browser repro. It needs a real signed-in session, and driving one locally means putting the fixture password in a command line — I did not do that. Steps 1–4 above are the check, and they need a human.
- **Not verified:** that this is what the owner actually hit. A failed `/logout` reproduces the reported symptom exactly, and it is the only path I found that does — but I could not observe their network at the time. If step 4 passes and they still see it, the cause is elsewhere and this fix is still correct on its own terms.
- No schema, env var or dependency change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
