### PR TITLE
fix(chat): decide consent before hydration so the Ask AI button does not wait

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -99,7 +99,30 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             paint (no flash of the wrong theme). Mirrors lib/theme.ts's
             getStoredTheme(): explicit localStorage choice wins, otherwise
             follow the device's prefers-color-scheme. */}
-        {/* SAFETY NET for consent-pending (#326).
+        {/* CONSENT DECIDED BEFORE HYDRATION (#337), with the #326 net behind it.
+
+            body.consent-pending hides the Ask AI FAB outright. It is set in
+            this server markup and was removed only by a useEffect in
+            CookieConsent - so the button waited on React, and QA measured a
+            first-time mobile visitor going ~2s with no button while a cold
+            instance hydrated.
+
+            A useEffect cannot run before hydration, so the button could not be
+            made to appear sooner from inside React. This reads the stored
+            consent answer HERE instead, before hydration: a returning visitor -
+            anyone who has already accepted or declined - gets the class cleared
+            in the same tick as first paint, and never waits at all.
+
+            A genuine first-time visitor still waits, and SHOULD: the banner is
+            about to appear and the FAB would be shoved by it, which is how this
+            got reported as "the FAB disappears" in the first place.
+
+            The 3s timeout stays as the net from #326. It now covers only the
+            case it was written for - the class never being cleared at all
+            because React did not run - rather than being the primary mechanism
+            on mobile, which is what QA measured it silently becoming.
+
+            SAFETY NET for consent-pending (#326).
             body.consent-pending hides the Ask AI FAB outright
             (visibility:hidden), it is set in this server markup, and the ONLY
             thing that removes it is a useEffect in components/CookieConsent.tsx.
@@ -113,7 +136,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             still wins - CookieConsent removes it within a frame or two - and
             this only ever fires when that did not happen. */}
         <Script id="consent-pending-failsafe" strategy="beforeInteractive">
-          {`(function(){try{setTimeout(function(){try{document.body.classList.remove('consent-pending');}catch(e){}},3000);}catch(e){}})();`}
+          {`(function(){var b=document.body;function go(){try{var v=localStorage.getItem('lhq_analytics_consent_v1');if(v==='granted'||v==='denied'){b.classList.remove('consent-pending');}}catch(e){}try{setTimeout(function(){try{b.classList.remove('consent-pending');}catch(e){}},3000);}catch(e){}}try{go();}catch(e){}})();`}
         </Script>
         <Script id="theme-init" strategy="beforeInteractive">
           {`(function(){try{var t=localStorage.getItem('theme');if(t!=='light'&&t!=='dark'){t=window.matchMedia('(prefers-color-scheme: light)').matches?'light':'dark';}document.documentElement.setAttribute('data-theme',t);}catch(e){}})();`}


### PR DESCRIPTION
**Dev Team**

Closes #337. Last item in the owner's queue.

```
returning visitor   consent already stored   class cleared at FIRST PAINT
first visit         no stored answer         still waits - and should
```

## The fix is where the problem was, not where the symptom was

Your analysis and mine agreed: **a `useEffect` cannot run before hydration**, so the button could not be made to appear sooner from inside React. That is why the 3s net exists outside it.

So the read moves out too. `localStorage` is available to the `beforeInteractive` script, and **most visitors have already answered** — for them the class clears in the same tick as first paint and the wait disappears entirely rather than shrinking.

## A first-time visitor still waits, deliberately

The banner is about to appear and the FAB would be displaced by it — **which is exactly how this was first reported: "the FAB disappears"**. Making the button appear a moment before something shoves it is not an improvement.

## What this does to the 3s net

It stops being the primary mechanism and goes back to being a net.

```
before   mobile first paint -> net fires at 3s          net was load-bearing
after    stored answer      -> cleared at first paint
         no stored answer   -> banner path, net unused
         React never runs   -> net fires                what it was written for
```

Your measurement is what showed it had silently become the primary path. **A safety net doing the main job looks identical to a safety net idling**, which is the same shape as everything else in `qa/STATUS.md`.

## How to test (QA)

1. **Phone, consent already answered** — button present from first paint, not up to 3s later. **This is the case that changed.**
2. **Clear site data, reload** — banner appears, button arrives with it. Unchanged, and must stay unchanged.
3. **Private mode / storage blocked** — the read throws, the net fires, button still appears.
4. Desktop: no change; the normal path already won there.

## Risk level

**Low-Medium.** Medium only because it touches the root layout on every page.

- Verified: 391 tests, lint 0 errors, tsc clean, build ✓.
- **Not verified: the timing improvement on a real cold mobile instance.** That is item 1 and it is exactly what you measured to find this — I cannot reproduce a cold Render start on demand.
- **Not verified: private mode.** The try/catch is there; nothing has exercised it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y