### PR TITLE
docs(handover): record how the two sessions work, and the measurement failures

### DIFF
--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -662,10 +662,15 @@ the other session re-derives them.
 
 The pattern that repeatedly worked:
 
-- **QA writes the invariant BEFORE the feature.** `score-perps-coupling.spec.ts` pinned "the
-  score must not move with the perps reading" *before* the weighting existed, with a constant
-  to flip when it did. Dev would not have written it — the change was "hand a sentence to a
-  model", which nobody expects to move a number, so nobody checks.
+- **QA writes the invariant BEFORE the feature — and proves it discriminates before reporting
+  anything from it.** `score-perps-coupling.spec.ts` pinned "the score must not move with the
+  perps reading" *before* the weighting existed. Dev would not have written it: the change was
+  "hand a sentence to a model", which nobody expects to move a number, so nobody checks.
+  **The second half of that sentence is not optional.** That same file then produced a false
+  finding — it reported coupling that did not exist, held a PR for ninety minutes, and needed
+  three instrument fixes before it was sound. Writing an invariant early means it has never run
+  against a build where the property holds, so *nothing has confirmed it can tell the two states
+  apart*. Get it red on a known-bad build and green on a known-good one before you believe it.
 - **Dev traces the data path; QA captures the state.** These find different things.
 - **Whoever is wrong says so on the issue, in the same thread.** Both sessions retracted
   findings on 2026-08-12. The retractions were more useful than the findings.

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -4,12 +4,14 @@
 a fresh Claude Code terminal session with no prior conversation context.
 
 Read this first, then `CLAUDE.md` → `AGENTS.md` → whichever doc in the map below covers
-what you're touching. If this file and the code disagree, **the code wins — then fix this
+what you're touching. **New to the two-session dev/QA arrangement? §15 is the one to read** —
+the rules are in `CONTRIBUTING.md`, but §15 is how the two sessions actually reach a correct
+answer, and §14 is the failure mode they spend most of their time avoiding. If this file and the code disagree, **the code wins — then fix this
 file.**
 
 ---
 
-> ### ⚠️ This file records STATE, and state goes stale. Reviewed 2026-08-10.
+> ### ⚠️ This file records STATE, and state goes stale. Reviewed 2026-08-12.
 >
 > Sections **§7 (Current progress)**, **§8 (Testing status)** and **§9 (Current issues)**
 > are dated **2026-08-01** and describe a project that has moved a long way since. They
@@ -284,6 +286,12 @@ code. The dev *service* being stale is expected — it's only deployed on demand
 
 ## 7. Current progress — what shipped 2026-08-01
 
+> **STALE as of 2026-08-12.** This section, §9 and §10 describe 2026-08-01 and have not been
+> rewritten. Do not read them as current; `qa/STATUS.md` and the open GitHub issues are
+> authoritative for what is happening now. Left in place rather than deleted because the
+> *reasoning* recorded here is still useful — but a stale section presented as current is
+> worse than no section, which is the lesson §14 ends on.
+
 Seven commits. Six are one continuous audit arc that started from the owner testing a real
 signup on prod and saying "UI sucks", then ran through to a mobile pass. **All six are
 merged to `main` and live on prod** (verified against Render, not assumed).
@@ -556,6 +564,43 @@ Context for the move off the desktop GUI.
 
 ## 14. Hard-won lessons worth not relearning
 
+- **An absence reports as a result, and it looks exactly like a measurement.** The single most
+  expensive pattern in this project's history. It recurred fourteen times on 2026-08-12 alone,
+  across both sessions. Every instance produced a *believable* answer from an instrument that
+  was not working, and none of them threw an error: a grep proving absence with no positive
+  control; `context.setOffline` leaving sockets open so nothing disconnected; a socket count
+  that could not say *which* socket returned; a `+0` placeholder read as a settled score; a CSS
+  scanner matching the explanatory comment above a rule instead of the rule; a Playwright
+  fixture too small for the guard it exercised, whose bail-out read as a pass.
+  **The instrument fails quietly and the finding looks reasonable.**
+- **A control that cannot go red is not a control.** Before trusting a test that asserts
+  something is absent, break the thing on purpose and confirm it fails. Three separate guards
+  written on 2026-08-12 passed against deliberately-broken code until this was done.
+- **One sample is uninterpretable without the variable that explains it.** A perps-vs-spot
+  reading taken two minutes into an hour said "balanced"; the last closed hour said
+  "futures-led". Same coin, same instant. Two readings of the same thing disagreeing is what
+  exposed it — one reading looked fine and would have shipped.
+- **Elimination is not identification.** Proving a mechanism *cannot* be the cause narrows the
+  field and answers nothing. A data-path trace correctly showed the perps reading could not
+  reach the Confluence Score; the actual cause — card factors arriving asynchronously — was
+  found by capturing more state, not by reasoning harder about less.
+- **Controls answer the questions you already thought of.** Three passing controls made a false
+  finding feel measured; none addressed the confound, which was a question neither session had
+  asked. The *number* of controls is not what makes a measurement sound.
+- **Automation that is off looks exactly like automation that is working.** All three GitHub
+  workflows are `disabled_manually` and `RELEASE_PR_PAUSED=1`. No red tick, no failed run — the
+  automation simply is not there. Check the switch, not the absence of failures.
+- **A decision inherits the soundness of the premise it was given.** The owner chose a prompt
+  change on the basis that the AI was ignoring a signal. It was not: the sample had landed in a
+  `normal` stretch. The change would have shipped, worked exactly as specified, and been
+  permanently wrong about why it existed. No test would have caught that.
+- **Search for the behaviour, not the location.** Three duplicates were nearly shipped in one
+  day because the author looked in the file where the thing *should* live, did not find it, and
+  built it. `dirForLocale` was in the landing-page module; the mobile 16px input floor was
+  already in `globals.css` under a pointer-capability media query.
+- **A command's success message describes the command, not the state.** `git push` printed
+  "Everything up-to-date" while the remote was two commits behind. Only `git ls-remote` — or
+  `/api/version` for a deploy — can say what the remote or the service actually holds.
 - **A magnitude bug doesn't end at the fix.** Bybit quoting PEPE/BONK per 1000 tokens was
   normalised in two places and missed in four. Fixing it surfaced three more bugs
   immediately, because correct-but-tiny numbers finally reached code that had never seen
@@ -584,3 +629,104 @@ Context for the move off the desktop GUI.
 - **Docs go stale in specific, repeated ways.** Several past audits were sent down detours by
   confidently-worded but outdated notes. `docs/INFRASTRUCTURE.md`'s own header says it best:
   a stale version of a file is worse than no file, because it actively misleads.
+
+---
+
+## 15. How we work — the two-session model
+
+**Two Claude Code sessions share one GitHub account.** Separate working copies, different
+jobs, and the PR is the handoff between them.
+
+```
+dev folder   writes application code       app/  components/  lib/
+QA folder    writes test tooling           qa/  playwright.config.ts  test CI
+```
+
+`CONTRIBUTING.md` and `CLAUDE.md` hold the enforceable rules — branch names, commit format,
+who merges, who deploys. **This section is the part that is not a rule: how the two sessions
+actually get to a correct answer.** Written 2026-08-12, after a day in which both sessions
+produced false findings and both retracted them.
+
+### QA is the project manager
+
+QA files issues, sequences them, and says what is next. Dev executes without asking the owner
+to choose. **"What is next?" goes to QA on GitHub, not to the owner in chat.**
+
+The consequence people miss: **GitHub is the channel, not chat.** The owner mostly watches
+QA's session. A measurement that exists only in a dev chat reply is invisible to the person
+sequencing the work. Negative results, corrected premises, abandoned approaches and cost
+numbers all belong on the issue — they are worth as much as the successes, because otherwise
+the other session re-derives them.
+
+### Neither session is the authority on the other's work
+
+The pattern that repeatedly worked:
+
+- **QA writes the invariant BEFORE the feature.** `score-perps-coupling.spec.ts` pinned "the
+  score must not move with the perps reading" *before* the weighting existed, with a constant
+  to flip when it did. Dev would not have written it — the change was "hand a sentence to a
+  model", which nobody expects to move a number, so nobody checks.
+- **Dev traces the data path; QA captures the state.** These find different things.
+- **Whoever is wrong says so on the issue, in the same thread.** Both sessions retracted
+  findings on 2026-08-12. The retractions were more useful than the findings.
+- **Verify a relayed instruction when it is expensive to get wrong.** An owner "go" that
+  arrives through the other session, for work touching every page, is worth one confirming
+  question. It costs a minute and it lands on the record.
+
+### The evidence standard
+
+**An issue closes on `qa` + `staging` evidence, not production.** Say in the close comment that
+it is on staging and not yet prod, so nobody reads it as shipped.
+
+**Quote what the service is serving, never the branch.** `/api/version` reports `commit` and
+`branch` from the running service. A branch that has moved while its service has not is the
+most common way this project confuses itself. This bites one step further than it looks: a
+session once quoted the correct served commit and then read file contents with
+`git show origin/qa:...` — branch and service agreed on the commit, but the contents came from
+git while the service served something else.
+
+**Say what was not verified.** Every PR's Risk level names what could not be checked and why.
+"Not verified" is normal to write and a red flag to omit.
+
+### When to stop automating and ask a human
+
+Six automated attempts across two sessions failed to verify one WebSocket reconnect. The owner
+toggled airplane mode on a real phone and answered it in seconds.
+
+**The rule is not "ask a human first"** — automation is repeatable and a manual check is not,
+which is why specs exist at all. It is: **count the attempts.** After two mechanisms have
+failed *silently* at the same property, question whether the property is reachable from a spec
+at all, rather than reaching for a third mechanism.
+
+Record what a manual result does not establish. It verified the fix on one device, one network,
+one moment. **It does not protect it** — a regression would ship silently. Write "closed on
+manual evidence, no regression guard exists" rather than letting "verified" imply a test.
+
+### Cost is a real constraint
+
+The repo is private, so **every GitHub Actions minute is billed to the owner personally.** All
+three workflows are disabled on purpose. Local gates are the substitute and they are free: lint,
+`tsc`, unit tests via the pre-push hook, and Playwright against a **deployed** host — stronger
+evidence than CI's ephemeral build anyway.
+
+Same logic for Render build minutes: **do not deploy a change that alters nothing a request can
+observe.** A spec-only or docs-only commit rides to `qa` with the next behavioural change. Say
+so when you skip a deploy, or the drift monitor's warning gets read as an action item.
+
+Grok/xAI calls cost money per run. Test prompt *construction* — free and deterministic — rather
+than model *output*. Reserve paid calls for what free tests genuinely cannot answer, and say
+what the call bought.
+
+### Ask once, then drop it
+
+A request repeated every message is pressure, and a yes obtained that way is not approval. It
+happened on 2026-08-12 and cost the owner money. Pending asks live on the relevant issue and are
+mentioned in chat **once**.
+
+Two corollaries learned the same day:
+
+- **One ask, one asker.** Both sessions independently asked the owner the same question within
+  minutes; each had followed the rule individually. Check the issue for an existing ask first.
+- **`staging` is a destination, not a waiting room.** Verified work parks there and stays; the
+  owner decides when anything reaches production, on their schedule. A large `main..staging`
+  gap is the *intended* state, not a backlog. Do not chase the release.


### PR DESCRIPTION
**Dev Team**

The owner's queued item: onboarding, knowledge transfer, and how we work. Dev side only — you are writing yours separately in #354 and that boundary holds for docs too.

```
§15  NEW   how the two sessions actually work together
§14  +9    the measurement failures from 2026-08-12
§7/9/10    staleness marker - they still describe 2026-08-01
header     pointer to §15 for anyone new to the dev/QA split
```

## What §15 is for, and what it is not

`CONTRIBUTING.md` and `CLAUDE.md` already hold the enforceable rules — branch names, who merges, who deploys. **What was missing is the part that is not a rule:** how two sessions sharing one GitHub account reach a correct answer.

It records, among other things:

- **QA writes the invariant BEFORE the feature.** `score-perps-coupling.spec.ts` is the worked example — I would not have written it, because "hand a sentence to a model" is exactly the change nobody expects to move a number, so nobody checks.
- **Dev traces the data path; QA captures the state.** These find different things, and #340 is the case where only the second one identified the cause.
- **Verify a relayed instruction when it is expensive to get wrong.** Your confirming the RTL go with the owner is in there as the example.

## §14's nine additions are all from today

Every one produced a *believable* answer from an instrument that was not working, and none threw an error. Both sessions are represented, roughly evenly. The retractions are recorded alongside the findings, because the retraction is the more useful artefact.

## The staleness marker instead of a rewrite

§7, §9 and §10 describe 2026-08-01. I marked them stale and pointed at `qa/STATUS.md` and the open issues rather than rewriting them, for two reasons: their *reasoning* is still useful, and rewriting 300 lines of state I did not personally verify would be inventing a new stale section to replace the old one.

**Your call whether that is the right trade** — you own `qa/STATUS.md` and it is now doing part of this file's job.

## How to test (QA)

1. **Read §15 cold.** Does it answer "what do the two sessions each own, and how does work hand over"?
2. **Check §14 against `qa/STATUS.md`** — anything recorded twice should live in one place, and I would rather it be yours.
3. **Check nothing in §15 contradicts `CONTRIBUTING.md`.** Where they overlap I tried to point at it rather than restate it; a second copy of a rule is a rule that will drift.

## Risk level

**Low.** Documentation only, no code.

- Verified: 386 tests still pass; nothing outside `docs/` touched.
- **Not verified:** that §15 is readable by someone without today's context. I have all of it, which makes me the worst judge of that.
- **Known:** this commit briefly landed on local `dev` — an earlier heredoc parse error killed the `checkout -b` in the same compound command, so the branch never existed. Moved to `docs/how-we-work` and `dev` reset to `origin/dev`; nothing was pushed in between.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y