### PR TITLE
fix(arena): compute signals on closed candles, and recompute when one closes

### DIFF
--- a/__tests__/candles.test.mts
+++ b/__tests__/candles.test.mts
@@ -1,0 +1,107 @@
+/* #316 - closed candles only, and recompute when one closes.
+ *
+ * The property that matters is the repaint guard: a signal must not be able to
+ * appear and disappear inside one candle. These pin the mechanism underneath
+ * it - which candles are visible, and when we look again.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  TF_MS, CLOSE_SKEW_MS, dropForming, msUntilNextClose, sameCandle,
+} from '../lib/candles.ts';
+
+const MIN = 60_000;
+const bar = (t: number) => ({ time: t, close: 1 });
+
+test('every supported interval divides a day, which is what epoch alignment needs', () => {
+  // If this ever fails, floor(t / intervalMs) is no longer the candle index and
+  // msUntilNextClose / sameCandle are both silently wrong. A weekly or monthly
+  // interval would break it - see the note in lib/candles.ts.
+  for (const [tf, ms] of Object.entries(TF_MS)) {
+    assert.equal(86_400_000 % ms, 0, `${tf} does not divide a day`);
+  }
+});
+
+test('msUntilNextClose counts to the boundary, not from now', () => {
+  const t = Date.UTC(2026, 7, 12, 13, 22, 30); // 13:22:30
+  assert.equal(msUntilNextClose(TF_MS['1m'], t), 30_000);
+  assert.equal(msUntilNextClose(TF_MS['5m'], t), 2 * MIN + 30_000);   // -> 13:25
+  assert.equal(msUntilNextClose(TF_MS['1h'], t), 37 * MIN + 30_000);  // -> 14:00
+  assert.equal(msUntilNextClose(TF_MS['4h'], t), 2 * 3600_000 + 37 * MIN + 30_000); // -> 16:00
+});
+
+test('exactly on a boundary returns a full period, never zero', () => {
+  // Zero would busy-loop: fire, land on the same boundary, fire again.
+  const t = Date.UTC(2026, 7, 12, 16, 0, 0);
+  assert.equal(msUntilNextClose(TF_MS['4h'], t), TF_MS['4h']);
+  assert.equal(msUntilNextClose(TF_MS['1m'], t), TF_MS['1m']);
+});
+
+test('the skew is positive, so we never ask before the candle exists', () => {
+  assert.ok(CLOSE_SKEW_MS > 0);
+});
+
+test('dropForming removes the still-open bar', () => {
+  const now = Date.UTC(2026, 7, 12, 13, 22, 30);
+  const open = Date.UTC(2026, 7, 12, 13, 20, 0);   // 13:20 5m bar, closes 13:25
+  const prev = Date.UTC(2026, 7, 12, 13, 15, 0);
+  const out = dropForming([bar(prev), bar(open)], TF_MS['5m'], now);
+  assert.deepEqual(out.map(c => c.time), [prev]);
+});
+
+test('a bar that closed exactly now is KEPT - it is closed, not forming', () => {
+  const closeAt = Date.UTC(2026, 7, 12, 13, 25, 0);
+  const openedAt = closeAt - TF_MS['5m'];
+  assert.deepEqual(
+    dropForming([bar(openedAt)], TF_MS['5m'], closeAt).map(c => c.time),
+    [openedAt],
+    'time + interval > now is false at exactly the close, so it survives',
+  );
+});
+
+test('a payload with no forming bar loses nothing', () => {
+  // Blind `slice(0, -1)` would silently discard a real closed candle here.
+  const now = Date.UTC(2026, 7, 12, 13, 30, 0);
+  const times = [13 * 60 + 15, 13 * 60 + 20].map(m => Date.UTC(2026, 7, 12, 0, m, 0));
+  assert.deepEqual(dropForming(times.map(bar), TF_MS['5m'], now).map(c => c.time), times);
+});
+
+test('more than one trailing unclosed bar is handled, not just the last', () => {
+  const now = Date.UTC(2026, 7, 12, 13, 22, 0);
+  const times = [
+    Date.UTC(2026, 7, 12, 13, 15, 0),  // closed 13:20
+    Date.UTC(2026, 7, 12, 13, 20, 0),  // closes 13:25 - open
+    Date.UTC(2026, 7, 12, 13, 25, 0),  // closes 13:30 - open (upstream oddity)
+  ];
+  assert.deepEqual(dropForming(times.map(bar), TF_MS['5m'], now).map(c => c.time), [times[0]]);
+});
+
+test('dropForming on an empty array is empty, not a crash', () => {
+  assert.deepEqual(dropForming([], TF_MS['1h'], Date.now()), []);
+});
+
+test('sameCandle is true within one period and false across a close', () => {
+  const fetched = Date.UTC(2026, 7, 12, 13, 21, 0);
+  assert.equal(sameCandle(fetched, TF_MS['5m'], Date.UTC(2026, 7, 12, 13, 24, 59)), true);
+  assert.equal(sameCandle(fetched, TF_MS['5m'], Date.UTC(2026, 7, 12, 13, 25, 0)), false,
+    'a close happened, so the cached candles no longer describe the present');
+});
+
+test('sameCandle scales with the interval instead of a flat five minutes', () => {
+  const fetched = Date.UTC(2026, 7, 12, 1, 0, 0);
+  // The old 5-minute TTL refetched a 1d chart 96 times a day to see one change.
+  assert.equal(sameCandle(fetched, TF_MS['1d'], Date.UTC(2026, 7, 12, 23, 59, 0)), true);
+  assert.equal(sameCandle(fetched, TF_MS['1d'], Date.UTC(2026, 7, 13, 0, 0, 1)), false);
+  // ...and served a 1m chart a candle five periods stale.
+  assert.equal(sameCandle(fetched, TF_MS['1m'], Date.UTC(2026, 7, 12, 1, 1, 0)), false);
+});
+
+test('the worst-case client staleness is now the skew, not the timeframe', () => {
+  // QA measured 5.5 min (1m) to 20 min (4h) worst case. The client half of that
+  // becomes CLOSE_SKEW_MS for every timeframe.
+  for (const ms of Object.values(TF_MS)) {
+    const justAfterClose = 1_000_000 * ms + CLOSE_SKEW_MS;
+    assert.equal(sameCandle(justAfterClose - CLOSE_SKEW_MS - 1, ms, justAfterClose), false,
+      'a fetch from before the close must not be reused after it');
+  }
+});

--- a/lib/candles.ts
+++ b/lib/candles.ts
@@ -1,0 +1,86 @@
+/* Candle boundaries - closed vs forming, and when the next close lands (#316).
+ *
+ * ── WHY THIS EXISTS ─────────────────────────────────────────────────────────
+ *
+ * Arena signals were computed over the STILL-FORMING candle. Nothing dropped
+ * it: the exchange returns the in-progress bar as the last element and
+ * useEMAStrategy used the array as-is. So an EMA cross could appear mid-candle,
+ * be shown as a signal, and then un-appear when price moved back before the
+ * close. The value displayed was never a value any candle closed at.
+ *
+ * That is repainting, and it is worse than a delay: a delayed signal was at
+ * least true at some point. Owner's decision on #316 was closed candles only.
+ *
+ * ── EPOCH ALIGNMENT ─────────────────────────────────────────────────────────
+ *
+ * Every interval we support (1m..1d) divides evenly into a day, and the Unix
+ * epoch begins at 00:00 UTC, so candle boundaries land on exact multiples of
+ * the interval. That makes `floor(t / intervalMs)` the candle index, which is
+ * what the functions below rely on rather than reading timestamps back out of
+ * the payload.
+ *
+ * This would NOT hold for a weekly or monthly interval (a week is not a
+ * divisor of the epoch offset, and months vary in length). If either is ever
+ * added, these need boundaries derived from the exchange's own candle times.
+ */
+
+export const TF_MS: Record<string, number> = {
+  '1m': 60_000,
+  '5m': 5 * 60_000,
+  '15m': 15 * 60_000,
+  '30m': 30 * 60_000,
+  '1h': 3_600_000,
+  '2h': 2 * 3_600_000,
+  '4h': 4 * 3_600_000,
+  '1d': 24 * 3_600_000,
+};
+
+/**
+ * Grace period after a boundary before we ask for the closed candle.
+ *
+ * The exchange does not publish a closed candle at boundary+0ms, and our clock
+ * is not theirs. Requesting too eagerly gets the previous candle back and the
+ * signal stays a full period behind - the exact bug being fixed, arrived at
+ * from the other direction.
+ */
+export const CLOSE_SKEW_MS = 3_000;
+
+/** Milliseconds until the current candle of this interval closes. */
+export function msUntilNextClose(intervalMs: number, nowMs: number): number {
+  if (!(intervalMs > 0)) return 0;
+  const elapsed = ((nowMs % intervalMs) + intervalMs) % intervalMs;
+  return intervalMs - elapsed;
+}
+
+/**
+ * Drop any trailing candle that has not closed yet.
+ *
+ * Compares each candle's own close time (`time + intervalMs`) against now,
+ * rather than blindly removing the last element. Blind removal is wrong twice
+ * over: it discards a genuinely closed candle when the payload happens not to
+ * include a forming one, and it leaves a forming candle in place if an upstream
+ * ever returns more than one trailing partial.
+ *
+ * Loops from the end because only trailing candles can be unclosed - a gap in
+ * the middle is missing data, not a forming bar, and is not this function's
+ * problem to solve.
+ */
+export function dropForming<T extends { time: number }>(
+  candles: readonly T[], intervalMs: number, nowMs: number,
+): T[] {
+  let end = candles.length;
+  while (end > 0 && candles[end - 1].time + intervalMs > nowMs) end--;
+  return candles.slice(0, end);
+}
+
+/**
+ * Is a cache entry fetched at `fetchedAt` still describing the current state?
+ *
+ * True only while no candle has closed since the fetch. This replaces the fixed
+ * 5-minute TTL, which was unrelated to the data: on 1m it served a candle five
+ * periods old, and on 1d it refetched 96 times to observe one change.
+ */
+export function sameCandle(fetchedAt: number, intervalMs: number, nowMs: number): boolean {
+  if (!(intervalMs > 0)) return false;
+  return Math.floor(fetchedAt / intervalMs) === Math.floor(nowMs / intervalMs);
+}

--- a/lib/useEMAStrategy.ts
+++ b/lib/useEMAStrategy.ts
@@ -10,6 +10,7 @@ import {
 } from './strategyCore';
 import { detectRSIDivergence } from './divergence';
 import { simulateTrades } from './backtestEngine';
+import { TF_MS, CLOSE_SKEW_MS, dropForming, msUntilNextClose, sameCandle } from './candles';
 import { getWaveTrendConfirmation } from './waveTrend';
 
 export type { SignalFilterParams } from './strategyCore';
@@ -132,7 +133,10 @@ export const STRATEGY_LOADING: StrategySignal = {
 /* ── Module-level kline cache - survives component unmount/remount ───────── */
 interface KlineCacheEntry { cRibbon: OHLCV[]; c1d: OHLCV[]; fetchedAt: number }
 const klineCache = new Map<string, KlineCacheEntry>();
-const KLINE_CACHE_TTL_MS = 5 * 60_000; // matches the 5-min refresh interval
+/* The cache entry is valid while no candle has CLOSED since it was written,
+   not for a fixed number of minutes (#316). The old 5-minute TTL had no
+   relationship to the data it guarded: on a 1m chart it served a candle five
+   periods old, and on a 1d chart it refetched 96 times to observe one change. */
 
 /* ── TF → exchange interval strings ─────────────────────────────────────── */
 const TF_BN: Record<string, string> = {
@@ -488,7 +492,8 @@ export function useEMAStrategy(
 
     const cacheKey = `${coin}:${tf}`;
     const cached = klineCache.get(cacheKey);
-    const cacheHit = !!cached && (Date.now() - cached.fetchedAt < KLINE_CACHE_TTL_MS);
+    const intervalMs = TF_MS[tf] ?? TF_MS['4h'];
+    const cacheHit = !!cached && sameCandle(cached.fetchedAt, intervalMs, Date.now());
 
     if (cacheHit) {
       candlesRef.current = { coin, tf, cRibbon: cached.cRibbon, c1d: cached.c1d };
@@ -501,31 +506,78 @@ export function useEMAStrategy(
     const bnInterval = TF_BN[tf] ?? '4h';
     const byInterval = TF_BY[tf] ?? '240';
 
-    const load = async () => {
+    const load = async (): Promise<boolean> => {
       try {
-        const [cRibbon, c1d] = await Promise.all([
+        const [rawRibbon, raw1d] = await Promise.all([
           fetchOHLCV(coin, bnInterval, byInterval, 1000),
           fetchOHLCV(coin, '1d', 'D', 1000),
         ]);
-        if (!mountedRef.current) return;
+        if (!mountedRef.current) return false;
+
+        /* CLOSED CANDLES ONLY (#316) - dropped here, at the single point every
+         * consumer downstream reads from, rather than in each of them.
+         *
+         * The exchange returns the in-progress bar as the last element and we
+         * used the array as-is, so the EMA/ATR/choppiness arrays all had a
+         * partial final value, a cross could appear mid-candle and vanish
+         * before the close, and simulateTrades resolved outcomes against a bar
+         * that had not finished printing. The signal shown was not necessarily
+         * a signal any candle ever closed on.
+         *
+         * FORMING is unaffected: `pending` means the PERSIST hold is
+         * incomplete, not "this is the live bar", so the hollow marker still
+         * appears on a signal awaiting confirmation. */
+        const nowMs = Date.now();
+        const cRibbon = dropForming(rawRibbon, intervalMs, nowMs);
+        const c1d     = dropForming(raw1d, TF_MS['1d'], nowMs);
         if (cRibbon.length < 55 || c1d.length < 5) {
           setSig({ ...STRATEGY_LOADING, loading: false, error: 'Not enough candle data', signalTimestamp: null, signalAnchorPrice: null, signalDir: null });
-          return;
+          return false;
         }
         klineCache.set(cacheKey, { cRibbon, c1d, fetchedAt: Date.now() });
         candlesRef.current = { coin, tf, cRibbon, c1d };
         computeRef.current();
+        return true;
       } catch (err) {
-        if (!mountedRef.current) return;
+        if (!mountedRef.current) return false;
         setSig({ ...STRATEGY_LOADING, loading: false, error: String(err) });
+        return false;
       }
     };
 
-    load();
-    const iv = setInterval(load, KLINE_CACHE_TTL_MS);
+    /* Recompute WHEN A CANDLE CLOSES, not every five minutes (#316).
+     *
+     * The old fixed interval was wrong in both directions at once: on 1m it
+     * missed four closes out of five, and on 1d it woke 96 times to observe a
+     * single change. Signals only change on a close, so that is when to look.
+     *
+     * CLOSE_SKEW_MS of grace after the boundary - the exchange does not have
+     * the closed candle at boundary+0ms and our clock is not theirs. Asking
+     * too early returns the previous candle and leaves the signal a full
+     * period behind, which is this bug approached from the other side.
+     *
+     * A failed load retries on the shorter of the next close and a minute,
+     * rather than waiting out a 4h period on a transient network error.
+     *
+     * Still a timer, not the chart's WebSocket. The socket is the better
+     * trigger and QA is right that it is the real answer - it is a larger
+     * change than this one and is tracked separately on #316. */
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const scheduleNext = (ok: boolean) => {
+      if (!mountedRef.current) return;
+      const untilClose = msUntilNextClose(intervalMs, Date.now()) + CLOSE_SKEW_MS;
+      timer = setTimeout(tick, ok ? untilClose : Math.min(untilClose, 60_000));
+    };
+    // Driven by the RESOLVED value, not by a rejection: load() catches its own
+    // errors to surface them in the UI, so the rejection branch would be dead
+    // code and every failure would wait out a full candle period.
+    const tick = () => { void load().then(scheduleNext); };
+
+    void load().then(scheduleNext);
+
     return () => {
       mountedRef.current = false;
-      clearInterval(iv);
+      if (timer) clearTimeout(timer);
     };
   }, [coin, tf]);
 


### PR DESCRIPTION
**Dev Team**

For #316. **Owner and QA independently reached the same decision — closed candles only.** Owner's words: *"go 1 closed candles only"*. QA's, with a better reason than mine.

## What changed

| File | Change |
|---|---|
| `lib/candles.ts` | new — `dropForming`, `msUntilNextClose`, `sameCandle`, `TF_MS`, `CLOSE_SKEW_MS` |
| `lib/useEMAStrategy.ts` | drops the forming bar at the single point every consumer reads from; recomputes on candle close instead of every 5 minutes; cache valid until a candle closes |
| `__tests__/candles.test.mts` | new — 12 tests |

## QA's reason was the stronger one

> The live signal and the win/loss record beside it are computed from different candle sets.

Correct. `simulateTrades` walks the same array, so `Recent record (1H): 9 wins / 24 losses` was scored over a candle set the live signal did not share. **Two numbers on one card, computed on different bases, nothing announcing the mismatch.** That is a better argument than my repainting one, because it is a visible contradiction rather than a theoretical one.

## One correction, measured

QA wrote:

> **`FORMING` already exists and is exactly the right UI for the provisional state.**

Right conclusion, and the mechanism is not what either of us assumed — which matters, because it changes what this PR had to do.

```
lib/strategyCore.ts:160   pending: boolean;  // true = PERSIST hold incomplete (live edge)
```

`pending` means **the PERSIST hold has not completed yet**, not "this is the live bar". It is a signal-maturity flag, not a candle flag. So dropping the forming candle does not touch FORMING at all — a signal on the last *closed* bar whose PERSIST window is still open is still `pending`, still renders the hollow dashed marker.

**No split was needed.** The provisional state survives for free, and I did not have to build the two-track UI we were both sketching.

## The delay half

Worst-case client staleness goes from your measured 5.5–20 minutes to `CLOSE_SKEW_MS` (3s) on **every** timeframe. The old fixed interval was wrong in both directions at once — on 1m it missed four closes in five; on 1d it woke 96 times to observe one change.

**Not in this PR, and I want it stated plainly rather than discovered:**

- `/api/market/klines` still expires on its own wall-clock TTL, so a recompute can still fetch a cached response. Boundary-aligned expiry there is the remaining work.
- **You are right that the socket is the real answer.** A timer is not the same thing as an event. This is a timer. It gets the staleness to 3s, which I think earns shipping it now, but it does not close your point and I am not pretending it does.

## How to test (QA)

Your five assertions map onto this directly. The one that pins the decision:

1. **The repaint guard, on 1m.** A signal that appears must **not** disappear while the same candle is still open. This was possible before.
2. **A bar closes → the confirmed signal updates within a few seconds, no reload.**
3. **FORMING still renders** — hollow dashed marker on a signal awaiting its PERSIST hold.
4. **4h and 1d change only at a close.** Less often than before. That is correct, and it is the thing most likely to be misread as a regression.
5. **CONTROL: a signal that should be absent stays absent.**

## Risk level

**Medium.** It changes what every Arena signal is computed from.

- Verified: 331 tests pass (12 new), lint 0 errors, tsc clean, build ✓.
- **Not verified: the repaint guard in a browser.** It needs a live 1m candle and a cross that would previously have flickered — I cannot force one. **Assertion 1 is the whole point of the PR and only you can run it.**
- **Not verified:** that 4h/1d still update at all. The unit tests cover the boundary maths, but a full-period wait is not something I sat through.
- No schema, env var or dependency change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
