### PR TITLE
fix(dashboard): give the coin rail's sparkline its own column

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -17,6 +17,12 @@ import Tip from '@/components/Tip';
 import { coinBadgeColor } from '@/lib/coinBadge';
 import { withAlpha } from '@/lib/color';
 import Sparkline24h from '@/components/Sparkline24h';
+
+/* The sparkline's width, shared with .csb2-bottom's middle grid column via the
+   --csb2-spark-w custom property below. The CSS used to hardcode nothing at all
+   and the prop said 36 - the column and the chart had no way to disagree
+   loudly, so they disagreed quietly (#401). One number, two consumers. */
+const SPARK_W = 36;
 import CoinIcon from '@/components/CoinIcon';
 import { GlobalSpotlight, useMobile } from '@/components/MagicBento';
 import { SkeletonBar } from '@/components/Skeleton';
@@ -190,11 +196,11 @@ function CoinSidebar() {
               </span>
             </div>
 
-            <div className="csb2-bottom">
+            <div className="csb2-bottom" style={{ '--csb2-spark-w': `${SPARK_W}px` } as React.CSSProperties}>
               <span className={`csb2-chg ${up ? 'chg-up' : 'chg-dn'}`}>
                 {up ? '▲' : '▼'} {Math.abs(chg).toFixed(2)}%
               </span>
-              <Sparkline24h coin={id} width={36} height={14} />
+              <Sparkline24h coin={id} width={SPARK_W} height={14} />
               {sig && (
                 <span className="csb2-sig" style={{ color: sig.col }}>
                   {sig.text}

--- a/app/globals.css
+++ b/app/globals.css
@@ -411,7 +411,18 @@ body::after {
 .csb2-top .csb2-price { margin-left: auto; }
 .csb2-name      { font-family: var(--font-mono), monospace; font-size: var(--fs-caption); font-weight: 700; color: var(--txt); letter-spacing: 0.02em; }
 .csb2-price     { font-size: var(--fs-data); font-weight: 700; color: var(--txt); font-family: var(--font-mono), monospace; font-variant-numeric: tabular-nums; }
-.csb2-bottom    { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
+/* GRID, not space-between (#401). `space-between` distributes leftover space
+   BETWEEN children, so with a fixed-width change badge on the left and a
+   variable-width signal on the right, the middle child absorbed every
+   difference - the sparkline drifted 9.5px and landed on a different x for
+   every distinct signal string. A middle item under space-between has no
+   column of its own by construction.
+   The middle column reads --csb2-spark-w, set inline from SPARK_W in
+   app/dashboard/page.tsx, so the column and the chart cannot drift apart.
+   The last column is 1fr and .csb2-sig keeps its own ellipsis, so a long
+   signal truncates instead of pushing anything. It also fixes the rows where
+   `sig` is absent entirely, which used to shove the sparkline to the right. */
+.csb2-bottom    { display: grid; grid-template-columns: auto var(--csb2-spark-w, 36px) 1fr; align-items: center; gap: 8px; margin-bottom: 8px; }
 .csb2-chg       { font-size: var(--fs-data); font-weight: 700; font-variant-numeric: tabular-nums; }
 /* 0.04 -> 0.02. This chip is the one surface in the app where the muted text
    tokens land short: 4% white over --bg3 computes to #191b1e, and on that


### PR DESCRIPTION
**Dev Team** · Closes #401. Took your grid, with one addition.

## The 36px coupling you flagged

> Those two numbers must agree, and right now the CSS does not know about the prop at all.

Made them **one** number rather than two documented ones:

```
app/dashboard/page.tsx   const SPARK_W = 36;
                         <Sparkline24h width={SPARK_W} />
                         style={{ '--csb2-spark-w': `${SPARK_W}px` }}
app/globals.css          grid-template-columns: auto var(--csb2-spark-w, 36px) 1fr;
```

The fallback `36px` is only for a card rendered without the inline property; the live value always comes from the prop's own constant. **A comment would have relied on someone reading it — this cannot drift.**

## A third case your measurement did not cover

`{sig && (...)}` — **the signal is conditional.** On a row with no signal, `space-between` had two children instead of three and shoved the sparkline to the *right edge*, not just a few px off. Grid fixes that for free, since the column exists whether or not it is filled.

## How to test (QA)

1. `/dashboard`, desktop — straight edge down the sparkline column; every row starts at the same x.
2. Long signals (`Tight consolidation`) and short ones align identically.
3. A very long signal ellipsises rather than pushing the chart.
4. **A coin with no signal at all** — its sparkline must sit in the same column, not at the right edge. This is the case above.
5. **1280x800 and 1440x900.**

## Risk level — **Low**

One CSS rule plus a shared constant. Gates: lint 0 errors, `tsc` clean, **407 tests**, build succeeds.

**Not verified: the rendered result.** My browser has been returning `viewport: 0x0` for local pages all session, so I have not seen the column line up — **every step above is unrun by me.** The mechanism is unambiguous from the CSS, but that is reasoning, not looking, and the gap between those two is where today's `searchs` typo lived.

Your #399 measurement at 1280x800 (578 of 1113px hidden, `gapBelow` 181px at **both** widths) is on that issue — the fixed 181px across two viewport heights is good evidence the constant over-reserves by a constant, and I have replied there.