### PR TITLE
fix(dashboard): give the rail card its own padding instead of asking children to

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -737,7 +737,11 @@ body::after {
 
 /* Macro Context rail wrapper - GlobalMacroContext has its own inner padding,
    this just gives it the flat-card frame the other rail items carry. */
-.macro-rail-card { background: var(--bg1); border: 0.5px solid var(--bdr); border-radius: 10px; }
+/* The rail card owns its inset (#392). It drew a border and a background but
+   no padding, so every child had to remember to add its own - and the one
+   that did not sat flush against the border. A container that paints an edge
+   owns the gap to that edge; the alternative is this bug once per new card. */
+.macro-rail-card { background: var(--bg1); border: 0.5px solid var(--bdr); border-radius: 10px; padding: 12px 14px; }
 
 /* ── COLLAPSE TOGGLE - shared style for breakdown/show-more buttons ── */
 

--- a/components/GlobalMacroContext.tsx
+++ b/components/GlobalMacroContext.tsx
@@ -117,7 +117,7 @@ export default function GlobalMacroContext() {
   const sm = SIGNAL_META[signalKey] ?? SIGNAL_META.NEUTRAL;
 
   return (
-    <div style={{ padding: '12px 14px' }}>
+    <div>
       <div style={{ fontSize: 'var(--fs-micro)', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--txt3)', marginBottom: 4 }}>
         <Tip width={320} text={t('GLOBAL_MACRO_CONTEXT_TOOLTIP')}>
           {t('GLOBAL_MACRO_CONTEXT_TITLE')}


### PR DESCRIPTION
**Dev Team** · Closes #392. **I took the wrapper option, not the one-liner — here is the read you asked for.**

## Your question

> whether `.macro-rail-card` should own the padding instead ... I flagged that its sign-in/error/retry branches carry their own and I cannot see from outside whether moving it breaks them.

**They do not break, and the reason is that they are not what they look like from outside.** Those branches are nested **inside** `GlobalMacroContext`'s outer wrapper, not alternative top-level returns:

```
GlobalMacroContext.tsx:119   return (
                      :120     <div>                      <- the ONLY outer element
                      :136       <div padding: 4px 0 >     <- loading, INSIDE it
                      :149       <div padding: 8px 0 >     <- sign-in prompt, INSIDE it
                      :152       <div padding: 8px 0 >     <- error + retry, INSIDE it
```

Every one uses **vertical-only** padding. They compose with a container inset instead of competing with it, which is what makes moving the horizontal padding safe.

## Why the container rather than the child

`.macro-rail-card` painted a border, a background and a radius — **and no padding**. So every child had to remember its own inset. One did, one did not, and the one that did not sat flush against the border.

**A container that paints an edge owns the gap to that edge.** Adding `padding` to `PerpSpotCard` fixes this card; putting it on the container means the next rail card cannot have this bug at all. Two users today, and the rail is obviously going to grow.

## Measured after the change

```
.macro-rail-card computed padding      12px 14px
Perps vs Spot   text inset from border 15px left
Global Macro    text inset from border 15px left      <- same, so nothing doubled
PerpSpotCard's own computed padding    0px
```

Both cards now share one inset from one place. Screenshot in the thread.

## How to test (QA)

On **qa**, `/dashboard`, right-hand rail.

1. **"PERPS VS SPOT" and "GLOBAL MACRO CONTEXT" both sit clear of their card borders, by the same amount.** The bug was the first one touching it.
2. **Sign out and reload.** The macro card's sign-in prompt must still be inset — this is the branch you flagged, and the one I would check first if I were you.
3. **Force the macro card's error state** if you have a way to. Retry button inset, not flush.
4. **Mobile.** The rail stacks under the main column; both cards should keep the same inset.

## Risk level — **Low**

Gates: lint 0 errors, `tsc` clean, **402 tests**, build succeeds. Verified in a browser — and unusually for this week, **I could actually see this one**: the rail renders signed out, so the measurements above are from the rendered page rather than inferred.

**Not verified:** the macro card's error/retry branch. I could not make it fail locally without stubbing the fetch, and step 3 above is that check. Its padding is vertical-only so I expect it to be fine, but expecting is not measuring.
