### PR TITLE
fix(auth): do not show a paywall before entitlement is known

### DIFF
--- a/app/alerts/page.tsx
+++ b/app/alerts/page.tsx
@@ -64,7 +64,7 @@ const LINK_CODE_TTL_SEC = 600;
 
 export default function AlertsPage() {
   const { t } = useLabels();
-  const { user, entitled } = useAuth();
+  const { user, entitled, loading: authLoading } = useAuth();
   const { settings, loading: settingsLoading, refresh: refreshSettings } = useSettings();
   const [upgradeGate, setUpgradeGate] = useState<string | null>(null);
 
@@ -538,7 +538,7 @@ export default function AlertsPage() {
           upgrade pitch. Free users now get a single locked-feature card
           (same component/pattern as Arena's other Pro-gated cards) instead
           of a form they can look at but not touch. */}
-      {!entitled ? (
+      {!authLoading && !entitled ? (
         <LockedFeatureCard
           title={t('ALERTS_CONNECT_TELEGRAM_TITLE')}
           description={t('ALERTS_LOCKED_FEATURE_DESC')}
@@ -774,7 +774,7 @@ export default function AlertsPage() {
         title={t('ALERTS_AUTHGATE_TITLE')}
         desc={t('ALERTS_AUTHGATE_DESC')}
       >
-        {!entitled ? (
+        {!authLoading && !entitled ? (
           /* Price alerts are delivered over Telegram, which the alert cron
              only sends to Pro/trial users. Creation used to be open to
              everyone, so a free user's alert saved and then silently never

--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -2102,7 +2102,14 @@ function ArenaContent() {
       {/* Confluence Score - EMA Ribbon + Order Flow + Multi-TF RSI combined, plus a
           separate macro/event risk overlay (econ calendar + JPY carry-trade risk).
           Pro-only: free users get an in-place locked card so the layout holds. */}
-      {entitled ? (
+      {/* Locked ONLY once we know the user is not entitled (#376).
+          entitled starts false while auth resolves, so gating on it alone
+          renders the paywall to a paying account for as long as that takes -
+          which reads as a broken subscription and costs a support message or a
+          chargeback, not a pixel.
+          Same guard as MultiTFAlignment:120, written for #310 and not carried
+          here at the time. */}
+      {authLoading || entitled ? (
         <ConfluenceScore coin={selectedCoin} emaSignal={emaSignal} jpyUsd={jpyUsd} structure={chartStructure} />
       ) : (
         <LockedFeatureCard

--- a/components/AuthProvider.tsx
+++ b/components/AuthProvider.tsx
@@ -76,8 +76,28 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
         if (sessionUser) touchActivity();
         setUser(sessionUser);
       }
-      setLoading(false);
-    });
+    }).finally(() => setLoading(false));
+    /* .finally, NOT a trailing statement inside the .then (QA, on #377).
+     *
+     * `touchActivity` and `isSessionExpired` above both read localStorage bare,
+     * and storage throws for real users - Safari private mode, blocked site
+     * data, quota. `lib/authSession.ts:43` already wraps its own storage access
+     * for exactly this reason.
+     *
+     * If any of them throws, the handler dies and `loading` stays true for the
+     * life of the page. That was harmless until this PR, because a stuck
+     * `loading` produced `entitled === false` and the paywall showed. The three
+     * call sites now read `authLoading || entitled`, which inverts it:
+     *
+     *   before   stuck loading -> paywall shown      FAIL CLOSED
+     *   after    stuck loading -> Pro content shown  FAIL OPEN
+     *
+     * A signed-in FREE user whose storage throws would get Arena's Confluence
+     * card and both Alerts sections unlocked until they reloaded. The bug is
+     * pre-existing; this PR removes the accident that was covering it.
+     *
+     * `.finally` makes "auth finished trying" true regardless of outcome, which
+     * is what `authLoading` means at all three call sites. */
 
     // Keep in sync on sign-in / sign-out / token refresh
     const { data: { subscription } } = sb.auth.onAuthStateChange((event, session) => {


### PR DESCRIPTION
**Dev Team**

Closes #376. **Three gates, not one** — and the fix already existed in this codebase.

```
app/arena/page.tsx:2105   {entitled ? ...}    ->  {authLoading || entitled ? ...}
app/alerts/page.tsx:541   {!entitled ? ...}   ->  {!authLoading && !entitled ? ...}
app/alerts/page.tsx:777   same
```

`app/alerts/page.tsx` had **no reference to `authLoading` at all**. Both its paywalls had the identical defect and nobody had looked at that page.

## The pattern was already written and I did not carry it

`components/MultiTFAlignment.tsx:120` has held `!authLoading && !entitled` since #310, with a comment saying exactly this. **I wrote that, then gated three other paywalls on `entitled` alone.**

Same omission as #317 — fix the reported instance, leave the class. Second time, and it is the rule I keep citing at other people.

## 🔴 The trade, stated rather than buried

While auth resolves, these now render the **unlocked** variant. So a free user can briefly see a Pro card before it locks.

That is the same direction #310 chose and you reviewed:

> a Pro user briefly seeing their own paid signal smeared is a worse error than a free user seeing it a moment longer

**But it is not free here.** `ConfluenceScore` computes from client-side market state rather than a Pro-gated route, so a free user briefly sees a real score — not an empty shell. I think that is still the right way round, because the alternative is charging someone and then showing them a paywall. **It is a judgement, not an obvious call, and if you disagree the fix is a neutral placeholder for both.**

## On your two non-reproducing runs

They do not weaken this. The mechanism is visible in the source rather than inferred: `entitled` is false until auth resolves, so the locked branch renders. One-in-five is exactly what a race that needs auth slower than first paint looks like.

**The code is the evidence here.** I would not have said that about a timing report yesterday.

## How to test (QA)

1. **Pro account, hard-reload Arena repeatedly.** The Confluence card must never show PRO FEATURE / Unlock with Pro. Your one-in-five sighting is the bar.
2. **Same on Alerts**, both paywalled sections.
3. **Signed out**, both still show the paywall — the guard must not disable gating.
4. **Free (non-trial) account** — the brief unlocked flash is expected now; worth seeing how visible it actually is.

## Risk level

**Medium.** Touches entitlement rendering on two pages, and item 3 is the one where a mistake gives Pro features away.

- Verified: 391 tests, lint 0 errors, tsc clean, build ✓.
- **Not verified: the race itself.** It needs a Pro session and a slow-enough load; I have neither. Item 1 is yours.
- **Not verified: how visible the unlocked flash is** to a free user. Item 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
