### PR TITLE
feat(arena): drop the second sentence from the futures-led explanation

### DIFF
--- a/__tests__/grokPerpSpot.test.mts
+++ b/__tests__/grokPerpSpot.test.mts
@@ -57,7 +57,7 @@ test('the prompt carries reading.explanation VERBATIM - not a paraphrase', () =>
 
   assert.ok(prompt.includes(r.explanation),
     'the prompt must contain the card sentence character-for-character');
-  assert.match(r.explanation, /leveraged traders/, 'sanity: this fixture is the perp-led wording');
+  assert.match(r.explanation, /usual share against spot/, 'sanity: this fixture is the perp-led wording');
 });
 
 test('every prompt builder carries it, not just the long one', () => {

--- a/__tests__/perpSpot.test.mts
+++ b/__tests__/perpSpot.test.mts
@@ -55,7 +55,10 @@ test('a genuine spike above the coin\'s own normal reads as futures-driven', () 
   const r = computePerpSpot(spot, perp, HOUR, nowMs);
   assert.equal(r.lean, 'perp');
   assert.ok(r.relative! > PERP_LED_AT);
-  assert.match(r.explanation, /leveraged traders/);
+  assert.match(r.explanation, /usual share against spot/);
+  // The owner removed the second sentence on #397. Asserted as an absence so
+  // it cannot drift back in via a copy edit nobody reviews.
+  assert.doesNotMatch(r.explanation, /leveraged traders|unwinds faster/);
 });
 
 test('unusually quiet futures reads as spot-led', () => {

--- a/lib/perpSpot.ts
+++ b/lib/perpSpot.ts
@@ -164,7 +164,7 @@ export function computePerpSpot(
      the explanation explicitly, which means it is the part they will read. */
   const explanation =
     lean === 'perp'
-      ? `Futures trading is ${times} its usual share against spot. The move is being driven by leveraged traders more than by people buying the coin itself, which unwinds faster if it turns.`
+      ? `Futures trading is ${times} its usual share against spot.`
       : lean === 'spot'
         ? `Futures trading is unusually quiet at ${times} its usual share. More of this move is people actually buying the coin, which tends to hold better.`
         : `Futures and spot are trading in their usual proportions for this coin. Nothing unusual about who is driving the move.`;


### PR DESCRIPTION
**Dev Team** · Closes #397.

```diff
- Futures trading is 1.4x its usual share against spot. The move is being driven by
- leveraged traders more than by people buying the coin itself, which unwinds faster
- if it turns.
+ Futures trading is 1.4x its usual share against spot.
```

## Both surfaces, per your recommendation

`lib/perpSpot.ts:167` is the only definition and it feeds `/arena` and `/dashboard`. **Agreed with your read and did not build a per-surface variant** — #393 finished making arena show this reading in every state earlier today, and splitting the copy would undo that the same day. The owner's reason is about the sentence, not the page.

**Only the `perp` branch.** `spot`, `normal` and `unknown` untouched.

## Two anchors you could not see from outside

Your issue named `score-perps-coupling.spec.ts`. There were **two more**, both mine:

```
__tests__/perpSpot.test.mts:58        assert.match(r.explanation, /leveraged traders/)
__tests__/grokPerpSpot.test.mts:60    same phrase, as a fixture sanity check
```

Both re-anchored onto `usual share against spot`. **`perpSpot.test.mts` now also asserts the removed sentence is ABSENT**, so it cannot drift back through a copy edit nobody reviews — the deletion is pinned, not just performed.

## What I deliberately did NOT remove

`lib/grok.ts:401` and `:428` carry the same idea:

```
11b. ... Positive basis with elevated activity = the move is leverage-led and unwinds faster.
  - Futures-led ...: subtract 20 from confidence. The move is driven by leverage rather
    than by people buying the coin, so it unwinds faster.
```

**Those are instructions to the model, not text a user reads.** Removing them would change how Grok weighs a futures-led move — a behaviour change, not a copy change, and not what was asked for. **Flagging it because someone will grep "unwinds faster" later and think the removal was incomplete.** If the owner wants the AI to stop reasoning that way too, that is a separate and much bigger decision.

## Your spec will go red, as you predicted

`score-perps-coupling.spec.ts:234` anchors on `if it turns`. **I have not touched it** — your file, and you asked to re-anchor it yourself so the "sentence was not found in either load" guard gets a real chance to fire. **Say when you want it and I will hold off promoting** — otherwise this lands on `qa` and your next run is the test of your own guard.

## How to test (QA)

1. **`/arena`, coin reading FUTURES LEADING** — the amber row is one sentence, ending `...against spot.`
2. **`/dashboard`, Perps vs Spot card** — same sentence, same truncation. This is the surface the owner did *not* mention and it changes too.
3. **A SPOT LEADING coin** — still gets the full two-sentence wording. Untouched.
4. **A NORMAL coin** — still the "usual proportions" sentence, in the neutral row from #393.

## Risk level — **Low**

Gates: lint 0 errors, `tsc` clean, **407 tests**, build succeeds.

**Not verified:** the rendered string, again — signed out locally, and the arena Confluence card is behind the Pro paywall. The unit tests cover what `computePerpSpot` returns; **nobody has seen the shortened sentence on screen.**
