### PR TITLE
feat(design): the Monochrome Terminal shell, behind a runtime flag

### DIFF
--- a/__tests__/designMode.test.mts
+++ b/__tests__/designMode.test.mts
@@ -1,0 +1,62 @@
+/* #413 - the redesign flag, and which destination owns which route.
+ *
+ * Both are pure and both decide something a user sees, so both live outside
+ * the .tsx. Third time this week that rule has paid for itself.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveDesignMode, designAttribute } from '../lib/designMode.ts';
+
+/* ── 1. the flag defaults OFF ────────────────────────────────────────────── */
+
+test('no query and no stored preference means the CURRENT design', () => {
+  // The whole safety property: nobody sees the redesign by accident, and a
+  // deploy of this branch changes nothing for anyone.
+  assert.equal(resolveDesignMode('', null), 'current');
+  assert.equal(resolveDesignMode(null, undefined), 'current');
+  assert.equal(resolveDesignMode('coin=btc&tf=15m', null), 'current');
+});
+
+test('a stored preference persists across navigation', () => {
+  assert.equal(resolveDesignMode('', 'terminal'), 'terminal');
+});
+
+/* ── 2. the query param wins, in BOTH directions ─────────────────────────── */
+
+test('?design=terminal turns it on even with nothing stored', () => {
+  assert.equal(resolveDesignMode('design=terminal', null), 'terminal');
+});
+
+test('?design=current turns it OFF again - the escape hatch', () => {
+  // Without this the only way out of the redesign is devtools or clearing
+  // site data, which is a bad trap to leave for whoever reviews it.
+  assert.equal(resolveDesignMode('design=current', 'terminal'), 'current');
+});
+
+test('an unrecognised value falls back to what was stored, not to terminal', () => {
+  assert.equal(resolveDesignMode('design=purple', 'terminal'), 'terminal');
+  assert.equal(resolveDesignMode('design=purple', null), 'current');
+  assert.equal(resolveDesignMode('design=', null), 'current');
+});
+
+/* ── 3. the attribute ────────────────────────────────────────────────────── */
+
+test('current REMOVES the attribute rather than setting a second value', () => {
+  // There is no [data-design="current"] block and there must never be one -
+  // the current design is what :root already does, and a second selector for
+  // it would give every token two homes.
+  assert.equal(designAttribute('current'), null);
+  assert.equal(designAttribute('terminal'), 'terminal');
+});
+
+/* ── 4. control ──────────────────────────────────────────────────────────── */
+
+test('CONTROL: resolveDesignMode can return both values', () => {
+  // Guards against a version that always answers 'current' - every assertion
+  // above except two would still pass.
+  const seen = new Set([
+    resolveDesignMode('design=terminal', null),
+    resolveDesignMode('', null),
+  ]);
+  assert.equal(seen.size, 2, 'the flag never turns on - it is not a flag');
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -5291,3 +5291,59 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
      in, the rest of the app does not move. */
   --font-sans: var(--font-sans-terminal), 'Segoe UI', system-ui, sans-serif;
 }
+
+/* ── Monochrome Terminal: navigation (#413) ───────────────────────────────
+   Scoped to [data-design="terminal"] like the tokens, so the existing NavDrawer
+   is untouched until the flag is on. Radius is 0 throughout - the design has no
+   rounded corners anywhere, so these rules set none rather than overriding. */
+
+[data-design="terminal"] .tnav {
+  display: none;
+  height: 44px; align-items: center; gap: 18px;
+  padding: 0 16px;
+  background: var(--bg0);
+  border-bottom: 1px solid var(--bdr);
+}
+[data-design="terminal"] .tnav-brand { text-decoration: none; display: inline-flex; align-items: center; }
+[data-design="terminal"] .tnav-wordmark {
+  font-family: var(--font-mono), monospace;
+  font-size: 12px; font-weight: 700; letter-spacing: .14em;
+  color: var(--txt);
+}
+[data-design="terminal"] .tnav-items { display: flex; align-items: center; gap: 2px; }
+[data-design="terminal"] .tnav-item {
+  font-family: var(--font-mono), monospace;
+  font-size: 11px; font-weight: 500; letter-spacing: .1em; text-transform: uppercase;
+  padding: 6px 12px; color: var(--txt3); text-decoration: none;
+  transition: color .12s;
+}
+[data-design="terminal"] .tnav-item:hover { color: var(--txt2); }
+/* The design's one inversion: active nav is amber-filled with #08090a text.
+   --bg0 IS #08090a, so this is the token rather than the literal. */
+[data-design="terminal"] .tnav-item.on { background: var(--accent); color: var(--bg0); font-weight: 700; }
+
+/* Mobile bottom tab bar - 60px, five items, active in --accent. */
+[data-design="terminal"] .tnav-tabs { display: none; }
+
+@media (min-width: 900px) {
+  [data-design="terminal"] .tnav { display: flex; }
+}
+@media (max-width: 899px) {
+  [data-design="terminal"] .tnav-tabs {
+    display: flex; position: fixed; bottom: 0; left: 0; right: 0; z-index: 997;
+    height: 60px; background: var(--bg0); border-top: 1px solid var(--bdr);
+  }
+  [data-design="terminal"] .tnav-tab {
+    flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center;
+    gap: 3px; color: var(--txt3); text-decoration: none;
+    /* 60px tall and a fifth of the viewport wide - comfortably past the 24x24
+       WCAG 2.2 AA minimum without needing an overlay like #388's control. */
+  }
+  [data-design="terminal"] .tnav-tab.on { color: var(--accent); }
+  [data-design="terminal"] .tnav-tab-label {
+    font-family: var(--font-mono), monospace;
+    font-size: 9px; letter-spacing: .1em; font-weight: 500;
+  }
+  /* The old drawer's tab bar must not stack with the new one. */
+  [data-design="terminal"] .mobile-tab-bar { display: none !important; }
+}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -4,6 +4,8 @@ import { usePathname } from 'next/navigation';
 import MarketProvider from './MarketProvider';
 import NewsProvider from './NewsProvider';
 import NavDrawer from './NavDrawer';
+import TerminalNav from './TerminalNav';
+import DesignModeProvider, { useDesignMode } from './DesignModeProvider';
 import GrokChat from './GrokChat';
 import NewsTicker from './NewsTicker';
 import AuthProvider from './AuthProvider';
@@ -120,6 +122,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   }
 
   return (
+    <DesignModeProvider>
     <PostHogProvider>
       <LabelsProvider>
         <AuthProvider>
@@ -131,7 +134,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
                     <LanguageSync />
                     <TimezoneSync />
                     <AnnouncementBanner banner={config?.announcementBanner ?? null} />
-                    <NavDrawer />
+                    <AppChrome />
                     <NewsTicker />
                     <main className="app-content">
                       <TrialBanner />
@@ -150,5 +153,14 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
         </AuthProvider>
       </LabelsProvider>
     </PostHogProvider>
+    </DesignModeProvider>
   );
+}
+
+/* Which navigation renders. Exactly one of them, ever - the two cannot stack,
+   and the terminal bar is only reachable with ?design=terminal (#413).
+   A component rather than a ternary inline so it can call useDesignMode(),
+   which needs to be inside the provider. */
+function AppChrome() {
+  return useDesignMode() === 'terminal' ? <TerminalNav /> : <NavDrawer />;
 }

--- a/components/DesignModeProvider.tsx
+++ b/components/DesignModeProvider.tsx
@@ -1,0 +1,79 @@
+'use client';
+import { createContext, useContext, useEffect, useSyncExternalStore } from 'react';
+import { usePathname } from 'next/navigation';
+import {
+  resolveDesignMode, designAttribute, DESIGN_STORAGE_KEY, type DesignMode,
+} from '@/lib/designMode';
+
+/* Sets data-design on <html> so the terminal tokens and typeface apply (#413).
+ *
+ * Reads ?design=terminal, remembers it, and re-applies on every navigation.
+ * Default is the current design - see lib/designMode.ts for why this is a
+ * runtime flag rather than a branch.
+ */
+
+const DesignModeContext = createContext<DesignMode>('current');
+
+/** Whether the terminal redesign is active. Components use this to render the
+ *  new chrome without deleting the old one while both have to coexist. */
+export function useDesignMode(): DesignMode {
+  return useContext(DesignModeContext);
+}
+
+/* The mode is read as an EXTERNAL STORE, not held in state.
+ *
+ * The obvious version - useState plus an effect that setStates the resolved
+ * mode - trips react-hooks/set-state-in-effect and re-renders on every
+ * navigation. It was also the only new lint warning this branch produced,
+ * which was a good signal it was the wrong shape.
+ *
+ * NOT useSearchParams() either. That hook forces the tree into a Suspense
+ * boundary during prerender and it broke `next build`:
+ *
+ *     Error occurred prerendering page "/_not-found"
+ *
+ * Reading window.location.search inside the client snapshot keeps this out of
+ * the prerender path; getServerSnapshot is what static generation sees.
+ *
+ * `subscribe` is a no-op: nothing else writes this key, and a `storage`
+ * listener would only fire for OTHER tabs - flipping the design under a
+ * reviewer mid-session, which nobody asked for.
+ */
+const noopSubscribe = () => () => {};
+
+/** Both inputs as one JSON string, because useSyncExternalStore compares
+ *  snapshots by identity - returning an object would rebuild it every render
+ *  and loop. JSON rather than a delimiter: a query string can contain any
+ *  character a separator might pick. */
+function readSnapshot(): string {
+  /* Storage throws in private mode, with site data blocked, or over quota -
+     the same class of failure that made a stuck `loading` grant Pro access on
+     #377. A flag that cannot be read is simply the default design. */
+  let stored: string | null = null;
+  try { stored = localStorage.getItem(DESIGN_STORAGE_KEY); } catch {}
+  return JSON.stringify([window.location.search, stored]);
+}
+const SERVER_SNAPSHOT = JSON.stringify(['', null]);
+
+export default function DesignModeProvider({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+
+  const snapshot = useSyncExternalStore(noopSubscribe, readSnapshot, () => SERVER_SNAPSHOT);
+  const [search, stored] = JSON.parse(snapshot) as [string, string | null];
+  const mode = resolveDesignMode(search, stored);
+
+  useEffect(() => {
+    // Effects here only touch things OUTSIDE React - storage and the <html>
+    // attribute - which is what an effect is for.
+    try { localStorage.setItem(DESIGN_STORAGE_KEY, mode); } catch {}
+
+    const attr = designAttribute(mode);
+    if (attr) document.documentElement.setAttribute('data-design', attr);
+    else      document.documentElement.removeAttribute('data-design');
+    // pathname re-asserts the attribute across client-side navigation.
+  }, [mode, pathname]);
+
+  return (
+    <DesignModeContext.Provider value={mode}>{children}</DesignModeContext.Provider>
+  );
+}

--- a/components/DesignModeProvider.tsx
+++ b/components/DesignModeProvider.tsx
@@ -63,15 +63,27 @@ export default function DesignModeProvider({ children }: { children: React.React
   const mode = resolveDesignMode(search, stored);
 
   useEffect(() => {
-    // Effects here only touch things OUTSIDE React - storage and the <html>
-    // attribute - which is what an effect is for.
-    try { localStorage.setItem(DESIGN_STORAGE_KEY, mode); } catch {}
+    /* PERSIST ONLY WHAT THE QUERY PARAM ASKED FOR.
+     *
+     * Writing `mode` unconditionally looked equivalent and was not: on a reload
+     * WITHOUT the param, the first commit renders from getServerSnapshot, where
+     * stored is null and the mode is therefore 'current'. This effect then ran
+     * with that value and overwrote a stored 'terminal' before the client
+     * snapshot was ever read - so the flag un-stuck itself on the next reload.
+     *
+     * QA measured it on #417: set the param, reload without it, stored had
+     * flipped to 'current'. The param is now the only thing that writes; a
+     * stored value is only ever read. */
+    const asked = new URLSearchParams(search).get('design');
+    if (asked === 'terminal' || asked === 'current') {
+      try { localStorage.setItem(DESIGN_STORAGE_KEY, asked); } catch {}
+    }
 
     const attr = designAttribute(mode);
     if (attr) document.documentElement.setAttribute('data-design', attr);
     else      document.documentElement.removeAttribute('data-design');
     // pathname re-asserts the attribute across client-side navigation.
-  }, [mode, pathname]);
+  }, [mode, pathname, search]);
 
   return (
     <DesignModeContext.Provider value={mode}>{children}</DesignModeContext.Provider>

--- a/components/TerminalNav.tsx
+++ b/components/TerminalNav.tsx
@@ -1,0 +1,108 @@
+'use client';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { NavDashboard, NavArena, NavScanner, NavTracking, NavJournal } from './icons';
+
+/* The Monochrome Terminal navigation (#413).
+ *
+ * Five destinations replacing twenty-five nav entries. The ROUTES are unchanged
+ * - every page keeps its own URL and its own page.tsx, which QA and I both
+ * verified against the handoff independently. This is a navigation change, not
+ * a routing one: bookmarks, deep links and the sitemap all keep working.
+ *
+ * GLYPHS ARE THE REPO'S OWN, per README:72 - "Reuse those components rather
+ * than the path strings in the prototypes". They are already currentColor and
+ * already the right stroke weight, so the design's spec and the existing icons
+ * agree without editing either.
+ *
+ * The seventeen other Nav* exports are not dead: the standalone routes still
+ * exist and may want them for in-page headers. Do not delete them on the
+ * strength of this file.
+ */
+
+interface Destination {
+  key:   string;
+  label: string;
+  href:  string;
+  Icon:  typeof NavDashboard;
+  /** Every route this destination is the active one for. From the handoff's
+   *  "Absorbs" table - `/funding` is still its own page, it just lights up
+   *  Flow in the nav rather than having a nav entry of its own. */
+  owns:  string[];
+}
+
+const DESTINATIONS: Destination[] = [
+  { key: 'overview', label: 'OVERVIEW', href: '/dashboard', Icon: NavDashboard,
+    owns: ['/dashboard', '/briefing'] },
+  { key: 'arena',    label: 'ARENA',    href: '/arena',     Icon: NavArena,
+    owns: ['/arena'] },
+  { key: 'scan',     label: 'SCAN',     href: '/markets',   Icon: NavScanner,
+    owns: ['/markets', '/scanner'] },
+  { key: 'flow',     label: 'FLOW',     href: '/liq',       Icon: NavTracking,
+    owns: ['/liq', '/funding', '/correlation'] },
+  { key: 'book',     label: 'BOOK',     href: '/journal',   Icon: NavJournal,
+    owns: ['/journal', '/alerts', '/calc', '/playbook', '/hours', '/research',
+           '/news', '/econ-calendar', '/settings'] },
+];
+
+/** Which destination a path belongs to, or null when none does.
+ *
+ *  Exact match, not prefix. `/liq` must not claim `/liquidations-something`
+ *  later, and the same reasoning as `isChromeless` in AppShell: a future route
+ *  that merely starts with one of these words should be a deliberate decision,
+ *  not something that silently inherits an active nav item. */
+export function activeDestination(pathname: string): string | null {
+  return DESTINATIONS.find(d => d.owns.includes(pathname))?.key ?? null;
+}
+
+export default function TerminalNav() {
+  const pathname = usePathname();
+  const active = activeDestination(pathname);
+
+  return (
+    <>
+      {/* ── Desktop: one 44px bar ── */}
+      <nav className="tnav" aria-label="Main navigation">
+        <Link href="/dashboard" className="tnav-brand">
+          <span className="tnav-wordmark">LIQUIDITYHQ</span>
+        </Link>
+
+        <div className="tnav-items">
+          {DESTINATIONS.map(d => (
+            <Link
+              key={d.key}
+              href={d.href}
+              className={`tnav-item${active === d.key ? ' on' : ''}`}
+              aria-current={active === d.key ? 'page' : undefined}
+              data-testid={`tnav-${d.key}`}
+            >
+              {d.label}
+            </Link>
+          ))}
+        </div>
+      </nav>
+
+      {/* ── Mobile: 60px bottom tab bar ──
+          Its own element rather than a media-query restyle of the desktop bar:
+          the two carry different content (glyph + label vs label only) and the
+          bottom bar is fixed while the top bar is not. */}
+      <nav className="tnav-tabs" aria-label="Main navigation">
+        {DESTINATIONS.map(d => {
+          const { Icon } = d;
+          return (
+            <Link
+              key={d.key}
+              href={d.href}
+              className={`tnav-tab${active === d.key ? ' on' : ''}`}
+              aria-current={active === d.key ? 'page' : undefined}
+              data-testid={`tnav-tab-${d.key}`}
+            >
+              <Icon size={19} />
+              <span className="tnav-tab-label">{d.label}</span>
+            </Link>
+          );
+        })}
+      </nav>
+    </>
+  );
+}

--- a/lib/designMode.ts
+++ b/lib/designMode.ts
@@ -1,0 +1,56 @@
+/* Which design the app renders in (#413).
+ *
+ * The colour tokens and IBM Plex Sans are already scoped to
+ * [data-design="terminal"], but nothing sets that attribute - so the redesign
+ * has been inert. This is the switch.
+ *
+ * WHY A SWITCH AND NOT A BRANCH. The shell is global chrome: unlike a screen,
+ * it cannot opt in one page at a time, because every page renders inside it.
+ * So the choice was a long-lived redesign branch that diverges for weeks, or a
+ * runtime flag that lets `dev` stay linear and lets QA review the new chrome on
+ * a DEPLOYED build rather than on somebody's localhost. The flag wins: the
+ * owner asked to review screens as they land, and a branch nobody can visit is
+ * not reviewable.
+ *
+ * DEFAULT IS THE CURRENT DESIGN. Turning this on is deliberate and per-browser.
+ * It is not an A/B test and it is not sampled - no user sees the redesign by
+ * accident, and no screen changes for anyone until the default flips at the end
+ * of the migration.
+ */
+
+export type DesignMode = 'current' | 'terminal';
+
+export const DESIGN_STORAGE_KEY = 'lhq-design-mode';
+export const DESIGN_QUERY_PARAM = 'design';
+
+/**
+ * Resolve the mode from a URL and a stored preference.
+ *
+ * The query param WINS and is sticky - `?design=terminal` turns it on and keeps
+ * it on across navigation, `?design=current` turns it off again. Without that
+ * second escape hatch the only way out would be devtools or clearing storage,
+ * which is a bad trap to leave for whoever reviews this.
+ *
+ * Pure so it can be tested without a DOM; the provider does the effects.
+ */
+export function resolveDesignMode(
+  search: string | null | undefined,
+  stored: string | null | undefined,
+): DesignMode {
+  const fromQuery = new URLSearchParams(search ?? '').get(DESIGN_QUERY_PARAM);
+  if (fromQuery === 'terminal') return 'terminal';
+  if (fromQuery === 'current')  return 'current';
+  return stored === 'terminal' ? 'terminal' : 'current';
+}
+
+/**
+ * What `data-design` should be, or null when the attribute should be absent.
+ *
+ * `current` REMOVES the attribute rather than setting `data-design="current"`.
+ * There is no `[data-design="current"]` block and there should never be one -
+ * the current design is what the stylesheet already does at :root, and adding a
+ * second selector for it would mean every token had two homes.
+ */
+export function designAttribute(mode: DesignMode): string | null {
+  return mode === 'terminal' ? 'terminal' : null;
+}


### PR DESCRIPTION
**Dev Team** · Refs #413. **Batch 0 complete — the shell, and the switch that makes the redesign visitable.**

## The decision worth reviewing first

**The shell cannot opt in per-screen.** Tokens and fonts could hide behind an attribute nothing set; global chrome cannot, because every page renders inside it. So it is a **runtime flag**, not a branch:

```
?design=terminal   turns it on, sticky per browser
?design=current    turns it OFF - a deliberate escape hatch
default            the current design, for everyone, always
```

**A redesign branch would have been the other option and I think it is worse**: the owner asked to review screens as they land, and a branch nobody can visit is not reviewable. This keeps `dev` linear and lets you check the new chrome on a **deployed** build instead of my localhost.

## Verified in a browser, both directions

```
?design=terminal   data-design=terminal   .tnav 44px, display flex
                   five items OVERVIEW ARENA SCAN FLOW BOOK
                   ARENA active on /arena, amber fill + --bg0 text
                   old drawer ABSENT
                   --accent #d9a626   --font-sans -> plexSans
?design=current    attribute removed, old nav back, --accent #1a7aff
```

**The off-state matters more than the on-state** and I checked it second on purpose.

## Two mistakes this cost, both recorded in the commit

**`useState` + effect was the only new lint warning on the branch.** `react-hooks/set-state-in-effect` — the same rule that caught the `searchExhausted` effect earlier today. Rewrote as `useSyncExternalStore`; back to **140 warnings, unchanged**.

**`useSearchParams()` broke `next build` outright:**

```
Error occurred prerendering page "/_not-found"
```

That hook forces the tree into a Suspense boundary during prerender. Reading `window.location.search` in the client snapshot keeps the provider off the prerender path. **The gates caught it; I did not reason my way there.**

## How to test (QA)

1. **Any page, no param — nothing changed.** This is the safety property; check it before anything else.
2. **`/arena?design=terminal`** — 44px bar, five items, ARENA amber-filled with dark text. The page BODY is still the old design; only the chrome moved.
3. **Navigate around with the flag on** — the bar persists, and the active item follows the destination table (`/funding` lights FLOW, `/settings` lights BOOK).
4. **`?design=current`** — the old nav returns. Without this you would be stuck in the redesign.
5. **Mobile width** — the 60px bottom tab bar replaces the desktop bar, and the OLD `.mobile-tab-bar` must not stack under it.
6. **`npm test`** — 427 pass, 7 new on the flag.

## Risk level — **Medium**

Not Low: it touches `AppShell`, which every non-`/ops` page renders inside. Gates: lint **0 errors / 140 warnings unchanged**, `tsc` clean, **427 tests**, build succeeds.

**What I have NOT verified:** the mobile tab bar rendered at 390px. My window reports a 2505px viewport and the resize did not take earlier in this session, so **step 5 is unrun by me** — including whether hiding the old `.mobile-tab-bar` works, which is the one rule that could leave two bars stacked.

**Also unverified: every screen with the flag ON.** I looked at `/dashboard` and `/arena`. The other 19 render inside this shell too, and a page whose layout assumed the drawer may sit oddly under a 44px bar.

## Next

Per your reorder: **`/disclaimer`, then landing.** Both are inside this shell, so this wants to land first.
