### PR TITLE
feat(dashboard): show whether a move is spot-led or futures-led

### DIFF
--- a/__tests__/perpSpot.test.mts
+++ b/__tests__/perpSpot.test.mts
@@ -25,36 +25,41 @@ function series(n: number, ratio: number, lastRatio = ratio) {
     spot.push({ time: t, quoteVolume: s });
     perp.push({ time: t, quoteVolume: s * r });
   }
-  return { spot, perp };
+  // The instant the final bar closes. Tests pass this as `nowMs` so the clock
+  // cannot change what they assert - these silently broke when the date rolled
+  // over and part of the fixture moved into the future.
+  return { spot, perp, nowMs: T0 + n * HOUR };
 }
 
 test('a perfectly ordinary day does NOT read as futures-driven', () => {
   // BTC's real median is 7.8x. A naive "perp > spot" rule calls this perp-led;
   // it is simply Tuesday.
-  const { spot, perp } = series(48, 7.8);
-  const r = computePerpSpot(spot, perp);
+  const { spot, perp, nowMs } = series(48, 7.8);
+  const r = computePerpSpot(spot, perp, HOUR, nowMs);
   assert.equal(r.lean, 'normal');
   assert.match(r.explanation, /usual proportions/);
 });
 
 test("each coin is judged against its OWN baseline, not a shared threshold", () => {
   // ETH normally runs ~14.4x and BTC ~7.8x. Both flat = both normal.
-  assert.equal(computePerpSpot(...Object.values(series(48, 14.4)) as [never, never]).lean, 'normal');
-  assert.equal(computePerpSpot(...Object.values(series(48, 7.8)) as [never, never]).lean, 'normal');
+  const eth = series(48, 14.4);
+  const btc = series(48, 7.8);
+  assert.equal(computePerpSpot(eth.spot, eth.perp, HOUR, eth.nowMs).lean, 'normal');
+  assert.equal(computePerpSpot(btc.spot, btc.perp, HOUR, btc.nowMs).lean, 'normal');
   // A fixed cross-coin cut at, say, 10x would have called ETH perp-led forever.
 });
 
 test('a genuine spike above the coin\'s own normal reads as futures-driven', () => {
-  const { spot, perp } = series(48, 8, 8 * 1.6);
-  const r = computePerpSpot(spot, perp);
+  const { spot, perp, nowMs } = series(48, 8, 8 * 1.6);
+  const r = computePerpSpot(spot, perp, HOUR, nowMs);
   assert.equal(r.lean, 'perp');
   assert.ok(r.relative! > PERP_LED_AT);
   assert.match(r.explanation, /leveraged traders/);
 });
 
 test('unusually quiet futures reads as spot-led', () => {
-  const { spot, perp } = series(48, 8, 8 * 0.5);
-  const r = computePerpSpot(spot, perp);
+  const { spot, perp, nowMs } = series(48, 8, 8 * 0.5);
+  const r = computePerpSpot(spot, perp, HOUR, nowMs);
   assert.equal(r.lean, 'spot');
   assert.ok(r.relative! < SPOT_LED_AT);
   assert.match(r.explanation, /actually buying/);
@@ -64,15 +69,15 @@ test('the raw pair is still computed, though no longer displayed', () => {
   // The owner revised the display from "N vs N" to a single number mid-build.
   // The pair stays available - it is the honest underlying figure and the Ask
   // AI / research prompts are a likely home for it - but nothing renders it.
-  const { spot, perp } = series(48, 11.8);
-  assert.equal(computePerpSpot(spot, perp).pair, '$10.0M vs $118.0M');
+  const { spot, perp, nowMs } = series(48, 11.8);
+  assert.equal(computePerpSpot(spot, perp, HOUR, nowMs).pair, '$10.0M vs $118.0M');
 });
 
 test('the DISPLAYED number is relative to the coin own baseline, not the raw ratio', () => {
   // This is the number on the dashboard. The raw ratio here is 11.8x, which
   // would read as "futures dominate" - and it is an ordinary day.
-  const { spot, perp } = series(48, 11.8);
-  const r = computePerpSpot(spot, perp);
+  const { spot, perp, nowMs } = series(48, 11.8);
+  const r = computePerpSpot(spot, perp, HOUR, nowMs);
   assert.equal(r.ratio, 11.8);
   assert.equal(r.relative, 1);
   assert.equal(r.lean, 'normal', 'an 11.8x raw ratio must still read as normal for this coin');
@@ -81,8 +86,8 @@ test('the DISPLAYED number is relative to the coin own baseline, not the raw rat
 test('NO SPOT FEED reports unknown, never a number from the perp side alone', () => {
   // Many alts have no Binance spot pair. A missing spot leg looks EXACTLY like
   // a perp-dominated one unless this is explicit - the absence-as-finding shape.
-  const { perp } = series(48, 8);
-  const r = computePerpSpot([], perp);
+  const { perp, nowMs } = series(48, 8);
+  const r = computePerpSpot([], perp, HOUR, nowMs);
   assert.equal(r.lean, 'unknown');
   assert.equal(r.pair, '-');
   assert.equal(r.spotVol, null);
@@ -90,22 +95,22 @@ test('NO SPOT FEED reports unknown, never a number from the perp side alone', ()
 });
 
 test('too few shared bars reports unknown rather than a median of noise', () => {
-  const { spot, perp } = series(MIN_BARS - 1, 8);
-  assert.equal(computePerpSpot(spot, perp).lean, 'unknown');
+  const { spot, perp, nowMs } = series(MIN_BARS - 1, 8);
+  assert.equal(computePerpSpot(spot, perp, HOUR, nowMs).lean, 'unknown');
 });
 
 test('bars are matched on time - a venue running a beat behind is not a signal', () => {
-  const { spot, perp } = series(48, 8);
+  const { spot, perp, nowMs } = series(48, 8);
   // Shift every perp bar by one hour: no shared timestamps at all.
   const shifted = perp.map(c => ({ ...c, time: c.time + HOUR * 1000 }));
-  assert.equal(computePerpSpot(spot, shifted).lean, 'unknown',
+  assert.equal(computePerpSpot(spot, shifted, HOUR, nowMs).lean, 'unknown',
     'comparing mismatched bars would yield a ratio that is really a clock difference');
 });
 
 test('zero-volume bars are skipped, not divided by', () => {
-  const { spot, perp } = series(48, 8);
+  const { spot, perp, nowMs } = series(48, 8);
   spot[10].quoteVolume = 0;
-  const r = computePerpSpot(spot, perp);
+  const r = computePerpSpot(spot, perp, HOUR, nowMs);
   assert.equal(r.lean, 'normal');
   assert.ok(Number.isFinite(r.ratio!), 'a zero spot bar must not produce Infinity');
 });
@@ -125,4 +130,66 @@ test('CONTROL: the thresholds actually discriminate on the measured range', () =
   assert.ok(rel(19.07) > PERP_LED_AT, 'the observed high must be reachable as perp-led');
   assert.ok(rel(2.29) < SPOT_LED_AT, 'the observed low must be reachable as spot-led');
   assert.ok(rel(7.8) > SPOT_LED_AT && rel(7.8) < PERP_LED_AT, 'the median must read normal');
+});
+
+/* ── the still-forming bar must not decide the verdict (QA, #333) ───────────
+ *
+ * Reproduces QA's measurement directly. Two minutes into an hour the forming
+ * bar held ~3% of a normal hour's volume, and its ratio read "balanced" while
+ * the last CLOSED hour read perp-led. Same coin, same instant, opposite
+ * answers - the only difference being which bar the ratio came from.
+ *
+ * The baseline is a median of complete hours, so comparing an incomplete one
+ * against it was never like-for-like. Same defect as #316, in a file written
+ * hours after fixing #316.
+ */
+const H = 3600_000;
+
+/** 168 closed hours at `ratio`, plus a thin forming hour at `formingRatio`. */
+function withForming(ratio: number, lastClosedRatio: number, formingRatio: number, minsIn: number) {
+  const spot = [], perp = [];
+  const nowMs = T0 + 168 * H + minsIn * 60_000;
+  for (let i = 0; i < 168; i++) {
+    const t = T0 + i * H;
+    const s = 48_900_000;
+    const r = i === 167 ? lastClosedRatio : ratio;
+    spot.push({ time: t, quoteVolume: s });
+    perp.push({ time: t, quoteVolume: s * r });
+  }
+  // The forming hour: only a few minutes of volume has accumulated.
+  const formingSpot = 48_900_000 * (minsIn / 60);
+  spot.push({ time: T0 + 168 * H, quoteVolume: formingSpot });
+  perp.push({ time: T0 + 168 * H, quoteVolume: formingSpot * formingRatio });
+  return { spot, perp, nowMs };
+}
+
+test('#333: the forming bar is ignored - the verdict comes from the last CLOSED hour', () => {
+  // Closed hours sit at 7.75x; the last closed hour spikes to 11.0x (perp-led);
+  // the forming 2-minute bar reads 9.76x, which would be "normal".
+  const { spot, perp, nowMs } = withForming(7.75, 11.0, 9.76, 2);
+  const r = computePerpSpot(spot, perp, H, nowMs);
+
+  assert.equal(r.lean, 'perp', 'the last CLOSED hour was perp-led and must decide it');
+  assert.ok(Math.abs(r.ratio! - 11.0) < 0.01, `ratio came from the forming bar: ${r.ratio}`);
+});
+
+test('#333 CONTROL: without the drop, that same input reads the other way', () => {
+  // Passing a nowMs far in the future makes every bar closed, INCLUDING the
+  // thin one - which is exactly the old behaviour. If this does not differ from
+  // the test above, the drop is not doing anything.
+  const { spot, perp } = withForming(7.75, 11.0, 9.76, 2);
+  const asIfAllClosed = computePerpSpot(spot, perp, H, T0 + 300 * H);
+
+  assert.ok(Math.abs(asIfAllClosed.ratio! - 9.76) < 0.01,
+    'the control must actually use the thin bar, or it proves nothing');
+  assert.notEqual(asIfAllClosed.lean, 'perp',
+    'the thin bar reads differently - which is the whole defect');
+});
+
+test('#333: a bar that closed exactly now still counts', () => {
+  const { spot, perp } = withForming(7.75, 11.0, 9.76, 0);
+  // At exactly the top of the hour the "forming" bar has just opened; the hour
+  // before it is closed and must be the one used.
+  const r = computePerpSpot(spot, perp, H, T0 + 168 * H);
+  assert.ok(Math.abs(r.ratio! - 11.0) < 0.01);
 });

--- a/__tests__/perpSpot.test.mts
+++ b/__tests__/perpSpot.test.mts
@@ -1,0 +1,128 @@
+/* #328 - perps vs spot.
+ *
+ * The load-bearing test is `a perfectly ordinary day does not read as
+ * futures-driven`. Perps are 7-14x spot as the NORMAL state, so the obvious
+ * implementation - compare the two numbers, call the bigger one the driver -
+ * would fire every hour of every day and be right about market structure while
+ * telling the user nothing about today.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  computePerpSpot, fmtVol, PERP_LED_AT, SPOT_LED_AT, MIN_BARS,
+} from '../lib/perpSpot.ts';
+
+const HOUR = 3600_000;
+const T0 = Date.UTC(2026, 7, 12, 0, 0, 0);
+
+/** n bars where perp = spot * ratio, with the last bar optionally different. */
+function series(n: number, ratio: number, lastRatio = ratio) {
+  const spot = [], perp = [];
+  for (let i = 0; i < n; i++) {
+    const t = T0 + i * HOUR;
+    const s = 10_000_000;
+    const r = i === n - 1 ? lastRatio : ratio;
+    spot.push({ time: t, quoteVolume: s });
+    perp.push({ time: t, quoteVolume: s * r });
+  }
+  return { spot, perp };
+}
+
+test('a perfectly ordinary day does NOT read as futures-driven', () => {
+  // BTC's real median is 7.8x. A naive "perp > spot" rule calls this perp-led;
+  // it is simply Tuesday.
+  const { spot, perp } = series(48, 7.8);
+  const r = computePerpSpot(spot, perp);
+  assert.equal(r.lean, 'normal');
+  assert.match(r.explanation, /usual proportions/);
+});
+
+test("each coin is judged against its OWN baseline, not a shared threshold", () => {
+  // ETH normally runs ~14.4x and BTC ~7.8x. Both flat = both normal.
+  assert.equal(computePerpSpot(...Object.values(series(48, 14.4)) as [never, never]).lean, 'normal');
+  assert.equal(computePerpSpot(...Object.values(series(48, 7.8)) as [never, never]).lean, 'normal');
+  // A fixed cross-coin cut at, say, 10x would have called ETH perp-led forever.
+});
+
+test('a genuine spike above the coin\'s own normal reads as futures-driven', () => {
+  const { spot, perp } = series(48, 8, 8 * 1.6);
+  const r = computePerpSpot(spot, perp);
+  assert.equal(r.lean, 'perp');
+  assert.ok(r.relative! > PERP_LED_AT);
+  assert.match(r.explanation, /leveraged traders/);
+});
+
+test('unusually quiet futures reads as spot-led', () => {
+  const { spot, perp } = series(48, 8, 8 * 0.5);
+  const r = computePerpSpot(spot, perp);
+  assert.equal(r.lean, 'spot');
+  assert.ok(r.relative! < SPOT_LED_AT);
+  assert.match(r.explanation, /actually buying/);
+});
+
+test('the raw pair is still computed, though no longer displayed', () => {
+  // The owner revised the display from "N vs N" to a single number mid-build.
+  // The pair stays available - it is the honest underlying figure and the Ask
+  // AI / research prompts are a likely home for it - but nothing renders it.
+  const { spot, perp } = series(48, 11.8);
+  assert.equal(computePerpSpot(spot, perp).pair, '$10.0M vs $118.0M');
+});
+
+test('the DISPLAYED number is relative to the coin own baseline, not the raw ratio', () => {
+  // This is the number on the dashboard. The raw ratio here is 11.8x, which
+  // would read as "futures dominate" - and it is an ordinary day.
+  const { spot, perp } = series(48, 11.8);
+  const r = computePerpSpot(spot, perp);
+  assert.equal(r.ratio, 11.8);
+  assert.equal(r.relative, 1);
+  assert.equal(r.lean, 'normal', 'an 11.8x raw ratio must still read as normal for this coin');
+});
+
+test('NO SPOT FEED reports unknown, never a number from the perp side alone', () => {
+  // Many alts have no Binance spot pair. A missing spot leg looks EXACTLY like
+  // a perp-dominated one unless this is explicit - the absence-as-finding shape.
+  const { perp } = series(48, 8);
+  const r = computePerpSpot([], perp);
+  assert.equal(r.lean, 'unknown');
+  assert.equal(r.pair, '-');
+  assert.equal(r.spotVol, null);
+  assert.match(r.explanation, /unavailable/);
+});
+
+test('too few shared bars reports unknown rather than a median of noise', () => {
+  const { spot, perp } = series(MIN_BARS - 1, 8);
+  assert.equal(computePerpSpot(spot, perp).lean, 'unknown');
+});
+
+test('bars are matched on time - a venue running a beat behind is not a signal', () => {
+  const { spot, perp } = series(48, 8);
+  // Shift every perp bar by one hour: no shared timestamps at all.
+  const shifted = perp.map(c => ({ ...c, time: c.time + HOUR * 1000 }));
+  assert.equal(computePerpSpot(spot, shifted).lean, 'unknown',
+    'comparing mismatched bars would yield a ratio that is really a clock difference');
+});
+
+test('zero-volume bars are skipped, not divided by', () => {
+  const { spot, perp } = series(48, 8);
+  spot[10].quoteVolume = 0;
+  const r = computePerpSpot(spot, perp);
+  assert.equal(r.lean, 'normal');
+  assert.ok(Number.isFinite(r.ratio!), 'a zero spot bar must not produce Infinity');
+});
+
+test('fmtVol matches the shape used in the measurement on #328', () => {
+  assert.equal(fmtVol(444_100_000), '$444.1M');
+  assert.equal(fmtVol(37_600_000), '$37.6M');
+  assert.equal(fmtVol(2_300_000_000), '$2.3B');
+  assert.equal(fmtVol(4_270), '$4K');
+});
+
+test('CONTROL: the thresholds actually discriminate on the measured range', () => {
+  // BTC ranged 2.29-19.07 around a 7.80 median, i.e. relative 0.29-2.44. If the
+  // thresholds sat outside that, one verdict would be unreachable in practice
+  // and the feature would have a state it could never show.
+  const rel = (r: number) => r / 7.8;
+  assert.ok(rel(19.07) > PERP_LED_AT, 'the observed high must be reachable as perp-led');
+  assert.ok(rel(2.29) < SPOT_LED_AT, 'the observed low must be reachable as spot-led');
+  assert.ok(rel(7.8) > SPOT_LED_AT && rel(7.8) < PERP_LED_AT, 'the median must read normal');
+});

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -22,6 +22,7 @@ import { GlobalSpotlight, useMobile } from '@/components/MagicBento';
 import { SkeletonBar } from '@/components/Skeleton';
 import { useLabels } from '@/lib/labels';
 import type { LabelKey } from '@/lib/labelKeys';
+import PerpSpotCard from '@/components/PerpSpotCard';
 
 const OI_TREND_META: Record<string, { txtKey: LabelKey; subKey: LabelKey; col: string }> = {
   strong_up:   { txtKey: 'OI_TREND_STRONG_UP_TXT',   subKey: 'OI_TREND_STRONG_UP_SUB',   col: 'var(--green)' },
@@ -549,6 +550,13 @@ export default function Dashboard() {
       <aside className="dash-right" ref={rightRef}>
         <CoinSidebar />
         <MarketPulseStrip />
+        {/* Perps vs spot (#328) - "is this a real buyer or just futures traders".
+            Above the macro card because it is per-coin and follows the coin
+            selection, where the macro backdrop is the same whatever is picked. */}
+        <div className="macro-rail-card">
+          <PerpSpotCard />
+        </div>
+
         {/* Macro backdrop - answers "what's the broad market doing", which nothing
             else on the dashboard covers. Last in the rail so it never pushes the
             per-coin essentials down on mobile. */}

--- a/components/PerpSpotCard.tsx
+++ b/components/PerpSpotCard.tsx
@@ -1,0 +1,149 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useMarket } from '@/lib/marketStore';
+import { BINANCE_SYMS } from '@/lib/coins';
+import { computePerpSpot, type PerpSpotReading } from '@/lib/perpSpot';
+
+/* Perps vs spot (#328) - "is there a real buyer, or is the pump just futures?"
+ *
+ * ── THE NUMBER, AND WHY IT IS THIS ONE ──────────────────────────────────────
+ *
+ * The owner revised the ask mid-build: not a pair, but *"a number with
+ * explanation below for user to interpret just like other items in dashboard"*.
+ * With a pair the user does the comparison; with one figure we have already
+ * done it, so which figure it is matters far more.
+ *
+ * It is NOT perp volume, and NOT perp share of total. Measured on #328 across
+ * 168 hourly bars, perps run 7-14x spot as the ordinary state - BTC 7.8x, ETH
+ * 14.4x, SOL 10.4x. Either of those numbers would sit at "futures dominate"
+ * every hour of every day: true about crypto market structure, silent about
+ * today, and unreadable as a signal.
+ *
+ * The number shown is the ratio measured against THIS COIN'S OWN recent median.
+ * 1.0x is a completely ordinary day. That is the only version of this figure
+ * that moves when something is actually happening.
+ *
+ * ── SHAPE ───────────────────────────────────────────────────────────────────
+ *
+ * Matches GlobalMacroContext deliberately - micro uppercase label, a verdict
+ * pill, the value, then a sentence. The owner asked for it to read as one more
+ * item in a list they already understand, not a new kind of widget.
+ *
+ * NOT wired into the Confluence Score. The ask was to SEE the split, not to
+ * have the score change underneath them, and QA was explicit on #328.
+ */
+
+const HOUR = 3600_000;
+const BARS = 168;   // 7 days of hourly bars - enough for a stable median
+
+type Kline = [number, string, string, string, string, string, number, string, ...unknown[]];
+
+async function fetchBars(source: 'binance' | 'binance-futures', symbol: string) {
+  const r = await fetch(
+    `/api/market/klines?source=${source}&symbol=${symbol}&interval=1h&limit=${BARS}`,
+    { signal: AbortSignal.timeout(12_000) },
+  );
+  if (!r.ok) throw new Error(`${source} ${r.status}`);
+  const rows = (await r.json()) as Kline[];
+  // Index 7 is quote-asset volume (USDT) - comparable across the two venues in
+  // a way base volume is not. Index 0 is the bar's open time.
+  return rows.map(k => ({ time: k[0], quoteVolume: parseFloat(k[7]) }));
+}
+
+const LABEL = 'FUTURES ACTIVITY VS NORMAL';
+
+export default function PerpSpotCard() {
+  const { store } = useMarket();
+  const coin = store.selectedCoin;
+  const [reading, setReading] = useState<PerpSpotReading | null>(null);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    const sym = BINANCE_SYMS[coin];
+
+    (async () => {
+      // No Binance spot pair means the question cannot be answered for this
+      // coin at all. With a single number there is nowhere for a missing half
+      // to show up, so it has to be said outright - otherwise the perp side
+      // alone renders as though it had been measured against something.
+      if (!sym) { if (!cancelled) setReading(computePerpSpot([], [])); return; }
+      try {
+        const [spot, perp] = await Promise.all([
+          fetchBars('binance', sym),
+          fetchBars('binance-futures', sym),
+        ]);
+        if (!cancelled) setReading(computePerpSpot(spot, perp));
+      } catch {
+        // A failed fetch is not a quiet market.
+        if (!cancelled) setReading(computePerpSpot([], []));
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [coin, tick]);
+
+  // Hourly bars, so refresh on the bar close rather than a rolling timer -
+  // same reasoning as #316. Re-arms itself via `tick`.
+  useEffect(() => {
+    const id = setTimeout(() => setTick(t => t + 1), HOUR - (Date.now() % HOUR) + 3_000);
+    return () => clearTimeout(id);
+  }, [tick]);
+
+  if (!reading) return null;
+
+  const unknown = reading.lean === 'unknown';
+  const tone =
+    reading.lean === 'perp' ? 'var(--amber)' :
+    reading.lean === 'spot' ? 'var(--green-2)' :
+    unknown ? 'var(--txt3)' : 'var(--txt-dim)';
+
+  const verdict =
+    reading.lean === 'perp' ? 'FUTURES LEADING' :
+    reading.lean === 'spot' ? 'SPOT LEADING' :
+    reading.lean === 'normal' ? 'NORMAL' :
+    'CANNOT MEASURE';
+
+  return (
+    <div data-testid="perp-spot-card">
+      <div style={{
+        fontSize: 'var(--fs-micro)', fontWeight: 700, textTransform: 'uppercase',
+        letterSpacing: '0.08em', color: 'var(--txt3)', marginBottom: 4,
+      }}>
+        Perps vs Spot · {coin.toUpperCase()}
+      </div>
+
+      <div style={{
+        display: 'inline-flex', alignItems: 'center', gap: 5, padding: '3px 10px',
+        borderRadius: 20, marginBottom: 8,
+        background: `color-mix(in srgb, ${tone} 12%, transparent)`,
+        border: `0.5px solid color-mix(in srgb, ${tone} 40%, transparent)`,
+      }}>
+        <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 800, color: tone, letterSpacing: '0.05em' }}>
+          {verdict}
+        </span>
+      </div>
+
+      {/* The number. A dash when it could not be measured - never a 1.0x, which
+          would read as "an ordinary day" and be indistinguishable from having
+          checked. */}
+      <div style={{ display: 'flex', flexDirection: 'column', marginBottom: 8 }}>
+        <span style={{
+          fontSize: 'var(--fs-micro)', color: 'var(--txt3)', textTransform: 'uppercase',
+          letterSpacing: '0.05em', marginBottom: 1,
+        }}>
+          {LABEL}
+        </span>
+        <span style={{
+          fontSize: 'var(--fs-section)', fontWeight: 700, color: unknown ? 'var(--txt3)' : 'var(--txt)',
+          fontFamily: 'var(--font-mono), monospace', fontVariantNumeric: 'tabular-nums',
+        }}>
+          {unknown ? '-' : `${reading.relative!.toFixed(1)}x`}
+        </span>
+      </div>
+
+      <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt2)', lineHeight: 1.55 }}>
+        {reading.explanation}
+      </div>
+    </div>
+  );
+}

--- a/components/PerpSpotCard.tsx
+++ b/components/PerpSpotCard.tsx
@@ -73,7 +73,7 @@ export default function PerpSpotCard() {
           fetchBars('binance', sym),
           fetchBars('binance-futures', sym),
         ]);
-        if (!cancelled) setReading(computePerpSpot(spot, perp));
+        if (!cancelled) setReading(computePerpSpot(spot, perp, HOUR, Date.now()));
       } catch {
         // A failed fetch is not a quiet market.
         if (!cancelled) setReading(computePerpSpot([], []));

--- a/lib/perpSpot.ts
+++ b/lib/perpSpot.ts
@@ -1,0 +1,142 @@
+/* Perps vs spot - is a move real buying, or futures traders? (#328)
+ *
+ * ── THE MEASUREMENT THAT DECIDED THE DESIGN ─────────────────────────────────
+ *
+ * The owner asked for "a number like N vs N". Taken literally that is spot
+ * volume beside perp volume, and on its own it would be useless. Measured
+ * against Binance, 168 hourly bars:
+ *
+ *     coin   latest spot   latest perp   ratio   7d median ratio
+ *     BTC        37.6M        444.1M     11.80        7.80
+ *     ETH        10.0M        218.0M     21.78       14.41
+ *     SOL         3.5M         41.5M     11.75       10.43
+ *
+ * Perps are SEVEN TO FOURTEEN TIMES spot as the normal state. A pair shown raw
+ * would say "futures dominate" every hour of every day, correctly and
+ * uselessly - and any fixed cross-coin threshold would be wrong too, because
+ * BTC's normal is 7.8 and ETH's is 14.4.
+ *
+ * So the pair is what gets DISPLAYED, because that is what was asked for and it
+ * is honest. The READING comes from the ratio measured against that coin's own
+ * recent baseline. "Perp share is 1.5x its own normal" is a statement about
+ * today; "perps are 11x spot" is a statement about crypto market structure.
+ *
+ * ── WHY QUOTE VOLUME ────────────────────────────────────────────────────────
+ *
+ * Kline index 7 is quote-asset volume (USDT), not base volume. Base volume
+ * would compare BTC-denominated spot against contract counts and is not
+ * comparable across the two venues.
+ */
+
+export interface OHLCVLike {
+  time: number;
+  /** Quote-asset volume - USDT, comparable between spot and perp. */
+  quoteVolume: number;
+}
+
+export type PerpSpotLean = 'spot' | 'perp' | 'normal' | 'unknown';
+
+export interface PerpSpotReading {
+  spotVol: number | null;
+  perpVol: number | null;
+  /** perp / spot on the latest shared bar. */
+  ratio: number | null;
+  /** Median ratio across the window - this coin's own normal. */
+  baseline: number | null;
+  /** ratio / baseline. 1.0 is a completely ordinary day. */
+  relative: number | null;
+  lean: PerpSpotLean;
+  /** The pair, formatted as the owner asked: "N vs N". */
+  pair: string;
+  /** Plain language, for someone who does not know what a perp is. */
+  explanation: string;
+}
+
+/* PROVISIONAL, and flagged as such on #328 rather than presented as settled.
+ *
+ * From the 168-bar sample, BTC's ratio ranged 2.29-19.07 around a median of
+ * 7.80, so `relative` spans roughly 0.29-2.44 in a normal week. 1.3 and 0.75
+ * sit inside that range without firing constantly.
+ *
+ * They are still numbers we chose. #311's threshold came from the owner, and QA
+ * was right that "a threshold invented by us is a threshold nobody can verify" -
+ * so these are defaults pending the same conversation, not a hidden judgement. */
+export const PERP_LED_AT = 1.30;
+export const SPOT_LED_AT = 0.75;
+
+/** Enough bars to have a stable median; below this the baseline is noise. */
+export const MIN_BARS = 24;
+
+function median(xs: number[]): number | null {
+  if (xs.length === 0) return null;
+  const s = [...xs].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+
+/** Compact money for display: 444100000 -> "$444.1M". */
+export function fmtVol(v: number): string {
+  const abs = Math.abs(v);
+  if (abs >= 1e9) return `$${(v / 1e9).toFixed(1)}B`;
+  if (abs >= 1e6) return `$${(v / 1e6).toFixed(1)}M`;
+  if (abs >= 1e3) return `$${(v / 1e3).toFixed(0)}K`;
+  return `$${v.toFixed(0)}`;
+}
+
+const UNAVAILABLE: PerpSpotReading = {
+  spotVol: null, perpVol: null, ratio: null, baseline: null, relative: null,
+  lean: 'unknown', pair: '-',
+  explanation: 'Spot data unavailable for this coin, so we cannot tell whether a move is real buying or futures.',
+};
+
+/**
+ * Compare spot and perp activity for one coin.
+ *
+ * Bars are matched on `time`. Comparing the latest spot bar against the latest
+ * perp bar when one venue is a beat behind produces a ratio that is really a
+ * clock difference - the sort of number that looks like a finding and is not.
+ *
+ * Returns `unknown` rather than a plausible number whenever it cannot answer:
+ * no spot feed (many alts have no Binance spot pair), too few shared bars, or a
+ * zero-volume bar. An absent reading and a quiet one must not look the same.
+ */
+export function computePerpSpot(
+  spot: readonly OHLCVLike[], perp: readonly OHLCVLike[],
+): PerpSpotReading {
+  if (spot.length === 0 || perp.length === 0) return UNAVAILABLE;
+
+  const perpByTime = new Map(perp.map(c => [c.time, c.quoteVolume]));
+  const paired: Array<{ time: number; s: number; p: number }> = [];
+  for (const c of spot) {
+    const p = perpByTime.get(c.time);
+    if (p !== undefined && c.quoteVolume > 0 && p > 0) {
+      paired.push({ time: c.time, s: c.quoteVolume, p });
+    }
+  }
+  if (paired.length < MIN_BARS) return UNAVAILABLE;
+
+  paired.sort((a, b) => a.time - b.time);
+  const latest = paired[paired.length - 1];
+  const ratio = latest.p / latest.s;
+  const baseline = median(paired.map(x => x.p / x.s));
+  if (baseline === null || !(baseline > 0)) return UNAVAILABLE;
+
+  const relative = ratio / baseline;
+  const lean: PerpSpotLean =
+    relative >= PERP_LED_AT ? 'perp' :
+    relative <= SPOT_LED_AT ? 'spot' : 'normal';
+
+  const pair = `${fmtVol(latest.s)} vs ${fmtVol(latest.p)}`;
+  const times = `${relative.toFixed(1)}x`;
+
+  /* Written for someone who does not know what a perp is - the owner asked for
+     the explanation explicitly, which means it is the part they will read. */
+  const explanation =
+    lean === 'perp'
+      ? `Futures trading is ${times} its usual share against spot. The move is being driven by leveraged traders more than by people buying the coin itself, which unwinds faster if it turns.`
+      : lean === 'spot'
+        ? `Futures trading is unusually quiet at ${times} its usual share. More of this move is people actually buying the coin, which tends to hold better.`
+        : `Futures and spot are trading in their usual proportions for this coin. Nothing unusual about who is driving the move.`;
+
+  return { spotVol: latest.s, perpVol: latest.p, ratio, baseline, relative, lean, pair, explanation };
+}

--- a/lib/perpSpot.ts
+++ b/lib/perpSpot.ts
@@ -54,15 +54,23 @@ export interface PerpSpotReading {
   explanation: string;
 }
 
-/* PROVISIONAL, and flagged as such on #328 rather than presented as settled.
+/* THE OWNER'S NUMBERS, not ours. Approved on #333.
  *
- * From the 168-bar sample, BTC's ratio ranged 2.29-19.07 around a median of
- * 7.80, so `relative` spans roughly 0.29-2.44 in a normal week. 1.3 and 0.75
- * sit inside that range without firing constantly.
+ * QA put three options to them framed in BEHAVIOUR rather than in figures -
+ * "fires most days" against "only on a genuinely unusual session" - and the
+ * balanced one was chosen. That framing is why the answer is usable: someone
+ * can pick between those without knowing what a volume ratio is, where the
+ * version I originally drafted asked them to bless a number.
  *
- * They are still numbers we chose. #311's threshold came from the owner, and QA
- * was right that "a threshold invented by us is a threshold nobody can verify" -
- * so these are defaults pending the same conversation, not a hidden judgement. */
+ * Recorded here because #311 established the rule and QA was right about it:
+ * a threshold invented by us is a threshold nobody can verify. If these ever
+ * need changing, that is another conversation with the owner, not a tuning
+ * exercise.
+ *
+ * Both remain reachable on the measured range - BTC's `relative` spans roughly
+ * 0.29-2.44 across a normal week - and there is a control test asserting that,
+ * because a threshold outside the observed range gives the feature a state it
+ * can never display. */
 export const PERP_LED_AT = 1.30;
 export const SPOT_LED_AT = 0.75;
 

--- a/lib/perpSpot.ts
+++ b/lib/perpSpot.ts
@@ -28,6 +28,8 @@
  * comparable across the two venues.
  */
 
+import { dropForming } from './candles.ts';
+
 export interface OHLCVLike {
   time: number;
   /** Quote-asset volume - USDT, comparable between spot and perp. */
@@ -92,6 +94,23 @@ const UNAVAILABLE: PerpSpotReading = {
 /**
  * Compare spot and perp activity for one coin.
  *
+ * THE STILL-FORMING BAR IS DROPPED FIRST, and it is not a detail. QA measured
+ * both readings two minutes into an hour:
+ *
+ *     FORMING bar   spot  1.6M  perp  15.7M  ratio  9.76  relative 1.26x -> balanced
+ *     LAST CLOSED   spot 48.9M  perp 539.0M  ratio 11.01  relative 1.42x -> PERP-LED
+ *
+ * Same coin, same instant, opposite verdicts. At two minutes past, the forming
+ * hour holds ~3% of a normal hour's volume, so its ratio is a thin noisy slice
+ * being compared against a median built from 167 COMPLETE hours. The comparison
+ * was not like-for-like, and PERP_LED_AT sits close enough to the middle that
+ * the noise crosses it.
+ *
+ * This is #316 again in a new place - a live reading taken from an incomplete
+ * bar while everything it is measured against uses closed ones. Costs up to one
+ * bar of freshness on a series whose baseline is a 7-day median; the number is
+ * not trying to be real-time.
+ *
  * Bars are matched on `time`. Comparing the latest spot bar against the latest
  * perp bar when one venue is a beat behind produces a ratio that is really a
  * clock difference - the sort of number that looks like a finding and is not.
@@ -102,12 +121,16 @@ const UNAVAILABLE: PerpSpotReading = {
  */
 export function computePerpSpot(
   spot: readonly OHLCVLike[], perp: readonly OHLCVLike[],
+  intervalMs = 3_600_000, nowMs = Date.now(),
 ): PerpSpotReading {
   if (spot.length === 0 || perp.length === 0) return UNAVAILABLE;
 
-  const perpByTime = new Map(perp.map(c => [c.time, c.quoteVolume]));
+  const closedSpot = dropForming(spot, intervalMs, nowMs);
+  const closedPerp = dropForming(perp, intervalMs, nowMs);
+
+  const perpByTime = new Map(closedPerp.map(c => [c.time, c.quoteVolume]));
   const paired: Array<{ time: number; s: number; p: number }> = [];
-  for (const c of spot) {
+  for (const c of closedSpot) {
     const p = perpByTime.get(c.time);
     if (p !== undefined && c.quoteVolume > 0 && p > 0) {
       paired.push({ time: c.time, s: c.quoteVolume, p });


### PR DESCRIPTION
**Dev Team**

Closes #328 (dashboard half).

Built to the **revised** ask — one number plus an explanation, scoped to the selected coin, in the house style. Your correction landed while I was mid-build; the pair version cost about twenty minutes and the library was unaffected, so no real churn.

## The measurement that decided the design

I checked the obvious implementation before writing it. 168 hourly bars, Binance:

```
coin   latest spot   latest perp   ratio    7d median ratio
BTC        37.6M        444.1M     11.80         7.80
ETH        10.0M        218.0M     21.78        14.41
SOL         3.5M         41.5M     11.75        10.43
```

**Perps run 7-14x spot as the ordinary state.** So perp volume, or perp share of total, would have read "futures dominate" every hour of every day — true about crypto market structure, silent about today. And a fixed cross-coin threshold fails too: BTC's normal is 7.8x, ETH's is 14.4x, so any single cut-off mislabels one of them permanently.

**The displayed number is this coin's current ratio against its OWN recent median.** `1.0x` is an ordinary day. It is the only version of the figure that moves when something is actually happening.

That is what your *"the choice of what that number IS matters much more than it did an hour ago"* turned into. It would have shipped as raw perp share otherwise, and it would have looked fine in review.

## Absent does not look like quiet

You flagged this as the danger with a single figure and you were right — there is nowhere for a missing half to surface. Four paths render **CANNOT MEASURE** and a dash, never `1.0x`:

```
no Binance spot pair       many alts - the perp side alone would look measured
fetch failed               a down feed is not a calm market
< 24 shared bars           a median of noise is not a baseline
no overlapping timestamps  a venue lagging produces a ratio that is a CLOCK difference
```

`1.0x` would have been the worst possible fallback: it reads as "checked, nothing unusual".

## What I did not do

- **Confluence Score untouched.** Tests still pin it. Whether this should feed the score is a separate decision.
- **Arena, Ask AI, Deep Research** — the owner named four surfaces originally, then scoped this message to the dashboard. `pair` and the full reading are computed and exported, so those are wiring, not new logic. **Say when you want them.**

## The thresholds are ours, and I am flagging that rather than hiding it

`PERP_LED_AT = 1.30`, `SPOT_LED_AT = 0.75`. Chosen so both verdicts are reachable on the measured range (BTC's relative spans ~0.29-2.44), and there is a control test asserting exactly that — a threshold outside the observed range would give the feature a state it could never display.

But they are still numbers we picked. **#311's came from the owner and you were right that "a threshold invented by us is a threshold nobody can verify."** Same conversation wanted here.

## How to test (QA)

1. **Dashboard, right rail, below Coin Signals** — "Perps vs Spot · BTC": a verdict pill, a number like `1.2x`, and a sentence.
2. **Switch coins.** It follows the selection and the number changes.
3. **A coin with no Binance spot market** must show **CANNOT MEASURE** and `-`. Not a number.
4. **Arena's Confluence Score is unchanged** — the score number must be identical to before this branch.
5. **Read the sentence as someone who does not know what a perp is.** The owner asked for the explanation explicitly, so it is the part they will read.

## Risk level

**Low-Medium.** New card on the dashboard, two extra klines calls on that route (cached, rate-limited, existing).

- Verified: 366 tests (12 new), lint 0 errors, tsc clean, build ✓. The upstream ratios above are measured, not assumed.
- **Not verified: the rendered card.** I have not seen it in a browser — no signed-in dashboard session here. Steps 1-3 need a human.
- **Not verified: a real no-spot-pair coin.** The path is unit-tested; I did not confirm which listed coin actually lacks a Binance spot market.
- No schema, env var or dependency change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
