### PR TITLE
fix(chat): stop the Ask AI button from vanishing permanently

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -99,6 +99,22 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             paint (no flash of the wrong theme). Mirrors lib/theme.ts's
             getStoredTheme(): explicit localStorage choice wins, otherwise
             follow the device's prefers-color-scheme. */}
+        {/* SAFETY NET for consent-pending (#326).
+            body.consent-pending hides the Ask AI FAB outright
+            (visibility:hidden), it is set in this server markup, and the ONLY
+            thing that removes it is a useEffect in components/CookieConsent.tsx.
+            So anything that stops that component mounting - blocked script,
+            failed or delayed hydration, an aggressive shields setting - leaves
+            the FAB permanently invisible, with no error and nothing to see in
+            the console. The button is fine; it is waiting for a signal that
+            never arrives.
+            This clears it after 3s regardless. Deliberately NOT React: the
+            failure being guarded against is React not running. The normal path
+            still wins - CookieConsent removes it within a frame or two - and
+            this only ever fires when that did not happen. */}
+        <Script id="consent-pending-failsafe" strategy="beforeInteractive">
+          {`(function(){try{setTimeout(function(){try{document.body.classList.remove('consent-pending');}catch(e){}},3000);}catch(e){}})();`}
+        </Script>
         <Script id="theme-init" strategy="beforeInteractive">
           {`(function(){try{var t=localStorage.getItem('theme');if(t!=='light'&&t!=='dark'){t=window.matchMedia('(prefers-color-scheme: light)').matches?'light':'dark';}document.documentElement.setAttribute('data-theme',t);}catch(e){}})();`}
         </Script>

--- a/components/GrokChat.tsx
+++ b/components/GrokChat.tsx
@@ -367,10 +367,27 @@ export default function GrokChat() {
   }, [coin, open]);
 
   /* ── Hide FAB while scrolling (mobile only) ── */
+  /* `open` is read through a ref rather than a dependency (#326).
+   *
+   * This effect used to depend on [open], and its cleanup clears the pending
+   * restore timer. So if `open` changed during the 400ms the FAB was hidden,
+   * the restore was cancelled and `fabVisible` stayed false - leaving the
+   * button at opacity 0 with pointer-events none until the user happened to
+   * scroll again. It reads as the Ask AI button being gone.
+   *
+   * Not hypothetical: the `grok-chat` custom event below opens the panel
+   * programmatically, so `open` can flip while the user is mid-scroll and has
+   * not touched the FAB at all.
+   *
+   * With a ref the listener is installed once and the timer is only cleared on
+   * unmount, when the state is being discarded anyway. */
+  const openRef = useRef(open);
+  useEffect(() => { openRef.current = open; }, [open]);
+
   useEffect(() => {
     const mq = window.matchMedia('(max-width: 639px)');
     const onScroll = () => {
-      if (!mq.matches || open) return;
+      if (!mq.matches || openRef.current) return;
       setFabVisible(false);
       if (scrollTimer.current) clearTimeout(scrollTimer.current);
       scrollTimer.current = setTimeout(() => setFabVisible(true), 400);
@@ -380,7 +397,12 @@ export default function GrokChat() {
       window.removeEventListener('scroll', onScroll);
       if (scrollTimer.current) clearTimeout(scrollTimer.current);
     };
-  }, [open]);
+  }, []);
+
+  /* Closing the panel always restores the FAB. Belt and braces alongside the
+   * ref above: whatever else happened, the button must be reachable once the
+   * thing it opens is shut. */
+  useEffect(() => { if (!open) setFabVisible(true); }, [open]);
 
 
   /* ── Auto-save current conversation whenever messages change ── */


### PR DESCRIPTION
**Dev Team**

For #326. **Two real defects found, neither Brave-specific, neither proven to be the owner's — and your mechanism does not hold. I checked it rather than building on it.**

## Correcting the diagnosis first

> The Ask AI chat decides its mobile variant from `matchMedia`, in JavaScript. So if `matchMedia` returns the wrong answer, GrokChat renders its desktop form — and the FAB the owner is missing is exactly what a desktop-form chat would not show.

**`GrokChat.tsx:371` cannot produce a missing FAB.** That `matchMedia` is used in exactly one place — inside the scroll handler, to decide whether to fade the FAB *while scrolling*:

```ts
const onScroll = () => {
  if (!mq.matches || open) return;    // <- the only use
  setFabVisible(false);
  ...
```

The button itself renders unconditionally at `:598-608`. There is no mobile variant of the chat and no `matchMedia` gate on rendering.

**And the direction is backwards.** If Brave made that query return `false` on a phone, the handler would return early and the FAB would *never hide* — more visible, not less. A faked `matchMedia` produces the opposite of the reported symptom.

Your instinct that one mechanism links both reports may still be right. That line is not it.

## What I did find

### 1. `consent-pending` is a permanent hang with no fallback

```
app/layout.tsx:96      <body className="consent-pending">        <- server markup
app/globals.css:4071   body.consent-pending .gchat-fab { visibility: hidden; }
CookieConsent.tsx:27   document.body.classList.remove('consent-pending')   <- the ONLY removal
```

**The FAB is hidden by default and unhidden by a React effect.** So anything that stops `CookieConsent` mounting — blocked script, failed or delayed hydration, aggressive shields — leaves the button invisible forever. No error, nothing in the console, nothing to inspect. **The button is not broken; it is waiting for a signal that never arrives.**

That is the same shape as everything else this week, and it is the most Brave-plausible thing I found, because shields interfere with script execution rather than with CSS.

I checked whether `readConsent()` could throw before reaching the removal — **it cannot**, `lib/consent.ts:26` wraps it. That path is dead; the mount path is not.

Fixed with a `beforeInteractive` script that clears the class after 3s regardless. **Deliberately not React** — the failure being guarded against is React not running.

### 2. The scroll-restore timer strands the FAB

The effect depended on `[open]`, and its cleanup clears the pending restore. If `open` changed during the 400ms hide window, the restore was cancelled and `fabVisible` stayed `false` — opacity 0, pointer-events none — until the user scrolled again.

**Reachable without touching the FAB:** `GrokChat.tsx:536` listens for a `grok-chat` custom event that opens the panel programmatically. Scroll, a card fires that event, close the panel, button gone.

Fixed with a ref so the listener installs once, plus closing the panel always restoring the FAB.

## What I have NOT explained

**"Desktop view after login."** No JS layout branch exists that could do it — your sweep found the only candidates and I agree with your reading of them. `viewport` is `width: 'device-width', initialScale: 1`. I have nothing, and I would rather say so than attach it to these two fixes because they are nearby.

**Whether either fix is what the owner hit.** Both are real, both produce "the button is gone, no error", neither is verified against Brave. I cannot reproduce Brave's protections either.

## Your two questions

**Yes to the Chromium spec** — pins the FAB present at mobile width, catches a regression in this logic. Not verification of the Brave case and should say so in the file.

**"Is Brave supported?" is the owner's call and I have put it to them.** Worth noting the fixes here are correct regardless of the answer — a FAB that can hang invisible forever is a defect on every browser.

## How to test (QA)

1. **The timer bug**, any mobile browser: scroll until the Ask AI button fades → use a card's Ask AI action to open the chat while faded → close it. **Button must be back.** Before this it stayed invisible until you scrolled again.
2. **The failsafe:** load any page, do not touch the cookie banner. Button appears within ~3s.
3. **No regression:** the button still fades while scrolling and returns ~400ms after you stop.
4. **Desktop unaffected** — the scroll-hide is mobile-only.

## Risk level

**Low-Medium.** Medium only because the failsafe touches the root layout for every page.

- Verified: 331 tests, lint 0 errors, tsc clean, build ✓.
- **Not verified: Brave.** Cannot reproduce it here.
- **Not verified: that either defect is the owner's report.** Both are real; that is a different claim.
- **Unexplained: the desktop-layout half of #326.** Not addressed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
