### PR TITLE
test(layout): report, do not assert, the obscured-control baseline on a runner

### DIFF
--- a/qa/e2e/layout.spec.ts
+++ b/qa/e2e/layout.spec.ts
@@ -367,6 +367,35 @@ test.describe('layout', () => {
         console.log(`[layout] ${testInfo.project.name}: ${gone.length} known entr(ies) not seen this run - possibly fixed, possibly timing: ${gone.join(' | ')}`);
       }
 
+      /* KNOWN_OBSCURED IS PLATFORM-SPECIFIC, despite this file otherwise being
+         cross-platform by design.
+       *
+       * It holds no screenshots - the header is right that there are no pixel
+       * baselines. But the SET of covered controls is still a product of font
+       * metrics: different glyph widths wrap text differently, elements size
+       * differently, and different things end up on top of each other.
+       *
+       * The set was derived on Windows. The first CI run - Linux - reported 3
+       * and 9 "new" entries on a commit whose layout spec passed locally,
+       * minutes apart, on the same code. The comparison was invalid, not the
+       * layout.
+       *
+       * So on a runner: REPORT the diff and do not fail on it. The signal is
+       * still useful - a genuine regression would show up as a large or
+       * structural change rather than a couple of wrap-driven entries - but it
+       * cannot be an assertion until a Linux baseline exists.
+       *
+       * Deriving one is the real fix and is not free: it means running this
+       * suite on Linux, reviewing every entry, and keeping two sets current. */
+      if (process.env.CI && unexpected.length) {
+        console.log(
+          `[layout] ${testInfo.project.name}: ${unexpected.length} entr(ies) not in the `
+          + `baseline. NOT asserted here - KNOWN_OBSCURED was derived on Windows and this is `
+          + `a Linux runner, so font metrics differ. Reported for eyeballing: `
+          + unexpected.join(' | '));
+        return;
+      }
+
       expect.soft(unexpected,
         `A control is covered by something that was NOT covered before. Every entry here is new ` +
         `since 2026-08-09.


### PR DESCRIPTION
**QA Team** · The last of the CI failure categories. **The baseline is platform-specific and nobody had noticed.**

```
KNOWN_OBSCURED     derived on Windows
CI                 Linux
first CI run       3 and 9 "new" entries on a commit whose layout spec passed
                   locally, minutes apart, on identical code
```

The file header is right that there are **no pixel baselines** — it holds no screenshots and compares geometry. But the *set* of covered controls is still a product of font metrics: different glyph widths wrap text differently, elements size differently, and different things end up on top of each other.

**So the comparison was invalid, not the layout.**

## What it does now

On a runner, an entry not in `KNOWN_OBSCURED` is **logged, not asserted**. A genuine regression would still show as a large or structural change; a couple of wrap-driven entries would not.

Verified locally, where the guard must **not** fire:

```
[layout] desktop: 0 distinct obscured control(s) across 30 routes
3 passed
```

## What this is NOT

**Not a fix.** Deriving a Linux baseline is the fix, and it is not free — run the suite on Linux, review every entry, keep two sets current and in step. **I have not done that**, and I would rather this PR say so than look like the problem is solved.

What it buys is that CI stops reporting a platform difference as a layout regression, which is what it was doing.

## Where that leaves the CI gate

```
~40 failures  market data unreachable from a runner   FIXED - skip, #375/#378
 4  kline socket / reconnect                          FIXED - skip
 2  cache-effective empty snapshot                    FIXED - skip
 4  tf-gating neutral grey                            FIXED - skip
3+9 layout baseline                                   THIS - reported, not asserted
 2  checkout button                                   INVESTIGATED - not a defect
                                                      (#379, closed - I sampled
                                                      during the loading state)
```

**Every category from the 34 is accounted for.** Whether the gate now goes green is a question for a run, not for reasoning — and that run is the owner's call, since it costs Actions minutes.

## Risk level: **Low**

QA-owned spec, no application code.
