### PR TITLE
perf(api): expire closed-candle klines at the candle boundary, not on a stopwatch

### DIFF
--- a/__tests__/candles.test.mts
+++ b/__tests__/candles.test.mts
@@ -105,3 +105,59 @@ test('the worst-case client staleness is now the skew, not the timeframe', () =>
       'a fetch from before the close must not be reused after it');
   }
 });
+
+/* ── #325: boundary-aligned cache expiry ─────────────────────────────────────
+ *
+ * The TTL for a closed-candle request is "time until this candle closes", not a
+ * fixed number of minutes. These pin the arithmetic the route relies on and the
+ * dialect handling, which is where it would silently go wrong: a bybit "60"
+ * and a binance "1h" are the same hour and must produce the same boundary.
+ */
+import { intervalToMs } from '../lib/candles.ts';
+
+test('#325: both exchange dialects map to the same milliseconds', () => {
+  // The route does not translate between dialects - each caller sends its own -
+  // so a boundary computed from one must match the other.
+  assert.equal(intervalToMs('1m'), intervalToMs('1'));
+  assert.equal(intervalToMs('15m'), intervalToMs('15'));
+  assert.equal(intervalToMs('1h'), intervalToMs('60'));
+  assert.equal(intervalToMs('4h'), intervalToMs('240'));
+  assert.equal(intervalToMs('1d'), intervalToMs('D'));
+});
+
+test('#325: intervals with no computable boundary return null, not a guess', () => {
+  // A week is not a divisor of the epoch offset and months vary in length, so
+  // the boundary maths in this file does not hold. The route falls back to the
+  // plain TTL rather than expiring at a wrong instant.
+  assert.equal(intervalToMs('W'), null);
+  assert.equal(intervalToMs('M'), null);
+  assert.equal(intervalToMs(''), null);
+  assert.equal(intervalToMs('0'), null);
+  assert.equal(intervalToMs('junk'), null);
+});
+
+test('#325: the TTL is always positive and never exceeds one period', () => {
+  // Zero would expire the entry instantly and hammer upstream; longer than a
+  // period would serve a closed candle into the next one.
+  for (const iv of ['1m', '15m', '1h', '4h', '1d']) {
+    const ms = intervalToMs(iv)!;
+    for (const offset of [0, 1, ms / 3, ms - 1]) {
+      const ttl = msUntilNextClose(ms, 1_000_000 * ms + offset) + CLOSE_SKEW_MS;
+      assert.ok(ttl > 0, `${iv} produced a non-positive TTL`);
+      assert.ok(ttl <= ms + CLOSE_SKEW_MS, `${iv} TTL ${ttl} exceeds one period`);
+    }
+  }
+});
+
+test('#325: upstream fetches per candle drop to one', () => {
+  // The measurement that justified this over a bypass. Old: ttlFor is a fixed
+  // stopwatch, so fetches = period / ttl. New: one per candle, by construction.
+  const ttlFor = (ms: number) => ms <= 5 * 60_000 ? 30_000 : ms <= 30 * 60_000 ? 60_000
+                                : ms <= 2 * 3600_000 ? 300_000 : 900_000;
+  for (const [iv, expectedOld] of [['1m', 2], ['15m', 15], ['1h', 12], ['4h', 16], ['1d', 96]] as const) {
+    const ms = intervalToMs(iv)!;
+    assert.equal(Math.round(ms / ttlFor(ms)), expectedOld, `${iv} old fetch count`);
+    // Boundary-aligned: the entry lives exactly one candle, so exactly one fetch.
+    assert.equal(Math.round(ms / (msUntilNextClose(ms, 1_000_000 * ms) )), 1, `${iv} new fetch count`);
+  }
+});

--- a/app/api/market/klines/route.ts
+++ b/app/api/market/klines/route.ts
@@ -35,6 +35,7 @@
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { cached } from '@/lib/apiCache';
+import { intervalToMs, msUntilNextClose, CLOSE_SKEW_MS } from '@/lib/candles';
 import { rateLimit, getClientIp } from '@/lib/rateLimit';
 import { apiError } from '@/lib/apiError';
 import { reportHealth } from '@/lib/apiHealth';
@@ -213,8 +214,42 @@ export async function GET(req: NextRequest) {
   };
 
   try {
-    const key = `klines:${source}:${symbol}:${interval}:${limit}`;
-    const raw = isRange ? await fetchUpstream() : await cached(key, ttlFor(interval), fetchUpstream);
+    /* BOUNDARY-ALIGNED EXPIRY for closed-candle callers (#325).
+     *
+     * `ttlFor` is a stopwatch with no relationship to the data: on a 4h chart
+     * it expires 16 times per candle to observe one change, and a caller that
+     * recomputes ON the close still gets a response up to 15 minutes old.
+     *
+     * A bypass was the obvious fix and is the wrong one. Since #316 the signal
+     * path recomputes when a candle closes, and a candle close is a GLOBAL
+     * event - every client on a timeframe crosses it in the same instant. So
+     * bypassing there converts a smooth trickle into a thundering herd, once
+     * per candle, aimed at the endpoint whose own header records that 418 is
+     * Binance's ban code.
+     *
+     * Expiring AT the boundary instead means everyone shares one cached
+     * response until the candle closes, and then it is stale for all of them at
+     * once - which is precisely the case #201's single-flight exists to
+     * collapse. Fewer upstream requests AND less delay: one fetch per candle
+     * instead of 2 (1m) to 96 (1d).
+     *
+     * OPT-IN, because it cannot apply globally. Anything wanting the forming
+     * bar to keep moving must not be pinned to the last close - freezing a
+     * chart until the next 4h boundary would be a far worse bug than the one
+     * being fixed. `closed=1` is the request shape that has already dropped the
+     * forming bar and only cares about closed candles.
+     *
+     * Falls back to ttlFor when the interval has no computable boundary (W, M)
+     * rather than guessing at one. */
+    const closedOnly = q.get('closed') === '1';
+    const ivMs = closedOnly ? intervalToMs(interval) : null;
+    const ttl = ivMs != null
+      ? msUntilNextClose(ivMs, Date.now()) + CLOSE_SKEW_MS
+      : ttlFor(interval);
+    // Distinct key: a boundary-aligned entry must never be served to a caller
+    // that asked for the default behaviour, or the chart inherits the freeze.
+    const key = `klines:${source}:${symbol}:${interval}:${limit}${ivMs != null ? ':closed' : ''}`;
+    const raw = isRange ? await fetchUpstream() : await cached(key, ttl, fetchUpstream);
     /* Slice AFTER the cache read, using the caller's own limit. The cache holds
        one bucket-sized copy that every caller in that bucket shares; each gets
        back the length it asked for. Range requests are returned untouched -

--- a/lib/candles.ts
+++ b/lib/candles.ts
@@ -84,3 +84,31 @@ export function sameCandle(fetchedAt: number, intervalMs: number, nowMs: number)
   if (!(intervalMs > 0)) return false;
   return Math.floor(fetchedAt / intervalMs) === Math.floor(nowMs / intervalMs);
 }
+
+/**
+ * Exchange interval string to milliseconds, across both dialects (#325).
+ *
+ * Bybit takes minutes as bare integers plus D/W/M; Binance takes suffixed
+ * strings. The klines route deliberately does not translate between them - each
+ * caller knows which dialect it wants - so this reads both rather than forcing
+ * one.
+ *
+ * Returns null for anything it does not recognise, including W and M. A week is
+ * not a divisor of the epoch offset and months vary in length, so the boundary
+ * arithmetic in this file does not hold for them; callers must fall back to a
+ * plain TTL rather than compute a wrong boundary.
+ */
+export function intervalToMs(interval: string): number | null {
+  const suffixed = /^(\d+)(m|h|d)$/.exec(interval);
+  if (suffixed) {
+    const n = Number(suffixed[1]);
+    const unit = { m: 60_000, h: 3_600_000, d: 86_400_000 }[suffixed[2] as 'm' | 'h' | 'd'];
+    return n > 0 ? n * unit : null;
+  }
+  if (/^\d+$/.test(interval)) {               // bybit minutes
+    const n = Number(interval);
+    return n > 0 ? n * 60_000 : null;
+  }
+  if (interval === 'D') return 86_400_000;    // bybit daily
+  return null;                                 // W, M, anything unexpected
+}

--- a/lib/useEMAStrategy.ts
+++ b/lib/useEMAStrategy.ts
@@ -78,7 +78,7 @@ interface OHLCV { time: number; open: number; high: number; low: number; close: 
 /* ── Fetch helpers ───────────────────────────────────────────────────────── */
 async function fetchBinanceFuturesKlines(sym: string, interval: string, limit: number): Promise<OHLCV[]> {
   const r = await fetch(
-    `/api/market/klines?source=binance-futures&symbol=${sym}&interval=${interval}&limit=${limit}`,
+    `/api/market/klines?source=binance-futures&symbol=${sym}&interval=${interval}&limit=${limit}&closed=1`,
     { signal: AbortSignal.timeout(12_000) }
   );
   if (!r.ok) throw new Error(`Binance futures klines ${r.status}`);
@@ -90,7 +90,7 @@ async function fetchBinanceFuturesKlines(sym: string, interval: string, limit: n
 
 async function fetchBybitKlines(sym: string, interval: string, limit: number): Promise<OHLCV[]> {
   const r = await fetch(
-    `/api/market/klines?source=bybit&symbol=${sym}&interval=${interval}&limit=${limit}`,
+    `/api/market/klines?source=bybit&symbol=${sym}&interval=${interval}&limit=${limit}&closed=1`,
     { signal: AbortSignal.timeout(12_000) }
   );
   if (!r.ok) throw new Error(`Bybit klines ${r.status}`);


### PR DESCRIPTION
**Dev Team**

Closes #325. The design you and the owner approved, built.

```
before   ttlFor(interval)                    a stopwatch, unrelated to the data
after    msUntilNextClose(iv) + CLOSE_SKEW   the entry dies when the candle does
scope    closed=1 only                       opt-in, distinct cache key
```

## Upstream fetches per candle

```
tf    before   after
1m       2       1
15m     15       1
1h      12       1
4h      16       1
1d      96       1
```

**Fewer requests and less delay at the same time** — which is the tell that `ttlFor` was misaligned rather than trading one against the other.

## Your negative result does not change the design

> I could not reproduce the staleness from outside, and that is NOT evidence against it

Right, and worth stating why: the module cache is **per server instance and per key**. A fresh external request with different params may miss the warm entry entirely, and Render may not even route you to the instance holding it. **Not observing a stale response from outside says nothing about what a client already inside that cache window receives.**

You called it a negative result rather than a refutation, which is the distinction that has mattered all day.

## What is opt-in, and why it has to be

Only `useEMAStrategy` sends `closed=1` — it is the caller that already drops the forming bar (#316) and only cares about closed candles. **Anything wanting the forming bar to keep moving must not be pinned to the last close**; freezing a chart until the next 4h boundary would be a far worse bug than the one being fixed.

The cache key differs too, so a boundary-aligned entry can never be served to a default caller.

## W and M fall back rather than guess

`intervalToMs` returns `null` for them. A week is not a divisor of the epoch offset and months vary in length, so the boundary arithmetic in `lib/candles.ts` does not hold — and computing a wrong boundary would be worse than not aligning. Tested.

## How to test (QA)

1. **A signal should update within seconds of a candle closing**, not within the old cache window. Most visible on 4h and 1d, where the wait was up to 15 minutes.
2. **The chart must be unaffected** — it does not send `closed=1`, and its forming bar must keep moving exactly as before. This is the regression I would look for hardest.
3. `/api/market/klines` with and without `closed=1` returns the same body shape.
4. **A weekly/monthly interval still works** — falls back to `ttlFor`, no boundary maths.

## Risk level

**Medium.** It changes caching on the endpoint that feeds the chart, the signal and the liquidation map, and #201's single-flight is what keeps it inside Binance's rate limits.

- Verified: 386 tests (4 new), lint 0 errors, tsc clean, build ✓. The dialect equivalence and the TTL bounds are pinned.
- **Not verified: the live latency improvement.** Same limit you hit — the module cache is per-instance and per-key, so it is not observable from outside. Step 1 needs a human watching a real candle close.
- **Not verified: upstream request volume in production.** The arithmetic is tested; the actual reduction is not measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y