### PR TITLE
test(auth): cover the ops console sign-out, the second pressable path

### DIFF
--- a/qa/e2e/signout-resilience.spec.ts
+++ b/qa/e2e/signout-resilience.spec.ts
@@ -135,6 +135,61 @@ test.describe('sign-out resilience', () => {
     } finally { await ctx.close(); }
   });
 
+  test('the OPS console sign-out also clears on a failed logout', async ({ browser }) => {
+    /* The second user-pressable sign-out, and #317 did not cover it.
+     *
+     * Dev swept the codebase after I flagged this and found FOUR callers of
+     * sb.auth.signOut(), of which #317 fixed one:
+     *
+     *   app/ops/layout.tsx:60         ops console, two buttons     bypassed
+     *   AuthProvider.tsx:69           >7-day inactivity expiry     bypassed
+     *   AuthProvider.tsx:130          BAN ENFORCEMENT              bypassed
+     *   AuthProvider.tsx:172          the button in #317           fixed
+     *
+     * The other two are not reachable from any button, which is exactly why
+     * testing the button would never have found them - dev's unit test covers
+     * those. This covers the second button, because a UI path deserves a UI
+     * assertion. Requires the admin fixture from #280. */
+    const adminEmail = process.env.E2E_USER_ADMIN_EMAIL ?? '';
+    const adminPw = process.env.E2E_USER_ADMIN_PASSWORD ?? '';
+    test.skip(!adminEmail || !adminPw,
+      'admin fixture absent - E2E_USER_ADMIN_EMAIL / E2E_USER_ADMIN_PASSWORD, see #280');
+
+    const res = await fetch(`${SUPABASE_URL}/auth/v1/token?grant_type=password`, {
+      method: 'POST',
+      headers: { apikey: SUPABASE_ANON, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: adminEmail, password: adminPw }),
+    });
+    const s = await res.json();
+    test.skip(!s?.access_token, `admin sign-in failed: HTTP ${res.status}`);
+
+    const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+    const page = await ctx.newPage();
+    try {
+      await seedSession(page, s as Record<string, unknown>, new URL(SUPABASE_URL).hostname.split('.')[0]);
+
+      let logoutHits = 0;
+      await page.route(LOGOUT, route => { logoutHits++; return route.abort('connectionfailed'); });
+
+      await page.goto('/ops', { waitUntil: 'domcontentloaded' });
+      await page.waitForTimeout(8000);
+
+      expect((await state(page)).token, 'not signed in on /ops - this run measured nothing').toBe(true);
+
+      const btn = page.locator('button', { hasText: /sign out/i }).first();
+      const found = await btn.isVisible().catch(() => false);
+      test.skip(!found, 'no sign-out button rendered on /ops - the admit path may have changed');
+
+      await btn.click();
+      await page.waitForTimeout(9000);
+
+      expect(logoutHits, 'the logout request was never attempted from /ops').toBeGreaterThan(0);
+      expect((await state(page)).token,
+        'the ops console sign-out left the session intact after a failed logout - it bypasses ' +
+        'the resilient path that the settings button uses').toBe(false);
+    } finally { await ctx.close(); }
+  });
+
   test('CONTROL: a HEALTHY sign-out still works and lands on the sign-in form', async ({ browser }) => {
     /* Stops the fix being "clear the session and never call logout". The
        request must still be made, and the normal path must still end on /login


### PR DESCRIPTION
**QA Team** · The fourth case for #320. **Reproduces the ops-console bypass** on the current build. Merge with or after #320.

## Verified on `qa @ 2e00034` — which carries #317 but not #320

```
the OPS console sign-out also clears on a failed logout   FAILED
  "the session survived - it bypasses the resilient path that the settings button uses"
```

Expect 4 passed once #320 is deployed.

## Why only this one, and not the other two

```
ops console (two buttons)   PRESSABLE   covered here
>7-day inactivity expiry    not pressable
ban enforcement             not pressable
```

The two non-button paths are yours — `signOutFailure.test.mts` is the right home for them, because a spec cannot press a thing that has no button. **That is exactly why testing the button never found them**, and it is worth stating in the issue: the surface I could reach was the smallest of the four.

## The ban-enforcement one is the finding of the day

Fire-and-forget, no `await`, error never inspected. **A banned user whose logout request failed stayed signed in, and nothing anywhere reported it.** A security control failing silently by construction — the first sign would have been someone noticing a banned account still active.

That is the same shape as every other thing this week: not an error, an *absence*. The empty-200s, the missing cron schedule, the `configured` block that exists because eleven days of silence looked like health. Worth adding to `qa/STATUS.md`'s standing risks once #320 lands — I will do it in a separate docs PR rather than bundle it here.

## On the sweep

You wrote:

> Three of four, not one. #317 fixed the path the owner happened to report and left the other three carrying the identical defect.

Worth being precise about the sequence: I asked about **one** site and called it "worth a check rather than an assumption". You swept the codebase and found three. **The sweep was the valuable half, not the question** — I would have accepted a one-line answer about `app/ops/layout.tsx` and never learned about ban enforcement.

## Skips are named, not silent

Two guarded skips: the admin fixture from #280 being absent, and no sign-out button rendering on `/ops`. Both say why. A vacuous pass on either would be worse than a skip — the second especially, since "no button found" and "button worked" are indistinguishable to an assertion that only checks the token afterwards.

## How to test (QA)

```bash
E2E_BASE_URL=https://liquidity-hq-qa.onrender.com \
  npx playwright test qa/e2e/signout-resilience.spec.ts --project=desktop
```

## Risk level: **Low**

QA-owned spec, one added case, no application code.
