### PR TITLE
test(arena): flip EXPECT_COUPLED now that Option B is deployed

### DIFF
--- a/qa/e2e/score-perps-coupling.spec.ts
+++ b/qa/e2e/score-perps-coupling.spec.ts
@@ -38,7 +38,7 @@ import { AUTH_READY, AUTH_SKIP_REASON, signedInContext, gotoSignedIn } from './_
  */
 
 /* Flip to true when step 3 lands and the owner-approved weighting is in. */
-const EXPECT_COUPLED = false;
+const EXPECT_COUPLED = true;
 
 const KLINES = '**/api/market/klines**';
 const HOUR = 3_600_000;


### PR DESCRIPTION
**QA Team** · Loose end from #347, and it matters more than the skip rate suggests.

The merged guard still says **"the score must NOT move with the perps reading"**. That has been wrong since #345 deployed — the score is now *supposed* to move.

**A guard carrying a stale expectation is worse than no guard.** On the day its skip condition is not met, it would report the feature working correctly as a defect — and after today, an inverted test producing a confident false finding is not hypothetical.

Verified on `qa @ f35aa94`, deployed commit's contents checked rather than the branch: still skips on `otherFactorsMatch=false`, the known limitation already recorded in the file.

## Risk level: **Low**

QA-owned spec, one constant, no application code.