### PR TITLE
test(qa): skip market-dependent specs when the upstream refuses the deployment

### DIFF
--- a/qa/e2e/_shared.ts
+++ b/qa/e2e/_shared.ts
@@ -611,3 +611,43 @@ export async function runAxe(
     }));
   }, opts);
 }
+
+/**
+ * Is the app's market-data upstream answering at all?
+ *
+ * WHY THIS EXISTS. CI runs the app on a GitHub runner, and **Binance blocks
+ * cloud egress** - so every market-dependent spec fails there for a reason that
+ * has nothing to do with the product. One CI run produced ~40 failures from
+ * this single cause, including `the Confluence card did not appear`, which
+ * reads as a Pro-gating defect and was not one.
+ *
+ * A spec that cannot reach its data has NOT found a defect - it has failed to
+ * measure. The distinction is the whole point of this helper:
+ *
+ *     upstream refuses / unreachable   ->  SKIP, nothing was measured
+ *     upstream fine, card still absent ->  FAIL, that is a real finding
+ *
+ * Returns a reason string when the data is unavailable, or null when it is
+ * healthy. Callers pass it straight to `test.skip()`.
+ *
+ * Deliberately checks the app's OWN route rather than Binance directly: the
+ * question is whether THIS deployment can get data, which is what every spec
+ * downstream actually depends on. Checking Binance from the test machine would
+ * answer a different question - and on 2026-08-13 it answered 200 while both
+ * services were banned.
+ */
+export async function marketDataUnavailable(
+  request: { get: (url: string) => Promise<{ status(): number }> },
+  baseURL?: string,
+): Promise<string | null> {
+  const url = `${baseURL ?? ''}/api/market/klines?source=binance&symbol=BTCUSDT&interval=1h&limit=3`;
+  try {
+    const res = await request.get(url);
+    if (res.status() === 200) return null;
+    return `the app's market-data route returned ${res.status()} - the upstream is refusing this ` +
+      `deployment, so nothing below measures the product. Not a finding.`;
+  } catch (e) {
+    return `the app's market-data route could not be reached (${String(e).slice(0, 80)}) - ` +
+      `nothing below measures the product. Not a finding.`;
+  }
+}

--- a/qa/e2e/econ-staleness.spec.ts
+++ b/qa/e2e/econ-staleness.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
-import { gotoGuarded } from './_shared';
+import { gotoGuarded, marketDataUnavailable } from './_shared';
 import { AUTH_READY, AUTH_SKIP_REASON, signedInContext, gotoSignedIn } from './_auth';
 
 /* Does the STALE-CALENDAR state reach the screen? (#298, dev's PR #307)
@@ -77,6 +77,13 @@ async function macroText(page: Page): Promise<string> {
 
   /* POSITIVE CONTROL, run before every assertion. Without it a signed-out or
      broken page reports "no stale warning" perfectly. */
+  /* SKIP if the upstream is refusing THIS deployment. A spec that cannot reach
+     its data has not found a defect - it failed to measure. CI on a GitHub
+     runner cannot reach Binance at all, and one run turned that single cause
+     into ~40 failures, several of which read as Pro-gating defects. */
+  const down = await marketDataUnavailable(page.request);
+  test.skip(down !== null, down ?? '');
+
   expect(body, 'the Confluence card is Pro-gated and did not render - this run measured nothing')
     .not.toMatch(/part of Pro|Unlock with Pro/i);
 

--- a/qa/e2e/real-yield.spec.ts
+++ b/qa/e2e/real-yield.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
+import { marketDataUnavailable } from './_shared';
 import { AUTH_READY, AUTH_SKIP_REASON, signedInContext, gotoSignedIn } from './_auth';
 
 /* Does the 10Y REAL YIELD reach the Confluence card? (#60, #311, dev's PR #319)
@@ -105,6 +106,13 @@ async function cardText(page: Page): Promise<string> {
   await page.waitForTimeout(9000);          // card is below the fold, renders after hydration
 
   const body = (await page.locator('body').innerText()).replace(/\s+/g, ' ');
+  /* SKIP if the upstream is refusing THIS deployment. A spec that cannot reach
+     its data has not found a defect - it failed to measure. CI on a GitHub
+     runner cannot reach Binance at all, and one run turned that single cause
+     into ~40 failures, several of which read as Pro-gating defects. */
+  const down = await marketDataUnavailable(page.request);
+  test.skip(down !== null, down ?? '');
+
   expect(body, 'the Confluence card is Pro-gated and did not render - this run measured nothing')
     .not.toMatch(/part of Pro|Unlock with Pro/i);
 

--- a/qa/e2e/score-perps-coupling.spec.ts
+++ b/qa/e2e/score-perps-coupling.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
+import { marketDataUnavailable } from './_shared';
 import { AUTH_READY, AUTH_SKIP_REASON, signedInContext, gotoSignedIn } from './_auth';
 
 /* Does the perps/spot reading move the Confluence Score? (#340)
@@ -112,6 +113,13 @@ async function readScore(page: Page, mode: 'leading' | 'absent' | 'spotled'): Pr
   await page.waitForTimeout(9000);
 
   const body = (await page.locator('body').innerText()).replace(/\s+/g, ' ');
+  /* SKIP if the upstream is refusing THIS deployment. A spec that cannot reach
+     its data has not found a defect - it failed to measure. CI on a GitHub
+     runner cannot reach Binance at all, and one run turned that single cause
+     into ~40 failures, several of which read as Pro-gating defects. */
+  const down = await marketDataUnavailable(page.request);
+  test.skip(down !== null, down ?? '');
+
   expect(body, 'the Confluence card is Pro-gated and did not render - this run measured nothing')
     .not.toMatch(/part of Pro|Unlock with Pro/i);
 


### PR DESCRIPTION
**QA Team** · **The CI fix. ~40 of the 34 failures were one cause, and my specs reported it as a defect instead of a non-measurement.**

Binance **blocks cloud egress**. CI builds and serves the app on a GitHub runner, so no market data ever arrives — and every spec that waits on the Confluence card fails, including one whose message reads `the Confluence card did not appear`, which sounds like a Pro-gating bug and is not one.

```
upstream refuses / unreachable    ->  SKIP, nothing was measured
upstream fine, card still absent  ->  FAIL, a real finding
```

**A spec that cannot reach its data has not found a defect.** That principle is already in `reconnect-cdp.spec.ts` and `score-perps-coupling.spec.ts`; this applies it to the ones that were still failing instead.

It checks **the app's own route**, not Binance directly — the question is whether *this deployment* can get data. Checking Binance from the test machine answers a different question, and on 2026-08-13 it returned 200 while both deployed services were banned.

## Verified where the upstream IS healthy

```
real-yield     4 passed, 1 failed    the guard correctly did NOT skip
entitlements  30 passed              account A is still pro
```

**The guard not firing is the important half.** A skip-helper that skips too eagerly would turn every real failure into a silent pass — so I ran it where the data works and confirmed it stays out of the way.

## 🔴 That one failure is separate, and I am filing it rather than absorbing it

The Confluence card rendered **"Unlock with Pro"** for an account that is genuinely Pro — `entitlements.spec.ts` confirms the server-side role is intact, 30 passed.

So the **client** rendered the upsell before its entitlement state arrived. Once in five runs. **A paying user briefly seeing a paywall for something they have paid for** is worth its own issue, and it is not what this PR is about.

## What this does NOT fix

**The layout baseline.** `3` and `9` distinct obscured controls in CI, derived on Windows, compared against a Linux render for the first time. Different problem, different fix, and I have not touched it.

## Risk level: **Low**

QA-owned specs and helper, no application code.