### PR TITLE
feat(arena): give the AI surfaces the perps-vs-spot reading

### DIFF
--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -38,6 +38,7 @@ import type { LabelKey } from '@/lib/labelKeys';
 import { GATED_TFS as LIMIT_GATED_TFS, FREE_FALLBACK_TF as LIMIT_FREE_FALLBACK_TF } from '@/lib/limits';
 import { computeSectorRotation } from '@/lib/sectorRotation';
 import { latestStructureSignal, describeStructureSignal, type PASignal } from '@/lib/priceAction';
+import { usePerpSpot } from '@/lib/usePerpSpot';
 
 /* ── Pattern detection - delegates to shared lib/patterns.ts ── */
 function detectPatterns(candles: Candle[]): string { return detectPatternsStr(candles); }
@@ -236,6 +237,15 @@ function ArenaContent() {
   const [coinCat, setCoinCat]           = useState<'all' | 'majors' | 'alts' | 'defi' | 'meme'>('all');
   const [copiedKey, setCopiedKey]           = useState<string | null>(null);
   const [jpyUsd, setJpyUsd]                 = useState<number | null>(null);
+  /* Perps vs spot (#340) - the same reading the dashboard card shows, from the
+     shared hook so the card and the AI cannot disagree about it. */
+  const perpSpot = usePerpSpot(selectedCoin);
+  /* Mirrored into a ref because the prompt payload is built inside a callback
+     that reads refs rather than closing over state - same pattern as
+     emaSignalRef and absDataRef beside it. Closing over `perpSpot` directly
+     would freeze it at whatever it was when the callback was created. */
+  const perpSpotRef = useRef(perpSpot);
+  useEffect(() => { perpSpotRef.current = perpSpot; }, [perpSpot]);
   const scannerRef      = useRef<HTMLDivElement>(null);
   const hoverOpenTimer  = useRef<ReturnType<typeof setTimeout> | null>(null);
   /* Whether the scanner was opened by hover rather than by a click. Only a
@@ -984,6 +994,10 @@ function ArenaContent() {
           : jpyUsd >= 158
             ? `${jpyUsd.toFixed(2)} - WARNING: Approaching 160 danger zone, watch for BOJ signals`
             : `${jpyUsd.toFixed(2)} - Safe: below 158, carry trade stable, low JPY liquidation risk`,
+      /* The card's own sentence, verbatim. Rewording it for the prompt would
+         give the model a second vocabulary for one fact, and a user reading the
+         dashboard and the AI answer would see two claims instead of one. */
+      perpSpot: perpSpotRef.current?.explanation ?? 'Perps vs spot could not be measured for this coin.',
       emaStrategy: strategyToGrokLine(emaSignalRef.current, readTf),
       emaATR: emaSignalRef.current.atrLast != null
         ? `ATR(14) = $${emaSignalRef.current.atrLast.toFixed(2)} · 35% buf = $${(emaSignalRef.current.atrLast * 0.35).toFixed(2)} min clearance above/below EMA50`

--- a/components/PerpSpotCard.tsx
+++ b/components/PerpSpotCard.tsx
@@ -1,8 +1,6 @@
 'use client';
-import { useEffect, useState } from 'react';
 import { useMarket } from '@/lib/marketStore';
-import { BINANCE_SYMS } from '@/lib/coins';
-import { computePerpSpot, type PerpSpotReading } from '@/lib/perpSpot';
+import { usePerpSpot } from '@/lib/usePerpSpot';
 
 /* Perps vs spot (#328) - "is there a real buyer, or is the pump just futures?"
  *
@@ -33,61 +31,14 @@ import { computePerpSpot, type PerpSpotReading } from '@/lib/perpSpot';
  * have the score change underneath them, and QA was explicit on #328.
  */
 
-const HOUR = 3600_000;
-const BARS = 168;   // 7 days of hourly bars - enough for a stable median
-
-type Kline = [number, string, string, string, string, string, number, string, ...unknown[]];
-
-async function fetchBars(source: 'binance' | 'binance-futures', symbol: string) {
-  const r = await fetch(
-    `/api/market/klines?source=${source}&symbol=${symbol}&interval=1h&limit=${BARS}`,
-    { signal: AbortSignal.timeout(12_000) },
-  );
-  if (!r.ok) throw new Error(`${source} ${r.status}`);
-  const rows = (await r.json()) as Kline[];
-  // Index 7 is quote-asset volume (USDT) - comparable across the two venues in
-  // a way base volume is not. Index 0 is the bar's open time.
-  return rows.map(k => ({ time: k[0], quoteVolume: parseFloat(k[7]) }));
-}
-
 const LABEL = 'FUTURES ACTIVITY VS NORMAL';
 
 export default function PerpSpotCard() {
   const { store } = useMarket();
   const coin = store.selectedCoin;
-  const [reading, setReading] = useState<PerpSpotReading | null>(null);
-  const [tick, setTick] = useState(0);
-
-  useEffect(() => {
-    let cancelled = false;
-    const sym = BINANCE_SYMS[coin];
-
-    (async () => {
-      // No Binance spot pair means the question cannot be answered for this
-      // coin at all. With a single number there is nowhere for a missing half
-      // to show up, so it has to be said outright - otherwise the perp side
-      // alone renders as though it had been measured against something.
-      if (!sym) { if (!cancelled) setReading(computePerpSpot([], [])); return; }
-      try {
-        const [spot, perp] = await Promise.all([
-          fetchBars('binance', sym),
-          fetchBars('binance-futures', sym),
-        ]);
-        if (!cancelled) setReading(computePerpSpot(spot, perp, HOUR, Date.now()));
-      } catch {
-        // A failed fetch is not a quiet market.
-        if (!cancelled) setReading(computePerpSpot([], []));
-      }
-    })();
-    return () => { cancelled = true; };
-  }, [coin, tick]);
-
-  // Hourly bars, so refresh on the bar close rather than a rolling timer -
-  // same reasoning as #316. Re-arms itself via `tick`.
-  useEffect(() => {
-    const id = setTimeout(() => setTick(t => t + 1), HOUR - (Date.now() % HOUR) + 3_000);
-    return () => clearTimeout(id);
-  }, [tick]);
+  // Shared with the Arena prompts and the chart signal (#340) - one fetch, one
+  // reading, so the card and the AI cannot disagree on screen.
+  const reading = usePerpSpot(coin);
 
   if (!reading) return null;
 

--- a/lib/grok.ts
+++ b/lib/grok.ts
@@ -146,6 +146,8 @@ export interface GrokContext {
   absorptionScore: string;
   /* Yen carry trade risk */
   yenWatch: string;
+  /* Perps vs spot - is the move real buying or leverage (#340) */
+  perpSpot: string;
   /* EMA Ribbon Strategy (Triple EMA 9/20/50, 4H) */
   emaStrategy: string;
   /* Anti-chop filters - ATR(14) buffer + EMA50 slope + EMA9/20 spread */
@@ -243,6 +245,10 @@ export function buildPrompt(ctx: GrokContext): string {
     `US 10Y Bond Yield: ${ctx.bonds10y}`,
     `DXY (US Dollar Index): ${ctx.dxyLine}`,
     `USD/JPY (Yen Carry Trade): ${ctx.yenWatch}`,
+    /* Deliberately the SAME sentence the dashboard card shows. One vocabulary
+       across every surface - if the model phrases this differently from the
+       card, a user reading both sees two facts where there is one. */
+    `Perps vs Spot: ${ctx.perpSpot}`,
     `S&P 500: ${ctx.spxLine}`,
     `Gold (XAU/USD): ${ctx.goldLine}`,
     `BTC Dominance (trend): ${ctx.btcDomTrend}`,

--- a/lib/usePerpSpot.ts
+++ b/lib/usePerpSpot.ts
@@ -1,0 +1,100 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { BINANCE_SYMS } from './coins';
+import { computePerpSpot, type PerpSpotReading } from './perpSpot';
+
+/* One source for the perps-vs-spot reading (#340).
+ *
+ * Extracted from PerpSpotCard when the owner asked for the same fact on five
+ * surfaces - the dashboard card, Quick Research, Deep Research, Ask AI, and the
+ * chart signal's confidence. Two fetches of the same thing would eventually
+ * disagree on screen, and "the card says futures-led while the AI says spot
+ * confirming" is a worse bug than either being wrong on its own.
+ *
+ * The module-level cache is what makes that guarantee real rather than
+ * incidental: every consumer of the same coin within the TTL gets the identical
+ * object, so they cannot drift even mid-hour.
+ */
+
+const HOUR = 3600_000;
+const BARS = 168;   // 7 days of hourly bars - enough for a stable median
+
+type Kline = [number, string, string, string, string, string, number, string, ...unknown[]];
+
+interface Entry { reading: PerpSpotReading; fetchedAt: number }
+const cache = new Map<string, Entry>();
+const inflight = new Map<string, Promise<PerpSpotReading>>();
+
+async function fetchBars(source: 'binance' | 'binance-futures', symbol: string) {
+  const r = await fetch(
+    `/api/market/klines?source=${source}&symbol=${symbol}&interval=1h&limit=${BARS}`,
+    { signal: AbortSignal.timeout(12_000) },
+  );
+  if (!r.ok) throw new Error(`${source} ${r.status}`);
+  const rows = (await r.json()) as Kline[];
+  // Index 7 is quote-asset volume (USDT) - comparable across the two venues in
+  // a way base volume is not. Index 0 is the bar's open time.
+  return rows.map(k => ({ time: k[0], quoteVolume: parseFloat(k[7]) }));
+}
+
+/**
+ * Read perps-vs-spot for a coin. Never throws; an unmeasurable state is a
+ * value, not an exception.
+ *
+ * Single-flight per coin: five surfaces mounting at once must not become five
+ * pairs of upstream calls. Same reasoning as #201 on the klines route.
+ */
+export async function readPerpSpot(coin: string): Promise<PerpSpotReading> {
+  const hit = cache.get(coin);
+  // Valid until the hour turns, matching the bar interval the reading is built
+  // from - a fresh fetch inside the same hour returns the same closed bar.
+  if (hit && Math.floor(hit.fetchedAt / HOUR) === Math.floor(Date.now() / HOUR)) {
+    return hit.reading;
+  }
+  const running = inflight.get(coin);
+  if (running) return running;
+
+  const sym = BINANCE_SYMS[coin];
+  const job = (async (): Promise<PerpSpotReading> => {
+    // No Binance spot pair means the question cannot be answered for this coin.
+    // computePerpSpot([], []) is the explicit "cannot tell" reading - never a
+    // number derived from the perp side alone.
+    if (!sym) return computePerpSpot([], []);
+    try {
+      const [spot, perp] = await Promise.all([
+        fetchBars('binance', sym), fetchBars('binance-futures', sym),
+      ]);
+      return computePerpSpot(spot, perp, HOUR, Date.now());
+    } catch {
+      return computePerpSpot([], []);   // a failed fetch is not a quiet market
+    }
+  })();
+
+  inflight.set(coin, job);
+  try {
+    const reading = await job;
+    cache.set(coin, { reading, fetchedAt: Date.now() });
+    return reading;
+  } finally {
+    inflight.delete(coin);
+  }
+}
+
+/** React binding. Re-reads when the hour turns, since the bar has changed. */
+export function usePerpSpot(coin: string): PerpSpotReading | null {
+  const [reading, setReading] = useState<PerpSpotReading | null>(null);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    readPerpSpot(coin).then(r => { if (!cancelled) setReading(r); });
+    return () => { cancelled = true; };
+  }, [coin, tick]);
+
+  useEffect(() => {
+    const id = setTimeout(() => setTick(t => t + 1), HOUR - (Date.now() % HOUR) + 3_000);
+    return () => clearTimeout(id);
+  }, [tick]);
+
+  return reading;
+}


### PR DESCRIPTION
**Dev Team**

For #340. **The three context surfaces only — the two that change numbers are not in here**, exactly as you split it.

```
Quick Research    context   in this PR
Deep Research     context   in this PR
Ask AI (FAB)      context   in this PR
Confluence Score  ARITHMETIC   not in this PR
chart confidence  ARITHMETIC   not in this PR
```

## The reversal, acknowledged rather than reconciled

> I said, twice and in bold: **"Do not touch the Confluence Score."** … the earlier constraint is lifted by the owner, not by me.

Noted, and thank you for saying it that way — it meant I did not have to work out which of two instructions was live. **The score tests still pin it as untouched and they still pass, because this PR genuinely does not touch it.** They will need rewriting for the arithmetic PR, not working around, and that is a separate change with its own review.

## One shared fetch, and that is the point

`lib/usePerpSpot.ts` — the fetch moves out of `PerpSpotCard`. Every surface reads one hour-cached, single-flighted value.

**Two independent fetches would eventually disagree mid-hour**, and *"the dashboard card says futures-led while the AI says spot confirming"* is a worse bug than either being wrong on its own. A user cannot tell which to believe, and the fix is invisible from either side alone.

Single-flight because five surfaces mounting at once must not become five pairs of upstream calls — same reasoning as #201 on the klines route.

## Your "one vocabulary" point is implemented literally

> reuse it rather than inventing a second wording for the same fact

The prompt receives `reading.explanation` — **the exact string the card renders**, not a paraphrase. If someone changes the wording later, both move together because there is only one.

## The unmeasurable case goes into the prompt too

`'Perps vs spot could not be measured for this coin.'` rather than omitting the line. **An absent line leaves the model to infer from silence**, which is the same failure we have been chasing all day, arrived at from the model's side instead of the user's.

## How to test (QA)

1. **Arena → Quick Research**, then **Deep Research**. The answer should be able to speak to whether the move is spot-led or futures-led.
2. **Ask AI (the FAB)** — same, in conversation.
3. **The agreement check, which is the one that matters:** the AI's characterisation must match the dashboard's Perps vs Spot card for the same coin. Same verdict, same wording. If they differ, the shared-fetch guarantee has broken.
4. **A coin with no Binance spot pair** — the model should say it cannot be measured, not guess.
5. **Confluence Score unchanged.** The number on Arena must be identical to before this branch.

## Risk level

**Low.** Context added to prompts; no arithmetic anywhere.

- Verified: 369 tests, lint 0 errors, tsc clean, build ✓.
- **Not verified: the model's actual output.** I cannot run Grok from here, so steps 1-3 need a human. Step 3 especially — a wording drift between card and AI is exactly what a passing build would not show.
- **Not verified: prompt length impact.** One line added to a large context; I have not measured token cost.
- **Note:** this is the first change to the Grok prompt inputs since #260/#277 tightened what goes into them. One line, factual, no trade levels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
