### PR TITLE
test(qa): record that the mobile contrast skip was measured, not assumed

### DIFF
--- a/qa/e2e/contrast.spec.ts
+++ b/qa/e2e/contrast.spec.ts
@@ -259,7 +259,32 @@ test.describe('colour contrast', () => {
    */
 
   test.beforeEach(({ }, testInfo) => {
-    test.skip(testInfo.project.name === 'mobile', 'same tokens as desktop; mobile doubles runtime for no extra signal');
+    /* MOBILE IS SKIPPED, AND THE REASON IS NOW MEASURED RATHER THAN ASSUMED.
+     *
+     * This said "same tokens as desktop; mobile doubles runtime for no extra
+     * signal" from the day it was written, and nobody had checked it. The
+     * premise is not obviously true: `.mobile-tab-bar` and `.mobile-tab-item`
+     * render ONLY below 900px, and light theme gives the bar its own override
+     *
+     *     .mobile-tab-item                       color: var(--txt3)
+     *     [data-theme="light"] .mobile-tab-bar   background: #ffffff
+     *
+     * - a pairing that exists at no other viewport or theme, so a desktop-only
+     * sweep could never have seen it.
+     *
+     * MEASURED 2026-08-14 (#403), by removing this skip and running the full
+     * sweep at 390px in both themes: **3 passed**. Mobile produces no more
+     * failing colours than the desktop-derived baseline, mobile-only chrome
+     * included. The skip is justified.
+     *
+     * Cost of confirming it: 9.5 minutes, against 5.8 for desktop. That is the
+     * runtime this skip buys back on every run, which is why it stays - but it
+     * stays as a measured trade rather than an assumption.
+     *
+     * RE-MEASURE IF mobile-only components gain their own colours, rather than
+     * inheriting tokens. That is the condition under which this stops holding,
+     * and it is not something the suite can notice on its own. */
+    test.skip(testInfo.project.name === 'mobile', 'same tokens as desktop - measured 2026-08-14, see comment');
   });
 
   /**


### PR DESCRIPTION
**QA Team** → **Dev Team** · A negative result, recorded rather than discarded.

## What this changes

Nothing about behaviour. `contrast.spec.ts` still skips mobile. **What changes is that the skip now carries the measurement that justifies it**, plus the condition under which it stops holding.

## Why it needed checking

The skip said *"same tokens as desktop; mobile doubles runtime for no extra signal"* from the day it was written, and nobody had tested that. **It is not obviously true:**

```
.mobile-tab-item                       color: var(--txt3)
[data-theme="light"] .mobile-tab-bar   background: #ffffff
```

`.mobile-tab-bar` and `.mobile-tab-item` render **only below 900px**, and light theme gives the bar its own override. **That pairing exists at no other viewport or theme** — so a desktop-only sweep could never have seen it, in either theme.

## Measured

Removed the skip, ran the full 32-route sweep at 390px in both themes:

```
desktop  dark + light + control   3 passed   5.8m
mobile   dark + light + control   3 passed   9.5m
```

**Mobile produces no more failing colours than the desktop-derived baseline, mobile-only chrome included.** The premise holds. The skip stays — 9.5 minutes against 5.8 is a real cost — but as a measured trade rather than an assumption.

## The part worth keeping

The comment names **when to re-measure**: if mobile-only components gain their own colours rather than inheriting tokens. That is the condition under which this stops being true, and **it is not something the suite can notice on its own.**

## Relevant to the redesign

The new design will almost certainly restyle the mobile chrome. **This is exactly the assumption that will quietly stop holding**, so having the condition written down is worth more than the result.

**Risk: Low.** Comment and skip-reason only. No assertion changes.