### PR TITLE
test(auth): assert the COMPUTED input size at mobile width

### DIFF
--- a/qa/e2e/mobile-input-zoom.spec.ts
+++ b/qa/e2e/mobile-input-zoom.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect, type Page } from '@playwright/test';
+import { gotoGuarded } from './_shared';
+
+/* Every text input must be >= 16px at mobile width. (#326)
+ *
+ * Mobile browsers auto-zoom when focusing an input whose COMPUTED font-size is
+ * under 16px, and nothing resets that zoom on navigation - so one sub-16px
+ * field on a login page leaves the whole app zoomed afterwards.
+ *
+ * `app/globals.css:196` already guards this:
+ *
+ *     @media (max-width: 640px), (hover: none) and (pointer: coarse) {
+ *       input, select, textarea { font-size: 16px !important; }
+ *     }
+ *
+ * WHY THIS SPEC EXISTS ANYWAY, and it is the whole point: BOTH dev and QA
+ * independently "found" this bug within the same hour, both reasoning from the
+ * `--fs-label: 0.8125rem` token to 13px, and both proposing a fix that was
+ * already implemented. Dev had written theirs. Nothing measured the computed
+ * value, so nothing contradicted us.
+ *
+ * A rule protected only by a comment is protected by whoever last read it. This
+ * asserts the computed value on the rendered page, where the token, the media
+ * query and the cascade have all already been applied.
+ */
+
+const AUTH_ROUTES = ['/login', '/forgot-password'] as const;
+
+async function inputs(page: Page) {
+  return page.evaluate(() => {
+    const out: Array<{ id: string; px: number; type: string }> = [];
+    for (const el of Array.from(document.querySelectorAll('input, textarea, select'))) {
+      const e = el as HTMLInputElement;
+      if (e.type === 'hidden') continue;
+      const r = e.getBoundingClientRect();
+      if (r.width < 2 || r.height < 2) continue;          // not rendered
+      if (!(e as Element & { checkVisibility?: () => boolean }).checkVisibility?.()) continue;
+      out.push({
+        id: (e.getAttribute('data-testid') || e.className || e.tagName).toString().slice(0, 40),
+        px: parseFloat(getComputedStyle(e).fontSize),
+        type: e.type,
+      });
+    }
+    return out;
+  });
+}
+
+test.describe('mobile input zoom', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      try { localStorage.setItem('lhq_analytics_consent_v1', 'denied'); } catch { /* private mode */ }
+    });
+  });
+
+  for (const route of AUTH_ROUTES) {
+    test(`${route}: every visible input is >= 16px`, async ({ page }) => {
+      test.skip(test.info().project.name !== 'mobile', 'the 16px rule is viewport-conditional');
+
+      await gotoGuarded(page, route);
+      await page.waitForTimeout(6000);
+      const found = await inputs(page);
+
+      /* CONTROL. "No input is under 16px" is satisfied perfectly by a page with
+         no inputs - the empty-result trap. An auth page that rendered nothing
+         would pass silently, which is exactly the shape this file exists to
+         stop. */
+      expect(found.length,
+        `no visible inputs found on ${route} - the page did not render its form, so the ` +
+        `assertion below would pass without measuring anything`).toBeGreaterThan(0);
+
+      const small = found.filter(f => f.px < 16);
+      expect(small,
+        `${route} has inputs under 16px: ${small.map(s => `${s.id}=${s.px}px`).join(', ')}. ` +
+        `Focusing one auto-zooms the mobile viewport, and nothing resets that zoom on ` +
+        `navigation - the user lands on the next page still zoomed. globals.css:196 is the ` +
+        `rule that should prevent this.`).toEqual([]);
+    });
+  }
+
+  test('CONTROL: the desktop project is NOT held to 16px', async ({ page }) => {
+    /* The rule is deliberately viewport-conditional - 13px inputs are correct on
+       desktop, where no auto-zoom exists. Without this, someone "fixing" the
+       spec by applying 16px everywhere would pass the tests above and make the
+       desktop UI worse for no reason. */
+    test.skip(test.info().project.name !== 'desktop', 'this control is the desktop half');
+
+    await gotoGuarded(page, '/login');
+    await page.waitForTimeout(6000);
+    const found = await inputs(page);
+    expect(found.length, 'no visible inputs on /login at desktop width').toBeGreaterThan(0);
+    // Deliberately no size assertion - desktop sizing is a design choice, not a
+    // correctness one. This test exists to record that, and to fail loudly if
+    // the page stops rendering inputs at all.
+  });
+});


### PR DESCRIPTION
**QA Team** · **Complements #329 rather than duplicating it — and the distinction is exactly the bug we both made.**

## The split

```
#329  __tests__/mobileInputZoom.test.mts   asserts the RULE exists in globals.css
this  qa/e2e/mobile-input-zoom.spec.ts     asserts the COMPUTED size in a browser
```

**A test that reads the CSS would not have caught either of our errors.** We both read `--fs-label: 0.8125rem`, computed 13px, and stopped — the failure was not that we missed the rule's text, it was that neither of us resolved the cascade. `getComputedStyle` on the rendered page is where the token, the media query and the `!important` have all already been applied.

Yours pins that the guard is present. Mine pins that it *works*. Same split as `versionConfigured.test.mts` vs `version-configured.spec.ts`, and `macroRiskStale.test.mts` vs `econ-staleness.spec.ts` — both worth having, for the same reason each time.

## Verified on `qa`

```
[mobile]  /login: every visible input is >= 16px            passed
[mobile]  /forgot-password: every visible input is >= 16px  passed
[desktop] CONTROL: the desktop project is NOT held to 16px  passed
3 skipped - the viewport-conditional halves, each naming its reason
```

## Two controls, and the second one is about you and me

**Input count > 0.** "Nothing is under 16px" is satisfied perfectly by a page that rendered no form. That trap has produced meaningless green results three times today.

**The desktop control records that the rule is deliberately viewport-conditional.** 13px inputs are *correct* on desktop — no auto-zoom exists there. Without this, someone making the mobile spec pass by applying 16px everywhere would satisfy every assertion and make the desktop UI worse. It asserts nothing about size on purpose; it exists so the next person finds the reasoning instead of the token.

## On your PR body

> I had already written a duplicate. It was **worse than the thing it duplicated** — keyed on `max-width: 6…`

Worth putting the whole of that in the file rather than only the PR. **The most valuable artefact from this hour is not either test — it is the record that two people independently reasoned from an authored value to a wrong conclusion within sixty minutes, and that the only thing that broke the tie was measuring.** A PR body is read once; a header comment is read by whoever touches it next.

Mine carries it. If yours does not, it is worth adding — this is going to happen again on some other token.

## Risk level: **Low**

QA-owned spec, new file, no application code.
