### PR TITLE
fix(chat): match search triggers on word boundaries, not substrings

### DIFF
--- a/__tests__/searchTriggers.test.mts
+++ b/__tests__/searchTriggers.test.mts
@@ -66,24 +66,42 @@ test('a plain market question does NOT escalate', () => {
 
 /* ── 2. the collisions - substring, not word boundary ───────────────────── */
 
-test('COLLISION: ordinary chart questions cost a live search', () => {
-  // MEASURED, not guessed - my first draft of this test asserted `wait`
-  // contains `war`, which it does not, and the test caught me. Every pair
-  // below was run before being written down.
-  //
-  // Documented, not endorsed. Each costs a SEARCH from a message that has
-  // nothing to do with live web data. Pinned so a future edit to
-  // SEARCH_TRIGGERS cannot widen the set unnoticed.
-  const collisions: Array<[string, string]> = [
+test('FIXED (#387): a trigger inside an unrelated word no longer escalates', () => {
+  // These all cost a live search until word boundaries landed. This test
+  // asserted `true` for one commit - it was the record of the defect, and
+  // flipping it is the record of the fix.
+  const wasCollision: Array<[string, string]> = [
     ['is the trend upward',            'war inside "upward" - a pure chart question'],
     ['is this a warning sign',         'war inside "warning"'],
     ['what does forward guidance mean', 'war inside "forward"'],
     ['what is a secondary market',     'sec inside "secondary"'],
     ['show me the seconds chart',      'sec inside "seconds"'],
   ];
-  for (const [q, why] of collisions) {
-    assert.equal(needsLiveSearch(q), true, `${JSON.stringify(q)} escalates: ${why}`);
+  for (const [q, why] of wasCollision) {
+    assert.equal(needsLiveSearch(q), false, `${JSON.stringify(q)} must NOT escalate (was: ${why})`);
   }
+});
+
+test('the words themselves still escalate - the fix must not gut the feature', () => {
+  // The failure mode opposite to #387: boundaries so tight that nothing
+  // matches and every question quietly becomes cheap-and-wrong.
+  for (const q of [
+    'any news on the war',
+    'what did the SEC say',
+    'is the Fed cutting',
+    'why is BTC down',
+    'what happened today',
+  ]) {
+    assert.equal(needsLiveSearch(q), true, `${JSON.stringify(q)} must still escalate`);
+  }
+});
+
+test('plurals and possessives still match - \\b alone would drop them', () => {
+  // `\betf\b` does NOT match "ETFs": `s` is a word character, so there is no
+  // boundary after `etf`. The trailing `s?` in the pattern is what covers it.
+  assert.equal(needsLiveSearch('anything on ETFs?'), true, 'plural');
+  assert.equal(needsLiveSearch("what is the CPI's effect"), true, "possessive - the apostrophe is already a boundary");
+  assert.equal(needsLiveSearch('are there sanctions'), true, 'sanction + s');
 });
 
 test('the shortest triggers are the ones that collide', () => {

--- a/lib/searchTriggers.ts
+++ b/lib/searchTriggers.ts
@@ -34,18 +34,43 @@ export const SEARCH_TRIGGERS = [
   'stablecoin', 'usdt', 'usdc',
 ];
 
+const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/* WORD BOUNDARIES, not substrings (#387).
+ *
+ * This matched with `includes` until 2026-08-13, so `is the trend upward` spent
+ * a live search because `upward` contains `war`. Every collision found came
+ * from a three-letter entry: why fed cpi ppi nfp gdp war boj yen etf sec okx.
+ *
+ * The owner's decision on #385 - that auto-escalation stays because those
+ * questions genuinely need live data - is about MEANING. `upward` has no
+ * meaning relationship to war, so this fixes the mechanism rather than
+ * reopening the ruling.
+ *
+ * The trailing `s?` is load-bearing and the boundary alone is not enough:
+ *
+ *     \betf\b     does NOT match "ETFs"   - `s` is a word char, no boundary
+ *     \betfs?\b   matches "ETF" and "ETFs"
+ *     \bcpi\b     ALREADY matches "CPI's" - the apostrophe is a boundary
+ *
+ * Built once at module load, not per call - this runs on every keystroke now
+ * that the chat panel prices the message in the box (#386).
+ */
+const TRIGGER_RE = new RegExp(
+  `\\b(?:${SEARCH_TRIGGERS.map(escapeRe).join('|')})s?\\b`,
+  'i',
+);
+
 /**
  * True when this message will be sent as a live search, spending
  * `chat_search_count` rather than `chat_count`.
  *
- * Substring match, NOT word-boundary - so `sec` matches inside `second` and
- * `war` inside `warning`. That is the shipped behaviour and this function does
- * not change it; `__tests__/searchTriggers.test.mts` pins the collisions that
- * exist so a future edit to the list cannot widen them unnoticed.
+ * Matches whole words only. `__tests__/searchTriggers.test.mts` pins both
+ * directions - the questions that must still escalate, and the ones that must
+ * not - so a future edit to the list cannot quietly widen either.
  */
 export function needsLiveSearch(text: string): boolean {
-  const t = text.toLowerCase();
-  return SEARCH_TRIGGERS.some(k => t.includes(k));
+  return TRIGGER_RE.test(text);
 }
 
 /* Plurals are stored, not derived. The first version of this appended "s" to


### PR DESCRIPTION
**Dev Team** · Closes #387. **Took word boundaries, your lean, and measured both directions before and after.**

## The measurement

27 realistic chat messages, old `includes` against new boundary matching:

```
escalated before   20
escalated after     9
changed            11   every one SEARCH -> chat
wrong direction     0   nothing that needed live data became cheap
```

The sweep also turned up a collision nobody had reported:

```
"is the market rewarding longs"    war inside re-WAR-ding
```

Which is the argument for boundaries over curating the list: **we keep finding these one at a time, and each one was already shipping.**

## The detail that would have broken the naive fix

You flagged `CPI's` as the risk in the curation-vs-boundaries trade-off. It turns out possessives were never the problem — **the apostrophe is already a word boundary**, so `\bcpi\b` matches `CPI's` unchanged. **Plurals are the problem:**

```
\betf\b     does NOT match "ETFs"    `s` is a word char - no boundary
\betfs?\b   matches "ETF" and "ETFs"
```

A boundary-only fix would have silently stopped escalating `anything on ETFs`, which is exactly the kind of question the feature exists for. **That is the failure mode opposite to #387 and it has its own test** — `the words themselves still escalate - the fix must not gut the feature`.

## What the tests now pin

```
FIXED (#387)              the five collisions must NOT escalate
still escalates           war / SEC / Fed / why / what happened - must escalate
plurals + possessives     ETFs, CPI's, sanctions
the 12 short triggers     list pinned, unchanged
```

**The collision test asserted `true` for exactly one commit.** It was the record of the defect; flipping it to `false` is the record of the fix. That is the shape you described when you said the test I added is what would show it.

## How to test (QA)

On **qa**, signed in, LiquidityAI open.

1. **`is the trend upward`, Fast selected** — the counter stays on **messages** and **no** "uses a live search" line appears. This is the whole issue.
2. **`any news on the war`** — still switches to searches, still shows the line. The feature must not be gutted.
3. **`anything on ETFs`** — must still escalate. This is the plural case; a boundary-only fix breaks it.
4. **`is the market rewarding longs`** — must not escalate. New find, was broken before.
5. **`why is BTC down today`** — unchanged, still escalates. The original #382 case.

## Risk level — **Low**

Gates: lint 0 errors, `tsc` clean, **404 tests**, build succeeds.

**Behaviour change on spend, in the user's favour only.** Nothing that escalated for a real reason stopped; 11 things that escalated for a string coincidence did.

**Not verified by me:** the rendered counter, again — signed out locally. The matching itself is unit-tested in both directions, which is the part that decides the spend, but **steps 1-5 above are all reads of a rendered number I cannot see.**

**One thing I deliberately did not do:** curate or shorten the 12 short triggers. Boundaries make the length harmless, and shortening the list would change which questions get live data — a meaning decision, and the owner's, not mine.
