### PR TITLE
docs(qa): record that a disabled workflow is indistinguishable from a passing one

### DIFF
--- a/qa/STATUS.md
+++ b/qa/STATUS.md
@@ -279,6 +279,63 @@ gh issue list --state open
   passed on `mobile` in the same run, on identical fixtures. A real defect does
   not pick one project and spare the other when the fixture is the same — so when
   a run is red, check whether the other project agrees before reporting anything.
+- **AUTOMATION THAT IS OFF LOOKS EXACTLY LIKE AUTOMATION THAT IS WORKING. Check
+  the switch, not the absence of failures.** Added 2026-08-13.
+
+  All four workflows are disabled, and two independent brakes stop the release
+  PR specifically:
+
+  ```
+  ci.yml               disabled_manually
+  ready-for-qa.yml     disabled_manually
+  release-signals.yml  disabled_manually
+  RELEASE_PR_PAUSED  = 1                    repo variable
+  ```
+
+  Both dev and QA spent 2026-08-13 referring to the "Ready for QA" issue and the
+  self-opening release PR as though they existed. **Neither has opened since the
+  workflows were switched off.** Every promotion announcement that day was made
+  by hand, and it worked only because someone happened to do it.
+
+  The general shape is the expensive part. A **failing** workflow produces a red
+  tick, an email, a run record. A **disabled** one produces nothing at all —
+  which is indistinguishable from a workflow that passed. So "no failures" is
+  not evidence of health, and the docs describing what the automation does keep
+  reading as true long after it stopped running.
+
+  This is the same error as `#285`, where a disabled workflow was diagnosed as
+  spent Actions quota and sent the owner to check their billing — the missing
+  signal got an explanation instead of a measurement.
+
+  **When something is supposed to happen automatically and you have not SEEN it
+  happen, check whether the automation is enabled before believing anything
+  built on top of it.** `gh workflow list --all` answers it in one call.
+
+  Consequence worth stating plainly, because it is not a fault: **the
+  `staging` → `main` release PR must be opened by hand.** It is not delayed, it
+  is impossible in this configuration. `staging` sitting hundreds of commits
+  ahead of `main` is the intended state — the owner decides when to ship, and
+  nothing opens on their behalf.
+
+  **The second consequence WAS NOT CHOSEN, and it is the one worth knowing.**
+  `release-signals.yml` holds two unrelated jobs: the release PR, and the
+  **production drift check** — daily cron, reads `/api/version` on
+  liquidity-hq.com, opens a `release-drift` issue when production is not serving
+  `main` or the deployed commit is untagged. It caught a real one on 2026-08-09
+  (#159, *"Production is not running `main`"*).
+
+  Disabling the workflow to stop the release PR **also turned off drift
+  monitoring.** Two functions, one switch, and only one of them was the
+  decision. Low impact today — nothing is being deployed to production and there
+  are no users — but the file `CLAUDE.md` points at as the answer to *"what is
+  in production?"* is not running, so that question now has no automated answer.
+
+  How this was nearly reported wrong: `git show origin/dev:.github/workflows/release-signals.yml | grep -c drift`
+  returned **0**, and the same command printed no content at all. The file is
+  16KB with ten `drift` references. **The grep did not measure the file, it
+  measured an empty stream** — and taken at face value it would have become
+  "the drift check does not exist". A command that returns nothing has not told
+  you the thing is absent; check that it read anything at all first.
 - **A COMMENT DESCRIBING AN INVARIANT IS THE THING THAT GOES STALE. The durable
   version is a check, not a note.** Three separate times on 2026-08-12, and each
   one was CORRECT WHEN WRITTEN:


### PR DESCRIPTION
**QA Team** · Docs only. New standing risk in `qa/STATUS.md`, from dev's catch on #337.

## The risk

**Automation that is off looks exactly like automation that is working.** A *failing* workflow leaves a red tick, an email, a run record. A *disabled* one leaves nothing — which is indistinguishable from one that passed.

```
ci.yml               disabled_manually
ready-for-qa.yml     disabled_manually
release-signals.yml  disabled_manually
RELEASE_PR_PAUSED  = 1
```

Both sessions spent today referring to the "Ready for QA" issue and the self-opening release PR as though they existed. Every promotion announcement was made by hand, and worked only because someone happened to do it.

Same error as #285, where a disabled workflow got diagnosed as spent Actions quota and sent the owner to check their billing. **A missing signal got an explanation instead of a measurement.**

## 🔴 The part that was not already known

`release-signals.yml` holds **two unrelated jobs**: the release PR, and the **production drift check** — daily cron, reads `/api/version` on liquidity-hq.com, opens a `release-drift` issue when production is not serving `main` or the deployed commit is untagged. It caught a real one on 2026-08-09 (#159).

**Disabling the workflow to stop the release PR also turned off drift monitoring.** Two functions, one switch, and only one of them was the decision.

Low impact today — nothing is being deployed to production and there are no users. But `CLAUDE.md` points at that check as the answer to *"what is in production?"*, and it is not running, so that question currently has no automated answer. **Flagging it rather than proposing a change**, since re-enabling anything is a cost decision and the owner's.

## How I nearly reported the opposite

```
$ git show origin/dev:.github/workflows/release-signals.yml | grep -c "drift"
0
```

The file is 16KB with ten `drift` references. The `git show` printed **nothing at all**, so the grep measured an empty stream. Taken at face value that becomes *"the drift check does not exist"* — a missing safety net reported on a command that never read the file.

**A command that returns nothing has not told you the thing is absent.** Check that it read anything first. That is in the entry too, because it is the more reusable half.

## Risk level: **Low**

Docs only, QA-owned file, no application code.
