### PR TITLE
fix(arena): name the two perp-vs-spot readings differently in the prompt

### DIFF
--- a/lib/grok.ts
+++ b/lib/grok.ts
@@ -218,7 +218,10 @@ export function buildPrompt(ctx: GrokContext): string {
     `OI Trend vs Price:  ${ctx.oiTrend}`,
     '',
     '=== DERIVATIVES - EXTENDED ===',
-    `Basis (perp premium vs spot):  ${ctx.basis}`,
+    /* PRICE premium. Distinct from the ACTIVITY line in the MACRO block below,
+       which is a volume ratio - both were called "perp vs spot" until #340 and
+       a model handed both can reasonably contradict itself between them. */
+    `Perp basis - PRICE premium of perps over spot: ${ctx.basis}`,
     `Squeeze score:  ${ctx.squeezeScore}`,
     `Setup Scanner: ${ctx.setupScan}`,
     '(Setup Scanner score 0-100: measures how overcrowded longs or shorts are. High Long Liq Risk = too many longs, whales incentivised to dump. High Short Squeeze = too many shorts, whales incentivised to pump.)',
@@ -247,8 +250,11 @@ export function buildPrompt(ctx: GrokContext): string {
     `USD/JPY (Yen Carry Trade): ${ctx.yenWatch}`,
     /* Deliberately the SAME sentence the dashboard card shows. One vocabulary
        across every surface - if the model phrases this differently from the
-       card, a user reading both sees two facts where there is one. */
-    `Perps vs Spot: ${ctx.perpSpot}`,
+       card, a user reading both sees two facts where there is one.
+       Labelled ACTIVITY to keep it distinct from the basis line above, which is
+       a price premium. They measure different things and can point opposite
+       ways at the same moment. */
+    `Perp vs spot ACTIVITY - trading volume, not price: ${ctx.perpSpot}`,
     `S&P 500: ${ctx.spxLine}`,
     `Gold (XAU/USD): ${ctx.goldLine}`,
     `BTC Dominance (trend): ${ctx.btcDomTrend}`,
@@ -388,6 +394,11 @@ export function buildPrompt(ctx: GrokContext): string {
     '9. FIBONACCI: In NEUTRAL regime, fib levels (61.8%, 38.2%) are high-probability reversal zones. In BEARISH REGIME, fib supports are likely to fail - treat them as pause zones only.',
     '10. ORDER FLOW (CVD): Positive CVD = net buying. Negative = selling pressure. In BEARISH REGIME, CVD bullish divergence is often a temporary absorption trap - require price confirmation before treating as reversal.',
     '11. OPTIONS (DERIBIT): P/C ratio > 1.2 = bearish positioning. Max pain acts as price magnet near expiry. Positive basis = healthy bull market.',
+    /* Added with #340. Rule 11 gives a bullish reading for positive basis, and
+       the activity line can say "leverage-led" at the same instant - both true,
+       measuring different things. Without this the model can assert both in one
+       answer and the user cannot tell which the app believes. */
+    '11b. PERP BASIS vs PERP ACTIVITY are DIFFERENT and may disagree. Basis is the PRICE premium of perps over spot. Activity is how much perp trading VOLUME there is against spot, measured against its own normal for that coin. Positive basis with normal activity = healthy demand for leverage. Positive basis with elevated activity = the move is leverage-led and unwinds faster. If they conflict, say so explicitly rather than choosing one silently.',
     '12. GEX (GAMMA EXPOSURE) - PRIMARY REGIME FILTER for BTC, weight it above the oscillators: Positive net GEX = dealers LONG gamma = range-bound/mean-reverting → fade extremes toward max pain, size down on breakout calls. Negative net GEX = moves amplified = trending/explosive volatility → trust breakouts, size up on momentum. Zero-gamma flip level crossing = regime shift; a call that ignores the GEX regime is low-conviction.',
     '13. ORDER BOOK: Large bid walls = support. Large ask walls = resistance. Price often hunts walls before reversing.',
     '14. STABLECOIN FLOWS: Growing USDT+USDC supply = dry powder entering = bullish medium-term. Shrinking = cashing out.',


### PR DESCRIPTION
**Dev Team**

Fixes the ambiguity QA found on #342.

```
before   Basis (perp premium vs spot): ...     PRICE      pre-existing
         Perps vs Spot: ...                    VOLUME     added by #342

after    Perp basis - PRICE premium of perps over spot: ...
         Perp vs spot ACTIVITY - trading volume, not price: ...
         + rule 11b, stating they are different and may disagree
```

## The finding was better than a naming nit

Rule 11 already tells the model *"Positive basis = healthy bull market."* The new line can say the move is leverage-led **at the same instant, correctly**. So the model could produce:

> "Basis is positive, so this is a healthy bull market … this move is leverage-driven and fragile"

Both sentences true, in one answer, reading as a contradiction. **The user cannot tell which the app believes — which is exactly the confusion this feature exists to remove.** A wrong answer is recoverable; an answer that argues with itself is not.

Rule 11b now states what each combination means and instructs the model to name the conflict explicitly rather than silently picking a side.

## On how it got there

**I should have grepped the prompt for existing perp/spot mentions before adding one.** `lib/grok.ts:221` has been there the whole time. Same sweep-the-area rule I missed on #317, where you found three sign-out sites after I fixed one.

That is twice today the same omission, in the same shape: I changed the thing I was looking at without checking what else already spoke to it.

## What is NOT claimed

**Neither of us has observed the model producing the contradiction.** You flagged the setup, said so plainly, and I have not measured it either — I do not have Grok access from here.

So this is a fix for a legible hazard, not a reproduced defect. Worth doing because the numeric surfaces land on top of it and the ambiguity gets harder to unpick once the score reads from the same value.

## How to test (QA)

1. **Quick Research and Deep Research on Arena.** The answer should not treat basis and activity as one fact.
2. **Where they disagree**, it should say so rather than asserting both as if they agree.
3. **The activity verdict must still match the dashboard card** — #342's guarantee is unaffected and this must not have broken it.
4. **`score-perps-coupling.spec.ts` still passes** — this is prompt text only, but it is the invariant and worth the run.

## Risk level

**Low.** Prompt text only; no arithmetic, no new data, no type changes beyond a label.

- Verified: 369 tests, lint 0 errors, tsc clean, build ✓.
- **Not verified: model output.** Cannot run Grok here. Steps 1-2 need a human, and they are judgement calls rather than assertions.
- **Not measured: token cost.** Rule 11b adds roughly 60 words to a large prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
