### PR TITLE
docs(handover): record the instrument-failure pattern and four more lessons

### DIFF
--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -629,6 +629,40 @@ Context for the move off the desktop GUI.
 - **Docs go stale in specific, repeated ways.** Several past audits were sent down detours by
   confidently-worded but outdated notes. `docs/INFRASTRUCTURE.md`'s own header says it best:
   a stale version of a file is worse than no file, because it actively misleads.
+- **A BROKEN INSTRUMENT RETURNS A CLEAN RESULT, NOT AN ERROR. This is the most expensive
+  pattern in the project and it recurred five times on 2026-08-13 alone.** Every instance
+  produced a confident answer from a tool that was not looking at the right thing:
+
+  | instrument | reported | actually |
+  |---|---|---|
+  | `grep /_next/static/css/` | "feature absent from the deploy" | wrong path - CSS is under `/chunks/` |
+  | rule matcher on `style.color` | "no rules match this element" | `style.color` is `''` for any `var()` value |
+  | `elementFromPoint` probe | geometry that contradicted itself | measured off-screen and clipped rects |
+  | a 7s wait on a free-plan host | "the rail is not in the DOM" | it renders later than that |
+  | Playwright `reuseExistingServer` | 3 consecutive PASSes | served a build from before the checkout |
+
+  **The defence is a positive control: break the thing on purpose and confirm the instrument
+  goes red.** A detector that has never failed has never been tested. Assert the precondition
+  before trusting a zero - "found nothing" and "looked in the wrong place" are the same output.
+- **`/api/version` does not protect you locally** — it reports `commit: "unknown"` on a dev
+  server. The local equivalent of quoting it is to **grep the SERVED asset for a string the
+  commit introduced**. A branch name proves nothing about what a browser received.
+- **Fixing the reported instance and leaving the class is the default failure, even when you
+  know the rule.** #404 took three passes - grid card, then the hero sixty lines above it,
+  then two more renderers sharing the same grid. The tell is closing a ticket rather than
+  looking for a class: search for the BEHAVIOUR (`grep` the destructive call), not the
+  component you were sent to.
+- **Logic that decides something important must live where it can be unit-tested.** Three
+  times in one week the deciding branch sat somewhere untestable: `needsLiveSearch` inside a
+  `.tsx`, `perpNoticeTone` inline in a component, `paidPeriodLapsed` behind the `@/lib` alias
+  the test runner cannot resolve. Each moved to `lib/` and each move immediately found a bug
+  the code review had not. **If it cannot be tested where it is, that is the finding.**
+- **NEWS CANNOT BE TESTED OUTSIDE PRODUCTION.** `lhq_dev_news` is fed by a cron that only
+  ever targeted prod, so it is permanently stale (67 rows, newest 2026-08-03 as of
+  2026-08-13). **localhost, `liquidity-hq-dev`, `qa` and `staging` all render zero news
+  cards** - qa and staging share the dev database. Missing local API keys are *not* the
+  cause and deploying to dev does not help. Any change to `/news` reaches production
+  unverified; say so in the PR rather than letting the reader assume it was checked.
 
 ---
 


### PR DESCRIPTION
**Dev Team** · Docs only. Picking up the owner's earlier request that the dev docs carry onboarding and knowledge transfer — **timely now that a redesign is about to bring fresh sessions into this repo.**

## The main entry: a broken instrument returns a clean result, not an error

Five in one day, all of them mine except the last:

| instrument | reported | actually |
|---|---|---|
| `grep /_next/static/css/` | "feature absent from the deploy" | wrong path — CSS is under `/chunks/` |
| rule matcher on `style.color` | "no rules match this element" | `style.color` is `''` for any `var()` value |
| `elementFromPoint` probe | geometry that contradicted itself | measured clipped and off-screen rects |
| a 7s wait on a free-plan host | "the rail is not in the DOM" | it renders later than that |
| `reuseExistingServer` | 3 consecutive PASSes | served a build from before the checkout |

**Written as a table because the shape is the lesson**: *"found nothing"* and *"looked in the wrong place"* are the same output. More care does not fix it — a positive control does.

**Your habit is what caught the ones that were caught**, and it is now written down as the defence rather than as a preference: assert the precondition before trusting a zero, and break the thing on purpose to confirm the detector goes red.

## Four more

```
/api/version locally      reports commit "unknown" - grep the SERVED asset instead
fix instance, leave class the default failure even when you know the rule (#404, 3 passes)
untestable logic          3 times in one week the deciding branch sat where the runner
                          could not reach it; every move found a bug review had missed
news outside prod         CANNOT be verified - measured, not inferred
```

**The news one is the entry I most wanted recorded.** `lhq_dev_news` holds 67 rows, newest `2026-08-03`, because the ingest cron only ever targeted prod — so localhost, `liquidity-hq-dev`, `qa` and `staging` all render zero cards, and **missing local API keys are not the cause.** The owner and I both spent time on that theory today. Whoever next tries to verify a `/news` change would have spent it again.

## How to test (QA)

Docs only, no code paths touched. **Read it as onboarding**: if any entry would not have saved you today, say so and I will cut it — the failure mode for this file is length, not accuracy, and §14 is now 23 entries.

## Risk level — **Low**

No application code. Gates run clean; nothing to exercise.

**One thing I would like your eye on:** I wrote the `reuseExistingServer` row from your #390 write-up rather than from my own run. If I have understated it — you described it as the one that would have fooled you completely — reword it. **It is your finding and the only one in that table I did not reproduce myself.**
