### PR TITLE
feat(auth): give paid entitlement a time-based backstop

### DIFF
--- a/__tests__/paidBackstop.test.mts
+++ b/__tests__/paidBackstop.test.mts
@@ -1,0 +1,67 @@
+/* #373 - the time-based backstop on a PAID entitlement.
+ *
+ * Trial expiry was already time-enforced; paid expiry was event-enforced, so a
+ * missed `subscription_expired` webhook granted Pro forever. These pin both
+ * directions, and the "must NOT demote" cases matter more than the demoting
+ * one: wrongly demoting someone who has paid is the expensive failure.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { paidPeriodLapsed, PAID_GRACE_MS } from '../lib/paidPeriod.ts';
+
+const NOW = Date.UTC(2026, 7, 13, 12, 0, 0);
+const iso = (msFromNow: number) => new Date(NOW + msFromNow).toISOString();
+const DAY = 86_400_000;
+
+/* ── 1. what the issue asked for ─────────────────────────────────────────── */
+
+test('a paid period long past demotes to free', () => {
+  assert.equal(paidPeriodLapsed('pro', iso(-30 * DAY), NOW), true);
+});
+
+test('the grace window is respected on both sides of its edge', () => {
+  // Just inside grace - still Pro. A renewal webhook is allowed to be late.
+  assert.equal(paidPeriodLapsed('pro', iso(-PAID_GRACE_MS + 60_000), NOW), false);
+  // Just outside - demoted.
+  assert.equal(paidPeriodLapsed('pro', iso(-PAID_GRACE_MS - 60_000), NOW), true);
+});
+
+/* ── 2. every way it must NOT demote ─────────────────────────────────────── */
+
+test('NULL period never demotes - this is the one that would break production', () => {
+  // Measured before the code was written: the only `pro` row on the dev project
+  // has current_period_end NULL. Treating null as expired would have locked out
+  // QA's pinned Pro fixture and every admin-granted or legacy Pro account.
+  assert.equal(paidPeriodLapsed('pro', null, NOW), false);
+  assert.equal(paidPeriodLapsed('pro', undefined, NOW), false);
+  assert.equal(paidPeriodLapsed('pro', '', NOW), false);
+});
+
+test('an unparseable timestamp never demotes', () => {
+  // NaN comparisons are false regardless, but a future refactor could invert
+  // the condition and turn "we cannot read this date" into "revoke access".
+  assert.equal(paidPeriodLapsed('pro', 'not-a-date', NOW), false);
+});
+
+test('a period in the future never demotes', () => {
+  assert.equal(paidPeriodLapsed('pro', iso(30 * DAY), NOW), false);
+});
+
+test('a free account is never touched by this check', () => {
+  // It has nothing to demote FROM, and a stale period on a free row must not
+  // become an input to anything.
+  assert.equal(paidPeriodLapsed('free', iso(-365 * DAY), NOW), false);
+});
+
+/* ── 3. control ──────────────────────────────────────────────────────────── */
+
+test('CONTROL: the function can return both values', () => {
+  // Without this, every assertion above passes against `() => false`, which is
+  // exactly the shape of a backstop that silently does nothing.
+  const results = new Set([
+    paidPeriodLapsed('pro', iso(-30 * DAY), NOW),
+    paidPeriodLapsed('pro', iso(30 * DAY), NOW),
+  ]);
+  assert.equal(results.size, 2, 'the backstop never demotes - it is not a backstop');
+  assert.ok(PAID_GRACE_MS > 0, 'sanity: the grace window is a real duration');
+});

--- a/lib/entitlements.ts
+++ b/lib/entitlements.ts
@@ -5,6 +5,11 @@
 import { createClient } from '@supabase/supabase-js';
 import { T } from '@/lib/tables';
 import type { UsageTier } from '@/lib/limits';
+import { paidPeriodLapsed } from '@/lib/paidPeriod';
+
+/* Re-exported so call sites keep one import. The logic lives in lib/paidPeriod
+   because this file cannot be unit-tested - see the note at the top of it. */
+export { paidPeriodLapsed, PAID_GRACE_MS } from '@/lib/paidPeriod';
 
 export type Role = 'free' | 'pro';
 
@@ -47,14 +52,19 @@ export interface Entitlement {
   proFeatures: boolean;
 }
 
-// Single source of truth for "does this token get Pro features". Reads role +
-// trial_ends_at in one RLS-scoped query (a token can only read its own row).
+// Single source of truth for "does this token get Pro features". Reads role,
+// trial_ends_at and current_period_end in one RLS-scoped query (a token can
+// only ever read its own row).
 export async function getEntitlement(token: string, userId: string): Promise<Entitlement> {
   const { data } = await sb(token).from(T.user_subscriptions)
-    .select('role, trial_ends_at')
+    .select('role, trial_ends_at, current_period_end')
     .eq('user_id', userId)
     .maybeSingle();
-  const role: Role = data?.role === 'pro' ? 'pro' : 'free';
+  const stored: Role = data?.role === 'pro' ? 'pro' : 'free';
+  // The backstop runs BEFORE trialActive is computed, so a lapsed paid account
+  // falls back to whatever its trial window says rather than straight to free.
+  const lapsed = paidPeriodLapsed(stored, data?.current_period_end as string | null);
+  const role: Role = lapsed ? 'free' : stored;
   const trialEnds = data?.trial_ends_at ? new Date(data.trial_ends_at as string).getTime() : 0;
   const trialActive = role !== 'pro' && trialEnds > Date.now();
   return { role, trialActive, proFeatures: role === 'pro' || trialActive };

--- a/lib/paidPeriod.ts
+++ b/lib/paidPeriod.ts
@@ -1,0 +1,55 @@
+/* The time-based backstop on a PAID entitlement (#373).
+ *
+ * Lives in its own module rather than inside lib/entitlements.ts because that
+ * file imports `@supabase/supabase-js` and the `@/lib` path alias, neither of
+ * which the unit-test runner can resolve - so anything defined there is
+ * untestable without a bundler. Third time this week that the logic which
+ * decides something important could not be tested where it sat
+ * (see lib/searchTriggers.ts, lib/perpSpot.ts#perpNoticeTone).
+ *
+ * Pure, dependency-free, and the only thing standing between a missed webhook
+ * and an account that keeps Pro forever.
+ */
+
+export type PaidRole = 'free' | 'pro';
+
+/* How long a paid period may be lapsed before the backstop demotes.
+ *
+ * NOT a policy about giving away access - it is slack for a LATE RENEWAL. On
+ * renewal LemonSqueezy sends a payment event and `current_period_end` moves
+ * forward; if that event is retried or delayed, a zero-grace check would flip a
+ * paying customer to free mid-subscription. Wrongly demoting someone who has
+ * paid is far worse than 48 extra hours for someone who has not.
+ *
+ * The number is mine, not the owner's, and #311 established that a threshold we
+ * invent is one nobody can verify - so it is named, exported and tested rather
+ * than inlined, and flagged on #373 for them to set. */
+export const PAID_GRACE_MS = 48 * 60 * 60 * 1000;
+
+/**
+ * True when a paid period has lapsed far enough to stop granting Pro.
+ *
+ * FAILS TOWARDS ACCESS ON PURPOSE. It demotes only when there is a real, past
+ * timestamp to demote against:
+ *
+ *   null / absent   NO demotion - lifetime grants, admin-set Pro and every row
+ *                   written before this column existed have no period. Measured
+ *                   before writing this: the only `pro` row on the dev project
+ *                   has current_period_end NULL, so treating null as expired
+ *                   would have locked out QA's pinned Pro fixture and broken
+ *                   entitlements.spec.ts.
+ *   unparseable     NO demotion - NaN comparisons are false anyway; the explicit
+ *                   isFinite check says so rather than relying on it.
+ *   in the future   NO demotion.
+ *   past + grace    demote.
+ */
+export function paidPeriodLapsed(
+  role: PaidRole,
+  currentPeriodEnd: string | null | undefined,
+  nowMs: number = Date.now(),
+): boolean {
+  if (role !== 'pro' || !currentPeriodEnd) return false;
+  const end = new Date(currentPeriodEnd).getTime();
+  if (!Number.isFinite(end)) return false;
+  return end + PAID_GRACE_MS < nowMs;
+}


### PR DESCRIPTION
**Dev Team** · Closes #373. Not UI — logic, unaffected by the redesign.

## What it does

`getEntitlement` now reads `current_period_end` and demotes a lapsed `pro`. Your suggested guard, with one addition you did not ask for and I think you will want.

```
trial expiry    time-enforced      unchanged
paid expiry     EVENT-enforced  ->  event-enforced, WITH A FLOOR
```

## The measurement that shaped it

Before writing anything I read the dev project:

```sql
select count(*), count(*) filter (where role='pro'),
       count(*) filter (where role='pro' and current_period_end is null)
from lhq_dev_user_subscriptions;

rows 8    pro 1    pro_with_null_period 1
```

**The only `pro` row has `current_period_end` NULL.** So a literal reading of *"if `current_period_end` is in the past, treat as free"* is safe — but a small slip in either direction is not:

- **null treated as expired** → locks out **your pinned Pro fixture**, breaks `entitlements.spec.ts`, and in production revokes every admin-granted and legacy Pro account.

It now demotes only against a real, past timestamp. `null`, `undefined`, `''`, an unparseable date and a future date all keep Pro, each with its own test.

## The addition: PAID_GRACE_MS, 48h — and it is my number

You suggested a bare "in the past". I added grace, because **zero grace makes the dangerous direction reachable through normal operation**: on renewal, LemonSqueezy sends a payment event and `current_period_end` moves forward. If that event is retried or delayed, a zero-grace check flips a **paying customer** to free mid-subscription.

**Wrongly demoting someone who has paid is far worse than 48 extra hours for someone who has not** — and the whole point of the issue is that unbounded access was the risk, which 48h still bounds.

**This is exactly the #311 situation and I am flagging it rather than burying it.** A threshold we invent is one nobody can verify. It is named, exported and tested rather than inlined, so **the owner can set it with a one-line change** — and it should be their number, not mine.

## Where the logic lives

`lib/paidPeriod.ts`, not `lib/entitlements.ts`. That file imports the `@/lib` alias, which the unit-test runner cannot resolve — **my first version of this test failed for that reason alone** and passed under `tsx`, which is how I found it.

**Third time this week** the code deciding something important could not be tested where it sat: `needsLiveSearch` in a `.tsx`, `perpNoticeTone` inline in a component, now this behind a path alias.

## How to test (QA)

**This cannot be exercised without a paid account, so most of it is unit-tested rather than observed.**

1. **`entitlements.spec.ts` must still pass.** Account A is `pro` with a NULL period — **that spec passing IS the regression check** for the dangerous direction. If it fails, this PR revoked a Pro account.
2. Account B (`free`) unaffected.
3. **What nobody can test:** an actually-lapsed paid period. No user has ever paid, so there is no row to expire and I did not create one — writing to the shared database is an owner carve-out.

## Risk level — **Medium**

Not Low: it can revoke access. Gates: lint 0 errors, `tsc` clean, **414 tests**, build succeeds.

**The failure mode I care about is a false demote**, so every no-demote path has its own test and the CONTROL asserts the function can return both values — a backstop that silently never fires would pass every other assertion in the file.
