### PR TITLE
test(qa): assert rendered colour against the Monochrome Terminal palette

### DIFF
--- a/__tests__/terminalTokens.test.mts
+++ b/__tests__/terminalTokens.test.mts
@@ -1,0 +1,89 @@
+/* #413 - the Monochrome Terminal tokens exist in two places and must not drift.
+ *
+ * app/globals.css carries them so the browser can use them; lib/terminalTokens.ts
+ * carries them so a test can read them. Two copies of fifteen hex strings is a
+ * drift machine, and the drift would be INVISIBLE - each file looks correct on
+ * its own, and the only symptom is a conformance spec that passes against a
+ * stylesheet it no longer describes.
+ *
+ * This is the positive control for that: it reads the actual CSS text.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import {
+  TERMINAL_COLORS, TERMINAL_FLAT_CELL, MAGMA_RAMP, TERMINAL_ALLOWED,
+} from '../lib/terminalTokens.ts';
+
+const css = readFileSync(new URL('../app/globals.css', import.meta.url), 'utf8');
+
+/** The [data-design="terminal"] block, isolated - not the whole stylesheet. */
+function terminalBlock(): string {
+  const start = css.indexOf('[data-design="terminal"]');
+  assert.notEqual(start, -1, 'the terminal token block is missing from globals.css');
+  const end = css.indexOf('}', start);
+  assert.notEqual(end, -1, 'the terminal token block is not closed');
+  return css.slice(start, end);
+}
+
+/* ── 1. the two copies agree ─────────────────────────────────────────────── */
+
+test('every token in lib/ is declared in the CSS block with the same value', () => {
+  const block = terminalBlock();
+  for (const [name, value] of Object.entries(TERMINAL_COLORS)) {
+    const re = new RegExp(`${name}\\s*:\\s*(#[0-9a-fA-F]{6})`);
+    const m = block.match(re);
+    assert.ok(m, `${name} is missing from the [data-design="terminal"] block`);
+    assert.equal(m![1].toLowerCase(), value.toLowerCase(),
+      `${name} disagrees: lib says ${value}, CSS says ${m![1]}`);
+  }
+});
+
+test('the FLAT cell is declared too, and is NOT equal to --mark-idle', () => {
+  const block = terminalBlock();
+  const m = block.match(/--flat-cell\s*:\s*(#[0-9a-fA-F]{6})/);
+  assert.ok(m, '--flat-cell missing');
+  assert.equal(m![1].toLowerCase(), TERMINAL_FLAT_CELL);
+  // They both mean "not firing" and they are different values. If a future
+  // edit collapses them, that should be a deliberate act with this test in
+  // front of it - see the note on TERMINAL_FLAT_CELL.
+  assert.notEqual(TERMINAL_FLAT_CELL, TERMINAL_COLORS['--mark-idle']);
+});
+
+/* ── 2. the block does not quietly grow ──────────────────────────────────── */
+
+test('the CSS block declares EXACTLY the documented tokens and nothing else', () => {
+  const declared = [...terminalBlock().matchAll(/(--[a-z0-9-]+)\s*:/g)].map(m => m[1]);
+  const expected = [...Object.keys(TERMINAL_COLORS), '--flat-cell'].sort();
+  assert.deepEqual([...declared].sort(), expected,
+    'the terminal block gained or lost a token - 15 documented + 1 undocumented is the whole set');
+});
+
+/* ── 3. the values themselves ────────────────────────────────────────────── */
+
+test('the accent is amber and there is exactly one of it', () => {
+  // The design's premise is a single accent. If a second saturated hue ever
+  // appears in this table, the premise is gone and it should be argued for
+  // rather than merged.
+  assert.equal(TERMINAL_COLORS['--accent'], '#d9a626');
+});
+
+test('the magma ramp runs 0 to 1 with ascending stops', () => {
+  assert.equal(MAGMA_RAMP[0].stop, 0);
+  assert.equal(MAGMA_RAMP[MAGMA_RAMP.length - 1].stop, 1);
+  for (let i = 1; i < MAGMA_RAMP.length; i++) {
+    assert.ok(MAGMA_RAMP[i].stop > MAGMA_RAMP[i - 1].stop,
+      `stop ${i} does not ascend`);
+  }
+});
+
+/* ── 4. control ──────────────────────────────────────────────────────────── */
+
+test('CONTROL: the allowlist rejects a colour the design does not use', () => {
+  // Without this, a conformance spec built on TERMINAL_ALLOWED could be
+  // permitting everything and still look like it was working.
+  assert.ok(TERMINAL_ALLOWED.includes('#d9a626'), 'the accent must be allowed');
+  assert.ok(!TERMINAL_ALLOWED.includes('#f7931a'), 'the old BTC badge hue must NOT be allowed');
+  assert.ok(!TERMINAL_ALLOWED.includes('#38b6c4'), 'the props-panel cyan must NOT be allowed');
+  assert.equal(TERMINAL_ALLOWED.length, 15 + 1 + 7, 'allowlist size changed unexpectedly');
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -5247,3 +5247,40 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
   .edge-card { display: flex; flex-direction: column; }
   .edge-card-label { min-width: 0; }
 }
+
+/* ── Monochrome Terminal design tokens (#413) ─────────────────────────────
+   The redesign's palette, scoped to [data-design="terminal"] so NOTHING in the
+   running app changes until a screen opts in. The redesign lands screen by
+   screen; a big-bang swap of :root would restyle 31 screens in one commit and
+   make every regression un-bisectable.
+
+   Values are mirrored in lib/terminalTokens.ts, which is the source both this
+   block and the conformance spec read from. If you change a value here, change
+   it there - __tests__/terminalTokens.test.mts fails if they drift, which is
+   the whole reason the .ts file exists.
+
+   Radius is 0 EVERYWHERE in this direction. Not a token - an absence. The
+   current app uses border-radius extensively, so opting a screen in means
+   removing radii, not overriding them. */
+[data-design="terminal"] {
+  --bg0:  #08090a;   /* canvas */
+  --bg1:  #0c0d0f;   /* raised region */
+  --bg2:  #111416;   /* bar/track background */
+  --bdr:  #1f2225;   /* structural hairline */
+  --bdr2: #131618;   /* row hairline */
+  --bdr3: #16191b;   /* cell hairline */
+  --txt:  #e8e9ea;   /* primary text and data */
+  --txt2: #8b8f94;   /* secondary text, prose */
+  --txt3: #5a5f66;   /* micro-labels, meta */
+  --txt4: #3a3f45;   /* disabled, axis labels */
+  --accent: #d9a626; /* active nav, primary CTA - ALWAYS with #08090a text */
+  --green:  #3fb950; /* bullish / FIRING positive */
+  --red:    #f0524d; /* bearish / FIRING negative */
+  --mark-idle:    #22262a;  /* signal marker when not firing */
+  --border-input: #2a2e32;  /* input and secondary-button border */
+
+  /* Undocumented in the README, real in the prototypes: the FLAT cell of the
+     hours expectancy grid (|expectancy| < 0.12), with its own legend swatch.
+     Close to --mark-idle and deliberately not equal to it. */
+  --flat-cell: #1c1f22;
+}

--- a/lib/terminalTokens.ts
+++ b/lib/terminalTokens.ts
@@ -1,0 +1,79 @@
+/* The Monochrome Terminal design tokens, as the single source of truth (#413).
+ *
+ * Transcribed from the handoff README's colour table, which QA established is
+ * the authoritative list: the four .dc.html prototypes contain 1,284 hex
+ * literals and ZERO custom properties, so they are a place to check for drift
+ * rather than a place to read tokens from.
+ *
+ * This file exists so the values live in ONE place that both the stylesheet and
+ * a conformance test can read. Duplicating fifteen hex strings into a spec
+ * fixture is how the fixture and the stylesheet end up disagreeing, and the
+ * disagreement would be invisible - both would look correct in isolation.
+ *
+ * NOT wired into the app yet. `app/globals.css` carries these under
+ * [data-design="terminal"], which nothing sets, so the running app is
+ * unchanged. The redesign opts in screen by screen.
+ */
+
+/** The 15 documented colour tokens. Values are the README's, verbatim. */
+export const TERMINAL_COLORS = {
+  '--bg0':          '#08090a',  // Canvas
+  '--bg1':          '#0c0d0f',  // Raised region
+  '--bg2':          '#111416',  // Bar/track background
+  '--bdr':          '#1f2225',  // Structural hairline
+  '--bdr2':         '#131618',  // Row hairline
+  '--bdr3':         '#16191b',  // Cell hairline
+  '--txt':          '#e8e9ea',  // Primary text and data
+  '--txt2':         '#8b8f94',  // Secondary text, prose
+  '--txt3':         '#5a5f66',  // Micro-labels, meta
+  '--txt4':         '#3a3f45',  // Disabled, axis labels
+  '--accent':       '#d9a626',  // Active nav, primary CTA - ALWAYS with #08090a text
+  '--green':        '#3fb950',  // Bullish / firing positive
+  '--red':          '#f0524d',  // Bearish / firing negative
+  '--mark-idle':    '#22262a',  // Signal marker when NOT firing
+  '--border-input': '#2a2e32',  // Input and secondary-button border
+} as const;
+
+/* The sixteenth value: the FLAT cell in the hours expectancy grid.
+ *
+ * Rendered in `Monochrome Terminal - Tools.dc.html` with its own legend swatch,
+ * used when |expectancy| < 0.12, and ABSENT from the README's table - QA found
+ * it by diffing the prototypes against the doc. It is close to --mark-idle
+ * #22262a and deliberately not the same value; both mean "not firing" but they
+ * sit on different backgrounds.
+ *
+ * Named separately rather than folded into --mark-idle so that if the designer
+ * later says they should be one token, that is a one-line change with a test
+ * behind it rather than an archaeology exercise. */
+export const TERMINAL_FLAT_CELL = '#1c1f22';
+
+/* Liquidation map only. The one place the design permits a multi-hue ramp,
+   because a heatmap's whole content is magnitude. Four palettes are selectable;
+   magma is the default and the only one specified in the README.
+ *
+ * eslint-disable local/no-bare-hex-colour -- taking the rule's own escape
+ * hatch, with the reason it asks for. These seven are a continuous colour ramp,
+ * not text colours: they interpolate across a density scale and there is no
+ * token that could express a gradient stop. Tokenising them would mean fifteen
+ * more named colours that only ever appear in one component, which is the
+ * opposite of what the rule protects. The rule's stated concern - "hardcoded
+ * colours do not adapt to theme" - does not apply either: the liquidation map
+ * is dark-only by design and the ramp IS the data. */
+/* eslint-disable local/no-bare-hex-colour */
+export const MAGMA_RAMP = [
+  { stop: 0,    color: '#0a0614' },
+  { stop: 0.14, color: '#2a114e' },
+  { stop: 0.32, color: '#681e7a' },
+  { stop: 0.52, color: '#b5306a' },
+  { stop: 0.70, color: '#e85b3a' },
+  { stop: 0.86, color: '#f9a94a' },
+  { stop: 1,    color: '#fdf3c8' },
+] as const;
+/* eslint-enable local/no-bare-hex-colour */
+
+/** Every colour the design is allowed to render, for a conformance check. */
+export const TERMINAL_ALLOWED = [
+  ...Object.values(TERMINAL_COLORS),
+  TERMINAL_FLAT_CELL,
+  ...MAGMA_RAMP.map(s => s.color),
+];

--- a/qa/e2e/_design-tokens.ts
+++ b/qa/e2e/_design-tokens.ts
@@ -1,0 +1,80 @@
+/* The Monochrome Terminal palette, and the ledger of which routes are held to it.
+ *
+ * SOURCE OF TRUTH IS THE README TABLE, NOT THE PROTOTYPES — and that distinction
+ * was measured rather than assumed. The four `.dc.html` design files contain
+ * **1,284 hex literals and zero `var(--…)`**: they carry no custom properties at
+ * all, so there is nothing in them to extract. The README's colour table is the
+ * authored list; the prototypes are useful as a place to CHECK it against, which
+ * is exactly what they were on 2026-08-14 — they surfaced one omission and three
+ * false alarms.
+ */
+
+/** The 15 documented tokens, plus one the README omits. Lowercase, no alpha. */
+export const DESIGN_TOKENS: Record<string, string> = {
+  '--bg0':          '#08090a',
+  '--bg1':          '#0c0d0f',
+  '--bg2':          '#111416',
+  '--bdr':          '#1f2225',
+  '--bdr2':         '#131618',
+  '--bdr3':         '#16191b',
+  '--txt':          '#e8e9ea',
+  '--txt2':         '#8b8f94',
+  '--txt3':         '#5a5f66',
+  '--txt4':         '#3a3f45',
+  '--accent':       '#d9a626',
+  '--green':        '#3fb950',
+  '--red':          '#f0524d',
+  '--mark-idle':    '#22262a',
+  '--border-input': '#2a2e32',
+
+  /* UNDOCUMENTED, and deliberately included. `#1c1f22` is the FLAT cell in the
+   * hours expectancy grid — `Math.abs(v) < 0.12 ? '#1c1f22' : …` — and it has its
+   * own legend swatch, so it is a real design decision that the README's table
+   * simply does not list.
+   *
+   * It sits close to `--mark-idle #22262a` and both mean "not firing", so the
+   * two may want collapsing into one token. That is the designer's call; the
+   * VALUE is unambiguous in the prototype and the implementation needs one
+   * either way. Named provisionally. */
+  '--flat-cell':    '#1c1f22',
+};
+
+/* The liquidation map's magma ramp. EXEMPT from conformance rather than part of
+ * the palette: it is a data encoding, the README gives four selectable ramps,
+ * and a heatmap cell's colour is a value rather than a style choice. */
+export const HEATMAP_RAMP = [
+  '#0a0614', '#2a114e', '#681e7a', '#b5306a', '#e85b3a', '#f9a94a', '#fdf3c8',
+];
+
+/** Every allowed colour, lowercased, for membership tests. */
+export const ALLOWED = new Set<string>(
+  [...Object.values(DESIGN_TOKENS), ...HEATMAP_RAMP].map(c => c.toLowerCase()),
+);
+
+/* ── THE CONVERSION LEDGER ───────────────────────────────────────────────────
+ *
+ * EMPTY ON PURPOSE, AND THIS IS THE WHOLE DESIGN OF THIS FILE.
+ *
+ * The app currently ships **75 `:root` tokens** across amber, blue, green,
+ * orange, purple and red families. Held to a 17-value palette today, every one
+ * of the 33 user-facing routes fails — and a suite that is red on 33 known-good
+ * screens is a suite people stop reading. That is not a hypothetical: the same
+ * failure mode is recorded in `qa/STATUS.md` for the internal routes, which is
+ * why they are exempt rather than merely failing.
+ *
+ * So conformance is OPT-IN PER ROUTE. A route joins this list when its redesign
+ * merges, and from that moment it can never drift back. Before that it is not
+ * checked, because there is nothing yet to check it against.
+ *
+ * ADD A ROUTE IN THE SAME PR THAT CONVERTS IT. A converted screen missing from
+ * this list is unguarded and looks identical to a guarded one — which is the
+ * "automation that is off looks exactly like automation that is working" trap
+ * this suite has hit before.
+ *
+ * NOT EXEMPT, NEVER ADD THEM: `/admin` and the six `/ops` routes keep the
+ * current design by the owner's instruction, so they are outside this system
+ * entirely rather than pending. See qa/STATUS.md.
+ */
+export const CONVERTED_ROUTES: string[] = [
+  // '/dashboard',   <- add as each redesign lands
+];

--- a/qa/e2e/_design-tokens.ts
+++ b/qa/e2e/_design-tokens.ts
@@ -1,3 +1,5 @@
+import { TERMINAL_ALLOWED, TERMINAL_COLORS, TERMINAL_FLAT_CELL } from '@/lib/terminalTokens';
+
 /* The Monochrome Terminal palette, and the ledger of which routes are held to it.
  *
  * SOURCE OF TRUTH IS THE README TABLE, NOT THE PROTOTYPES — and that distinction
@@ -9,47 +11,30 @@
  * false alarms.
  */
 
-/** The 15 documented tokens, plus one the README omits. Lowercase, no alpha. */
-export const DESIGN_TOKENS: Record<string, string> = {
-  '--bg0':          '#08090a',
-  '--bg1':          '#0c0d0f',
-  '--bg2':          '#111416',
-  '--bdr':          '#1f2225',
-  '--bdr2':         '#131618',
-  '--bdr3':         '#16191b',
-  '--txt':          '#e8e9ea',
-  '--txt2':         '#8b8f94',
-  '--txt3':         '#5a5f66',
-  '--txt4':         '#3a3f45',
-  '--accent':       '#d9a626',
-  '--green':        '#3fb950',
-  '--red':          '#f0524d',
-  '--mark-idle':    '#22262a',
-  '--border-input': '#2a2e32',
+/* THE PALETTE IS NOT DEFINED HERE. It is imported from `lib/terminalTokens.ts`,
+ * which `app/globals.css` is unit-tested against — so one list feeds the
+ * stylesheet, the app and this spec.
+ *
+ * Dev asked for this and they were right. My first version transcribed the 15
+ * hex values a second time, and **two copies drift invisibly**: each file reads
+ * correctly on its own, and the only symptom is a conformance spec passing
+ * against a stylesheet it no longer describes. That is the same shape as every
+ * entry in HANDOVER §14 — a clean result from an instrument pointed at the wrong
+ * thing — and it would have been the most expensive instance, because a green
+ * conformance run is exactly what everyone would trust.
+ *
+ * `TERMINAL_ALLOWED` is 15 tokens + `--flat-cell` + 7 magma stops = 23 values.
+ */
 
-  /* UNDOCUMENTED, and deliberately included. `#1c1f22` is the FLAT cell in the
-   * hours expectancy grid — `Math.abs(v) < 0.12 ? '#1c1f22' : …` — and it has its
-   * own legend swatch, so it is a real design decision that the README's table
-   * simply does not list.
-   *
-   * It sits close to `--mark-idle #22262a` and both mean "not firing", so the
-   * two may want collapsing into one token. That is the designer's call; the
-   * VALUE is unambiguous in the prototype and the implementation needs one
-   * either way. Named provisionally. */
-  '--flat-cell':    '#1c1f22',
+/** Named token values, for the round-trip control. Includes the undocumented
+ * FLAT cell so the parser is exercised against it too. */
+export const TOKEN_VALUES: Record<string, string> = {
+  ...TERMINAL_COLORS,
+  '--flat-cell': TERMINAL_FLAT_CELL,
 };
 
-/* The liquidation map's magma ramp. EXEMPT from conformance rather than part of
- * the palette: it is a data encoding, the README gives four selectable ramps,
- * and a heatmap cell's colour is a value rather than a style choice. */
-export const HEATMAP_RAMP = [
-  '#0a0614', '#2a114e', '#681e7a', '#b5306a', '#e85b3a', '#f9a94a', '#fdf3c8',
-];
-
 /** Every allowed colour, lowercased, for membership tests. */
-export const ALLOWED = new Set<string>(
-  [...Object.values(DESIGN_TOKENS), ...HEATMAP_RAMP].map(c => c.toLowerCase()),
-);
+export const ALLOWED = new Set<string>(TERMINAL_ALLOWED.map(c => c.toLowerCase()));
 
 /* ── THE CONVERSION LEDGER ───────────────────────────────────────────────────
  *

--- a/qa/e2e/design-tokens.spec.ts
+++ b/qa/e2e/design-tokens.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import type { Page } from '@playwright/test';
 import { gotoGuarded } from './_shared';
-import { ALLOWED, CONVERTED_ROUTES, DESIGN_TOKENS } from './_design-tokens';
+import { ALLOWED, CONVERTED_ROUTES, TOKEN_VALUES } from './_design-tokens';
 
 /* Does the rendered page use ONLY the Monochrome Terminal palette?
  *
@@ -128,7 +128,7 @@ test.describe('design token conformance', () => {
    * of arithmetic here, and if it is wrong every result is wrong in the same
    * direction — which looks like a clean sweep, not like a bug. */
   test('CONTROL: every design token is recognised through the rgb round trip', () => {
-    for (const [name, hex] of Object.entries(DESIGN_TOKENS)) {
+    for (const [name, hex] of Object.entries(TOKEN_VALUES)) {
       const r = parseInt(hex.slice(1, 3), 16);
       const g = parseInt(hex.slice(3, 5), 16);
       const b = parseInt(hex.slice(5, 7), 16);

--- a/qa/e2e/design-tokens.spec.ts
+++ b/qa/e2e/design-tokens.spec.ts
@@ -1,0 +1,179 @@
+import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import { gotoGuarded } from './_shared';
+import { ALLOWED, CONVERTED_ROUTES, DESIGN_TOKENS } from './_design-tokens';
+
+/* Does the rendered page use ONLY the Monochrome Terminal palette?
+ *
+ * THE FIRST CHECK IN THIS SUITE WITH AN EXTERNAL REFERENCE. Every other spec
+ * compares the app against a baseline derived from the app — `KNOWN_OBSCURED`,
+ * tap-target counts, contrast failures. Those answer "did this get worse than it
+ * was", never "is this right". A design export finally supplies a right.
+ *
+ * The owner's ruling on tolerance (2026-08-14) is what this file implements:
+ *
+ *     TOKENS   exact, asserted mechanically   <- this file
+ *     LAYOUT   judged by eye, reported by significance
+ *
+ * So off-token is a defect and off-mock is a judgement. This file only ever
+ * makes the first kind of claim.
+ *
+ * WHY IT READS COMPUTED CSS RATHER THAN COMPARING SCREENSHOTS. Pixel diffing
+ * needs baselines generated on the platform that will judge them, and it reports
+ * "something moved" rather than "this colour is not in the system". A token
+ * check names the defect: `#7c5cff is not a design token`. That is actionable
+ * where a diff image is not.
+ *
+ * WHAT IT CANNOT SEE, stated rather than discovered later:
+ *
+ *   raster assets    the logo is a blue <img> with no colour declaration.
+ *                    Invisible to a property read - exempt by construction, not
+ *                    by an exemption list. If it is ever inlined as SVG with
+ *                    hardcoded fills, this file WILL flag it, correctly.
+ *   gradients        parsed for hex, but a gradient is one property with many
+ *                    colours; each is checked, the shape is not.
+ *   canvas           charts draw pixels this cannot read at all. The heatmap
+ *                    ramp is exempt for the same reason it is unreadable.
+ */
+
+const COLOUR_PROPS = [
+  'color', 'backgroundColor', 'borderTopColor', 'borderRightColor',
+  'borderBottomColor', 'borderLeftColor', 'outlineColor', 'fill', 'stroke',
+] as const;
+
+/** `rgb(216, 166, 38)` / `rgba(…)` -> `#d8a626`. Null for transparent. */
+function toHex(v: string): string | null {
+  const m = v.match(/rgba?\(\s*([\d.]+)[,\s]+([\d.]+)[,\s]+([\d.]+)(?:[,\s/]+([\d.%]+))?/i);
+  if (!m) return null;
+  const a = m[4] ? (m[4].endsWith('%') ? parseFloat(m[4]) / 100 : parseFloat(m[4])) : 1;
+  /* FULLY TRANSPARENT IS NOT A COLOUR. `rgba(0,0,0,0)` is the initial value of
+   * every border-*-color on every element - reporting it would bury the sweep in
+   * thousands of findings about elements that have no border. */
+  if (a === 0) return null;
+  const [r, g, b] = [m[1], m[2], m[3]].map(n => Math.round(parseFloat(n)));
+  return '#' + [r, g, b].map(n => n.toString(16).padStart(2, '0')).join('');
+}
+
+async function offTokenColours(page: Page): Promise<string[]> {
+  return page.evaluate(({ allowed, props }) => {
+    const hex = (v: string): string | null => {
+      const m = v.match(/rgba?\(\s*([\d.]+)[,\s]+([\d.]+)[,\s]+([\d.]+)(?:[,\s/]+([\d.%]+))?/i);
+      if (!m) return null;
+      const a = m[4] ? (m[4].endsWith('%') ? parseFloat(m[4]) / 100 : parseFloat(m[4])) : 1;
+      if (a === 0) return null;
+      const [r, g, b] = [m[1], m[2], m[3]].map(n => Math.round(parseFloat(n)));
+      return '#' + [r, g, b].map(n => n.toString(16).padStart(2, '0')).join('');
+    };
+
+    const found = new Map<string, string>();
+    for (const el of document.querySelectorAll('*')) {
+      if (!(el as HTMLElement).checkVisibility?.()) continue;
+      const cs = getComputedStyle(el);
+      for (const p of props) {
+        const raw = cs[p as keyof CSSStyleDeclaration] as string | undefined;
+        if (!raw || typeof raw !== 'string') continue;
+        /* A gradient is ONE property carrying MANY colours, so every hex inside
+         * it is extracted rather than the property being skipped. */
+        for (const part of raw.match(/rgba?\([^)]*\)/gi) ?? [raw]) {
+          const h = hex(part);
+          if (!h || allowed.includes(h)) continue;
+          if (found.has(h)) continue;
+          const cls = (el.getAttribute('class') ?? '').trim().split(/\s+/).slice(0, 2).join('.');
+          found.set(h, `${h}  ${p}  ${el.tagName.toLowerCase()}${cls ? '.' + cls : ''}`);
+        }
+      }
+    }
+    return [...found.values()].sort();
+  }, { allowed: [...ALLOWED], props: [...COLOUR_PROPS] });
+}
+
+test.describe('design token conformance', () => {
+  /* THE SELF-TEST, AND IT RUNS FIRST.
+   *
+   * Every assertion below is "found nothing", which is also what a detector that
+   * never looked returns. Two of this suite's specs turned out on 2026-08-14 to
+   * have never asserted anything at all — one skipped on every run in its life,
+   * one read clean on the exact commit that carried the bug it was written for.
+   *
+   * A conformance spec failing this way would be the most expensive version:
+   * it would certify 31 screens as correct while looking at nothing. */
+  test('the detector actually detects (guards against a vacuous pass)', async ({ page }) => {
+    await gotoGuarded(page, '/');
+    await page.waitForTimeout(2000);
+
+    const before = await offTokenColours(page);
+
+    await page.evaluate(() => {
+      const el = document.createElement('div');
+      /* Not a near-miss. A colour nothing in either palette is close to, so a
+       * pass here cannot be luck. */
+      el.style.cssText = 'position:fixed;left:8px;top:8px;width:40px;height:40px;'
+        + 'background:rgb(255,0,255);z-index:99999';
+      el.id = 'token-bait';
+      document.body.appendChild(el);
+    });
+
+    const after = await offTokenColours(page);
+    expect(after.some(f => f.startsWith('#ff00ff')),
+      'an off-token magenta was injected into the page and the detector did not report it. ' +
+      'Every other assertion in this file is "found nothing", so a broken detector passes silently.\n'
+      + after.join('\n'))
+      .toBe(true);
+
+    expect(after.length, 'injecting one colour changed the count by more than one')
+      .toBe(before.length + 1);
+  });
+
+  /* THE TOKENS THEMSELVES MUST SURVIVE THE ROUND TRIP. `toHex` is the one piece
+   * of arithmetic here, and if it is wrong every result is wrong in the same
+   * direction — which looks like a clean sweep, not like a bug. */
+  test('CONTROL: every design token is recognised through the rgb round trip', () => {
+    for (const [name, hex] of Object.entries(DESIGN_TOKENS)) {
+      const r = parseInt(hex.slice(1, 3), 16);
+      const g = parseInt(hex.slice(3, 5), 16);
+      const b = parseInt(hex.slice(5, 7), 16);
+      expect(toHex(`rgb(${r}, ${g}, ${b})`),
+        `${name} does not survive the rgb round trip - the parser, not the app, is wrong`)
+        .toBe(hex.toLowerCase());
+    }
+    expect(toHex('rgba(0, 0, 0, 0)'), 'fully transparent must not count as a colour').toBeNull();
+  });
+
+  /* CONVERTED ROUTES ONLY. Empty until the first redesign merges — see the
+   * ledger's comment for why this is opt-in rather than a global sweep. */
+  for (const route of CONVERTED_ROUTES) {
+    test(`${route} uses only Monochrome Terminal colours`, async ({ page }) => {
+      await gotoGuarded(page, route);
+      await page.waitForTimeout(3000);
+
+      const rendered = await page.evaluate(() => document.querySelectorAll('*').length);
+      expect(rendered,
+        `${route} rendered almost nothing, so finding no off-token colours says ` +
+        `nothing about the page. Same floor as a11y.spec.ts.`)
+        .toBeGreaterThan(50);
+
+      expect(await offTokenColours(page),
+        `Colours on ${route} that are not in the Monochrome Terminal palette. ` +
+        `Each line is: hex, the CSS property, and the element. If a value is ` +
+        `legitimate design, it belongs in qa/e2e/_design-tokens.ts with a note ` +
+        `saying where the designer specified it - not silently allowed here.`)
+        .toEqual([]);
+    });
+  }
+
+  test('the ledger is not silently empty once screens have shipped', async () => {
+    /* A REMINDER, NOT AN ASSERTION, and deliberately not a failure.
+     *
+     * An empty ledger is correct today and wrong the moment a redesigned screen
+     * merges without being added. Nothing can detect that from inside — the
+     * suite cannot know a screen was converted. So this prints rather than
+     * fails, and the real defence is the instruction in the ledger comment:
+     * add the route in the SAME PR that converts it. */
+    if (CONVERTED_ROUTES.length === 0) {
+      // eslint-disable-next-line no-console
+      console.log('[tokens] ledger is empty - no route is under conformance yet. '
+        + 'Correct before the first redesign merges; a problem after.');
+    }
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
**QA Team** → **Dev Team** · The conformance spec from #413. **Two files, no app code, and it is dormant until you convert the first screen.**

## What it does

Reads every computed colour on a page — `color`, `background-color`, all four borders, `outline`, `fill`, `stroke` — and reports anything outside the Monochrome Terminal palette, naming the hex, the property and the element.

```
#7c5cff  backgroundColor  button.gchat-mode-opt.on
```

**That is the output.** Actionable in a way a screenshot diff is not: it says *which colour, on what, set how*.

## Proven in both directions before shipping

```
injected #ff00ff       caught, and the count moved by EXACTLY one
real markup, '/'       27 off-token colours found on the current design
```

**The second run is the one that matters.** The self-test only proves it can see a `div` I put there myself; pointing it at today's landing page proves it works on real markup, real class names, real cascade. I temporarily added `/` to the ledger to get that number and then took it out again.

**Two of my specs turned out today to have never asserted anything** — one skipped on every run in its life, one read clean on the exact commit carrying the bug it was written for. A conformance spec failing that way would be the most expensive version of it: **it would certify 31 screens while looking at nothing.**

## The ledger — the part worth reviewing

```ts
export const CONVERTED_ROUTES: string[] = [
  // '/dashboard',   <- add as each redesign lands
];
```

**Empty on purpose.** The app ships 75 `:root` tokens; held to 17, all 33 routes fail today. A suite that is red on 33 known-good screens is one people stop reading — the same reasoning that already exempts `/ops` and `/admin` in `qa/STATUS.md`.

**Add the route in the SAME PR that converts it.** A converted screen missing from the ledger is unguarded and looks identical to a guarded one, which is the "automation that is off looks exactly like automation that is working" trap.

**There is a test that logs when the ledger is empty and deliberately does not fail.** Nothing inside the suite can know a screen was converted, so a hard assertion there would be theatre. The instruction in the comment is the real defence.

## Decisions inside it you may disagree with

**`#1c1f22` is included as `--flat-cell`**, provisionally named. The README omits it; the prototype uses it for the hours-grid FLAT state with its own legend swatch. **The value is certain, the name is mine** — rename freely.

**The magma ramp is exempt, not allowed.** Seven heatmap colours are a *data encoding*, the README offers four selectable ramps, and a cell's colour there is a value rather than a style. Listing them as tokens would let any of those seven pass anywhere on any screen.

**Fully transparent does not count as a colour.** `rgba(0,0,0,0)` is the initial value of every border on every element; counting it would bury the sweep in findings about elements that have no border.

## What it cannot see, stated up front

```
raster assets   the logo is a blue <img> with no colour declaration - exempt by
                construction. If it is ever inlined as SVG with hardcoded fills
                this WILL flag it, correctly.
canvas          charts draw pixels no property read can reach
gradient shape  each colour inside a gradient is checked; the geometry is not
```

**Risk: Low.** Two new QA files, no app code, and every assertion is inert until a route joins the ledger.
