### PR TITLE
feat(arena): show the perps vs spot reading on the Confluence card in every state

### DIFF
--- a/__tests__/perpSpot.test.mts
+++ b/__tests__/perpSpot.test.mts
@@ -10,6 +10,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   computePerpSpot, fmtVol, PERP_LED_AT, SPOT_LED_AT, MIN_BARS,
+  perpNoticeTone,
 } from '../lib/perpSpot.ts';
 
 const HOUR = 3600_000;
@@ -287,4 +288,37 @@ test('#340 THE DEFINITION: the reading is VOLUME, and price cannot reach it', ()
     assert.doesNotMatch(r.explanation, /premium|priced above|price of/i,
       `explanation makes a PRICE claim: ${r.explanation}`);
   }
+});
+
+/* ── the Confluence card's perps line (owner, in session) ────────────────── */
+
+test('every lean produces a line - none falls through to nothing', () => {
+  // Before this, `normal` and `spot` rendered NOTHING on the arena page. The
+  // reading was computed, fed to the score and to the AI, and never shown.
+  // The owner found it by looking for it and not finding it.
+  for (const lean of ['perp', 'spot', 'normal', 'unknown'] as const) {
+    assert.ok(['caution', 'neutral'].includes(perpNoticeTone(lean)),
+      `${lean} must resolve to a tone, not to nothing`);
+  }
+});
+
+test('only perp-led and unmeasurable are dressed as warnings', () => {
+  assert.equal(perpNoticeTone('perp'), 'caution');
+  assert.equal(perpNoticeTone('unknown'), 'caution');
+  // Spot-led is CONFIRMING - real buying rather than leverage. Amber would
+  // invert its meaning.
+  assert.equal(perpNoticeTone('spot'), 'neutral');
+  assert.equal(perpNoticeTone('normal'), 'neutral');
+});
+
+test('CONTROL: the tone does not track the score penalty', () => {
+  // These two answer different questions and must not be wired together.
+  // `unknown` is amber but carries NO penalty - that is the whole point of
+  // the #340 note in ConfluenceScore, and a refactor that "simplifies" one
+  // into the other would silently start docking the score for a failed fetch.
+  assert.equal(perpNoticeTone('unknown'), 'caution');
+  assert.equal(perpScorePenalty('unknown'), 0);
+  assert.equal(perpScorePenalty('spot'), 0);
+  assert.equal(perpScorePenalty('normal'), 0);
+  assert.ok(perpScorePenalty('perp') > 0);
 });

--- a/components/ConfluenceScore.tsx
+++ b/components/ConfluenceScore.tsx
@@ -16,7 +16,7 @@ import { useNews } from './NewsProvider';
 import { computeSectorRotation, isAlt } from '@/lib/sectorRotation';
 import type { PASignal } from '@/lib/priceAction';
 import { usePerpSpot } from '@/lib/usePerpSpot';
-import { perpScorePenalty } from '@/lib/perpSpot';
+import { perpScorePenalty, perpNoticeTone } from '@/lib/perpSpot';
 
 const VERDICT_CONFIG: Record<string, { labelKey: LabelKey; color: string }> = {
   STRONG_BULL:  { labelKey: 'CONFLUENCE_SCORE_VERDICT_STRONG_BULL',  color: 'var(--green-2)' },
@@ -169,13 +169,26 @@ export default function ConfluenceScore(
     perpSpot?.lean === 'perp' ? perpSpot.explanation
     : perpSpot?.lean === 'unknown'
       ? 'Perps vs spot could not be measured for this coin - the score does not account for whether this move is real buying or leverage.'
-      : null;
+      : perpSpot?.explanation ?? null;
+
+  /* Only two of the four readings are a REASON TO SIZE DOWN, and only those two
+   * colour the band amber. `balanced` and `spot` are now shown too (owner, in
+   * session) - previously they fell through to null, so "spot is doing the
+   * buying" - the most confirming thing this measure can say - appeared nowhere
+   * on this page. Showing them in amber would turn a confirmation into a
+   * warning, so they get a neutral row instead.
+   *
+   * NONE of this touches `result.score`: the line is rendered from the same
+   * reading the score already ignores for these leans. `perpScorePenalty` is
+   * unchanged and still fires only for `perp`, which is what
+   * qa/e2e/score-perps-coupling.spec.ts pins. */
+  const perpCaution = !!perpSpot && perpNoticeTone(perpSpot.lean) === 'caution';
   /* `unknown` renders in the same amber band as `caution` on purpose (#298).
      "We could not check for upcoming releases" is a reason to size down, which
      is what amber already means here - and giving it a colour of its own would
      add a fourth state to a card whose whole job is to be read in a second. */
   const macroCol = macro.level === 'danger' ? 'var(--red)'
-    : (macro.level === 'caution' || macro.unknown || perpLine) ? 'var(--amber)' : null;
+    : (macro.level === 'caution' || macro.unknown || perpCaution) ? 'var(--amber)' : null;
 
   return (
     <div className="sms-card">
@@ -200,7 +213,18 @@ export default function ConfluenceScore(
           background: withAlpha(macroCol, '14'), border: `0.5px solid ${withAlpha(macroCol, '44')}`,
         }}>
           {macro.reasons.map((r, i) => <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 5 }}><Warn /> {r}</div>)}
-          {perpLine && <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}><Warn /> {perpLine}</div>}
+          {perpCaution && perpLine && <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}><Warn /> {perpLine}</div>}
+        </div>
+      )}
+
+      {/* balanced / spot-led: shown, but not dressed as a warning. */}
+      {!perpCaution && perpLine && (
+        <div data-testid="confluence-perp-line" style={{
+          margin: '0 14px 10px', fontSize: 'var(--fs-caption)', fontWeight: 600, lineHeight: 1.5,
+          color: 'var(--txt3)', padding: '8px 10px', borderRadius: 8,
+          background: 'var(--bg2)', border: '0.5px solid var(--bdr)',
+        }}>
+          {perpLine}
         </div>
       )}
 

--- a/lib/perpSpot.ts
+++ b/lib/perpSpot.ts
@@ -250,3 +250,20 @@ export function perpConfidenceMultiplier(lean: PerpSpotLean): number {
 export function perpScorePenalty(lean: PerpSpotLean): number {
   return lean === 'perp' ? PERP_LED_SCORE_PENALTY : 0;
 }
+
+/**
+ * How the Confluence card should DRESS the perps line - never whether the score
+ * moves. `perpScorePenalty` above owns that, and only `perp` moves it.
+ *
+ * `caution` is the amber band: `perp` is a reason to size down, and `unknown`
+ * means the check could not run, which is also a reason to size down.
+ *
+ * `neutral` is a plain row: `normal` and `spot` are not warnings. Until this
+ * existed both fell through to null and rendered NOTHING - so "spot is doing
+ * the buying", the most confirming thing this measure can say, appeared nowhere
+ * on the arena page (owner, in session). Showing them in amber instead would
+ * turn a confirmation into a warning, which is the opposite error.
+ */
+export function perpNoticeTone(lean: PerpSpotLean): 'caution' | 'neutral' {
+  return lean === 'perp' || lean === 'unknown' ? 'caution' : 'neutral';
+}


### PR DESCRIPTION
**Dev Team** · Owner's request, found by opening `/arena?coin=btc&tf=15m` and looking for the perps reading.

## Summary

The Confluence Score card showed the perps vs spot reading **only** when it was `perp` or `unknown`. `normal` and `spot` fell through to `null` and rendered nothing.

```
lean       before            after
perp       amber + warning   unchanged
unknown    amber + warning   unchanged
normal     NOTHING           neutral grey row
spot       NOTHING           neutral grey row
```

**`spot` is the one that mattered.** "Spot is doing the buying rather than leverage" is the most confirming thing this measure can say, and it appeared nowhere on the page it exists to inform.

## Why it looked like a bug and was not

BTC read `normal` when the owner looked, so the page was correctly silent — which is precisely why it read as broken. Measured on prod at the time:

```
last CLOSED hour ratio   9.064
median (7d)              7.489
relative to normal       1.21     below the 1.30 perp-led line -> normal
dashboard card           "NORMAL - 1.2x"   agrees
```

**My first measurement said `1.364` and I nearly reported arena as broken.** It included the *forming* hour, which is partial; the app drops it. That is the trap already in `HANDOVER.md` §14 — *one sample is uninterpretable without the variable that explains it* — hit from the opposite direction this time.

## The score does not move

```
perpScorePenalty       unchanged - fires for `perp` only
the factor list        untouched
perpNoticeTone         NEW, and deliberately does not track the penalty
```

A **CONTROL test asserts the two disagree**: `unknown` is amber but carries **zero** penalty. Wiring the tone to the penalty would silently start docking the score for a failed fetch, which is the specific thing the #340 note in `ConfluenceScore.tsx` warns against. `score-perps-coupling.spec.ts` should stay green — **please confirm rather than take my word for it**, since that is your invariant and I changed a file it watches.

## Where the logic lives

`perpNoticeTone` is in `lib/perpSpot.ts`, not inline in the component — the same reason `needsLiveSearch` moved in #386. **A decision that only exists inside a `.tsx` cannot be tested, and this is the second time this week that the untested inline branch was the wrong one.** Three tests cover it, including that every lean resolves to a tone rather than to nothing, which is the defect stated as a property.

## How to test (QA)

On **qa**, signed in as Pro.

1. Open `/dashboard` and read the **Perps vs Spot** card for BTC — note whether it says NORMAL, FUTURES LEADING, or SPOT LEADING.
2. Open `/arena?coin=btc`. **The Confluence Score card must carry the same sentence.**
3. **When the dashboard says NORMAL or SPOT**, the arena row is plain grey — no amber, no warning triangle.
4. **When it says FUTURES LEADING**, the row is amber with the triangle, and a `Leverage-led` factor appears in the factor list. Unchanged from before.
5. **The score and the factor list must be identical to what they are on `qa` today** for a coin reading NORMAL. This is the one that would catch me getting it wrong.
6. Try a coin with no Binance spot pair if one is handy — `unknown` should still be amber and still say the check could not run.

## Risk level — **Medium**

Not Low: it touches a file `score-perps-coupling.spec.ts` watches, and **the render is unverified by me**.

**What I could not check:** local is signed out, so the Confluence card is behind the Pro paywall and I never saw the new row draw. Gates all pass — lint 0 errors, `tsc` clean, **405 tests**, build succeeds — and the decision is unit-tested, but **the rendering is inferred**. Third PR running where the thing I cannot see is the thing most worth seeing.

Also unaddressed here: the reading still does not appear on `/arena` for the **AI prompts** path in any visible form, and `#392` (the dashboard card's padding) is a separate cosmetic issue on the same feature.
