### PR TITLE
fix(chat): price the string being sent, not the one in the box

### DIFF
--- a/components/GrokChat.tsx
+++ b/components/GrokChat.tsx
@@ -316,6 +316,14 @@ export default function GrokChat() {
 
   const [fabVisible,    setFabVisible]    = useState(true);
 
+  /* The string the badge should PRICE, when it is not the one in the box (#382).
+   *
+   * Three call sites send text the user never typed - the `grok-chat` window
+   * event (EMASignal, arena, the news feed), follow-up chips and suggested
+   * chips. The badge priced `input`, which is empty on all three, so it showed
+   * the CHAT pool while the request billed the SEARCH pool. A user clicking a
+   * chip we wrote, reading "40 messages left", spent one of ten searches. */
+  const [pendingText,  setPendingText]  = useState<string | null>(null);
   const modeRefs       = useRef<(HTMLButtonElement | null)[]>([]);
   const bottomRef      = useRef<HTMLDivElement>(null);
   const inputRef       = useRef<HTMLTextAreaElement>(null);
@@ -433,6 +441,9 @@ export default function GrokChat() {
       return;
     }
 
+    // Price what is actually being sent, before anything can clear the box.
+    setPendingText(text);
+
     const activeCoin = coinOverride ?? coin;
     const ts = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 
@@ -544,6 +555,7 @@ export default function GrokChat() {
       setError(e instanceof Error ? e.message : 'Unknown error');
     } finally {
       setLoading(false);
+      setPendingText(null);
     }
   }, [msgs, coin, liveActive, store, latestHeadlines, geoEvents, user, usage, setUsage]);
 
@@ -600,7 +612,10 @@ export default function GrokChat() {
    * still misreport the cost of exactly the messages that prompted #382 -
    * "why is BTC down today" spends a search from Fast. `needsLiveSearch` is a
    * pure local substring match, so this is free and needs no network. */
-  const willSearch      = liveActive || needsLiveSearch(input);
+  /* `pendingText` wins while a send is in flight - it is the string the route
+     will bill. Falls back to the box, which is correct for typed messages. */
+  const pricedText      = pendingText ?? input;
+  const willSearch      = liveActive || needsLiveSearch(pricedText);
   const activeRemaining = willSearch ? searchRemaining : chatRemaining;
   const counterText     = activeRemaining === null
     ? null


### PR DESCRIPTION
**Dev Team** · Refs #382. **Your call was right and the scope you drew is exactly what I built.**

## The change

```diff
- const willSearch = liveActive || needsLiveSearch(input);
+ const pricedText = pendingText ?? input;
+ const willSearch = liveActive || needsLiveSearch(pricedText);
```

`sendMsg` sets `pendingText` to the string it is about to bill, as its first act on a real message, and clears it in the same `finally` that clears `loading`.

**No visual change.** Same component, same markup, same copy, same position — it is fed a different string. That is why it survives the freeze, and it is the whole diff.

## Honest about what this does and does not achieve

**It makes the badge truthful at the moment of billing.** It does **not** warn before the click, because a chip sends instantly — there is no interval in which a user could read a warning and reconsider.

**You already ruled that out and I agree with the reasoning**: reprice-on-hover is a new interaction, it is genuinely UI, and it does nothing for `app/news/page.tsx:63` where nothing is hovered. So the achievable fix is that the number on screen stops contradicting the pool being charged — which is what the issue title actually says.

**If the owner wants "tell me before I spend a search", that is a different feature** and it belongs to the redesign, where chips could carry their own cost marker. Recorded rather than built.

## How to test (QA)

Signed in, LiquidityAI open, **box empty**.

1. **Badge reads `N messages left`.**
2. **Click a follow-up chip containing a trigger** — `today`, `why`, `news`, `what happened`. While in flight the badge must read **searches**, and the *"This question uses a live search"* line must appear.
3. **After it resolves**, the search count must have decremented, not the chat count.
4. **A chip with no trigger** — badge stays on messages, chat count decrements.
5. **Typed messages behave exactly as before.** This is the regression check: `pendingText` is null when idle, so `pricedText` falls back to the box.
6. **The `grok-chat` deep link** — from the news feed (`page.tsx:63`) or a coin signal. Same as 2, with nothing typed and nothing hovered.

## Risk level — **Low**

One derived value plus one piece of state, cleared in an existing `finally`. Gates: lint 0 errors, `tsc` clean, **414 tests**, build succeeds.

**Not verified: any of the six steps.** They need a signed-in account and I am signed out locally; the chat panel is behind auth. The wrong-input diagnosis is a code fact, but **whether the badge visibly flips during a chip send is unrun**, and step 3 — that the right counter decrements — is the one I would most want a human eye on.

**Answering your other question: no, not done for the day.** This is the last thing I had; the board is otherwise clear and everything of mine is merged or in your hands.
