### PR TITLE
fix(i18n): hold quantitative axes physical under RTL

### DIFF
--- a/app/briefing/page.tsx
+++ b/app/briefing/page.tsx
@@ -665,7 +665,13 @@ export default function MorningBriefing() {
             </div>
 
             {/* Danger zone bar */}
-            <div style={{ position: 'relative', paddingBottom: 18, marginBottom: 6 }}>
+            {/* dir="ltr": a QUANTITATIVE AXIS DOES NOT MIRROR (#353).
+                 Arabic text reads right-to-left; a 140-165 USD/JPY scale does not.
+                 Flipping this would put the low end on the right and every
+                 marker at a position meaning a different value - rendering
+                 perfectly and lying. Explicit rather than inherited so it stays
+                 true when the document direction changes. */}
+            <div dir="ltr" style={{ position: 'relative', paddingBottom: 18, marginBottom: 6 }}>
               <div style={{
                 height: 6, borderRadius: 3, overflow: 'hidden',
                 background: `linear-gradient(to right,

--- a/app/hours/page.tsx
+++ b/app/hours/page.tsx
@@ -131,7 +131,13 @@ export default function BestHours() {
         </div>
 
         {/* Bar + needle wrapper - overflow visible so needle tip shows */}
-        <div style={{ position: 'relative', marginBottom: 6 }}>
+        {/* dir="ltr": a QUANTITATIVE AXIS DOES NOT MIRROR (#353).
+             Arabic text reads right-to-left; a 24-hour TIME axis does not.
+             Flipping it puts every session bar at an hour it does not mean -
+             rendering perfectly and lying. Covers the bar, its marker and its
+             label together: they are three layers of one axis and any
+             treatment applied to fewer than all three separates them. */}
+        <div dir="ltr" style={{ position: 'relative', marginBottom: 6 }}>
           {/* Segment strips */}
           <div style={{ position: 'relative', height: 44, borderRadius: 8, background: 'var(--bg3)', overflow: 'hidden' }}>
             {/* Client-only: the viewer's UTC offset both shifts the blocks and can

--- a/components/CycleDayCounter.tsx
+++ b/components/CycleDayCounter.tsx
@@ -91,7 +91,12 @@ export default function CycleDayCounter() {
           }} />
         </div>
         {/* Peak window markers */}
-        <div style={{ position: 'relative', height: 12, marginTop: 2 }}>
+        {/* dir="ltr": a QUANTITATIVE AXIS DOES NOT MIRROR (#353).
+             Arabic text reads right-to-left; a cycle-window ratio does not. Flipping
+             this puts every marker at a position meaning a different value -
+             rendering perfectly and lying. Explicit rather than inherited, so
+             it stays true when the document direction changes. */}
+        <div dir="ltr" style={{ position: 'relative', height: 12, marginTop: 2 }}>
           <span style={{
             position: 'absolute', fontSize: '0.6875rem', color: 'var(--amber)',
             left: `${(PEAK_WINDOW.start / PEAK_WINDOW.end) * 100}%`,

--- a/components/MarketRead.tsx
+++ b/components/MarketRead.tsx
@@ -68,7 +68,15 @@ export default function MarketRead() {
           of where 78 sits on the range or what counts as good. Plain "≥70" is
           numerals + a symbol, not prose, so it skips the label/i18n system. */}
       <div className="mr-track-wrap">
-        <div className="mr-track">
+        {/* dir="ltr": a QUANTITATIVE AXIS DOES NOT MIRROR (#353).
+             A 0-100 score track with a fixed "Good >= 70" tick. Mirrored, the
+             tick marks 30 and the fill grows from the wrong end - both render
+             perfectly and mean the opposite.
+             Found by sweeping ALL percentage positions, static and computed.
+             The original survey filtered for computed offsets and missed this
+             and MultiTFAlignment; a hardcoded percentage on an axis mirrors
+             exactly as wrongly as a calculated one. */}
+        <div dir="ltr" className="mr-track">
           <div suppressHydrationWarning className="mr-fill" style={{ width: read.score + '%' }} />
           <div className="mr-track-good-tick" style={{ left: '70%' }} title="Good ≥ 70" />
         </div>

--- a/components/MultiTFAlignment.tsx
+++ b/components/MultiTFAlignment.tsx
@@ -72,7 +72,14 @@ function RsiRow({ tf, rsi, bias, last, locked }: { tf: string; rsi: number | nul
           free user can see that 5m and 15m exist and are Pro rather than facing
           an unexplained smear. aria-hidden on each blurred part keeps a screen
           reader from reading out a value the screen is deliberately hiding. */}
-      <div aria-hidden={locked || undefined} style={{ position: 'relative', height: 5, borderRadius: 3, background: 'rgba(255,255,255,0.08)', ...(locked ? { filter: 'blur(5px)' } : {}) }}>
+      {/* dir="ltr": a QUANTITATIVE AXIS DOES NOT MIRROR (#353).
+           An RSI track runs 0 on the left to 100 on the right, with the 50
+           midline fixed at 50%. Mirroring it inverts the reading - an
+           oversold bar would render as overbought, perfectly, and lie.
+           This one is STATIC (left: '50%'), which is why the #353 survey
+           missed it: that enumeration filtered for COMPUTED offsets, and a
+           hardcoded percentage on an axis mirrors just as wrongly. */}
+      <div dir="ltr" aria-hidden={locked || undefined} style={{ position: 'relative', height: 5, borderRadius: 3, background: 'rgba(255,255,255,0.08)', ...(locked ? { filter: 'blur(5px)' } : {}) }}>
         <div style={{
           position: 'absolute', left: 0, top: 0, bottom: 0,
           width: `${pct}%`, borderRadius: 3,

--- a/components/VolatilityRegime.tsx
+++ b/components/VolatilityRegime.tsx
@@ -107,7 +107,12 @@ function HVRow({ label, data }: { label: string; data: LoadState }) {
       </div>
 
       {/* Percentile track */}
-      <div style={{ position: 'relative', height: 5, borderRadius: 3, background: 'rgba(255,255,255,0.06)', overflow: 'visible' }}>
+      {/* dir="ltr": a QUANTITATIVE AXIS DOES NOT MIRROR (#353).
+           Arabic text reads right-to-left; a 0-100 percentile track does not. Flipping
+           this puts every marker at a position meaning a different value -
+           rendering perfectly and lying. Explicit rather than inherited, so
+           it stays true when the document direction changes. */}
+      <div dir="ltr" style={{ position: 'relative', height: 5, borderRadius: 3, background: 'rgba(255,255,255,0.06)', overflow: 'visible' }}>
         {/* Low zone (0–20%) */}
         <div style={{ position: 'absolute', left: 0, width: '20%', height: '100%', background: 'rgba(52,211,153,0.2)', borderRadius: '3px 0 0 3px' }} />
         {/* High zone (80–100%) */}


### PR DESCRIPTION
**Dev Team**

#353 step 2. Your corrected spec goes green: **4 passed**, desktop.

```
/briefing   PASS      /hours   PASS
/arena      PASS      CONTROL  PASS   ordinary text still flips
```

## Six containers, not five — the survey missed two

```
app/briefing/page.tsx          USD/JPY 140-165 scale
app/hours/page.tsx             24h session timeline
components/VolatilityRegime    percentile track
components/CycleDayCounter     cycle-window bar
components/MultiTFAlignment    RSI track          <- MISSED, left: '50%'
components/MarketRead          score track        <- MISSED, left: '70%'
```

**My enumeration filtered for COMPUTED offsets.** Those two are hardcoded percentages, and a static percentage on an axis mirrors exactly as wrongly as a calculated one — MarketRead's tick is labelled *"Good ≥ 70"* and would mark 30.

Re-swept every percentage position, static or computed. The other four hits are `50%` + `translateX(-50%)` centering, which is direction-neutral, and are left alone.

**"Computed" was the wrong filter and `/arena` had no exempt container at all until your spec failed on it.** Your test found the hole in my survey, which is not what either of us expected it to do.

## What this actually changes today: nothing

Physical `left` does not flip on its own. **This is the explicit marker, not a behaviour fix** — it makes the exemption survive step 3's sweep, where converting these to logical properties *would* flip them.

Your framing was right: holding a position physical *by accident* and *on purpose* look identical until someone refactors.

## Three wrong requirements, zero code bugs

```
mine    "each needs 100 - x"           they should not mirror at all
yours   "assert the mirrored position" would have pinned the bug
yours   "assert absolute position"     cannot hold if RTL works
```

Each would have produced a **passing test enforcing wrong behaviour**. Writing the invariant first stops it being shaped by the implementation; it does not stop it being wrong about the requirement.

## How to test (QA)

1. `rtl-exemptions.spec.ts` green on both projects.
2. **Baseline: 68.** I re-ran it on `b778fe7` before starting — 34 desktop + 34 mobile, matching your `763cd75` capture, so the three intervening merges moved nothing.
3. **Nothing looks different in English.** This is the check that matters for the 99% of users who never see RTL.

## Risk level

**Low.** Six `dir` attributes, no positioning changed, no CSS.

- Verified: 391 unit tests, lint 0 errors, tsc clean, build ✓, exemption spec 4/4 desktop.
- **Not verified: mobile project** for the exemption spec — running it is yours.
- **Not verified: that these read correctly to an Arabic speaker.** Unchanged from the survey; we still have nobody who can judge that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y