### PR TITLE
fix(chart): backfill the candles that closed during a network outage

### DIFF
--- a/__tests__/candles.test.mts
+++ b/__tests__/candles.test.mts
@@ -166,3 +166,38 @@ test('#325: near the close the floor takes over, which is the safe direction', (
   const ttl = closedCandleTtl(ms, ttlFor('4h'), 1_000_000 * ms + ms - 1000);
   assert.equal(ttl, ttlFor('4h'), 'the last moments fall back to the pre-feature TTL');
 });
+
+/* ── #313: the gap left behind after an outage ─────────────────────────────── */
+import { barsAfter, type Bar } from '../lib/candles.ts';
+
+const gapBar = (t: number, close = 100): Bar =>
+  ({ timestamp: t, open: 99, high: 101, low: 98, close, volume: 5 });
+
+test('#313: returns exactly the candles that closed during the outage', () => {
+  const rows = [gapBar(1000), gapBar(2000), gapBar(3000), gapBar(4000), gapBar(5000)];
+  assert.deepEqual(barsAfter(rows, 2000).map(b => b.timestamp), [3000, 4000, 5000]);
+});
+
+test('#313: the bar the stream already delivered is NOT re-sent', () => {
+  // Same timestamp, fetched later, would have a different close - it would
+  // rewrite a candle the user watched form.
+  const rows = [gapBar(2000, 111), gapBar(3000)];
+  assert.deepEqual(barsAfter(rows, 2000).map(b => b.timestamp), [3000]);
+});
+
+test('#313: ascending order, even when the upstream returns newest-first', () => {
+  // Bybit returns newest-first. Delivered in that order through an upsert path,
+  // each older bar overwrites the newer one and the chart ends up showing the
+  // START of the gap as its latest candle.
+  const rows = [gapBar(5000), gapBar(4000), gapBar(3000)];
+  assert.deepEqual(barsAfter(rows, 2000).map(b => b.timestamp), [3000, 4000, 5000]);
+});
+
+test('#313: nothing streamed yet means getBars owns the series, not the backfill', () => {
+  assert.deepEqual(barsAfter([gapBar(1000), gapBar(2000)], 0), []);
+});
+
+test('#313: a drop with no elapsed candles backfills nothing', () => {
+  // Reconnecting inside the same candle must not re-push it.
+  assert.deepEqual(barsAfter([gapBar(1000), gapBar(2000)], 2000), []);
+});

--- a/components/KLineProChart.tsx
+++ b/components/KLineProChart.tsx
@@ -7,6 +7,7 @@ import type { CombinedResult } from '@/lib/grok';
 import type { StrategySignal } from '@/lib/useEMAStrategy';
 import { detectStructureSignals, type PASignal } from '@/lib/priceAction';
 import { Warn } from '@/components/icons';
+import { barsAfter } from '@/lib/candles';
 
 // ── v10 Period mapping ────────────────────────────────────────────────────
 
@@ -412,6 +413,10 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
   const [countdown,    setCountdown]   = useState('-');
   const [priceLabelY,  setPriceLabelY] = useState<number | null>(null);
   const lastCloseRef   = useRef<number>(0);
+  /* Newest bar timestamp the live stream has delivered. The backfill on
+     reconnect (#313) fetches everything after it - without this there is no way
+     to know how much of the series the outage cost. */
+  const lastBarTsRef   = useRef<number>(0);
   const [showSR, setShowSR]       = useState(true);
   const [srLevels, setSrLevels]   = useState<SRLevel[]>([]);
   const srSetRef                  = useRef(setSrLevels);
@@ -1206,12 +1211,63 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
                relying on the call happening later would break the moment someone
                moved it. */
             let live: WebSocket | null = null;
+            /* False until the first connect completes, so the initial open does
+               not trigger a backfill that getBars has already done. */
+            let reconnected = false;
+
+            /* Fetch what closed while we were away and push it through the same
+               callback the stream uses.
+               Ascending order matters: klinecharts' update path upserts by
+               timestamp, so bars must arrive oldest-first or a later bar is
+               overwritten by an earlier one. */
+            const backfillGap = async (
+              sym: string, interval: string,
+              cb: (bar: { timestamp: number; open: number; high: number; low: number; close: number; volume: number }) => void,
+            ) => {
+              const since = lastBarTsRef.current;
+              if (!since) return;                       // nothing streamed yet - getBars owns it
+              try {
+                const r = await fetch(
+                  `/api/market/klines?source=binance&symbol=${sym}&interval=${interval}&limit=500`,
+                  { signal: AbortSignal.timeout(12_000) },
+                );
+                if (!r.ok || cancelled) return;
+                const rows = (await r.json()) as Array<[number, string, string, string, string, string]>;
+                if (cancelled) return;
+                const missed = barsAfter(
+                  rows.map(k => ({ timestamp: Number(k[0]), open: +k[1], high: +k[2], low: +k[3], close: +k[4], volume: +k[5] })),
+                  since,
+                );
+                for (const bar of missed) {
+                  lastBarTsRef.current = bar.timestamp;
+                  lastCloseRef.current = bar.close;
+                  upsertEmaBar(bar);
+                  cb(bar);
+                }
+              } catch { /* the stream is already live; a failed backfill leaves
+                           the gap rather than breaking the chart */ }
+            };
 
             const connect = () => {
               if (cancelled) return;
               const ws = new WebSocket(`wss://stream.binance.com:9443/ws/${bnSym.toLowerCase()}@kline_${iv}`);
               live = ws;
-              ws.onopen    = () => { attempt = 0; setWsStatus('live'); };
+              ws.onopen    = () => {
+                attempt = 0;
+                setWsStatus('live');
+                /* BACKFILL THE GAP (#313).
+                 *
+                 * #309 restores the stream; it does not recover the candles that
+                 * closed while it was down. getBars only runs on mount and on a
+                 * symbol/period change, so before this the chart resumed live and
+                 * kept a hole where the outage was - and a hole in a candle series
+                 * is not visibly a hole, it is a chart that looks fine and is wrong.
+                 *
+                 * Only after a real gap: `reconnected` is false on the first
+                 * connect, so a normal page load does not fire a second fetch. */
+                if (reconnected) void backfillGap(bnSym, iv, callback);
+                reconnected = true;
+              };
               ws.onerror   = () => setWsStatus('error');
               ws.onclose   = (e) => {
                 if (cancelled || e.wasClean) return;   // a clean close is us, not the network
@@ -1225,6 +1281,7 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
                 const { k } = JSON.parse(e.data as string) as { k: Record<string, string | number> };
                 const bar = { timestamp: Number(k.t), open: Number(k.o), high: Number(k.h), low: Number(k.l), close: Number(k.c), volume: Number(k.v) };
                 lastCloseRef.current = bar.close;
+                lastBarTsRef.current = bar.timestamp;
                 upsertEmaBar(bar);
                 callback(bar);
               };

--- a/lib/candles.ts
+++ b/lib/candles.ts
@@ -135,3 +135,29 @@ export function intervalToMs(interval: string): number | null {
 export function closedCandleTtl(intervalMs: number, fallbackTtlMs: number, nowMs: number): number {
   return Math.max(msUntilNextClose(intervalMs, nowMs) + CLOSE_SKEW_MS, fallbackTtlMs);
 }
+
+export interface Bar {
+  timestamp: number; open: number; high: number; low: number; close: number; volume: number;
+}
+
+/**
+ * The bars that closed while the stream was down (#313).
+ *
+ * #309 restores the socket; it does not recover the candles that closed while it
+ * was gone. getBars only runs on mount and on a symbol/period change, so the
+ * chart resumed live with a hole where the outage was — and **a hole in a candle
+ * series is not visibly a hole.** It is a chart that looks fine and is wrong.
+ *
+ * ASCENDING ORDER IS LOAD-BEARING. klinecharts' update path upserts by
+ * timestamp, so bars must arrive oldest-first; delivered newest-first, each
+ * older bar overwrites the newer one and the chart ends up showing the START of
+ * the gap as its latest candle.
+ *
+ * STRICTLY AFTER `since`, never inclusive. Re-delivering the bar the stream
+ * already gave us would rewrite a candle the user watched form, with a version
+ * fetched later — same timestamp, different close.
+ */
+export function barsAfter(rows: readonly Bar[], since: number): Bar[] {
+  if (!since) return [];        // nothing streamed yet: getBars owns the series
+  return rows.filter(b => b.timestamp > since).sort((a, b) => a.timestamp - b.timestamp);
+}


### PR DESCRIPTION
**Dev Team**

Closes #313. Queue item 1 of 3, on its own as the owner asked.

```
#309 restored   the stream
#309 did NOT    the series
```

`getBars` runs on mount and on a symbol/period change — never on reconnect. So the chart came back live with a hole where the outage was.

**A hole in a candle series is not visibly a hole.** It is a chart that looks fine and is wrong, and every indicator computed from it is wrong with it. That is why this outranked its "low priority" label once #306 confirmed the reconnect works.

## Your assertion is the right one and I built for it

> the chart's data contains those N bars — not merely "getBars ran"

`barsAfter(rows, since)` is pure and tested, so the *selection* is pinned here and your spec can assert the *result*:

```
returns exactly the candles that closed during the outage
the bar already streamed is NOT re-sent
ascending order, even when the upstream returns newest-first
nothing streamed yet -> getBars owns the series, backfill returns []
a drop inside one candle backfills nothing
```

## Three things that would each look fine and be wrong

**Order.** klinecharts upserts by timestamp. Bybit returns newest-first — delivered in that order, each older bar overwrites the newer one and the chart shows the **start** of the gap as its latest candle. Plausible-looking, completely wrong.

**Inclusive vs exclusive.** Re-sending the last streamed bar rewrites a candle the user watched form, with a version fetched later: same timestamp, different close.

**First connect.** A `reconnected` flag stays false through the initial open, so a page load does not fire a second fetch behind `getBars`.

## What I could not do

**A failed backfill is swallowed on purpose.** The stream is already live by then, so leaving the gap beats breaking a working chart — and the gap is what we had before this commit. It means a silent failure looks like the old behaviour, which I do not love, but the alternative is worse.

## How to test (QA)

1. **Count the bars, do not watch for motion.** Load Arena, kill networking for a few minutes, restore. The candles that closed while it was off must be present — "the chart is moving again" was true before this change too.
2. **A normal page load fetches history exactly once.** No second request behind `getBars`.
3. **Reconnect inside a single candle backfills nothing.**
4. On a coin without a Binance spot pair, no crash — the fetch fails and the chart keeps streaming.

## Risk level

**Medium.** Touches the chart's live data path, which is the surface #352 was on when it caused last night's ban — though this adds one fetch per reconnect, not per candle.

- Verified: 391 tests (5 new), lint 0 errors, tsc clean, build ✓.
- **Not verified: the gap closing in a browser.** I cannot drop a socket reliably — six attempts across two sessions failed at that, and only the owner's airplane-mode test settled #306. **Item 1 needs a human doing the same thing.**
- **Not verified: behaviour on a very long outage.** `limit=500` bounds it; a gap longer than 500 candles backfills partially and silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y