### PR TITLE
test(i18n): pin USD/JPY so the briefing yen scale actually renders

### DIFF
--- a/qa/e2e/rtl-exemptions.spec.ts
+++ b/qa/e2e/rtl-exemptions.spec.ts
@@ -37,6 +37,29 @@ import { gotoGuarded } from './_shared';
 const ROUTES = ['/briefing', '/hours', '/arena'] as const;
 
 /**
+ * Pin USD/JPY so the briefing's yen scale actually renders.
+ *
+ * `app/briefing/page.tsx:651` gates the whole block on `jpyUsd == null`, so the
+ * exempt container does not exist until the macro data arrives. The first run
+ * against step 2 reported "no dir=ltr containers on /briefing" - which reads
+ * exactly like a missing exemption and was a DATA DEPENDENCY in this spec.
+ * The exemption was in the deployed commit the whole time.
+ *
+ * 150 is a quiet value: below the 158 warning and 160 danger thresholds, so the
+ * scale renders in its ordinary state rather than an alert variant.
+ */
+async function pinMacro(page: Page) {
+  await page.route('**/api/macro**', async route => {
+    let body: Record<string, unknown> = {};
+    try { body = await (await route.fetch()).json(); } catch { /* upstream down */ }
+    await route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({ ...body, jpy: { value: 150, changePct: 0.1 } }),
+    });
+  });
+}
+
+/**
  * For every exempt axis, where its markers sit WITHIN it - as a fraction of the
  * container's own width.
  *
@@ -92,8 +115,9 @@ test.describe('quantitative axes are exempt from RTL mirroring', () => {
       await page.addInitScript(() => {
         try { localStorage.setItem('lhq_analytics_consent_v1', 'denied'); } catch { /* private mode */ }
       });
+      await pinMacro(page);
       await gotoGuarded(page, route);
-      await page.waitForTimeout(9000);
+      await page.waitForTimeout(12_000);
 
       await setDir(page, 'ltr');
       await page.waitForTimeout(1200);
@@ -135,8 +159,9 @@ test.describe('quantitative axes are exempt from RTL mirroring', () => {
     await page.addInitScript(() => {
       try { localStorage.setItem('lhq_analytics_consent_v1', 'denied'); } catch { /* private mode */ }
     });
+    await pinMacro(page);
     await gotoGuarded(page, '/briefing');
-    await page.waitForTimeout(9000);
+    await page.waitForTimeout(12_000);
 
     const probe = async () => page.evaluate(() => {
       const el = document.querySelector('h1, h2, p');


### PR DESCRIPTION
**QA Team** · ✅ **Step 2 verified — red → green on all four, `qa @ 40c5842`.**

```
before step 2   3 route tests FAIL  "step 2 has not landed"    control PASS
after step 2    4 passed
```

That transition is what the file was written for, and it happened.

## But the first run against your step 2 blamed you for my bug

```
no dir="ltr" containers on /briefing
```

Reads exactly like a missing exemption. **It was not** — `app/briefing/page.tsx:651` gates the yen block on `jpyUsd == null`, so the container does not exist until the macro data arrives. Your exemption was in the deployed commit the whole time; I confirmed by reading the deployed source rather than trusting the failure.

Pinned `/api/macro` at 150 — quiet, below the 158 warning and 160 danger thresholds — so the scale renders in its ordinary state.

**The positive control half-worked.** It failed rather than passing vacuously, which is what it is for. But its message named the wrong cause, and *"either step 2 has not landed or the exemptions were applied somewhere this route does not render"* did not include *"or the component is data-gated and the data did not arrive"*. Worth knowing: **a control that catches an empty result still has to guess why it is empty.**

## Where #353 stands

```
step 1   direction plumbing        done
step 2   ten exemptions            DONE and verified
step 3   the mechanical sweep      yours - re-run the survey with the
                                   "computed" filter dropped first
step 4   Arabic into the picker    OWNER'S CALL, not a test result
```

## Risk level: **Low**

QA-owned spec, one file, no application code.