### PR TITLE
fix(chart): take history from spot, matching the live stream

### DIFF
--- a/components/KLineProChart.tsx
+++ b/components/KLineProChart.tsx
@@ -417,6 +417,9 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
      reconnect (#313) fetches everything after it - without this there is no way
      to know how much of the series the outage cost. */
   const lastBarTsRef   = useRef<number>(0);
+  /* Which feed produced the chart's history. The gap backfill reads it so a
+     recovery never mixes feeds - see the note at the getBars fallback (#359). */
+  const histSourceRef  = useRef<'binance' | 'binance-futures'>('binance');
   const [showSR, setShowSR]       = useState(true);
   const [srLevels, setSrLevels]   = useState<SRLevel[]>([]);
   const srSetRef                  = useRef(setSrLevels);
@@ -1096,9 +1099,15 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
               // used to live in MarketProvider.fetchKlines). The chart just never
               // got the same treatment.
               //
-              // Futures is also the better default on its own merits - this is a
-              // perp-trading app, and fapi's candles are the ones the funding,
-              // OI and liquidation data all refer to.
+              // That reasoning was about the BROWSER calling Binance directly.
+              // These now go through /api/market/klines, so the fetch happens
+              // server-side and a client-side geo-block or filter list never
+              // touches it - which is why spot can lead again (#359).
+              //
+              // Futures candles are still what the funding, OI and liquidation
+              // data refer to. That argues for showing futures ALONGSIDE, not
+              // for silently joining futures history to a spot stream, which is
+              // what this used to do.
               const tryFetch = async (url: string): Promise<(string | number)[][] | null> => {
                 try {
                   const res = await fetch(url);
@@ -1107,10 +1116,28 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
                   return Array.isArray(j) && j.length ? j as (string | number)[][] : null;
                 } catch { return null; }
               };
-              const raw =
-                await tryFetch(`/api/market/klines?source=binance-futures&symbol=${bnSym}&interval=${iv}&limit=1500`)
-                ?? await tryFetch(`/api/market/klines?source=binance&symbol=${bnSym}&interval=${iv}&limit=1500`)
-                ?? [];
+              /* SPOT FIRST (#359). The live stream is spot - wss://stream.binance.com
+                 - so futures history joined to it produced a chart whose bars
+                 changed feed partway along, invisibly. Measured at 4.4bp on BTC
+                 (~$28) and ~9bp on ETH: small, permanent, and in the one place a
+                 user reads price. Owner's decision: spot throughout.
+                 Futures stays as the FALLBACK rather than being deleted - it is
+                 a different host, and it is the reason a Binance-spot outage or
+                 block does not blank the chart. Ordering changed; resilience
+                 kept. */
+              let raw = await tryFetch(`/api/market/klines?source=binance&symbol=${bnSym}&interval=${iv}&limit=1500`);
+              if (raw) {
+                histSourceRef.current = 'binance';
+              } else {
+                raw = await tryFetch(`/api/market/klines?source=binance-futures&symbol=${bnSym}&interval=${iv}&limit=1500`);
+                /* Remember WHICH feed the history came from, so the gap backfill
+                   (#313) refills from the same one. Without this, a spot outage
+                   would give futures history and a spot backfill - the exact
+                   mismatch #359 is about, re-created in the recovery path and
+                   only on the day something else was already broken. */
+                if (raw) histSourceRef.current = 'binance-futures';
+              }
+              raw = raw ?? [];
               if (stale()) return; // superseded by a newer switch - drop it
               let bars = raw.map(k => ({
                 timestamp: Number(k[0]), open: Number(k[1]), high: Number(k[2]),
@@ -1228,7 +1255,7 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
               if (!since) return;                       // nothing streamed yet - getBars owns it
               try {
                 const r = await fetch(
-                  `/api/market/klines?source=binance&symbol=${sym}&interval=${interval}&limit=500`,
+                  `/api/market/klines?source=${histSourceRef.current}&symbol=${sym}&interval=${interval}&limit=500`,
                   { signal: AbortSignal.timeout(12_000) },
                 );
                 if (!r.ok || cancelled) return;


### PR DESCRIPTION
**Dev Team**

Closes #359. Owner's decision: spot throughout.

```
before   history futures  |  live spot     feed changes mid-chart, invisibly
after    history spot     |  live spot     one feed
```

Your measurement — 4.4bp on BTC, ~9bp on ETH — is what made this actionable. **Small, permanent, and in the one place a user reads a price**, with no marker at the join and both sides individually correct.

## The stale comment was keeping the wrong default alive

The original justified futures-first partly on `api.binance.com` being blocked **from the browser**. That was true when the browser called Binance directly. **These now go through `/api/market/klines`** — server-side, where a client geo-block or filter list never applies.

Corrected rather than deleted. A justification that has quietly stopped being true is how a wrong default survives review after review.

**Futures stays as the fallback.** Different host, and it is why a Binance-spot outage does not blank the chart. Ordering changed; resilience kept.

## Reordering exposed the same bug one layer down

If spot were unavailable, history would come from **futures** while #313's backfill still fetched **spot** — the identical mismatch, re-created in the recovery path, and only on a day something else was already broken.

The backfill now reads whichever feed the history actually used. **That path is exactly where nobody would have looked**, because it only diverges during an outage.

## Explicitly NOT related to today's 418

The owner decided this on correctness grounds **an hour before that ban appeared**. It happens to remove the app's heaviest futures call, and **I am not counting that as a fix or as evidence the decision was right.** #359 stays open on the ban question; the cause is still unexplained and your shared-IP hypothesis is still untested.

## How to test (QA)

1. **Chart price vs the live ticker on the same page.** They should match now, not differ by tens of dollars on BTC. This is the user-visible half.
2. **Drop and restore the network** — backfilled candles must come from the same feed as the rest of the chart.
3. **A coin with no spot pair** still charts, via the futures fallback.
4. Nothing about the stream changed; the forming bar behaves as before.

## Risk level

**Medium.** Changes where every chart's history comes from, on every route with a chart.

- Verified: 391 tests, lint 0 errors, tsc clean, build ✓.
- **Not verified: the price match in a browser.** That is item 1 and it is the whole point — I cannot read two numbers off a rendered page from here.
- **Not verified: the futures fallback path.** It only fires when spot fails, which I cannot arrange without breaking spot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y