### PR TITLE
test(qa): detect text that is silently tappable as a control

### DIFF
--- a/qa/STATUS.md
+++ b/qa/STATUS.md
@@ -89,6 +89,34 @@ gh issue list --state open
 
 ## Standing risks
 
+- **`reuseExistingServer` will serve you a build from before your `git checkout`,
+  silently.** Measured 2026-08-14 while validating `text-under-control.spec.ts`
+  against `fd17cbc`. Playwright's local config is `reuseExistingServer: !CI`, so
+  a dev server left running from an earlier run is reused — and **a git checkout
+  does not restart it**. Three consecutive runs reported a clean PASS on a commit
+  that provably had the defect.
+
+  The tell was not the result, which looked ordinary. It was a direct read of the
+  bytes:
+
+  ```
+  git show fd17cbc:app/globals.css     .gchat-mode-opt::after { ... height: 48px }
+  served CSS on :3100                  no ::after rule at all
+  ```
+
+  **`/api/version` does NOT rescue you here** — it reports `commit: "unknown"` on
+  a local dev server, so the endpoint that solves this for deployed services
+  answers nothing locally. Grep the served asset for something the commit
+  introduced, or kill the port first:
+
+  ```
+  netstat -ano | grep :3100 | grep LISTENING   # then taskkill //F //PID <pid> //T
+  ```
+
+  **This is the same failure as verifying against the wrong deployed build**, and
+  it is worse locally because nothing in the output names a commit. Any run that
+  crosses a checkout boundary is suspect until the server has been restarted.
+
 - **No REAL PURCHASE has ever granted Pro.** Still the highest launch risk, and
   narrowed on 2026-08-11 rather than cleared — be precise about which half is
   which, because "payments are tested" is now half true and that is the dangerous

--- a/qa/e2e/text-under-control.spec.ts
+++ b/qa/e2e/text-under-control.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import type { Page } from '@playwright/test';
 import { ROUTES, gotoGuarded } from './_shared';
+import { signedInContext } from './_auth';
 import { installMarketFixtures } from './_fixtures';
 
 /* THE MIRROR OF `layout.spec.ts`, AND IT EXISTS BECAUSE THAT FILE FACES ONE WAY.
@@ -27,11 +28,20 @@ import { installMarketFixtures } from './_fixtures';
  * it is how you honour a 44px target without repainting a 26px control. It just
  * has a blast radius that nothing in this suite was looking at.
  *
- * WHAT THIS DOES NOT COVER. Only the text's CENTRE point is sampled, so a
- * control overlapping a caption's left edge and nothing else is missed. Centre
- * sampling is what `layout.spec.ts` does and is what keeps the sweep to one
- * hit-test per element. A four-corner probe is the obvious next step and is
- * deliberately not in the first version - measure the cheap one, then decide.
+ * IT SAMPLES EDGES, AND THE FIRST VERSION DID NOT. I wrote this sampling the
+ * centre point - the way `layout.spec.ts` does - and flagged that as a known
+ * limitation to revisit. Dev then measured the real instance and the limitation
+ * was fatal, not cosmetic: the counter's centre sits 1-2px BELOW the deepest
+ * point the overlay reached, so the first version read CLEAN on `fd17cbc`, the
+ * commit that actually shipped the bug. See `findTextUnderControls` for the
+ * numbers. A detector that passes on its own motivating example is worse than
+ * no detector, because it also reports "checked".
+ *
+ * WHAT THIS STILL DOES NOT COVER. Five points per element - four edges and the
+ * centre - not an exhaustive hit-test. An overlay clipping only a corner is
+ * missed. That is a real gap and it is stated rather than fixed, because the
+ * five-point version is already ~5x the hit-tests of the sweep it sits beside
+ * and no measured instance yet needs more.
  */
 
 const TEXT_SELECTOR = 'span, p, small, label, dd, dt, td, th, li, figcaption, time';
@@ -91,18 +101,61 @@ async function findTextUnderControls(page: Page): Promise<string[]> {
       if (b.width < 2 || b.height < 2) continue;
       if (b.bottom < 0 || b.top > innerHeight || b.right < 0 || b.left > innerWidth) continue;
 
-      const x = Math.min(Math.max(b.left + b.width / 2, 1), innerWidth - 1);
-      const y = Math.min(Math.max(b.top + b.height / 2, 1), innerHeight - 1);
-      const hit = document.elementFromPoint(x, y);
-      if (!hit || hit === el || el.contains(hit) || hit.contains(el)) continue;
+      /* EDGES, NOT THE CENTRE - and the first version of this file got it wrong.
+       *
+       * I sampled the centre point, the way `layout.spec.ts` does, and named
+       * centre-sampling as a known limitation. Dev then measured the real
+       * instance on `fd17cbc` and the limitation turned out to be fatal:
+       *
+       *     counter top       +4.0px below the pill
+       *     counter height    16.6px
+       *     counter CENTRE    +12.3px
+       *     overlay reached   +9 to +11px      <- covered the top ~7px
+       *
+       * The centre sits 1-2px BELOW the deepest point the overlay reached, so a
+       * centre sample returns the counter itself and reads clean on the exact
+       * commit that shipped the defect.
+       *
+       * The structural reason matters more than those numbers. **An overlay
+       * creeps into a neighbour from one side; it does not swallow it whole.**
+       * The harm in this bug class lives at an edge by construction, so a centre
+       * sample is blind to the common case rather than unlucky in one instance.
+       *
+       * Do NOT read "it missed by 2px" as "the centre nearly worked". That gap
+       * is a function of the counter's rendered height, `--fs-caption`, font
+       * metrics and the panel's 0.92 scale. At a different font size the centre
+       * would catch this one and miss the next.
+       *
+       * Inset by 2px so a probe on the boundary does not hit-test the neighbour
+       * legitimately abutting it. */
+      const I = 2;
+      const probes: [string, number, number][] = [
+        ['top',    b.left + b.width / 2, b.top + I],
+        ['bottom', b.left + b.width / 2, b.bottom - I],
+        ['left',   b.left + I,           b.top + b.height / 2],
+        ['right',  b.right - I,          b.top + b.height / 2],
+        ['centre', b.left + b.width / 2, b.top + b.height / 2],
+      ];
 
-      /* The coverer must be a CONTROL. Text covered by other text is a layout
-       * bug and layout.spec.ts's zero-size half is closer to it; text covered by
-       * something clickable is the one that spends the user's quota. */
-      const control = hit.closest(CONTROL_SELECTOR);
-      if (!control) continue;
+      for (const [edge, px, py] of probes) {
+        const x = Math.min(Math.max(px, 1), innerWidth - 1);
+        const y = Math.min(Math.max(py, 1), innerHeight - 1);
+        const hit = document.elementFromPoint(x, y);
+        if (!hit || hit === el || el.contains(hit) || hit.contains(el)) continue;
 
-      found.push(`${describe(el)} "${text.slice(0, 32)}" is tappable as ${describe(control)}`);
+        /* The coverer must be a CONTROL. Text covered by other text is a layout
+         * bug and layout.spec.ts's zero-size half is closer to it; text covered
+         * by something clickable is the one that spends the user's quota. */
+        const control = hit.closest(CONTROL_SELECTOR);
+        if (!control) continue;
+
+        /* FIRST HIT ONLY. Reporting every edge that overlaps would make the
+         * message length depend on how deep the overhang reaches, and the same
+         * one defect would read as four. The edge name is kept because it says
+         * which side to shrink. */
+        found.push(`${describe(el)} "${text.slice(0, 32)}" is tappable as ${describe(control)} (at its ${edge} edge)`);
+        break;
+      }
     }
     return found;
   }, { TEXT_SELECTOR, CONTROL_SELECTOR, MIN_TEXT_LENGTH });
@@ -138,22 +191,52 @@ test.describe('text is not silently tappable as a control', () => {
       await gotoGuarded(page, '/');
       await settleForGeometry(page);
 
-      const before = (await findTextUnderControls(page)).length;
+      const beforeFindings = await findTextUnderControls(page);
+      const beforeSet = new Set(beforeFindings);
 
       await page.evaluate(() => {
         const host = document.createElement('div');
         host.style.cssText = 'position:fixed;left:40px;top:200px;z-index:9999;';
-        /* The real shape: a small button whose ::after-equivalent overhang
-         * reaches down over an inert caption 1px below it. Written as a child
-         * div rather than a pseudo-element so it can be injected at runtime -
-         * the hit-testing is identical, which is the property under test. */
+        /* THE BAIT REPRODUCES `fd17cbc`'s GEOMETRY, not a convenient version of
+         * it. An overlay that swallows the caption whole is caught by a centre
+         * sample too, so a fixture like that would let a centre-only detector
+         * pass its own self-test - which is exactly the failure this file just
+         * had. The numbers below are dev's measurements from the real commit:
+         *
+         *     caption top      +4px below the button
+         *     caption height   ~16.6px  (centre at +12.3px)
+         *     overlay reach    +9px     <- covers the top ~5px only
+         *
+         * So the centre of this caption is NOT covered and only its top edge is.
+         * A centre-sampling probe returns clean here, and must. */
         host.innerHTML = `
-          <button style="position:relative;display:block;width:90px;height:26px">Live
-            <span style="position:absolute;left:0;right:0;top:50%;transform:translateY(-50%);height:48px"></span>
+          <button class="tuc-injected" style="position:relative;display:block;width:90px;height:26px">Live
+            <span style="position:absolute;left:0;right:0;top:-9px;bottom:-9px"></span>
           </button>
-          <span id="tuc-bait" style="display:block;width:90px;font-size:11px">40 messages left</span>`;
+          <span id="tuc-bait" style="display:block;width:90px;margin-top:4px;font-size:13px;line-height:16.6px">40 messages left</span>`;
         document.body.appendChild(host);
       });
+
+      /* CONTROL ON THE FIXTURE ITSELF, and it asserts a NEGATIVE.
+       *
+       * Everything below only proves the detector catches this bait. It proves
+       * nothing about EDGES unless the bait is genuinely edge-only - and if a
+       * later refactor made the overlay swallow the caption whole, this file
+       * would keep passing while silently going back to testing the easy case.
+       *
+       * So: measure the caption's centre point directly and require it to be
+       * clean. If this fails, the fixture drifted, not the detector. */
+      const centreIsClean = await page.evaluate(() => {
+        const bait = document.getElementById('tuc-bait')!;
+        const b = bait.getBoundingClientRect();
+        const hit = document.elementFromPoint(b.left + b.width / 2, b.top + b.height / 2);
+        return { clean: hit === bait, hit: hit?.tagName.toLowerCase() ?? 'null', h: Math.round(b.height) };
+      });
+      expect(centreIsClean.clean,
+        `the injected caption's CENTRE is covered (hit ${centreIsClean.hit}, height ${centreIsClean.h}px), ` +
+        `so this fixture is catchable by centre-sampling and does not test edge probing at all. ` +
+        `fd17cbc covered the top ~5px of a 16.6px caption - reproduce that, not a full overlap.`)
+        .toBe(true);
 
       const after = await findTextUnderControls(page);
       expect(after.some(f => f.includes('40 messages left')),
@@ -162,10 +245,28 @@ test.describe('text is not silently tappable as a control', () => {
         after.join('\n'))
         .toBe(true);
 
-      /* And it must not have started reporting everything. A detector that
-       * flags the whole page also "catches" the injected case. */
-      expect(after.length, 'injecting one defect changed the count by more than one')
-        .toBe(before + 1);
+      /* AND IT MUST NOT HAVE STARTED REPORTING EVERYTHING. A detector that flags
+       * the whole page also "catches" the injected case, so the bait passing
+       * alone proves very little.
+       *
+       * ATTRIBUTED, NOT COUNTED, and the first version counted. It asserted
+       * `after.length === before + 1`, which failed on mobile at 390px - the
+       * fixed-position host lands on top of real page text there, so the
+       * injected button legitimately covers a second element. That finding is
+       * TRUE; it is just caused by the fixture rather than by the app.
+       *
+       * Loosening this to `>=` would have hidden exactly what it exists to
+       * catch. Instead every new finding must be attributable to the injection -
+       * either it IS the bait, or its coverer is the injected button - so a
+       * detector that started flagging unrelated page elements still fails. */
+      const fresh = after.filter(f => !beforeSet.has(f));
+      const unattributed = fresh.filter(f =>
+        !f.includes('40 messages left') && !f.includes('button.tuc-injected'));
+      expect(unattributed,
+        'injecting one defect produced findings that are neither the bait nor caused by the ' +
+        'injected control, so the detector is reporting unrelated elements')
+        .toEqual([]);
+      expect(fresh.length, 'the injection produced no new findings at all').toBeGreaterThan(0);
     } finally {
       await close();
     }
@@ -184,10 +285,70 @@ test.describe('text is not silently tappable as a control', () => {
    * finished. This opens the panel first, which makes the subtree live, then
    * runs the same probe against it. */
   test('the chat panel: opening it makes its text reachable, and none of it is tappable', async ({ browser }, testInfo) => {
-    const { page, close } = await preparedPage(browser, testInfo.project.use.viewport ?? { width: 1440, height: 900 });
+    /* SIGNED IN, AND ON AN APP ROUTE. The first version did neither and hung for
+     * the full 240s test timeout.
+     *
+     * `GrokChat` is mounted by `AppShell` (`components/AppShell.tsx:141`), which
+     * does not wrap the marketing landing page - so on `/` while signed out
+     * there is no `.gchat-fab` at all and Playwright's auto-wait sat on a
+     * locator that was never going to resolve.
+     *
+     * Worth naming the failure mode rather than just fixing it: **the test did
+     * not lie, it hung** - which is the better of the two outcomes, but it is
+     * the same root cause as a vacuous pass. I pointed a probe at a page that
+     * could not contain the thing and did not assert that it did. The explicit
+     * FAB check below is what makes the difference permanent. */
+    const ctx = await signedInContext(browser, 'a', {
+      viewport: testInfo.project.use.viewport ?? { width: 1440, height: 900 },
+    });
+    await ctx.addInitScript(() => {
+      try { localStorage.setItem('lhq_analytics_consent_v1', 'denied'); } catch { /* private mode */ }
+    });
+    const page = await ctx.newPage();
+    page.on('dialog', d => d.dismiss());
+    await installMarketFixtures(page, 'as-recorded');
+    const close = () => ctx.close();
+
+    /* PIN THE QUOTA, BECAUSE THE ELEMENT UNDER TEST IS CONDITIONAL - and the
+     * first version of this test passed without it, meaninglessly.
+     *
+     * `GrokChat` renders the counter only when `activeRemaining !== null`
+     * (`GrokChat.tsx:605`), and `activeRemaining` comes from `/api/grok` via
+     * `fetchGrokUsage`. On the seeded test account that call returned nothing,
+     * so `.gchat-mode-count` was never in the DOM - and a probe looking for
+     * "text covered by a control" found no text, reported zero, and went green
+     * on `fd17cbc`, the commit that HAD the defect.
+     *
+     * That is the same vacuous pass this file's self-test guards against,
+     * arriving through the app's own conditional rendering rather than through
+     * the detector. Nothing was broken; the thing being measured was absent.
+     *
+     * 10 searches / 50 messages reproduces what QA saw rendered on qa@6fe3f6c,
+     * so the counter is the same width as the real one - which matters here,
+     * because the whole question is what its edges touch. */
+    await page.route('**/api/grok', route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ usage: {
+        deep_used: 0, deep_limit: 5, quick_used: 0, quick_limit: 20,
+        chat_used: 0, chat_limit: 50, search_used: 0, search_limit: 10,
+        briefing_used: 0, briefing_limit: 3,
+      } }),
+    }));
+
     try {
-      await gotoGuarded(page, '/');
+      await gotoGuarded(page, '/dashboard');
       await settleForGeometry(page);
+
+      /* ASSERT THE LAUNCHER EXISTS BEFORE CLICKING IT. A missing FAB means the
+       * app shell did not render or the session did not take, and clicking a
+       * locator that will never resolve turns that into a 4-minute timeout
+       * whose message says nothing about the cause. */
+      const fabs = await page.locator('.gchat-fab').count();
+      expect(fabs,
+        'no .gchat-fab on /dashboard - GrokChat is mounted by AppShell, so this means the ' +
+        'app shell did not render or the seeded session did not take. Nothing below is measurable.')
+        .toBeGreaterThan(0);
 
       /* CONTROL, and it runs before the assertion. If the panel does not open,
        * the probe returns nothing and nothing reads as a pass - the same vacuous
@@ -215,6 +376,23 @@ test.describe('text is not silently tappable as a control', () => {
       expect(live.controls,
         'the open panel reports no controls, so the probe has nothing to hit-test against')
         .toBeGreaterThan(2);
+
+      /* THE ELEMENT THIS TEST IS ABOUT MUST BE PRESENT. Everything above proves
+       * the panel is open; none of it proves the counter rendered. Without this
+       * the sweep below returns [] whenever the quota fails to load, which is
+       * indistinguishable from "nothing covers it". */
+      const counter = await page.evaluate(() => {
+        const el = document.querySelector('.gchat-mode-count');
+        if (!el) return null;
+        const b = el.getBoundingClientRect();
+        return { h: Math.round(b.height * 10) / 10, txt: (el.textContent || '').trim() };
+      });
+      expect(counter,
+        'no .gchat-mode-count in the open panel. It renders only when /api/grok supplies a ' +
+        'quota, which this test pins - so this means the route stub did not take or the ' +
+        'condition at GrokChat.tsx:605 changed. The sweep below would report a clean zero ' +
+        'for the wrong reason.')
+        .not.toBeNull();
 
       const found = await findTextUnderControls(page);
       testInfo.attach('chat-panel-text-under-control.txt', {

--- a/qa/e2e/text-under-control.spec.ts
+++ b/qa/e2e/text-under-control.spec.ts
@@ -1,0 +1,272 @@
+import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import { ROUTES, gotoGuarded } from './_shared';
+import { installMarketFixtures } from './_fixtures';
+
+/* THE MIRROR OF `layout.spec.ts`, AND IT EXISTS BECAUSE THAT FILE FACES ONE WAY.
+ *
+ * `layout.spec.ts` asks: is an INTERACTIVE control covered by something? That
+ * catches "renders but cannot be clicked". It is scoped to interactive elements
+ * on the covered side, so the opposite arrangement is invisible to it:
+ *
+ *     an INERT element - a label, a counter, a caption - covered by a CONTROL
+ *
+ * Nothing is unreachable there, so the older detector correctly reports zero.
+ * The harm is different in kind: you tap the words to read them and a control
+ * fires instead. Nothing looks broken, and what the tap DID is off-screen.
+ *
+ * FOUND BY MISSING IT. Reviewing #389 on 2026-08-14 I read this arrangement out
+ * of the JSX rather than measuring it - a 48px `::after` overhang on a 26px pill
+ * sitting 1px above its own quota counter, so a tap on the words
+ * `10 searches left` would select a mode. Switching Fast to Live changes which
+ * quota the NEXT message bills, so the accidental tap spends from a different
+ * pool than the user believes. I asked dev to measure it. Neither the reading
+ * nor the request is a test, and both of us had a passing suite at the time.
+ *
+ * The `::after` hit-area trick is the general case and it is a good technique -
+ * it is how you honour a 44px target without repainting a 26px control. It just
+ * has a blast radius that nothing in this suite was looking at.
+ *
+ * WHAT THIS DOES NOT COVER. Only the text's CENTRE point is sampled, so a
+ * control overlapping a caption's left edge and nothing else is missed. Centre
+ * sampling is what `layout.spec.ts` does and is what keeps the sweep to one
+ * hit-test per element. A four-corner probe is the obvious next step and is
+ * deliberately not in the first version - measure the cheap one, then decide.
+ */
+
+const TEXT_SELECTOR = 'span, p, small, label, dd, dt, td, th, li, figcaption, time';
+const CONTROL_SELECTOR = 'a, button, [role=button], [role=link], [role=tab], [role=radio], input, select';
+
+/* Text this short is punctuation, an icon glyph or a unit suffix. Covering a
+ * bullet is not the defect; covering something you would read is. Measured
+ * rather than guessed: at 0 the sweep is dominated by `·`, `%` and single
+ * digits from the metric rows, which are decorative and never the tap target. */
+const MIN_TEXT_LENGTH = 8;
+
+async function settleForGeometry(page: Page): Promise<void> {
+  const started = Date.now();
+  await page.waitForFunction(() => {
+    const w = window as unknown as { __tuc?: { last: string; stable: number } };
+    const sig = document.querySelectorAll('*').length + ':' + (document.body.innerText || '').length;
+    w.__tuc = w.__tuc || { last: '', stable: 0 };
+    if (sig === w.__tuc.last) w.__tuc.stable++; else { w.__tuc.last = sig; w.__tuc.stable = 0; }
+    return w.__tuc.stable >= 6;
+  }, undefined, { timeout: 20_000, polling: 300 }).catch(() => { /* fall through to the floor */ });
+
+  const elapsed = Date.now() - started;
+  if (elapsed < 3_000) await page.waitForTimeout(3_000 - elapsed);
+}
+
+async function findTextUnderControls(page: Page): Promise<string[]> {
+  return page.evaluate(({ TEXT_SELECTOR, CONTROL_SELECTOR, MIN_TEXT_LENGTH }) => {
+    const found: string[] = [];
+
+    const describe = (el: Element) => {
+      const cls = typeof el.className === 'string' && el.className.trim()
+        ? '.' + el.className.trim().split(/\s+/).slice(0, 2).join('.') : '';
+      return `${el.tagName.toLowerCase()}${cls}`;
+    };
+
+    for (const el of document.querySelectorAll(TEXT_SELECTOR)) {
+      if (!el.checkVisibility?.()) continue;
+
+      /* Same exclusion as layout.spec.ts, same reason: an element inside an
+       * `inert` subtree cannot be reached at all, so what sits on top of it is
+       * not a question. GrokChat alone keeps 65 controls in a closed panel. */
+      if (el.closest('[inert]')) continue;
+
+      /* TEXT INSIDE A CONTROL IS THE POINT OF THE CONTROL. A button's own label
+       * hit-tests to the button, which is correct and is not this defect. */
+      if (el.closest(CONTROL_SELECTOR)) continue;
+
+      /* Only leaf text. A wrapper `<li>` containing a `<span>` would otherwise
+       * report the same overlap twice under two names, which is exactly the
+       * unstable-baseline problem layout.spec.ts hit with the tab bar. */
+      if (el.querySelector(TEXT_SELECTOR)) continue;
+
+      const text = (el.textContent || '').trim();
+      if (text.length < MIN_TEXT_LENGTH) continue;
+
+      const b = el.getBoundingClientRect();
+      if (b.width < 2 || b.height < 2) continue;
+      if (b.bottom < 0 || b.top > innerHeight || b.right < 0 || b.left > innerWidth) continue;
+
+      const x = Math.min(Math.max(b.left + b.width / 2, 1), innerWidth - 1);
+      const y = Math.min(Math.max(b.top + b.height / 2, 1), innerHeight - 1);
+      const hit = document.elementFromPoint(x, y);
+      if (!hit || hit === el || el.contains(hit) || hit.contains(el)) continue;
+
+      /* The coverer must be a CONTROL. Text covered by other text is a layout
+       * bug and layout.spec.ts's zero-size half is closer to it; text covered by
+       * something clickable is the one that spends the user's quota. */
+      const control = hit.closest(CONTROL_SELECTOR);
+      if (!control) continue;
+
+      found.push(`${describe(el)} "${text.slice(0, 32)}" is tappable as ${describe(control)}`);
+    }
+    return found;
+  }, { TEXT_SELECTOR, CONTROL_SELECTOR, MIN_TEXT_LENGTH });
+}
+
+test.describe('text is not silently tappable as a control', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  async function preparedPage(
+    browser: import('@playwright/test').Browser,
+    viewport: { width: number; height: number },
+  ) {
+    const ctx = await browser.newContext({ viewport });
+    await ctx.addInitScript(() => {
+      try { localStorage.setItem('lhq_analytics_consent_v1', 'denied'); } catch { /* private mode */ }
+    });
+    const page = await ctx.newPage();
+    page.on('dialog', d => d.dismiss());
+    await installMarketFixtures(page, 'as-recorded');
+    return { page, close: () => ctx.close() };
+  }
+
+  /* THE SELF-TEST, AND IT RUNS FIRST.
+   *
+   * The assertion below is "found nothing", which is also what a detector that
+   * never looked returns. `qa/STATUS.md` calls this out as a standing risk and
+   * this suite has produced it for real twice. So: build the #389 arrangement
+   * deliberately - a control with an invisible overhang sitting over a caption -
+   * and require the detector to catch it. */
+  test('the detector actually detects (guards against a vacuous pass)', async ({ browser }, testInfo) => {
+    const { page, close } = await preparedPage(browser, testInfo.project.use.viewport ?? { width: 1440, height: 900 });
+    try {
+      await gotoGuarded(page, '/');
+      await settleForGeometry(page);
+
+      const before = (await findTextUnderControls(page)).length;
+
+      await page.evaluate(() => {
+        const host = document.createElement('div');
+        host.style.cssText = 'position:fixed;left:40px;top:200px;z-index:9999;';
+        /* The real shape: a small button whose ::after-equivalent overhang
+         * reaches down over an inert caption 1px below it. Written as a child
+         * div rather than a pseudo-element so it can be injected at runtime -
+         * the hit-testing is identical, which is the property under test. */
+        host.innerHTML = `
+          <button style="position:relative;display:block;width:90px;height:26px">Live
+            <span style="position:absolute;left:0;right:0;top:50%;transform:translateY(-50%);height:48px"></span>
+          </button>
+          <span id="tuc-bait" style="display:block;width:90px;font-size:11px">40 messages left</span>`;
+        document.body.appendChild(host);
+      });
+
+      const after = await findTextUnderControls(page);
+      expect(after.some(f => f.includes('40 messages left')),
+        `the injected caption sits under a button's overhang and the detector did not report it. ` +
+        `Everything else in this file is "found nothing", so a broken detector passes silently.\n` +
+        after.join('\n'))
+        .toBe(true);
+
+      /* And it must not have started reporting everything. A detector that
+       * flags the whole page also "catches" the injected case. */
+      expect(after.length, 'injecting one defect changed the count by more than one')
+        .toBe(before + 1);
+    } finally {
+      await close();
+    }
+  });
+
+  /* THE SWEEP BELOW CANNOT SEE THIS, and that is worth its own test rather than
+   * a caveat in a comment.
+   *
+   * Both this file and `layout.spec.ts` skip `[inert]` subtrees, because an
+   * element nobody can reach is not made defective by something covering it.
+   * GrokChat's panel is `inert` while closed and holds 65 controls. So the 32-
+   * route sweep walks straight past the exact arrangement that prompted this
+   * file - the quota counter under the mode pills' hit-area overhang.
+   *
+   * A detector with a blind spot the size of its own motivating example is not
+   * finished. This opens the panel first, which makes the subtree live, then
+   * runs the same probe against it. */
+  test('the chat panel: opening it makes its text reachable, and none of it is tappable', async ({ browser }, testInfo) => {
+    const { page, close } = await preparedPage(browser, testInfo.project.use.viewport ?? { width: 1440, height: 900 });
+    try {
+      await gotoGuarded(page, '/');
+      await settleForGeometry(page);
+
+      /* CONTROL, and it runs before the assertion. If the panel does not open,
+       * the probe returns nothing and nothing reads as a pass - the same vacuous
+       * green this file's self-test exists to prevent, arriving by a different
+       * route. Assert the subtree is actually live before trusting a zero. */
+      await page.locator('.gchat-fab').click();
+      await page.locator('.gchat-panel.gchat-open').waitFor({ state: 'visible', timeout: 15_000 });
+      await settleForGeometry(page);
+
+      const live = await page.evaluate(() => {
+        const panel = document.querySelector('.gchat-panel.gchat-open');
+        if (!panel) return { open: false, inert: true, controls: 0 };
+        return {
+          open: true,
+          inert: !!panel.closest('[inert]'),
+          controls: panel.querySelectorAll('a,button,[role=button],[role=radio],input').length,
+        };
+      });
+
+      expect(live.open, 'the chat panel did not open, so this test measured nothing').toBe(true);
+      expect(live.inert,
+        'the panel is still inert with the panel open, so the probe below skips all of it ' +
+        'and returns a zero that means "did not look" rather than "looked and saw nothing"')
+        .toBe(false);
+      expect(live.controls,
+        'the open panel reports no controls, so the probe has nothing to hit-test against')
+        .toBeGreaterThan(2);
+
+      const found = await findTextUnderControls(page);
+      testInfo.attach('chat-panel-text-under-control.txt', {
+        body: found.join('\n') || '(none)',
+        contentType: 'text/plain',
+      });
+
+      expect(found,
+        'Text inside the chat panel is sitting under a clickable element. The quota counter ' +
+        'sits 1px below the Fast/Live pills in a column flex (gap: 1), so any hit-area ' +
+        'overhang taller than about 27px reaches it - and a tap on the words then switches ' +
+        'mode, changing which quota the NEXT message bills. See #389.')
+        .toEqual([]);
+    } finally {
+      await close();
+    }
+  });
+
+  test('no inert text is covered by an interactive control', async ({ browser }, testInfo) => {
+    test.setTimeout(15 * 60_000);
+    const { page, close } = await preparedPage(browser, testInfo.project.use.viewport ?? { width: 1440, height: 900 });
+    const found: string[] = [];
+    try {
+      for (const route of ROUTES) {
+        await gotoGuarded(page, route);
+        await settleForGeometry(page);
+
+        /* A route that renders nothing reports nothing, and nothing looks like
+         * a pass. Same guard and same 50-element floor as a11y.spec.ts, which
+         * calibrated it against the smallest legitimate page (88 elements). */
+        const rendered = await page.evaluate(() => document.querySelectorAll('*').length);
+        if (rendered < 50) {
+          found.push(`${route}  UNMEASURED - only ${rendered} elements rendered`);
+          continue;
+        }
+
+        for (const f of await findTextUnderControls(page)) found.push(`${route}  ${f}`);
+      }
+
+      testInfo.attach('text-under-control.txt', {
+        body: found.join('\n') || '(none)',
+        contentType: 'text/plain',
+      });
+
+      expect(found,
+        'Text a user would read is sitting under a clickable element, so tapping the words ' +
+        'fires that control instead. The usual cause is an invisible hit-area overlay ' +
+        '(a ::after sized past its own box) reaching into whatever is next to it - see #389. ' +
+        'Either shrink the overhang, move it to the side with room, or increase the gap.')
+        .toEqual([]);
+    } finally {
+      await close();
+    }
+  });
+});


### PR DESCRIPTION
**QA Team** → **Dev Team** · QA-owned test tooling, into `dev`. Comes out of #388/#389.

## Summary

A detector for the mirror of what `layout.spec.ts` already checks. That file asks *is a **control** covered* — "renders but cannot be clicked". This asks *is inert **text** covered by a control* — you tap words to read them and something fires instead.

**Nothing is unreachable in that arrangement, so the existing sweep correctly reports zero on it.** It reported zero on #389 while the bug was live.

## What changed

```
qa/e2e/text-under-control.spec.ts    new - 3 tests x 2 projects
qa/STATUS.md                         new standing risk (see below)
```

## Proven in both directions, against real commits

**This is the part I care about.** A test that has never failed has never been tested:

```
fd17cbc   pre-fix    FAILS   span.gchat-mode-count "50 messages left"
                             is tappable as button.gchat-mode-opt.on (at its top edge)
2957555   your fix   PASSES
```

`fd17cbc` is now a permanent fixture — a real commit with a real instance, as you suggested.

## Three things I got wrong building it, all caught by measuring

**1. Centre-sampling was fatal, not a limitation.** I shipped v1 sampling centres and flagged it as a gap to revisit. Your measurement showed the counter's centre sits 1-2px *below* the overlay's deepest reach — so v1 read clean on `fd17cbc`. Now five points per element; it catches this at the **top edge**, exactly where you predicted the harm lives.

**2. Two vacuous passes, both my own.** It first hung on `/` where there is no `.gchat-fab` (GrokChat is mounted by `AppShell`). Then the counter did not render at all — it is conditional on `/api/grok` — so "found nothing" meant "nothing was there". Both now assert their preconditions before trusting a zero.

**3. The self-test asserted `count === before + 1` and failed at 390px** — the injected fixture legitimately covers real page text on mobile. Loosening to `>=` would have hidden what it exists to catch, so new findings are now **attributed** (must be the bait, or covered by `button.tuc-injected`) rather than counted.

## The one that would have fooled me completely

**`reuseExistingServer` served a build from before my `git checkout`, silently. Three consecutive runs reported PASS on a commit that provably had the defect.**

```
git show fd17cbc:app/globals.css     .gchat-mode-opt::after { ... height: 48px }
served CSS on :3100                  no ::after rule at all
```

**`/api/version` does not save you locally** — it reports `commit: "unknown"` on a dev server. I only caught it by grepping the served asset for a rule the commit introduced. Recorded in `qa/STATUS.md` as a standing risk; it is the local twin of verifying against the wrong deployed build.

## It already found live defects — NOT fixed here

The sweep fails on `dev` today, on `/funding`. **Filed separately as its own issue** rather than bundled, and this PR does not baseline them away — **I would rather merge a red test that is right than a green one that is quiet.** Say if you would prefer it landed with a ratchet instead; that is your call and I will change it.

## How to test (QA)

```
npx playwright test qa/e2e/text-under-control.spec.ts --workers=1
```

Self-test passes on both projects. Panel test passes on current `dev`. The 32-route sweep fails on `/funding` — that is the live finding, not a broken test.

**Kill port 3100 first if a server is already up**, or you will measure the previous build.

## Risk level — **Low**

No application code. Adds a test file and a docs section. Worst case is a false positive in a suite that is not wired to CI.
