### PR TITLE
perf(api): boundary-aligned kline cache, with a floor this time

### DIFF
--- a/__tests__/candles.test.mts
+++ b/__tests__/candles.test.mts
@@ -105,3 +105,64 @@ test('the worst-case client staleness is now the skew, not the timeframe', () =>
       'a fetch from before the close must not be reused after it');
   }
 });
+
+/* ── #325 second attempt: the TTL floor, swept ───────────────────────────────
+ *
+ * The first attempt shipped and got both non-prod environments banned by
+ * Binance. Its tests asserted the TTL was positive and never exceeded one
+ * period; a four-second trough at one end of the range passes both.
+ *
+ * These SWEEP the offset across the whole period instead of sampling it. The
+ * bug lived at one end and no mid-candle sample could see it - which is the
+ * "controls answer the questions you already thought of" failure, in the test
+ * that was supposed to be the control.
+ */
+import { intervalToMs, closedCandleTtl } from '../lib/candles.ts';
+
+/** The route's own TTLs, so the floor is compared against the real fallback. */
+const ttlFor = (iv: string): number =>
+  /^(1|3|5)$|^(1|3|5)m$/.test(iv) ? 30_000
+  : /^(15|30)$|^(15|30)m$/.test(iv) ? 60_000
+  : /^(60|120)$|^(1|2)h$/.test(iv) ? 300_000
+  : 900_000;
+
+test('#325 THE BAN: TTL never drops below the pre-feature fallback, swept', () => {
+  // 200 offsets per interval, INCLUDING the last millisecond of the candle -
+  // which is where the four-second trough was and where every client lands.
+  for (const iv of ['1m', '5m', '15m', '30m', '1h', '4h', '1d']) {
+    const ms = intervalToMs(iv)!;
+    const floor = ttlFor(iv);
+    for (let i = 0; i <= 200; i++) {
+      const offset = Math.min(ms - 1, Math.round((i / 200) * ms));
+      const ttl = closedCandleTtl(ms, floor, 1_000_000 * ms + offset);
+      assert.ok(ttl >= floor,
+        `${iv} at +${offset}ms: TTL ${ttl}ms is BELOW the ${floor}ms fallback - this is the ban`);
+    }
+  }
+});
+
+test('#325: TTL never exceeds one period plus the skew', () => {
+  for (const iv of ['1m', '15m', '1h', '4h', '1d']) {
+    const ms = intervalToMs(iv)!;
+    for (let i = 0; i <= 200; i++) {
+      const offset = Math.min(ms - 1, Math.round((i / 200) * ms));
+      const ttl = closedCandleTtl(ms, ttlFor(iv), 1_000_000 * ms + offset);
+      assert.ok(ttl <= ms + CLOSE_SKEW_MS, `${iv} at +${offset}ms: TTL ${ttl} exceeds a period`);
+    }
+  }
+});
+
+test('#325: the benefit survives - mid-candle still expires AT the close', () => {
+  // The floor must not swallow the feature. Mid-candle on a slow interval, the
+  // boundary distance dominates and the entry still dies when the candle does.
+  const ms = intervalToMs('4h')!;
+  const ttl = closedCandleTtl(ms, ttlFor('4h'), 1_000_000 * ms + ms / 2);
+  assert.equal(ttl, ms / 2 + CLOSE_SKEW_MS, 'mid-candle should be boundary-aligned, not floored');
+  assert.ok(ttl > ttlFor('4h'), 'and longer than the old fixed TTL, which is the point');
+});
+
+test('#325: near the close the floor takes over, which is the safe direction', () => {
+  const ms = intervalToMs('4h')!;
+  const ttl = closedCandleTtl(ms, ttlFor('4h'), 1_000_000 * ms + ms - 1000);
+  assert.equal(ttl, ttlFor('4h'), 'the last moments fall back to the pre-feature TTL');
+});

--- a/app/api/market/klines/route.ts
+++ b/app/api/market/klines/route.ts
@@ -35,6 +35,7 @@
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { cached } from '@/lib/apiCache';
+import { intervalToMs, closedCandleTtl } from '@/lib/candles';
 import { rateLimit, getClientIp } from '@/lib/rateLimit';
 import { apiError } from '@/lib/apiError';
 import { reportHealth } from '@/lib/apiHealth';
@@ -213,8 +214,36 @@ export async function GET(req: NextRequest) {
   };
 
   try {
-    const key = `klines:${source}:${symbol}:${interval}:${limit}`;
-    const raw = isRange ? await fetchUpstream() : await cached(key, ttlFor(interval), fetchUpstream);
+    /* BOUNDARY-ALIGNED EXPIRY for closed-candle callers (#325), FLOORED.
+     *
+     * ttlFor is a stopwatch unrelated to the data: on a 4h chart it expires 16
+     * times per candle to observe one change, and since #316 the signal path
+     * recomputes ON the close and then gets a response up to 15 minutes old.
+     *
+     * A bypass is the wrong fix - candle close is a global event, so the moment
+     * you would bypass is the moment the cache matters most.
+     *
+     * THE FIRST ATTEMPT AT THIS GOT BOTH NON-PROD ENVIRONMENTS BANNED. Without
+     * a floor the TTL bottoms out at CLOSE_SKEW_MS just before any close - four
+     * seconds, on every interval, at exactly the instant #316 synchronises
+     * clients onto. Binance replied 418.
+     *
+     * closedCandleTtl takes the MAXIMUM of the boundary distance and the
+     * caller's existing TTL, so this can only ever lengthen the cache. More
+     * upstream traffic than the pre-#325 baseline is impossible by
+     * construction rather than by anyone remembering.
+     *
+     * OPT-IN: it cannot apply globally. Anything wanting the forming bar to
+     * keep moving must not be pinned to the last close. Distinct cache key so a
+     * boundary-aligned entry is never served to a default caller. Falls back
+     * entirely for intervals with no computable boundary (W, M). */
+    const closedOnly = q.get('closed') === '1';
+    const ivMs = closedOnly ? intervalToMs(interval) : null;
+    const ttl = ivMs != null
+      ? closedCandleTtl(ivMs, ttlFor(interval), Date.now())
+      : ttlFor(interval);
+    const key = `klines:${source}:${symbol}:${interval}:${limit}${ivMs != null ? ':closed' : ''}`;
+    const raw = isRange ? await fetchUpstream() : await cached(key, ttl, fetchUpstream);
     /* Slice AFTER the cache read, using the caller's own limit. The cache holds
        one bucket-sized copy that every caller in that bucket shares; each gets
        back the length it asked for. Range requests are returned untouched -

--- a/lib/candles.ts
+++ b/lib/candles.ts
@@ -84,3 +84,54 @@ export function sameCandle(fetchedAt: number, intervalMs: number, nowMs: number)
   if (!(intervalMs > 0)) return false;
   return Math.floor(fetchedAt / intervalMs) === Math.floor(nowMs / intervalMs);
 }
+
+/**
+ * Exchange interval string to milliseconds, across both dialects (#325).
+ *
+ * Bybit takes minutes as bare integers plus D/W/M; Binance takes suffixed
+ * strings. The klines route deliberately does not translate between them, so
+ * this reads both. Returns null for W and M: a week is not a divisor of the
+ * epoch offset and months vary in length, so the boundary arithmetic here does
+ * not hold and a caller must fall back rather than compute a wrong boundary.
+ */
+export function intervalToMs(interval: string): number | null {
+  const suffixed = /^(\d+)(m|h|d)$/.exec(interval);
+  if (suffixed) {
+    const n = Number(suffixed[1]);
+    const unit = { m: 60_000, h: 3_600_000, d: 86_400_000 }[suffixed[2] as 'm' | 'h' | 'd'];
+    return n > 0 ? n * unit : null;
+  }
+  if (/^\d+$/.test(interval)) { const n = Number(interval); return n > 0 ? n * 60_000 : null; }
+  if (interval === 'D') return 86_400_000;
+  return null;
+}
+
+/**
+ * Cache TTL for a closed-candle klines request (#325, second attempt).
+ *
+ * ── THE FLOOR IS THE WHOLE POINT ────────────────────────────────────────────
+ *
+ * The first attempt was `msUntilNextClose + CLOSE_SKEW_MS` with no floor. That
+ * bottoms out at the skew - four seconds - just before any close, on every
+ * interval, and #316 synchronises every client onto exactly that instant.
+ * Binance answered with 418, their ban code, on both non-prod environments.
+ *
+ *     4h  mid-candle          7203 s
+ *     4h  1s before close        4 s      <- the ban
+ *
+ * `fallbackTtlMs` is the caller's existing TTL - `ttlFor(interval)` in the
+ * route. Taking the MAXIMUM means this can only ever make the cache live
+ * LONGER than it did before the feature existed, so more upstream traffic than
+ * the pre-#325 baseline is impossible by construction rather than by anyone
+ * remembering to check.
+ *
+ * The cost is honest: an entry written in the last moments of a candle serves
+ * the old candle for up to `fallbackTtlMs` past the close, which is exactly the
+ * behaviour before #325. The feature degrades to the old behaviour in the
+ * narrow window where being aggressive is dangerous, and keeps the benefit
+ * across the rest of the candle, where an entry written mid-candle still
+ * expires at the close.
+ */
+export function closedCandleTtl(intervalMs: number, fallbackTtlMs: number, nowMs: number): number {
+  return Math.max(msUntilNextClose(intervalMs, nowMs) + CLOSE_SKEW_MS, fallbackTtlMs);
+}

--- a/lib/useEMAStrategy.ts
+++ b/lib/useEMAStrategy.ts
@@ -78,7 +78,7 @@ interface OHLCV { time: number; open: number; high: number; low: number; close: 
 /* ── Fetch helpers ───────────────────────────────────────────────────────── */
 async function fetchBinanceFuturesKlines(sym: string, interval: string, limit: number): Promise<OHLCV[]> {
   const r = await fetch(
-    `/api/market/klines?source=binance-futures&symbol=${sym}&interval=${interval}&limit=${limit}`,
+    `/api/market/klines?source=binance-futures&symbol=${sym}&interval=${interval}&limit=${limit}&closed=1`,
     { signal: AbortSignal.timeout(12_000) }
   );
   if (!r.ok) throw new Error(`Binance futures klines ${r.status}`);
@@ -90,7 +90,7 @@ async function fetchBinanceFuturesKlines(sym: string, interval: string, limit: n
 
 async function fetchBybitKlines(sym: string, interval: string, limit: number): Promise<OHLCV[]> {
   const r = await fetch(
-    `/api/market/klines?source=bybit&symbol=${sym}&interval=${interval}&limit=${limit}`,
+    `/api/market/klines?source=bybit&symbol=${sym}&interval=${interval}&limit=${limit}&closed=1`,
     { signal: AbortSignal.timeout(12_000) }
   );
   if (!r.ok) throw new Error(`Bybit klines ${r.status}`);


### PR DESCRIPTION
**Dev Team**

Second attempt at #325. Design unchanged, the flaw that got us banned is closed by construction.

```
closedCandleTtl(intervalMs, fallbackTtlMs, nowMs)
  = max(msUntilNextClose + CLOSE_SKEW_MS, fallbackTtlMs)
```

**Taking the maximum means this can only ever LENGTHEN the cache.** More upstream traffic than the pre-#325 baseline is impossible by construction rather than by anyone remembering to look.

## I watched it fail first, which is the step I skipped last time

Removed the floor, reproducing #352's exact formula:

```
✖ #325 THE BAN: TTL never drops below the pre-feature fallback, swept
✖ #325: near the close the floor takes over, which is the safe direction
   pass 14   fail 2
```

Restored it: **16 pass**. The test discriminates, demonstrated rather than asserted.

## The sweep is the difference

The old tests checked the TTL was positive and never exceeded one period. **A four-second trough at one end of the range passes both.**

```
for each of 1m 5m 15m 30m 1h 4h 1d:
  for 200 offsets across the whole period, including the last millisecond:
      ttl >= ttlFor(interval)
      ttl <= one period + skew
```

The bug lived where no mid-candle sample could see it. **Sampling was the failure; sweeping is the fix.**

## The cost, stated rather than buried

An entry written in the last moments of a candle serves the old candle for up to `ttlFor` past the close — **exactly the pre-#325 behaviour**. So the feature degrades to the old behaviour in the narrow window where being aggressive is dangerous, and keeps the benefit across the rest of the candle:

```
4h mid-candle       7203s   boundary-aligned, the benefit
4h 1s before close   900s   floored to ttlFor, the safe direction
```

I would rather lose the last few seconds of alignment than have another mechanism that is only safe when nobody is looking.

## How to test (QA)

1. **`?source=binance-futures` keeps returning 200 across several candle closes** — not one probe. The failure last time appeared at boundaries, so a single check between them proves nothing. **This is the one that matters.**
2. A signal updates within seconds of a close on 4h/1d.
3. **The chart is unaffected** — no `closed=1`, forming bar still moving.
4. `closed=1` and default still return the same body shape and hold separate cache keys.

## Risk level

**Medium-High.** Same endpoint and same mechanism that caused tonight's ban.

- Verified: 386 tests, lint 0 errors, tsc clean, build ✓, and the sweep proven to go red without the floor.
- **Not verified: behaviour across a real candle boundary under load.** That is exactly what was not verified last time and it is what bit us. Step 1 is a human watching, not a probe.
- **Not verified: the latency win.** Still unobservable from outside — per-instance, per-key cache.
- Prod unaffected: `main` is `d07d291`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y