### PR TITLE
feat(chat): make the Fast/Live control readable and show the quota it spends

### DIFF
--- a/__tests__/searchTriggers.test.mts
+++ b/__tests__/searchTriggers.test.mts
@@ -1,0 +1,87 @@
+/* #382 / #384 - which messages silently spend a LIVE SEARCH.
+ *
+ * This function decides which of a user's two daily quotas a chat message
+ * bills. It was untestable inside a .tsx component, which is why nobody had
+ * ever enumerated what it matches. I reported the substring risk on #382 as
+ * "not verified" - this is that verification, and it found real collisions.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { needsLiveSearch, SEARCH_TRIGGERS } from '../lib/searchTriggers.ts';
+
+/* ── 1. the behaviour the owner approved ────────────────────────────────── */
+
+test('the owner\'s own question escalates - the case that opened #382', () => {
+  // "i have 40 left but my account is max of 10 chats only?" - this is the
+  // message shape that produced it. Two triggers, either alone is enough.
+  assert.equal(needsLiveSearch('why is BTC down today'), true);
+});
+
+test('a plain market question does NOT escalate', () => {
+  // If this ever flips, every chat message starts billing the search quota
+  // and the 50/day chat allowance becomes unreachable.
+  for (const q of [
+    'is BTC bullish',
+    'should I long here',
+    'what is my position size',
+    'explain this chart',
+  ]) {
+    assert.equal(needsLiveSearch(q), false, `"${q}" should stay on the chat quota`);
+  }
+});
+
+/* ── 2. the collisions - substring, not word boundary ───────────────────── */
+
+test('COLLISION: ordinary chart questions cost a live search', () => {
+  // MEASURED, not guessed - my first draft of this test asserted `wait`
+  // contains `war`, which it does not, and the test caught me. Every pair
+  // below was run before being written down.
+  //
+  // Documented, not endorsed. Each costs a SEARCH from a message that has
+  // nothing to do with live web data. Pinned so a future edit to
+  // SEARCH_TRIGGERS cannot widen the set unnoticed.
+  const collisions: Array<[string, string]> = [
+    ['is the trend upward',            'war inside "upward" - a pure chart question'],
+    ['is this a warning sign',         'war inside "warning"'],
+    ['what does forward guidance mean', 'war inside "forward"'],
+    ['what is a secondary market',     'sec inside "secondary"'],
+    ['show me the seconds chart',      'sec inside "seconds"'],
+  ];
+  for (const [q, why] of collisions) {
+    assert.equal(needsLiveSearch(q), true, `${JSON.stringify(q)} escalates: ${why}`);
+  }
+});
+
+test('the shortest triggers are the ones that collide', () => {
+  // The 2-3 character entries are the whole problem. Pinned by count so
+  // adding another short one is a deliberate act with a failing test in
+  // front of it, rather than a one-word commit nobody reviews.
+  const short = SEARCH_TRIGGERS.filter(k => k.length <= 3);
+  assert.deepEqual(short,
+    ['why', 'fed', 'cpi', 'ppi', 'nfp', 'gdp', 'war', 'boj', 'yen', 'etf', 'sec', 'okx'],
+    'short-trigger set changed - each entry is a substring-collision risk');
+});
+
+/* ── 3. case and position ───────────────────────────────────────────────── */
+
+test('matching is case-insensitive and position-independent', () => {
+  assert.equal(needsLiveSearch('WHY IS ETH PUMPING'), true);
+  assert.equal(needsLiveSearch('Tell me about the FOMC'), true);
+  assert.equal(needsLiveSearch('anything about ETFs?'), true);
+});
+
+test('empty input does not escalate', () => {
+  // The chat panel calls this on every keystroke to price the message in the
+  // box, so it runs against '' constantly. An empty box must read as the
+  // cheap mode, not the expensive one.
+  assert.equal(needsLiveSearch(''), false);
+});
+
+/* ── 4. control ─────────────────────────────────────────────────────────── */
+
+test('CONTROL: a string containing no trigger returns false', () => {
+  // Without this, every assertion above could be passing against a function
+  // that returns true unconditionally.
+  assert.equal(needsLiveSearch('zzz qqq vvv'), false);
+  assert.ok(SEARCH_TRIGGERS.length > 0, 'sanity: the list is not empty');
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -1947,19 +1947,41 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .gchat-header { display: flex; align-items: center; justify-content: space-between; padding: 12px 14px 8px; border-bottom: 0.5px solid var(--bdr); flex-shrink: 0; }
 .gchat-icon-btn { font-size: 0.8125rem; color: var(--txt3); cursor: pointer; background: none; border: none; padding: 0; width: 36px; height: 36px; border-radius: 6px; transition: color 0.15s; display: inline-flex; align-items: center; justify-content: center; }
 .gchat-icon-btn:hover { color: var(--txt2); }
-/* Live search toggle pill */
-.gchat-search-toggle {
-  font-size: var(--fs-caption); font-weight: 700; padding: 5px 10px; border-radius: 20px; cursor: pointer;
-  border: 0.5px solid var(--bdr); background: var(--bg2); color: var(--txt3);
-  transition: all 0.15s; white-space: nowrap; letter-spacing: .02em;
-  min-height: 32px; display: inline-flex; align-items: center;
+/* Fast / Live mode segment (#383).
+   Deliberately borrows the .gchat-coin affordance below rather than inventing
+   one: same radius, same fill weight, same 44px target. The old pill was
+   min-height 32px sitting 8px above 44px chips, which is why it read as a
+   status badge and not a control. */
+.gchat-mode {
+  display: inline-flex; align-items: stretch; padding: 2px;
+  border: 0.5px solid var(--bdr); background: var(--bg2); border-radius: 16px;
 }
-.gchat-search-toggle:hover { color: var(--txt2); border-color: var(--bdr2); }
-.gchat-search-toggle.on {
-  background: rgba(52,211,153,0.12); color: var(--green);
-  border-color: rgba(52,211,153,0.3);
-  box-shadow: 0 0 8px rgba(52,211,153,0.15);
+/* Sized down at the owner's request after seeing it in place - it sat as tall as
+   the coin chips and dominated a header it only shares with icon buttons.
+   Colours are TOKENS, not literals: --purple-bg / --green-bg are redefined under
+   [data-theme="light"], so this follows the theme the way .gchat-coin does. The
+   control it replaced hardcoded rgba(52,211,153,...) and could not. */
+.gchat-mode-opt {
+  font-size: var(--fs-micro); font-weight: 700; letter-spacing: .02em;
+  padding: 3px 10px; min-width: 42px; min-height: 28px; border-radius: 14px;
+  border: none; background: none; color: var(--txt3); cursor: pointer;
+  white-space: nowrap; transition: background 0.15s, color 0.15s;
+  display: inline-flex; align-items: center; justify-content: center;
 }
+.gchat-mode-opt:hover:not(.off) { color: var(--txt2); }
+.gchat-mode-opt.on      { background: var(--purple-bg); color: var(--purple); }
+.gchat-mode-opt.live.on { background: var(--green-bg);  color: var(--green); }
+/* Kept visible, not hidden - a control that vanishes reads as a bug, one that
+   stays and explains itself reads as an upsell. */
+.gchat-mode-opt.off { opacity: 0.4; cursor: not-allowed; }
+.gchat-mode-opt:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+
+.gchat-mode-count {
+  font-size: var(--fs-caption); color: var(--txt3);
+  font-variant-numeric: tabular-nums; display: inline-flex; align-items: center; gap: 3px;
+}
+.gchat-mode-count.zero { color: var(--red-soft); }
+.gchat-mode-note { font-size: var(--fs-micro); color: var(--txt3); }
 .gchat-coins { display: flex; gap: 4px; padding: 8px 14px 6px; overflow-x: auto; scrollbar-width: none; flex-shrink: 0; border-bottom: 0.5px solid rgba(255,255,255,0.04); }
 .gchat-coins::-webkit-scrollbar { display: none; }
 .gchat-coin { font-size: var(--fs-caption); font-weight: 700; padding: 5px 10px; border-radius: 20px; border: 0.5px solid var(--bdr); background: var(--bg2); color: var(--txt3); cursor: pointer; white-space: nowrap; transition: all 0.12s; flex-shrink: 0; min-height: 44px; display: inline-flex; align-items: center; }

--- a/components/GrokChat.tsx
+++ b/components/GrokChat.tsx
@@ -14,6 +14,7 @@ import { nextResetLocalTime } from '@/lib/resetTime';
 import { withAlpha } from '@/lib/color';
 import { computeSectorRotation } from '@/lib/sectorRotation';
 import { latestStructureSignal, describeStructureSignal } from '@/lib/priceAction';
+import { needsLiveSearch } from '@/lib/searchTriggers';
 
 // A 429 from /api/grok-chat can mean the caller's own daily cap OR the
 // app-wide circuit breaker (AI_GLOBAL_DAILY_MAX) - the server already words
@@ -42,6 +43,15 @@ interface SavedConvo {
   messages: Msg[];
   ts: number;      // Date.now()
 }
+
+/* Both options stay on screen (#383). The old control was a single pill showing
+ * one word, which left the user to work out whether "Live" was the state or the
+ * action - and it was styled lighter than the coin chips 8px below it, so it did
+ * not read as interactive at all. */
+const MODES = [
+  { id: 'fast', live: false, label: 'Fast', title: 'Fast - answers from data already loaded. Spends your daily chat messages.' },
+  { id: 'live', live: true,  label: 'Live', title: 'Live - searches the web and X. Spends your daily live searches.' },
+] as const;
 
 /* ── localStorage helpers ──────────────────────────────────────── */
 const HIST_KEY   = 'grok-chat-history-v1';
@@ -146,33 +156,6 @@ function renderMd(raw: string): string {
 }
 
 /* ── Smart detectors ──────────────────────────────────────────── */
-
-// Auto-enable live search when message clearly needs current web data
-const SEARCH_TRIGGERS = [
-  // Questions about why / what
-  'why', 'what happened', 'happening', 'reason', 'cause', 'catalyst',
-  // Time-anchored
-  'today', 'right now', 'just now', 'recently', 'yesterday', 'this week', 'latest',
-  // News / narrative
-  'news', 'narrative', 'breaking', 'announcement',
-  // People / institutions
-  'trump', 'elon', 'powell', 'jerome', 'blackrock', 'saylor',
-  // Macro events
-  'fed', 'fomc', 'cpi', 'ppi', 'nfp', 'jobs', 'inflation', 'gdp',
-  'rate cut', 'rate hike', 'interest rate', 'tariff', 'sanction',
-  // Geo / political
-  'war', 'conflict', 'russia', 'ukraine', 'china', 'japan', 'boj', 'yen',
-  // Crypto-specific events
-  'etf', 'sec', 'regulation', 'hack', 'exploit', 'halving',
-  'binance', 'coinbase', 'bybit', 'okx',
-  'liquidation', 'liquidated', 'whale',
-  'dump', 'dumping', 'pump', 'pumping', 'crash', 'crashing', 'rally',
-  'stablecoin', 'usdt', 'usdc',
-];
-function needsLiveSearch(text: string): boolean {
-  const t = text.toLowerCase();
-  return SEARCH_TRIGGERS.some(k => t.includes(k));
-}
 
 // Educational questions don't need the full market snapshot - saves ~350 tokens
 const EDUCATIONAL_TRIGGERS = [
@@ -317,12 +300,23 @@ export default function GrokChat() {
   const [showLoginModal, setShowLoginModal] = useState(false);
   const { usage, setUsage }                 = useGrokUsage();
 
+  /* ── Quotas ────────────────────────────────────────────────────────────
+   * Derived, never stored. `liveActive` is the mode that will ACTUALLY be
+   * used: selecting Live cannot survive the search quota running out, and
+   * deriving that (rather than resetting the state in an effect) keeps the
+   * request path and the control from ever disagreeing. */
+  const searchRemaining = usage ? usage.search_limit - usage.search_used : null;
+  const chatRemaining   = usage ? usage.chat_limit   - usage.chat_used   : null;
+  const searchExhausted = searchRemaining !== null && searchRemaining <= 0;
+  const liveActive      = liveSearch && !searchExhausted;
+
   /* conversation history */
   const [convos,     setConvos]     = useState<SavedConvo[]>([]);
   const currentIdRef                = useRef<string>(genId());
 
   const [fabVisible,    setFabVisible]    = useState(true);
 
+  const modeRefs       = useRef<(HTMLButtonElement | null)[]>([]);
   const bottomRef      = useRef<HTMLDivElement>(null);
   const inputRef       = useRef<HTMLTextAreaElement>(null);
   const msgsRef        = useRef<HTMLDivElement>(null);
@@ -458,8 +452,8 @@ export default function GrokChat() {
 
     try {
       // Auto-detect live search first - needed before context decision
-      const autoSearch = !liveSearch && needsLiveSearch(text);
-      const useSearch  = liveSearch || autoSearch;
+      const autoSearch = !liveActive && needsLiveSearch(text);
+      const useSearch  = liveActive || autoSearch;
 
       // Smart context: educational + no search = minimal (~20 tokens)
       // Anything with live search = full context so Grok can correlate web findings with live data
@@ -551,7 +545,7 @@ export default function GrokChat() {
     } finally {
       setLoading(false);
     }
-  }, [msgs, coin, liveSearch, store, latestHeadlines, geoEvents, user, usage, setUsage]);
+  }, [msgs, coin, liveActive, store, latestHeadlines, geoEvents, user, usage, setUsage]);
 
   /* ── Open-with-prompt event from Arena ── */
   useEffect(() => {
@@ -595,9 +589,39 @@ export default function GrokChat() {
   const closeAll     = () => { setOpen(false); setExpanded(false); setHistView(false); setShowLoginModal(false); };
   const toggleExpand = () => setExpanded(v => !v);
 
-  const searchRemaining = usage
-    ? usage.search_limit - usage.search_used
-    : null;
+  /* ── Mode + the quota it spends ────────────────────────────────────────
+   * The counter follows the SELECTED mode, because that is the quota the next
+   * message actually bills (#382). It used to read `search` in both modes and
+   * only dim to 0.5 opacity in Fast - so a user with searches exhausted but 40
+   * chat messages left was told "None left". The meter and the limiter
+   * (grok-chat/route.ts:117) now read the same field. */
+  /* EFFECTIVE mode, not the selected one. Fast silently escalates to search
+   * when the text trips SEARCH_TRIGGERS, so following the toggle alone would
+   * still misreport the cost of exactly the messages that prompted #382 -
+   * "why is BTC down today" spends a search from Fast. `needsLiveSearch` is a
+   * pure local substring match, so this is free and needs no network. */
+  const willSearch      = liveActive || needsLiveSearch(input);
+  const activeRemaining = willSearch ? searchRemaining : chatRemaining;
+  const activeUnit      = willSearch ? 'search' : 'message';
+  const counterText     = activeRemaining === null
+    ? null
+    : activeRemaining <= 0
+      ? `No ${activeUnit}s left · resets ${nextResetLocalTime()}`
+      : `${activeRemaining} ${activeUnit}${activeRemaining === 1 ? '' : 's'} left`;
+
+  const selectMode = (live: boolean) => {
+    if (live && searchExhausted) return;
+    setLiveSearch(live);
+    modeRefs.current[live ? 1 : 0]?.focus();
+  };
+
+  /* Two options, so any arrow key moves to the other one - the radiogroup
+   * pattern's expected keyboard behaviour. */
+  const onModeKeys = (e: React.KeyboardEvent) => {
+    if (!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) return;
+    e.preventDefault();
+    selectMode(!liveActive);
+  };
 
   /* ── Coin badge color ── */
   const COIN_COLORS: Record<string, string> = {
@@ -685,23 +709,50 @@ export default function GrokChat() {
           <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
             {!histView && (
               <>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-                  <button
-                    className={`gchat-search-toggle${liveSearch ? ' on' : ''}`}
-                    onClick={() => setLiveSearch(v => !v)}
-                    title={liveSearch ? 'Live web+X search ON - click to turn off' : 'Search OFF - click to enable live web+X search'}
-                  >
-                    {liveSearch ? 'Live' : 'Fast'}
-                  </button>
-                  {searchRemaining !== null && (
-                    <span style={{
-                      fontSize: 'var(--fs-caption)',
-                      color: searchRemaining === 0 ? 'var(--red-soft)' : searchRemaining === 1 ? '#f59e0b' : '#666',
-                      opacity: liveSearch ? 1 : 0.5,
-                      fontVariantNumeric: 'tabular-nums',
-                    }}>
-                      {searchRemaining === 0 ? '✕ None left' : searchRemaining === 1 ? <><Warn size={11} /> 1 left</> : `${searchRemaining} left`}
+                <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 1 }}>
+                  <div className="gchat-mode" role="radiogroup" aria-label="Response mode" onKeyDown={onModeKeys}>
+                    {MODES.map((m, i) => {
+                      const selected = m.live === liveActive;
+                      const disabled = m.live && searchExhausted;
+                      return (
+                        <button
+                          key={m.id}
+                          ref={el => { modeRefs.current[i] = el; }}
+                          role="radio"
+                          aria-checked={selected}
+                          aria-disabled={disabled || undefined}
+                          tabIndex={selected ? 0 : -1}
+                          data-testid={`grok-mode-${m.id}`}
+                          className={`gchat-mode-opt${m.live ? ' live' : ''}${selected ? ' on' : ''}${disabled ? ' off' : ''}`}
+                          onClick={() => selectMode(m.live)}
+                          title={disabled ? `No searches left - resets ${nextResetLocalTime()}` : m.title}
+                        >
+                          {m.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                  {counterText && (
+                    <span
+                      data-testid="grok-mode-count"
+                      className={`gchat-mode-count${activeRemaining !== null && activeRemaining <= 0 ? ' zero' : ''}`}
+                    >
+                      {activeRemaining === 1 && <Warn size={10} />}
+                      {counterText}
                     </span>
+                  )}
+                  {/* The escalation the user never consented to. Fast spends a
+                      SEARCH when the text trips a trigger word, so say it while
+                      the message is still editable rather than after the 429. */}
+                  {!liveActive && willSearch && (
+                    <span className="gchat-mode-note" data-testid="grok-auto-search">
+                      This question uses a live search
+                    </span>
+                  )}
+                  {/* Why the Live half is dead. A control that is present and
+                      explains itself beats one that silently refuses. */}
+                  {searchExhausted && !liveActive && !willSearch && (
+                    <span className="gchat-mode-note">No searches left · resets {nextResetLocalTime()}</span>
                   )}
                 </div>
                 {msgs.length > 0 && (
@@ -858,7 +909,7 @@ export default function GrokChat() {
                         {coin.toUpperCase()}/USDT
                       </div>
                       <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)' }}>
-                        {liveSearch ? 'Live search ON' : 'Fast mode · toggle Live for web search'}
+                        {liveActive ? 'Live search ON' : 'Fast mode · toggle Live for web search'}
                       </div>
                     </>
                   ) : (

--- a/lib/searchTriggers.ts
+++ b/lib/searchTriggers.ts
@@ -1,0 +1,49 @@
+/* Which chat messages silently cost a LIVE SEARCH instead of a chat message.
+ *
+ * Extracted from GrokChat.tsx for #382. It lived inside a `.tsx` component,
+ * which meant the one piece of logic that decides which of a user's two daily
+ * quotas gets spent could not be tested without a JSX loader - so it never was.
+ *
+ * The behaviour is unchanged. What changed is that it is now visible: the chat
+ * panel reads this to tell the user, before they send, which quota the message
+ * in the box will bill (#384). The route bills the mode it is handed
+ * (`app/api/grok-chat/route.ts:117`), so this function and that column have to
+ * agree or the meter lies.
+ */
+
+// Auto-enable live search when message clearly needs current web data
+export const SEARCH_TRIGGERS = [
+  // Questions about why / what
+  'why', 'what happened', 'happening', 'reason', 'cause', 'catalyst',
+  // Time-anchored
+  'today', 'right now', 'just now', 'recently', 'yesterday', 'this week', 'latest',
+  // News / narrative
+  'news', 'narrative', 'breaking', 'announcement',
+  // People / institutions
+  'trump', 'elon', 'powell', 'jerome', 'blackrock', 'saylor',
+  // Macro events
+  'fed', 'fomc', 'cpi', 'ppi', 'nfp', 'jobs', 'inflation', 'gdp',
+  'rate cut', 'rate hike', 'interest rate', 'tariff', 'sanction',
+  // Geo / political
+  'war', 'conflict', 'russia', 'ukraine', 'china', 'japan', 'boj', 'yen',
+  // Crypto-specific events
+  'etf', 'sec', 'regulation', 'hack', 'exploit', 'halving',
+  'binance', 'coinbase', 'bybit', 'okx',
+  'liquidation', 'liquidated', 'whale',
+  'dump', 'dumping', 'pump', 'pumping', 'crash', 'crashing', 'rally',
+  'stablecoin', 'usdt', 'usdc',
+];
+
+/**
+ * True when this message will be sent as a live search, spending
+ * `chat_search_count` rather than `chat_count`.
+ *
+ * Substring match, NOT word-boundary - so `sec` matches inside `second` and
+ * `war` inside `warning`. That is the shipped behaviour and this function does
+ * not change it; `__tests__/searchTriggers.test.mts` pins the collisions that
+ * exist so a future edit to the list cannot widen them unnoticed.
+ */
+export function needsLiveSearch(text: string): boolean {
+  const t = text.toLowerCase();
+  return SEARCH_TRIGGERS.some(k => t.includes(k));
+}


### PR DESCRIPTION
**Dev Team** · Closes #383, #384, and the labelling half of #382.

## Summary

The Live/Fast pill becomes a two-option segmented control, and the counter beside it names its unit and follows **the quota the next message will actually bill**.

```
before          Live        ✕ None left
after           [ Fast | Live ]
                40 messages left
                (typing "why is BTC down today")
                9 searches left
                This question uses a live search
```

## What changed

**A segmented control, both states visible** (#383). The old control showed one word and left the user to work out whether `Live` was the state or the action. It also used `min-height: 32px` while the coin chips 8px below it use `44px`, which is why it read as a status badge. It now borrows the coin-chip affordance rather than inventing one — QA's finding, and the right call.

**The counter follows the EFFECTIVE mode** (#384, #382). It used to always show `search` remaining, dimmed to `opacity: 0.5` in Fast mode. A user with searches exhausted and 40 chat messages left was told `✕ None left`. 50% opacity was the only thing distinguishing "this applies to you" from "this is about the other mode".

**Auto-escalation is now visible.** `GrokChat.tsx` escalated Fast to search whenever the text tripped a trigger word — so following the *toggle* would still misreport the cost of exactly the messages that caused the report. The counter now reprices as you type and says when a question will spend a search. Per the owner's decision on #383: auto-escalation stays, it becomes visible.

**`needsLiveSearch` moved to `lib/searchTriggers.ts`.** The single function deciding which of two quotas a user spends lived inside a `.tsx` and had never been tested.

**`liveActive` is derived, not stored.** A Live selection cannot survive the quota running out, so the request path and the control cannot disagree. No `setState` in an effect.

## What the new test found

Seven tests, all passing — and they caught two of my own wrong assumptions before this shipped. `SEARCH_TRIGGERS` uses `includes`, not word boundaries:

```
"is the trend upward"             costs a live search   war inside "upward"
"is this a warning sign"          costs a live search   war inside "warning"
"what does forward guidance mean" costs a live search   war inside "forward"
"what is a secondary market"      costs a live search   sec inside "secondary"
```

**Pinned, not fixed.** Changing the matching is a product decision and nobody has asked for it. The test fails if the short-trigger set changes, so widening it is now a deliberate act. Filed for triage rather than fixed here.

## Why

The owner hit a cap of 10 while a meter said 40 remaining. **Both numbers were correct. Neither said what it counted.**

## How to test (QA)

On the **qa** environment, signed in, open LiquidityAI (the ✦ button, bottom right).

1. **The control reads as a control** — `Fast` and `Live` both visible, active one filled. Click `Live`, it fills green; click `Fast`, it fills accent.
2. **Keyboard** — Tab to the control, press ← or →. Selection moves and focus follows. It announces as a radio group.
3. **The counter names its unit** — reads `N messages left`, not a bare number.
4. **Type `why is BTC down today` with Fast selected.** The counter must switch to `N searches left` and a line must appear reading *This question uses a live search*. Clear the box — it switches back to messages.
5. **Type `is the trend upward`** — same thing. This is the surprising one and it is intended: `upward` contains `war`.
6. **With searches exhausted**, `Live` is visibly present but disabled and says when it resets. It must not disappear.
7. **Light mode and mobile** — the control is legible in both and the header does not overflow.

## Risk level — **Low**, with three things named as unverified

**Verified locally:** all four gates (lint 0 errors / `tsc` clean / 398 tests pass / build succeeds). Exercised in a browser: the control renders, click and arrow-key selection both work, focus follows selection, `role="radiogroup"` and `aria-checked` are correct, and the old `.gchat-search-toggle` class is gone with no stale references.

**NOT verified — please check these:**

- **The counter and the auto-search line were never seen rendered.** They only appear when `usage` is non-null, which needs a signed-in account. The *logic* is unit-tested; the *rendering* is not. **Steps 3, 4 and 5 above are the ones that have never actually been run.**
- **Light-mode contrast is not measured.** I tried and got contradictory readings — the element resolved `--purple` to `#0052cc` while rendering `rgb(26,122,255)`, and two of my measuring scripts turned out to be silently broken (one filtered on `style.color`, which returns empty for `var()` values, and reported "no rules match"). Rather than publish a number I do not trust, this is for `contrast.spec.ts`. **Colours are now theme tokens (`--purple-bg`, `--green-bg`) rather than the hardcoded `rgba(52,211,153,…)` the old control used, so light mode is at least reachable — but reachable is not measured.**
- **Touch target is 28px declared, not 44px.** Deliberate: the owner asked for the control to be smaller after seeing it at 44px, where it was as tall as the coin chips and dominated a header it shares with icon buttons. **This conflicts with the 44px assertion in your #383 spec plan — your call how to handle it, and the owner's decision is the one that should win.** Separately, `.gchat-panel.gchat-open` carries `transform: scale(0.92)` at times, so *every* control in the panel renders ~8% smaller than declared, including the coin chips and the send button. I could not establish whether that scale is a resting state or animation — it measured both ways. Not introduced here, and worth its own issue if it matters.
