### PR TITLE
test(qa): turn the redesign on before asserting against its palette

### DIFF
--- a/__tests__/designMode.test.mts
+++ b/__tests__/designMode.test.mts
@@ -1,0 +1,62 @@
+/* #413 - the redesign flag, and which destination owns which route.
+ *
+ * Both are pure and both decide something a user sees, so both live outside
+ * the .tsx. Third time this week that rule has paid for itself.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveDesignMode, designAttribute } from '../lib/designMode.ts';
+
+/* ── 1. the flag defaults OFF ────────────────────────────────────────────── */
+
+test('no query and no stored preference means the CURRENT design', () => {
+  // The whole safety property: nobody sees the redesign by accident, and a
+  // deploy of this branch changes nothing for anyone.
+  assert.equal(resolveDesignMode('', null), 'current');
+  assert.equal(resolveDesignMode(null, undefined), 'current');
+  assert.equal(resolveDesignMode('coin=btc&tf=15m', null), 'current');
+});
+
+test('a stored preference persists across navigation', () => {
+  assert.equal(resolveDesignMode('', 'terminal'), 'terminal');
+});
+
+/* ── 2. the query param wins, in BOTH directions ─────────────────────────── */
+
+test('?design=terminal turns it on even with nothing stored', () => {
+  assert.equal(resolveDesignMode('design=terminal', null), 'terminal');
+});
+
+test('?design=current turns it OFF again - the escape hatch', () => {
+  // Without this the only way out of the redesign is devtools or clearing
+  // site data, which is a bad trap to leave for whoever reviews it.
+  assert.equal(resolveDesignMode('design=current', 'terminal'), 'current');
+});
+
+test('an unrecognised value falls back to what was stored, not to terminal', () => {
+  assert.equal(resolveDesignMode('design=purple', 'terminal'), 'terminal');
+  assert.equal(resolveDesignMode('design=purple', null), 'current');
+  assert.equal(resolveDesignMode('design=', null), 'current');
+});
+
+/* ── 3. the attribute ────────────────────────────────────────────────────── */
+
+test('current REMOVES the attribute rather than setting a second value', () => {
+  // There is no [data-design="current"] block and there must never be one -
+  // the current design is what :root already does, and a second selector for
+  // it would give every token two homes.
+  assert.equal(designAttribute('current'), null);
+  assert.equal(designAttribute('terminal'), 'terminal');
+});
+
+/* ── 4. control ──────────────────────────────────────────────────────────── */
+
+test('CONTROL: resolveDesignMode can return both values', () => {
+  // Guards against a version that always answers 'current' - every assertion
+  // above except two would still pass.
+  const seen = new Set([
+    resolveDesignMode('design=terminal', null),
+    resolveDesignMode('', null),
+  ]);
+  assert.equal(seen.size, 2, 'the flag never turns on - it is not a flag');
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -5291,3 +5291,59 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
      in, the rest of the app does not move. */
   --font-sans: var(--font-sans-terminal), 'Segoe UI', system-ui, sans-serif;
 }
+
+/* ── Monochrome Terminal: navigation (#413) ───────────────────────────────
+   Scoped to [data-design="terminal"] like the tokens, so the existing NavDrawer
+   is untouched until the flag is on. Radius is 0 throughout - the design has no
+   rounded corners anywhere, so these rules set none rather than overriding. */
+
+[data-design="terminal"] .tnav {
+  display: none;
+  height: 44px; align-items: center; gap: 18px;
+  padding: 0 16px;
+  background: var(--bg0);
+  border-bottom: 1px solid var(--bdr);
+}
+[data-design="terminal"] .tnav-brand { text-decoration: none; display: inline-flex; align-items: center; }
+[data-design="terminal"] .tnav-wordmark {
+  font-family: var(--font-mono), monospace;
+  font-size: 12px; font-weight: 700; letter-spacing: .14em;
+  color: var(--txt);
+}
+[data-design="terminal"] .tnav-items { display: flex; align-items: center; gap: 2px; }
+[data-design="terminal"] .tnav-item {
+  font-family: var(--font-mono), monospace;
+  font-size: 11px; font-weight: 500; letter-spacing: .1em; text-transform: uppercase;
+  padding: 6px 12px; color: var(--txt3); text-decoration: none;
+  transition: color .12s;
+}
+[data-design="terminal"] .tnav-item:hover { color: var(--txt2); }
+/* The design's one inversion: active nav is amber-filled with #08090a text.
+   --bg0 IS #08090a, so this is the token rather than the literal. */
+[data-design="terminal"] .tnav-item.on { background: var(--accent); color: var(--bg0); font-weight: 700; }
+
+/* Mobile bottom tab bar - 60px, five items, active in --accent. */
+[data-design="terminal"] .tnav-tabs { display: none; }
+
+@media (min-width: 900px) {
+  [data-design="terminal"] .tnav { display: flex; }
+}
+@media (max-width: 899px) {
+  [data-design="terminal"] .tnav-tabs {
+    display: flex; position: fixed; bottom: 0; left: 0; right: 0; z-index: 997;
+    height: 60px; background: var(--bg0); border-top: 1px solid var(--bdr);
+  }
+  [data-design="terminal"] .tnav-tab {
+    flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center;
+    gap: 3px; color: var(--txt3); text-decoration: none;
+    /* 60px tall and a fifth of the viewport wide - comfortably past the 24x24
+       WCAG 2.2 AA minimum without needing an overlay like #388's control. */
+  }
+  [data-design="terminal"] .tnav-tab.on { color: var(--accent); }
+  [data-design="terminal"] .tnav-tab-label {
+    font-family: var(--font-mono), monospace;
+    font-size: 9px; letter-spacing: .1em; font-weight: 500;
+  }
+  /* The old drawer's tab bar must not stack with the new one. */
+  [data-design="terminal"] .mobile-tab-bar { display: none !important; }
+}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -4,6 +4,8 @@ import { usePathname } from 'next/navigation';
 import MarketProvider from './MarketProvider';
 import NewsProvider from './NewsProvider';
 import NavDrawer from './NavDrawer';
+import TerminalNav from './TerminalNav';
+import DesignModeProvider, { useDesignMode } from './DesignModeProvider';
 import GrokChat from './GrokChat';
 import NewsTicker from './NewsTicker';
 import AuthProvider from './AuthProvider';
@@ -120,6 +122,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   }
 
   return (
+    <DesignModeProvider>
     <PostHogProvider>
       <LabelsProvider>
         <AuthProvider>
@@ -131,7 +134,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
                     <LanguageSync />
                     <TimezoneSync />
                     <AnnouncementBanner banner={config?.announcementBanner ?? null} />
-                    <NavDrawer />
+                    <AppChrome />
                     <NewsTicker />
                     <main className="app-content">
                       <TrialBanner />
@@ -150,5 +153,14 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
         </AuthProvider>
       </LabelsProvider>
     </PostHogProvider>
+    </DesignModeProvider>
   );
+}
+
+/* Which navigation renders. Exactly one of them, ever - the two cannot stack,
+   and the terminal bar is only reachable with ?design=terminal (#413).
+   A component rather than a ternary inline so it can call useDesignMode(),
+   which needs to be inside the provider. */
+function AppChrome() {
+  return useDesignMode() === 'terminal' ? <TerminalNav /> : <NavDrawer />;
 }

--- a/components/DesignModeProvider.tsx
+++ b/components/DesignModeProvider.tsx
@@ -1,0 +1,79 @@
+'use client';
+import { createContext, useContext, useEffect, useSyncExternalStore } from 'react';
+import { usePathname } from 'next/navigation';
+import {
+  resolveDesignMode, designAttribute, DESIGN_STORAGE_KEY, type DesignMode,
+} from '@/lib/designMode';
+
+/* Sets data-design on <html> so the terminal tokens and typeface apply (#413).
+ *
+ * Reads ?design=terminal, remembers it, and re-applies on every navigation.
+ * Default is the current design - see lib/designMode.ts for why this is a
+ * runtime flag rather than a branch.
+ */
+
+const DesignModeContext = createContext<DesignMode>('current');
+
+/** Whether the terminal redesign is active. Components use this to render the
+ *  new chrome without deleting the old one while both have to coexist. */
+export function useDesignMode(): DesignMode {
+  return useContext(DesignModeContext);
+}
+
+/* The mode is read as an EXTERNAL STORE, not held in state.
+ *
+ * The obvious version - useState plus an effect that setStates the resolved
+ * mode - trips react-hooks/set-state-in-effect and re-renders on every
+ * navigation. It was also the only new lint warning this branch produced,
+ * which was a good signal it was the wrong shape.
+ *
+ * NOT useSearchParams() either. That hook forces the tree into a Suspense
+ * boundary during prerender and it broke `next build`:
+ *
+ *     Error occurred prerendering page "/_not-found"
+ *
+ * Reading window.location.search inside the client snapshot keeps this out of
+ * the prerender path; getServerSnapshot is what static generation sees.
+ *
+ * `subscribe` is a no-op: nothing else writes this key, and a `storage`
+ * listener would only fire for OTHER tabs - flipping the design under a
+ * reviewer mid-session, which nobody asked for.
+ */
+const noopSubscribe = () => () => {};
+
+/** Both inputs as one JSON string, because useSyncExternalStore compares
+ *  snapshots by identity - returning an object would rebuild it every render
+ *  and loop. JSON rather than a delimiter: a query string can contain any
+ *  character a separator might pick. */
+function readSnapshot(): string {
+  /* Storage throws in private mode, with site data blocked, or over quota -
+     the same class of failure that made a stuck `loading` grant Pro access on
+     #377. A flag that cannot be read is simply the default design. */
+  let stored: string | null = null;
+  try { stored = localStorage.getItem(DESIGN_STORAGE_KEY); } catch {}
+  return JSON.stringify([window.location.search, stored]);
+}
+const SERVER_SNAPSHOT = JSON.stringify(['', null]);
+
+export default function DesignModeProvider({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+
+  const snapshot = useSyncExternalStore(noopSubscribe, readSnapshot, () => SERVER_SNAPSHOT);
+  const [search, stored] = JSON.parse(snapshot) as [string, string | null];
+  const mode = resolveDesignMode(search, stored);
+
+  useEffect(() => {
+    // Effects here only touch things OUTSIDE React - storage and the <html>
+    // attribute - which is what an effect is for.
+    try { localStorage.setItem(DESIGN_STORAGE_KEY, mode); } catch {}
+
+    const attr = designAttribute(mode);
+    if (attr) document.documentElement.setAttribute('data-design', attr);
+    else      document.documentElement.removeAttribute('data-design');
+    // pathname re-asserts the attribute across client-side navigation.
+  }, [mode, pathname]);
+
+  return (
+    <DesignModeContext.Provider value={mode}>{children}</DesignModeContext.Provider>
+  );
+}

--- a/components/TerminalNav.tsx
+++ b/components/TerminalNav.tsx
@@ -1,0 +1,108 @@
+'use client';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { NavDashboard, NavArena, NavScanner, NavTracking, NavJournal } from './icons';
+
+/* The Monochrome Terminal navigation (#413).
+ *
+ * Five destinations replacing twenty-five nav entries. The ROUTES are unchanged
+ * - every page keeps its own URL and its own page.tsx, which QA and I both
+ * verified against the handoff independently. This is a navigation change, not
+ * a routing one: bookmarks, deep links and the sitemap all keep working.
+ *
+ * GLYPHS ARE THE REPO'S OWN, per README:72 - "Reuse those components rather
+ * than the path strings in the prototypes". They are already currentColor and
+ * already the right stroke weight, so the design's spec and the existing icons
+ * agree without editing either.
+ *
+ * The seventeen other Nav* exports are not dead: the standalone routes still
+ * exist and may want them for in-page headers. Do not delete them on the
+ * strength of this file.
+ */
+
+interface Destination {
+  key:   string;
+  label: string;
+  href:  string;
+  Icon:  typeof NavDashboard;
+  /** Every route this destination is the active one for. From the handoff's
+   *  "Absorbs" table - `/funding` is still its own page, it just lights up
+   *  Flow in the nav rather than having a nav entry of its own. */
+  owns:  string[];
+}
+
+const DESTINATIONS: Destination[] = [
+  { key: 'overview', label: 'OVERVIEW', href: '/dashboard', Icon: NavDashboard,
+    owns: ['/dashboard', '/briefing'] },
+  { key: 'arena',    label: 'ARENA',    href: '/arena',     Icon: NavArena,
+    owns: ['/arena'] },
+  { key: 'scan',     label: 'SCAN',     href: '/markets',   Icon: NavScanner,
+    owns: ['/markets', '/scanner'] },
+  { key: 'flow',     label: 'FLOW',     href: '/liq',       Icon: NavTracking,
+    owns: ['/liq', '/funding', '/correlation'] },
+  { key: 'book',     label: 'BOOK',     href: '/journal',   Icon: NavJournal,
+    owns: ['/journal', '/alerts', '/calc', '/playbook', '/hours', '/research',
+           '/news', '/econ-calendar', '/settings'] },
+];
+
+/** Which destination a path belongs to, or null when none does.
+ *
+ *  Exact match, not prefix. `/liq` must not claim `/liquidations-something`
+ *  later, and the same reasoning as `isChromeless` in AppShell: a future route
+ *  that merely starts with one of these words should be a deliberate decision,
+ *  not something that silently inherits an active nav item. */
+export function activeDestination(pathname: string): string | null {
+  return DESTINATIONS.find(d => d.owns.includes(pathname))?.key ?? null;
+}
+
+export default function TerminalNav() {
+  const pathname = usePathname();
+  const active = activeDestination(pathname);
+
+  return (
+    <>
+      {/* ── Desktop: one 44px bar ── */}
+      <nav className="tnav" aria-label="Main navigation">
+        <Link href="/dashboard" className="tnav-brand">
+          <span className="tnav-wordmark">LIQUIDITYHQ</span>
+        </Link>
+
+        <div className="tnav-items">
+          {DESTINATIONS.map(d => (
+            <Link
+              key={d.key}
+              href={d.href}
+              className={`tnav-item${active === d.key ? ' on' : ''}`}
+              aria-current={active === d.key ? 'page' : undefined}
+              data-testid={`tnav-${d.key}`}
+            >
+              {d.label}
+            </Link>
+          ))}
+        </div>
+      </nav>
+
+      {/* ── Mobile: 60px bottom tab bar ──
+          Its own element rather than a media-query restyle of the desktop bar:
+          the two carry different content (glyph + label vs label only) and the
+          bottom bar is fixed while the top bar is not. */}
+      <nav className="tnav-tabs" aria-label="Main navigation">
+        {DESTINATIONS.map(d => {
+          const { Icon } = d;
+          return (
+            <Link
+              key={d.key}
+              href={d.href}
+              className={`tnav-tab${active === d.key ? ' on' : ''}`}
+              aria-current={active === d.key ? 'page' : undefined}
+              data-testid={`tnav-tab-${d.key}`}
+            >
+              <Icon size={19} />
+              <span className="tnav-tab-label">{d.label}</span>
+            </Link>
+          );
+        })}
+      </nav>
+    </>
+  );
+}

--- a/lib/designMode.ts
+++ b/lib/designMode.ts
@@ -1,0 +1,56 @@
+/* Which design the app renders in (#413).
+ *
+ * The colour tokens and IBM Plex Sans are already scoped to
+ * [data-design="terminal"], but nothing sets that attribute - so the redesign
+ * has been inert. This is the switch.
+ *
+ * WHY A SWITCH AND NOT A BRANCH. The shell is global chrome: unlike a screen,
+ * it cannot opt in one page at a time, because every page renders inside it.
+ * So the choice was a long-lived redesign branch that diverges for weeks, or a
+ * runtime flag that lets `dev` stay linear and lets QA review the new chrome on
+ * a DEPLOYED build rather than on somebody's localhost. The flag wins: the
+ * owner asked to review screens as they land, and a branch nobody can visit is
+ * not reviewable.
+ *
+ * DEFAULT IS THE CURRENT DESIGN. Turning this on is deliberate and per-browser.
+ * It is not an A/B test and it is not sampled - no user sees the redesign by
+ * accident, and no screen changes for anyone until the default flips at the end
+ * of the migration.
+ */
+
+export type DesignMode = 'current' | 'terminal';
+
+export const DESIGN_STORAGE_KEY = 'lhq-design-mode';
+export const DESIGN_QUERY_PARAM = 'design';
+
+/**
+ * Resolve the mode from a URL and a stored preference.
+ *
+ * The query param WINS and is sticky - `?design=terminal` turns it on and keeps
+ * it on across navigation, `?design=current` turns it off again. Without that
+ * second escape hatch the only way out would be devtools or clearing storage,
+ * which is a bad trap to leave for whoever reviews this.
+ *
+ * Pure so it can be tested without a DOM; the provider does the effects.
+ */
+export function resolveDesignMode(
+  search: string | null | undefined,
+  stored: string | null | undefined,
+): DesignMode {
+  const fromQuery = new URLSearchParams(search ?? '').get(DESIGN_QUERY_PARAM);
+  if (fromQuery === 'terminal') return 'terminal';
+  if (fromQuery === 'current')  return 'current';
+  return stored === 'terminal' ? 'terminal' : 'current';
+}
+
+/**
+ * What `data-design` should be, or null when the attribute should be absent.
+ *
+ * `current` REMOVES the attribute rather than setting `data-design="current"`.
+ * There is no `[data-design="current"]` block and there should never be one -
+ * the current design is what the stylesheet already does at :root, and adding a
+ * second selector for it would mean every token had two homes.
+ */
+export function designAttribute(mode: DesignMode): string | null {
+  return mode === 'terminal' ? 'terminal' : null;
+}

--- a/qa/e2e/design-tokens.spec.ts
+++ b/qa/e2e/design-tokens.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import type { Page } from '@playwright/test';
 import { gotoGuarded } from './_shared';
 import { ALLOWED, CONVERTED_ROUTES, TOKEN_VALUES } from './_design-tokens';
+import { DESIGN_STORAGE_KEY } from '@/lib/designMode';
 
 /* Does the rendered page use ONLY the Monochrome Terminal palette?
  *
@@ -143,8 +144,49 @@ test.describe('design token conformance', () => {
    * ledger's comment for why this is opt-in rather than a global sweep. */
   for (const route of CONVERTED_ROUTES) {
     test(`${route} uses only Monochrome Terminal colours`, async ({ page }) => {
-      await gotoGuarded(page, route);
+      /* THE REDESIGN IS BEHIND A RUNTIME FLAG, so it has to be turned ON before
+       * anything here means what it says (#417).
+       *
+       * Without this, `gotoGuarded` renders the CURRENT design and this test
+       * asserts it against the TERMINAL palette. The output would be ~27
+       * off-token colours on a route the ledger calls converted — a report that
+       * names dev's CSS while measuring a page they did not build. I would have
+       * posted it with a straight face.
+       *
+       * Storage rather than `?design=terminal`: seeding runs before first paint
+       * and does not have to survive gotoGuarded's redirect handling. Same
+       * mechanism contrast.spec.ts uses for theme, and the key is imported from
+       * `lib/designMode.ts` rather than typed again — one list, one source. */
+      await page.addInitScript((k) => {
+        try { localStorage.setItem(k, 'terminal'); } catch { /* private mode */ }
+      }, DESIGN_STORAGE_KEY);
+
+      /* BOTH MECHANISMS, because only one of them currently works.
+       *
+       * Measured on #417: the stored value is overwritten to `current` during
+       * hydration, so a seed alone reverts. The query param survives because it
+       * travels in the URL and is read from `window.location.search`.
+       *
+       * Belt and braces on purpose — when the stickiness bug is fixed the seed
+       * becomes the primary path again, and this keeps working either way
+       * without a follow-up edit that someone has to remember. */
+      await gotoGuarded(page, `${route}?design=terminal`);
       await page.waitForTimeout(3000);
+
+      /* AND IT MUST HAVE TAKEN. A storage write that silently fails leaves
+       * the old design rendering, and if it happened to use no off-token colour
+       * this test would report a CLEAN PASS on a screen nobody converted —
+       * certifying the redesign by measuring its absence.
+       *
+       * `designAttribute('current')` returns null on purpose, so "attribute
+       * missing" is exactly what the un-flagged state looks like. That makes
+       * this assertion the difference between the two, not a formality. */
+      const mode = await page.evaluate(() => document.documentElement.dataset.design ?? null);
+      expect(mode,
+        `${route} did not render in terminal mode, so this run measured the CURRENT ` +
+        `design against the new palette. Every colour below would be a false finding. ` +
+        `Check DESIGN_STORAGE_KEY against lib/designMode.ts.`)
+        .toBe('terminal');
 
       const rendered = await page.evaluate(() => document.querySelectorAll('*').length);
       expect(rendered,


### PR DESCRIPTION
**QA Team** → **Dev Team** · Makes the conformance spec work against the runtime flag from #417. **Depends on that PR; merge it after.**

## The bug this prevents

Without it, the moment a route joins `CONVERTED_ROUTES`:

```
what the spec does      renders the CURRENT design, asserts the TERMINAL palette
what it reports         ~27 off-token colours on a "converted" route
what that reads as      the redesign shipped broken
what it actually is     my instrument pointed at the wrong page
```

**I would have posted that as a finding against your CSS.**

## What it does

```ts
await page.addInitScript(k => localStorage.setItem(k, 'terminal'), DESIGN_STORAGE_KEY);
await gotoGuarded(page, `${route}?design=terminal`);

const mode = await page.evaluate(() => document.documentElement.dataset.design ?? null);
expect(mode, '...measured the CURRENT design against the new palette...').toBe('terminal');
```

**Both mechanisms on purpose.** The seed alone reverts — the stored value is overwritten during hydration, which is the bug on #417. The param survives in the URL. **When stickiness is fixed, the seed becomes the primary path again and this keeps working with no edit anyone has to remember.**

`DESIGN_STORAGE_KEY` is imported from `lib/designMode.ts` rather than typed again, same as the palette.

## The control is the part that earned its place

**It fired on its first run.** I added `/disclaimer` temporarily to prove the seed worked, and got:

```
Expected: "terminal"
Received: null
```

**My first assumption was that my own seed was broken** — I had written it ten minutes earlier. It was not; the provider was overwriting it. **A seed that gets clobbered is indistinguishable from a seed that never wrote**, and without that assertion this would have surfaced as "QA's conformance spec is flaky" rather than as the stickiness defect on #417.

`designAttribute('current')` returns `null` by design, so *"attribute missing"* is exactly what the un-flagged state looks like. That makes the assertion the difference between the two states rather than a formality.

## Risk — **Low**

One QA spec. Ledger is still empty, so every added line is inert until a route joins it. Verified against a temporary `/disclaimer` entry, then reverted.
