### PR TITLE
test(chat): make the FAB race test actually fail on the broken build

### DIFF
--- a/qa/e2e/fab-visibility.spec.ts
+++ b/qa/e2e/fab-visibility.spec.ts
@@ -102,34 +102,85 @@ test.describe('Ask AI button visibility', () => {
     } finally { await ctx.close(); }
   });
 
-  test('the FAB returns after opening and closing the panel', async ({ browser }) => {
-    /* The timer race, independent of consent and reachable on any browser: the
-       restore was cancelled if `open` changed during the 400ms hide window,
-       stranding the button at opacity 0 with pointer-events none. */
-    const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } });
-    const page = await ctx.newPage();
-    await ctx.addInitScript(() => {
+  test('the FAB survives the panel opening mid-scroll', async ({ page }) => {
+    /* THE TIMER RACE. The first version of this test asserted the wrong thing in
+       the wrong place and passed on the broken build - see the note at the
+       bottom of this file. The mechanism, from GrokChat.tsx:
+     *
+     *     const mq = window.matchMedia('(max-width: 639px)');    // MOBILE ONLY
+     *     const onScroll = () => {
+     *       if (!mq.matches || openRef.current) return;          // and only while CLOSED
+     *       setFabVisible(false);
+     *       scrollTimer.current = setTimeout(() => setFabVisible(true), 400);
+     *     };
+     *
+     * SCROLLING starts the 400ms window, not clicking. Pre-fix the effect
+     * depended on [open] and its cleanup cleared that timer, so `open` flipping
+     * inside the window cancelled the restore and left fabVisible false - until
+     * the user happened to scroll again.
+     *
+     * `open` flips without the user touching the FAB because Arena opens the
+     * panel programmatically via the `grok-chat` event. That is dev's own
+     * account of how it happens in the wild, so it is what this fires. */
+    test.skip(test.info().project.name !== 'mobile',
+      'the scroll-hide effect is guarded by max-width:639px - there is no race to lose on desktop');
+
+    await page.addInitScript(() => {
       try { localStorage.setItem('lhq_analytics_consent_v1', 'denied'); } catch { /* private mode */ }
     });
-    try {
-      await gotoGuarded(page, '/arena');
-      await page.waitForTimeout(9000);
+    await gotoGuarded(page, '/arena');
+    await page.waitForTimeout(9000);
 
-      const fab = page.locator(FAB).first();
-      await expect(fab, 'no FAB to open - this run measured nothing').toBeVisible({ timeout: 20_000 });
+    const before = await fabState(page);
+    expect(before.present, 'no FAB on the page - this run measured nothing').toBe(true);
+    expect(Number(before.opacity),
+      'the FAB was already hidden before the scroll - nothing to race').toBeGreaterThan(0.1);
 
-      await fab.click();
-      await page.waitForTimeout(300);          // inside the 400ms hide window
-      const close = page.locator('.gchat-icon-btn', { hasText: '✕' }).first();
-      if (await close.isVisible().catch(() => false)) await close.click();
-      else await page.keyboard.press('Escape');
+    /* Panel closed, so the scroll handler engages and arms the 400ms timer. */
+    await page.mouse.wheel(0, 600);
+    await page.waitForTimeout(120);            // inside the 400ms window
 
-      await page.waitForTimeout(6000);
-      const s = await fabState(page);
-      expect(Number(s.opacity),
-        `the FAB is stranded at opacity ${s.opacity} after a fast open/close - the restore timer ` +
-        `was cancelled by the state change and never re-armed`).toBeGreaterThan(0.1);
-      expect(s.pointer, 'the FAB is visible but not clickable after a fast open/close').not.toBe('none');
-    } finally { await ctx.close(); }
+    /* Flip `open` while the restore is still pending. */
+    await page.evaluate(() => {
+      window.dispatchEvent(new CustomEvent('grok-chat', { detail: { coin: 'bitcoin' } }));
+    });
+    await page.waitForTimeout(400);
+
+    /* Close it again and give the restore far longer than it needs. */
+    await page.keyboard.press('Escape');
+    const closeBtn = page.locator('.gchat-icon-btn').filter({ hasText: '✕' }).first();
+    if (await closeBtn.isVisible().catch(() => false)) await closeBtn.click();
+    await page.waitForTimeout(3000);
+
+    const after = await fabState(page);
+    expect(Number(after.opacity),
+      `the FAB is stranded at opacity ${after.opacity}. The panel opened during the 400ms ` +
+      `scroll-hide window, the restore timer was cancelled with it, and nothing re-armed it - ` +
+      `the button stays gone until the user scrolls again, which is exactly what "the FAB is ` +
+      `missing" looks like from the outside.`).toBeGreaterThan(0.1);
+    expect(after.pointer,
+      'the FAB is visible but unclickable after the panel opened mid-scroll').not.toBe('none');
   });
 });
+
+/* ─────────────────────────────────────────────────────────────────────────────
+ * WHAT THE FIRST VERSION OF THIS FILE GOT WRONG - kept because the mistake is
+ * more instructive than the test.
+ *
+ * The race test originally ran on the DESKTOP project and triggered the window
+ * by CLICKING the FAB. Both are wrong: the effect is guarded by
+ * `max-width: 639px`, and the window opens on SCROLL. So it exercised nothing,
+ * and it passed on qa @ d34377d - a build that did NOT contain the fix.
+ *
+ * It was reported as "verified on qa @ d34377d, which carries #327". The branch
+ * carried the fix; the RUNNING SERVICE was still serving the older commit. The
+ * check was `git show origin/qa:...` when it should have been the deployed
+ * build. CONTRIBUTING.md says exactly this - `/api/version` reports what the
+ * service is serving, quote it rather than the branch - and quoting the commit
+ * while trusting git for its contents is the same error one step removed.
+ *
+ * A test that passes on the broken build and the fixed build measures neither.
+ * Confirmed by measurement, not argument: 3/3 green on d34377d (no fix) and
+ * 3/3 green on 6a03e58 (fix). The only way to know a regression test works is
+ * to watch it fail.
+ * ───────────────────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
**QA Team** · 🔴 **Retracting the verification claim on #331. The test I shipped an hour ago passed on a build that did not contain your fix.**

## What I got wrong

Two errors, and the second is the serious one.

**The test measured nothing.** I triggered the 400ms window by *clicking* the FAB on the *desktop* project. Both wrong:

```js
const mq = window.matchMedia('(max-width: 639px)');   // MOBILE ONLY
const onScroll = () => {
  if (!mq.matches || openRef.current) return;         // and only while CLOSED
  setFabVisible(false);
  scrollTimer.current = setTimeout(() => setFabVisible(true), 400);
};
```

The window opens on **scroll**, and the effect does not exist above 639px. A desktop click never entered it.

**I reported it as verified against your fix, and it was not.** I quoted `/api/version` — `d34377d` — but read the file contents with `git show origin/qa:...`. The branch had your fix. The running service was still serving the older commit. `CONTRIBUTING.md` says to quote what the service is serving rather than the branch, and I quoted the commit while trusting git for what was in it. Same mistake, one step removed, and this project has made it enough times to have a rule about it.

## The corrected test, verified the only way that counts

```
d34377d  no fix, local build, mobile   FAILED - opacity 0
6a03e58  fix, qa deployment            5 passed, 1 skipped
```

I built `d34377d` locally and **watched it fail** before trusting it. It now scrolls, then fires the `grok-chat` event inside the window — which is your own account of how `open` flips without the user touching the FAB.

## Your failsafe is doing real work on mobile

First honest run of the control, and it caught something:

```
[mobile]   at 2s: visibility=hidden  pending=true    FAILSAFE was needed
[desktop]  at 2s: visibility=visible pending=false   NORMAL PATH won
```

**On mobile, `CookieConsent` does not clear `consent-pending` within 2s** — your 3s net is what makes the button appear. Not a defect and not a blocker: the outcome is correct. But it means on mobile the button is invisible for somewhere between 2 and 3 seconds on a first visit, and the normal path is not what rescues it. That is close to the owner's original complaint, and without your net it is the complaint.

Worth a look at whether `CookieConsent` can mount sooner on mobile. Filing the measurement on #326 rather than opening a new issue, since it is your fix's own telemetry.

## What this file now proves, precisely

- **The race** — genuinely covered, fails without your fix.
- **First visit / `consent-pending`** — guarded, **not** demonstrated. Chromium cannot reproduce blocked scripts or Brave shields.

The header comment carries the whole account, including what I got wrong, so the next person finds it in the file rather than in a merged PR thread.

## Risk level: **Low**

QA-owned spec, one file, no application code.
