### PR TITLE
feat(arena): move the chart read directly under the chart

### DIFF
--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -1973,6 +1973,46 @@ function ArenaContent() {
         <div className="arena-ws-chart">
       {/* ── CHART - KLineChart with auto Entry/SL/TP overlays ── */}
       <KLineProChart coin={selectedCoin} tf={readTf} onTfChange={handleTfChange} result={result} emaSignal={emaSignal} chartAlerts={chartAlerts} onAlertMove={handleAlertMove} gexLevels={selectedCoin === 'btc' ? { flip: store.btcGexFlip, maxPain: store.btcMaxPain } : null} onStructure={setChartStructure} />
+      {/* Directly under the chart, on the owner's request (#370). The read
+          refers to what the chart shows - "price below EMAs", "closing below
+          the swing low", "lower wick at Fib support" - so anything between
+          them makes the reader hold the chart in their head while scrolling.
+
+          This pushes the EMA Ribbon card down one slot. The comment there
+          says it "sits directly under the chart"; that was true and is no
+          longer, and the owner asked for this order explicitly. */}
+      {/* AI long-form reasoning / chart read / patterns - only when a read has run */}
+      {result && (
+        <>
+          {result.chartAnalysis && (
+            <div className="arena-reasoning" style={{ margin: '10px 0' }}>
+              <div className="arena-reasoning-title">{t('ARENA_REASONING_CHART_TITLE')}</div>
+              <div className="arena-reasoning-text"><ReasoningText text={result.chartAnalysis} /></div>
+            </div>
+          )}
+          {result.patterns && result.patterns.length > 0 && (
+            <div style={{ margin: '10px 0' }}>
+              <div className="arena-reasoning-title" style={{ marginBottom: 8 }}>{t('ARENA_REASONING_PATTERNS_TITLE')}</div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                {result.patterns.map((p, i) => {
+                  const isBull = /bull|higher high|engulf.*bull|hammer|morning/i.test(p);
+                  const isBear = /bear|lower high|engulf.*bear|shooting|evening|head.*shoulder|double top/i.test(p);
+                  const col = isBull ? 'var(--green-2)' : isBear ? 'var(--red)' : '#1a7aff';
+                  const bg  = isBull ? 'rgba(52,211,153,0.08)' : isBear ? 'rgba(248,113,113,0.08)' : 'rgba(26,122,255,0.08)';
+                  const bdr = isBull ? 'rgba(52,211,153,0.25)' : isBear ? 'rgba(248,113,113,0.25)' : 'rgba(26,122,255,0.25)';
+                  return (
+                    <span key={i} style={{ fontSize: 'var(--fs-caption)', fontWeight: 600, padding: '3px 10px', borderRadius: 6, background: bg, color: col, border: `0.5px solid ${bdr}` }}>{p}</span>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+          <div className="arena-reasoning">
+            <div className="arena-reasoning-title">{t('ARENA_REASONING_TITLE')}</div>
+            <div className="arena-reasoning-text"><ReasoningText text={result.reasoning} /></div>
+          </div>
+        </>
+      )}
 
       {/* Anti-chop filter toggle */}
       <div style={{ marginBottom: 8, display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
@@ -2127,38 +2167,6 @@ function ArenaContent() {
           the 4h has already moved a lot, so a same-direction lower-TF signal doesn't
           look more trustworthy than it is. Only shows on 1m/5m/15m/30m. */}
       <HigherTfMoveBadge coin={selectedCoin} tf={readTf} signalDir={emaSignal.signalDir} />
-      {/* AI long-form reasoning / chart read / patterns - only when a read has run */}
-      {result && (
-        <>
-          {result.chartAnalysis && (
-            <div className="arena-reasoning" style={{ margin: '10px 0' }}>
-              <div className="arena-reasoning-title">{t('ARENA_REASONING_CHART_TITLE')}</div>
-              <div className="arena-reasoning-text"><ReasoningText text={result.chartAnalysis} /></div>
-            </div>
-          )}
-          {result.patterns && result.patterns.length > 0 && (
-            <div style={{ margin: '10px 0' }}>
-              <div className="arena-reasoning-title" style={{ marginBottom: 8 }}>{t('ARENA_REASONING_PATTERNS_TITLE')}</div>
-              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
-                {result.patterns.map((p, i) => {
-                  const isBull = /bull|higher high|engulf.*bull|hammer|morning/i.test(p);
-                  const isBear = /bear|lower high|engulf.*bear|shooting|evening|head.*shoulder|double top/i.test(p);
-                  const col = isBull ? 'var(--green-2)' : isBear ? 'var(--red)' : '#1a7aff';
-                  const bg  = isBull ? 'rgba(52,211,153,0.08)' : isBear ? 'rgba(248,113,113,0.08)' : 'rgba(26,122,255,0.08)';
-                  const bdr = isBull ? 'rgba(52,211,153,0.25)' : isBear ? 'rgba(248,113,113,0.25)' : 'rgba(26,122,255,0.25)';
-                  return (
-                    <span key={i} style={{ fontSize: 'var(--fs-caption)', fontWeight: 600, padding: '3px 10px', borderRadius: 6, background: bg, color: col, border: `0.5px solid ${bdr}` }}>{p}</span>
-                  );
-                })}
-              </div>
-            </div>
-          )}
-          <div className="arena-reasoning">
-            <div className="arena-reasoning-title">{t('ARENA_REASONING_TITLE')}</div>
-            <div className="arena-reasoning-text"><ReasoningText text={result.reasoning} /></div>
-          </div>
-        </>
-      )}
       {/* ── SESSION HISTORY ── */}
       {history.length > 0 && (
         <div style={{ marginTop: 20 }}>


### PR DESCRIPTION
**Dev Team**

Closes #370. Built to the owner's clarification, not my first reading of it.

```
before   chart ... anti-chop, EMA card, snapshot, Confluence,
                   heatmap, pullback, Multi-TF ... CHART/PATTERNS/REASONING
after    chart
         CHART / PATTERNS / REASONING
```

> *"put this below the chart not multiple timeframe"*

**Directly after `<KLineProChart>`** — not one section up, which is where it would land if it simply moved above Multi-TF. Your clarification arrived while I was placing it and matched what I had done, but it is the kind of thing I would have got subtly wrong from the original wording alone.

## What it displaces, said out loud

The EMA Ribbon card moves down a slot. **Its own comment says it "sits directly under the chart so it reads as" part of the chart** — that was true and is now not. I have marked the comment rather than leaving it to mislead the next reader.

The owner asked for this order knowing what is there. **But a comment that quietly stops being true is how a wrong default survives**, which is exactly what #359 turned out to be this morning.

## Nothing else changed

Same markup, same `result &&` gate, same conditions. **This is a move, not a rewrite** — if anything about the block itself renders differently, that is a bug and not an intended side effect.

## How to test (QA)

1. **Run a read on Arena.** CHART, PATTERNS, REASONING directly beneath the chart, nothing between.
2. **375px.** The REASONING paragraph is long and now sits in a narrower column position than before — this is where overflow would show up.
3. **Nothing it displaced overlaps or is cut off** — the EMA card, snapshot and Confluence all shifted down one slot.
4. **`layout.spec.ts` obscured-control baseline unchanged.** You flagged this and it is the right check: moving a block reshuffles what covers what.
5. **Before a read has run, nothing renders** — the `result &&` gate is unchanged and the page must look exactly as it did.

## Risk level

**Low-Medium.** Pure JSX reorder, no logic, no styles — but it is the busiest page in the app and layout moves are where baselines shift silently.

- Verified: 391 tests, lint 0 errors, tsc clean, build ✓.
- **Not verified: anything visual.** I moved markup; I have not seen the page. Items 1-4 are all yours and item 4 is the one a build cannot catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y