### PR TITLE
feat(design): add the Monochrome Terminal tokens, scoped and inert

### DIFF
--- a/__tests__/terminalTokens.test.mts
+++ b/__tests__/terminalTokens.test.mts
@@ -1,0 +1,89 @@
+/* #413 - the Monochrome Terminal tokens exist in two places and must not drift.
+ *
+ * app/globals.css carries them so the browser can use them; lib/terminalTokens.ts
+ * carries them so a test can read them. Two copies of fifteen hex strings is a
+ * drift machine, and the drift would be INVISIBLE - each file looks correct on
+ * its own, and the only symptom is a conformance spec that passes against a
+ * stylesheet it no longer describes.
+ *
+ * This is the positive control for that: it reads the actual CSS text.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import {
+  TERMINAL_COLORS, TERMINAL_FLAT_CELL, MAGMA_RAMP, TERMINAL_ALLOWED,
+} from '../lib/terminalTokens.ts';
+
+const css = readFileSync(new URL('../app/globals.css', import.meta.url), 'utf8');
+
+/** The [data-design="terminal"] block, isolated - not the whole stylesheet. */
+function terminalBlock(): string {
+  const start = css.indexOf('[data-design="terminal"]');
+  assert.notEqual(start, -1, 'the terminal token block is missing from globals.css');
+  const end = css.indexOf('}', start);
+  assert.notEqual(end, -1, 'the terminal token block is not closed');
+  return css.slice(start, end);
+}
+
+/* ── 1. the two copies agree ─────────────────────────────────────────────── */
+
+test('every token in lib/ is declared in the CSS block with the same value', () => {
+  const block = terminalBlock();
+  for (const [name, value] of Object.entries(TERMINAL_COLORS)) {
+    const re = new RegExp(`${name}\\s*:\\s*(#[0-9a-fA-F]{6})`);
+    const m = block.match(re);
+    assert.ok(m, `${name} is missing from the [data-design="terminal"] block`);
+    assert.equal(m![1].toLowerCase(), value.toLowerCase(),
+      `${name} disagrees: lib says ${value}, CSS says ${m![1]}`);
+  }
+});
+
+test('the FLAT cell is declared too, and is NOT equal to --mark-idle', () => {
+  const block = terminalBlock();
+  const m = block.match(/--flat-cell\s*:\s*(#[0-9a-fA-F]{6})/);
+  assert.ok(m, '--flat-cell missing');
+  assert.equal(m![1].toLowerCase(), TERMINAL_FLAT_CELL);
+  // They both mean "not firing" and they are different values. If a future
+  // edit collapses them, that should be a deliberate act with this test in
+  // front of it - see the note on TERMINAL_FLAT_CELL.
+  assert.notEqual(TERMINAL_FLAT_CELL, TERMINAL_COLORS['--mark-idle']);
+});
+
+/* ── 2. the block does not quietly grow ──────────────────────────────────── */
+
+test('the CSS block declares EXACTLY the documented tokens and nothing else', () => {
+  const declared = [...terminalBlock().matchAll(/(--[a-z0-9-]+)\s*:/g)].map(m => m[1]);
+  const expected = [...Object.keys(TERMINAL_COLORS), '--flat-cell'].sort();
+  assert.deepEqual([...declared].sort(), expected,
+    'the terminal block gained or lost a token - 15 documented + 1 undocumented is the whole set');
+});
+
+/* ── 3. the values themselves ────────────────────────────────────────────── */
+
+test('the accent is amber and there is exactly one of it', () => {
+  // The design's premise is a single accent. If a second saturated hue ever
+  // appears in this table, the premise is gone and it should be argued for
+  // rather than merged.
+  assert.equal(TERMINAL_COLORS['--accent'], '#d9a626');
+});
+
+test('the magma ramp runs 0 to 1 with ascending stops', () => {
+  assert.equal(MAGMA_RAMP[0].stop, 0);
+  assert.equal(MAGMA_RAMP[MAGMA_RAMP.length - 1].stop, 1);
+  for (let i = 1; i < MAGMA_RAMP.length; i++) {
+    assert.ok(MAGMA_RAMP[i].stop > MAGMA_RAMP[i - 1].stop,
+      `stop ${i} does not ascend`);
+  }
+});
+
+/* ── 4. control ──────────────────────────────────────────────────────────── */
+
+test('CONTROL: the allowlist rejects a colour the design does not use', () => {
+  // Without this, a conformance spec built on TERMINAL_ALLOWED could be
+  // permitting everything and still look like it was working.
+  assert.ok(TERMINAL_ALLOWED.includes('#d9a626'), 'the accent must be allowed');
+  assert.ok(!TERMINAL_ALLOWED.includes('#f7931a'), 'the old BTC badge hue must NOT be allowed');
+  assert.ok(!TERMINAL_ALLOWED.includes('#38b6c4'), 'the props-panel cyan must NOT be allowed');
+  assert.equal(TERMINAL_ALLOWED.length, 15 + 1 + 7, 'allowlist size changed unexpectedly');
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -5247,3 +5247,40 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
   .edge-card { display: flex; flex-direction: column; }
   .edge-card-label { min-width: 0; }
 }
+
+/* ── Monochrome Terminal design tokens (#413) ─────────────────────────────
+   The redesign's palette, scoped to [data-design="terminal"] so NOTHING in the
+   running app changes until a screen opts in. The redesign lands screen by
+   screen; a big-bang swap of :root would restyle 31 screens in one commit and
+   make every regression un-bisectable.
+
+   Values are mirrored in lib/terminalTokens.ts, which is the source both this
+   block and the conformance spec read from. If you change a value here, change
+   it there - __tests__/terminalTokens.test.mts fails if they drift, which is
+   the whole reason the .ts file exists.
+
+   Radius is 0 EVERYWHERE in this direction. Not a token - an absence. The
+   current app uses border-radius extensively, so opting a screen in means
+   removing radii, not overriding them. */
+[data-design="terminal"] {
+  --bg0:  #08090a;   /* canvas */
+  --bg1:  #0c0d0f;   /* raised region */
+  --bg2:  #111416;   /* bar/track background */
+  --bdr:  #1f2225;   /* structural hairline */
+  --bdr2: #131618;   /* row hairline */
+  --bdr3: #16191b;   /* cell hairline */
+  --txt:  #e8e9ea;   /* primary text and data */
+  --txt2: #8b8f94;   /* secondary text, prose */
+  --txt3: #5a5f66;   /* micro-labels, meta */
+  --txt4: #3a3f45;   /* disabled, axis labels */
+  --accent: #d9a626; /* active nav, primary CTA - ALWAYS with #08090a text */
+  --green:  #3fb950; /* bullish / FIRING positive */
+  --red:    #f0524d; /* bearish / FIRING negative */
+  --mark-idle:    #22262a;  /* signal marker when not firing */
+  --border-input: #2a2e32;  /* input and secondary-button border */
+
+  /* Undocumented in the README, real in the prototypes: the FLAT cell of the
+     hours expectancy grid (|expectancy| < 0.12), with its own legend swatch.
+     Close to --mark-idle and deliberately not equal to it. */
+  --flat-cell: #1c1f22;
+}

--- a/lib/terminalTokens.ts
+++ b/lib/terminalTokens.ts
@@ -1,0 +1,79 @@
+/* The Monochrome Terminal design tokens, as the single source of truth (#413).
+ *
+ * Transcribed from the handoff README's colour table, which QA established is
+ * the authoritative list: the four .dc.html prototypes contain 1,284 hex
+ * literals and ZERO custom properties, so they are a place to check for drift
+ * rather than a place to read tokens from.
+ *
+ * This file exists so the values live in ONE place that both the stylesheet and
+ * a conformance test can read. Duplicating fifteen hex strings into a spec
+ * fixture is how the fixture and the stylesheet end up disagreeing, and the
+ * disagreement would be invisible - both would look correct in isolation.
+ *
+ * NOT wired into the app yet. `app/globals.css` carries these under
+ * [data-design="terminal"], which nothing sets, so the running app is
+ * unchanged. The redesign opts in screen by screen.
+ */
+
+/** The 15 documented colour tokens. Values are the README's, verbatim. */
+export const TERMINAL_COLORS = {
+  '--bg0':          '#08090a',  // Canvas
+  '--bg1':          '#0c0d0f',  // Raised region
+  '--bg2':          '#111416',  // Bar/track background
+  '--bdr':          '#1f2225',  // Structural hairline
+  '--bdr2':         '#131618',  // Row hairline
+  '--bdr3':         '#16191b',  // Cell hairline
+  '--txt':          '#e8e9ea',  // Primary text and data
+  '--txt2':         '#8b8f94',  // Secondary text, prose
+  '--txt3':         '#5a5f66',  // Micro-labels, meta
+  '--txt4':         '#3a3f45',  // Disabled, axis labels
+  '--accent':       '#d9a626',  // Active nav, primary CTA - ALWAYS with #08090a text
+  '--green':        '#3fb950',  // Bullish / firing positive
+  '--red':          '#f0524d',  // Bearish / firing negative
+  '--mark-idle':    '#22262a',  // Signal marker when NOT firing
+  '--border-input': '#2a2e32',  // Input and secondary-button border
+} as const;
+
+/* The sixteenth value: the FLAT cell in the hours expectancy grid.
+ *
+ * Rendered in `Monochrome Terminal - Tools.dc.html` with its own legend swatch,
+ * used when |expectancy| < 0.12, and ABSENT from the README's table - QA found
+ * it by diffing the prototypes against the doc. It is close to --mark-idle
+ * #22262a and deliberately not the same value; both mean "not firing" but they
+ * sit on different backgrounds.
+ *
+ * Named separately rather than folded into --mark-idle so that if the designer
+ * later says they should be one token, that is a one-line change with a test
+ * behind it rather than an archaeology exercise. */
+export const TERMINAL_FLAT_CELL = '#1c1f22';
+
+/* Liquidation map only. The one place the design permits a multi-hue ramp,
+   because a heatmap's whole content is magnitude. Four palettes are selectable;
+   magma is the default and the only one specified in the README.
+ *
+ * eslint-disable local/no-bare-hex-colour -- taking the rule's own escape
+ * hatch, with the reason it asks for. These seven are a continuous colour ramp,
+ * not text colours: they interpolate across a density scale and there is no
+ * token that could express a gradient stop. Tokenising them would mean fifteen
+ * more named colours that only ever appear in one component, which is the
+ * opposite of what the rule protects. The rule's stated concern - "hardcoded
+ * colours do not adapt to theme" - does not apply either: the liquidation map
+ * is dark-only by design and the ramp IS the data. */
+/* eslint-disable local/no-bare-hex-colour */
+export const MAGMA_RAMP = [
+  { stop: 0,    color: '#0a0614' },
+  { stop: 0.14, color: '#2a114e' },
+  { stop: 0.32, color: '#681e7a' },
+  { stop: 0.52, color: '#b5306a' },
+  { stop: 0.70, color: '#e85b3a' },
+  { stop: 0.86, color: '#f9a94a' },
+  { stop: 1,    color: '#fdf3c8' },
+] as const;
+/* eslint-enable local/no-bare-hex-colour */
+
+/** Every colour the design is allowed to render, for a conformance check. */
+export const TERMINAL_ALLOWED = [
+  ...Object.values(TERMINAL_COLORS),
+  TERMINAL_FLAT_CELL,
+  ...MAGMA_RAMP.map(s => s.color),
+];


### PR DESCRIPTION
**Dev Team** · Refs #413. **The token layer, scoped and inert — and I think it is what your #414 should import instead of its own copy.**

## What landed

```
lib/terminalTokens.ts              the 15 documented tokens + --flat-cell + the magma ramp
app/globals.css                    [data-design="terminal"] { ... }
__tests__/terminalTokens.test.mts  6 tests, and it reads the actual CSS text
```

**Nothing sets `data-design`, so the running app is unchanged.** Scoped rather than replacing `:root` on purpose: the redesign lands screen by screen, and a big-bang `:root` swap would restyle 31 screens in one commit and make every regression un-bisectable.

## The bit that matters for #414

**Please import `TERMINAL_ALLOWED` rather than transcribing the palette a second time.**

Two copies of fifteen hex strings is a drift machine, and **the drift is invisible** — each file looks correct alone, and the only symptom is a conformance spec that passes against a stylesheet it no longer describes. That is the same failure shape as everything in HANDOVER §14: a clean result from an instrument pointed at the wrong thing.

`TERMINAL_ALLOWED` is `15 tokens + --flat-cell + 7 ramp stops = 23` values.

## I broke it on purpose before trusting it

```
--accent: #d9a626 -> #d9a627 in the CSS

✖ every token in lib/ is declared in the CSS block with the same value
  lib says #d9a626, CSS says #d9a627
```

Restored, 6/6 green. **Your rule, applied to my own drift detector.**

## Two judgement calls to push back on if you disagree

**`--flat-cell` kept separate from `--mark-idle`**, with a test asserting they differ. They both mean "not firing" and the designer may well say they should be one token — but merging them should be a deliberate act with a failing test in front of it, not a tidy-up.

**The magma ramp takes `no-bare-hex-colour`'s documented escape hatch.** Seven gradient stops cannot be tokens; the liquidation map is dark-only so the rule's theme-adaptation concern does not apply; and tokenising them would add fifteen names used by exactly one component. Lint is back to **140 warnings, 0 errors** — the same count as before this branch, not a suppressed increase.

## How to test (QA)

1. **`grep -rn "data-design" app/ components/`** — zero hits outside the token block. This PR cannot change a pixel.
2. `npm test` — 420 pass, 6 of them new.
3. **Break a value in `globals.css` and confirm the test goes red**, as above. That is the check I would most want a second pair of eyes on, since it is the only thing standing between the two copies.

## Risk level — **Low**

Additive CSS under an unused attribute selector, one new lib file, one new test. Gates: lint 0 errors / 140 warnings (unchanged), `tsc` clean, **420 tests**, build succeeds.

**Not verified:** that the values match the *designer's intent* — only that they match the README table, transcribed by hand. **If you diff my 15 against the prototypes' computed values you may find the same class of gap you found with `#1c1f22`**, and that is worth doing before any screen opts in.
