### PR TITLE
feat(disclaimer): rebuild in the Monochrome Terminal design

### DIFF
--- a/app/disclaimer/page.tsx
+++ b/app/disclaimer/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 import Link from 'next/link';
 import { useLabels } from '@/lib/labels';
+import { useDesignMode } from '@/components/DesignModeProvider';
+import DisclaimerTerminal from '@/components/DisclaimerTerminal';
 
 const SECTIONS = [
   { titleKey: 'DISCLAIMER_SECTION_EDUCATIONAL_TITLE', bodyKey: 'DISCLAIMER_SECTION_EDUCATIONAL_BODY' },
@@ -17,6 +19,13 @@ const SECTIONS = [
 
 export default function Disclaimer() {
   const { t } = useLabels();
+
+  /* One screen, two designs, while the redesign lands page by page (#413).
+     The terminal version is a separate component rather than a pile of
+     conditionals: the two layouts share their COPY and nothing else, and
+     interleaving them would make both harder to read than either. Deleting
+     this branch is the last step of the migration. */
+  if (useDesignMode() === 'terminal') return <DisclaimerTerminal />;
 
   return (
     <div style={{ maxWidth: 1100, margin: '0 auto', padding: '48px 24px 80px' }}>

--- a/app/globals.css
+++ b/app/globals.css
@@ -5347,3 +5347,76 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
   /* The old drawer's tab bar must not stack with the new one. */
   [data-design="terminal"] .mobile-tab-bar { display: none !important; }
 }
+
+/* ── Monochrome Terminal: /disclaimer (#413) ──────────────────────────────
+   Radius 0 throughout, hairlines never doubled - each region owns its bottom
+   border, per the handoff's spacing rules. */
+
+[data-design="terminal"] .dterm { max-width: 1180px; margin: 0 auto; padding: 40px 24px 96px; }
+
+[data-design="terminal"] .dterm-head { border-bottom: 1px solid var(--bdr); padding-bottom: 28px; margin-bottom: 32px; }
+[data-design="terminal"] .dterm-eyebrow {
+  font-family: var(--font-mono), monospace; font-size: 10px; font-weight: 600;
+  letter-spacing: .18em; text-transform: uppercase; color: var(--txt3); margin-bottom: 12px;
+}
+[data-design="terminal"] .dterm-title {
+  font-family: var(--font-mono), monospace; font-size: 34px; font-weight: 700;
+  color: var(--txt); margin: 0; line-height: 1.1; letter-spacing: -.01em;
+}
+
+/* The risk row. --red because these ARE firing signals in the design's sense:
+   the number is the event, not a decoration. */
+[data-design="terminal"] .dterm-risk { display: flex; flex-wrap: wrap; gap: 1px; margin-top: 26px; background: var(--bdr3); }
+[data-design="terminal"] .dterm-risk-cell { flex: 1 1 200px; background: var(--bg1); padding: 13px 16px; }
+[data-design="terminal"] .dterm-risk-label {
+  font-family: var(--font-mono), monospace; font-size: 9px; font-weight: 600;
+  letter-spacing: .14em; text-transform: uppercase; color: var(--txt3); margin-bottom: 7px;
+}
+[data-design="terminal"] .dterm-risk-value {
+  font-family: var(--font-mono), monospace; font-size: 26px; font-weight: 700;
+  color: var(--red); font-variant-numeric: tabular-nums; line-height: 1;
+}
+[data-design="terminal"] .dterm-risk-note { font-size: 12px; color: var(--txt3); margin-top: 6px; }
+
+[data-design="terminal"] .dterm-body { display: grid; grid-template-columns: 264px 1fr; gap: 48px; align-items: start; }
+
+/* Contents rail - active item carries a 2px amber left border, per README:165. */
+[data-design="terminal"] .dterm-toc { position: sticky; top: 60px; display: flex; flex-direction: column; }
+[data-design="terminal"] .dterm-toc-item {
+  display: flex; gap: 10px; align-items: baseline;
+  padding: 7px 0 7px 12px; border-left: 2px solid transparent;
+  font-size: 12.5px; color: var(--txt3); text-decoration: none; line-height: 1.4;
+  transition: color .12s, border-color .12s;
+}
+[data-design="terminal"] .dterm-toc-item:hover { color: var(--txt2); }
+[data-design="terminal"] .dterm-toc-item.on { border-left-color: var(--accent); color: var(--txt); }
+[data-design="terminal"] .dterm-toc-num {
+  font-family: var(--font-mono), monospace; font-size: 10px; color: var(--txt4); flex-shrink: 0;
+}
+
+[data-design="terminal"] .dterm-section { padding-bottom: 26px; margin-bottom: 26px; border-bottom: 1px solid var(--bdr2); scroll-margin-top: 64px; }
+[data-design="terminal"] .dterm-section:last-of-type { border-bottom: none; }
+[data-design="terminal"] .dterm-section-num {
+  font-family: var(--font-mono), monospace; font-size: 10px; font-weight: 600;
+  letter-spacing: .14em; color: var(--accent); margin-bottom: 8px;
+}
+[data-design="terminal"] .dterm-section-title {
+  font-family: var(--font-mono), monospace; font-size: 15px; font-weight: 700;
+  color: var(--txt); margin: 0 0 8px; letter-spacing: .01em;
+}
+[data-design="terminal"] .dterm-section-body { font-size: 13.5px; line-height: 1.65; color: var(--txt2); margin: 0; text-wrap: pretty; }
+
+[data-design="terminal"] .dterm-foot { border-top: 1px solid var(--bdr); padding-top: 22px; font-size: 12.5px; color: var(--txt3); line-height: 1.7; }
+[data-design="terminal"] .dterm-foot-meta { display: flex; gap: 20px; flex-wrap: wrap; margin-top: 14px; }
+[data-design="terminal"] .dterm-foot-meta a { color: var(--txt3); }
+
+@media (max-width: 899px) {
+  /* The rail becomes a scrolling strip above the sections - a 264px column has
+     nowhere to go at 390px, and dropping it entirely would lose the numbering. */
+  [data-design="terminal"] .dterm-body { grid-template-columns: 1fr; gap: 24px; }
+  [data-design="terminal"] .dterm-toc { position: static; flex-direction: row; overflow-x: auto; gap: 4px; padding-bottom: 12px; border-bottom: 1px solid var(--bdr2); }
+  [data-design="terminal"] .dterm-toc-item { border-left: none; border-bottom: 2px solid transparent; white-space: nowrap; padding: 6px 10px; }
+  [data-design="terminal"] .dterm-toc-item.on { border-left-color: transparent; border-bottom-color: var(--accent); }
+  [data-design="terminal"] .dterm-title { font-size: 26px; }
+  [data-design="terminal"] .dterm { padding-bottom: 84px; }
+}

--- a/components/DisclaimerTerminal.tsx
+++ b/components/DisclaimerTerminal.tsx
@@ -1,0 +1,156 @@
+'use client';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { useMarket } from '@/lib/marketStore';
+import { useLabels } from '@/lib/labels';
+import type { LabelKey } from '@/lib/labelKeys';
+
+/* /disclaimer in the Monochrome Terminal design (#413).
+ *
+ * THE COPY IS UNCHANGED. Same ten sections, same label keys, same words - this
+ * is a visual rebuild, not a rewrite of a legal page. Any wording change is a
+ * separate decision with the owner.
+ *
+ * The design opens with four red risk figures ($412M across five venues, the
+ * largest single position, a cascade duration). Three of them describe data
+ * this app does not have: the store carries a rolling 15-minute Binance
+ * forceOrder aggregate for seven majors - no 24h window, no five venues, no
+ * per-position rows, no cascade duration. The owner chose to show what is real
+ * and label it honestly rather than print figures we cannot stand behind on the
+ * page whose whole purpose is telling users the truth about risk.
+ */
+
+interface Section { titleKey: LabelKey; bodyKey: LabelKey }
+
+const SECTIONS: Section[] = [
+  { titleKey: 'DISCLAIMER_SECTION_EDUCATIONAL_TITLE',          bodyKey: 'DISCLAIMER_SECTION_EDUCATIONAL_BODY' },
+  { titleKey: 'DISCLAIMER_SECTION_TRADING_RISKS_TITLE',        bodyKey: 'DISCLAIMER_SECTION_TRADING_RISKS_BODY' },
+  { titleKey: 'DISCLAIMER_SECTION_NO_GUARANTEES_TITLE',        bodyKey: 'DISCLAIMER_SECTION_NO_GUARANTEES_BODY' },
+  { titleKey: 'DISCLAIMER_SECTION_NOT_FINANCIAL_ADVICE_TITLE', bodyKey: 'DISCLAIMER_SECTION_NOT_FINANCIAL_ADVICE_BODY' },
+  { titleKey: 'DISCLAIMER_SECTION_NO_TRADE_EXECUTION_TITLE',   bodyKey: 'DISCLAIMER_SECTION_NO_TRADE_EXECUTION_BODY' },
+  { titleKey: 'DISCLAIMER_SECTION_AI_ANALYSIS_TITLE',          bodyKey: 'DISCLAIMER_SECTION_AI_ANALYSIS_BODY' },
+  { titleKey: 'DISCLAIMER_SECTION_DATA_PROVIDERS_TITLE',       bodyKey: 'DISCLAIMER_SECTION_DATA_PROVIDERS_BODY' },
+  { titleKey: 'DISCLAIMER_SECTION_BACKTESTS_TITLE',            bodyKey: 'DISCLAIMER_SECTION_BACKTESTS_BODY' },
+  { titleKey: 'DISCLAIMER_SECTION_NO_LIABILITY_TITLE',         bodyKey: 'DISCLAIMER_SECTION_NO_LIABILITY_BODY' },
+  { titleKey: 'DISCLAIMER_SECTION_PLATFORM_IDENTITY_TITLE',    bodyKey: 'DISCLAIMER_SECTION_PLATFORM_IDENTITY_BODY' },
+];
+
+const num = (i: number) => String(i + 1).padStart(2, '0');
+const slug = (i: number) => `s${num(i)}`;
+
+function fmtUsd(v: number): string {
+  if (v >= 1e9) return `$${(v / 1e9).toFixed(1)}B`;
+  if (v >= 1e6) return `$${(v / 1e6).toFixed(1)}M`;
+  if (v >= 1e3) return `$${(v / 1e3).toFixed(0)}K`;
+  return `$${Math.round(v)}`;
+}
+
+/** The two cells we can actually stand behind.
+ *
+ *  Summed across whichever majors currently carry a reading, because the store
+ *  holds this per coin and the honest headline is the market-wide figure - not
+ *  BTC's alone dressed up as the market's. */
+function useRiskFacts() {
+  const { store } = useMarket();
+  let longUsd = 0, shortUsd = 0, coins = 0;
+  for (const c of Object.values(store.coins)) {
+    if (c?.liqLongUsd == null || c?.liqShortUsd == null) continue;
+    longUsd += c.liqLongUsd;
+    shortUsd += c.liqShortUsd;
+    coins++;
+  }
+  const total = longUsd + shortUsd;
+  return {
+    coins,
+    total,
+    /* Guarded: with no liquidations in the window this is 0/0. A NaN rendered
+       as "NaN% longs" on a legal page is worse than showing nothing. */
+    longPct: total > 0 ? Math.round((longUsd / total) * 100) : null,
+  };
+}
+
+export default function DisclaimerTerminal() {
+  const { t } = useLabels();
+  const { total, longPct, coins } = useRiskFacts();
+  const [active, setActive] = useState(0);
+
+  /* Contents rail highlight. IntersectionObserver rather than a scroll handler:
+     it fires only when a section crosses the band and costs nothing while the
+     page is still, which matters on a page people scroll slowly and read. */
+  useEffect(() => {
+    const els = SECTIONS.map((_, i) => document.getElementById(slug(i))).filter(Boolean) as HTMLElement[];
+    if (!els.length) return;
+    const io = new IntersectionObserver(
+      entries => {
+        const top = entries.filter(e => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)[0];
+        if (top) setActive(els.indexOf(top.target as HTMLElement));
+      },
+      { rootMargin: '-72px 0px -65% 0px' },
+    );
+    els.forEach(el => io.observe(el));
+    return () => io.disconnect();
+  }, []);
+
+  return (
+    <div className="dterm">
+      <header className="dterm-head">
+        <div className="dterm-eyebrow">{t('DISCLAIMER_EYEBROW')}</div>
+        <h1 className="dterm-title">{t('DISCLAIMER_PAGE_TITLE')}</h1>
+
+        {/* The risk row. Rendered only when the stream has given us something -
+            a "$0" opener on a risk-warning page reads as broken rather than as
+            calm, and the 15-minute window is genuinely empty sometimes. */}
+        {total > 0 && (
+          <div className="dterm-risk" data-testid="disclaimer-risk">
+            <div className="dterm-risk-cell">
+              <div className="dterm-risk-label">Liquidations · last 15m</div>
+              <div className="dterm-risk-value">{fmtUsd(total)}</div>
+              <div className="dterm-risk-note">Binance perps · {coins} majors</div>
+            </div>
+            {longPct !== null && (
+              <div className="dterm-risk-cell">
+                <div className="dterm-risk-label">Longs liquidated</div>
+                <div className="dterm-risk-value">{longPct}%</div>
+                <div className="dterm-risk-note">of that total</div>
+              </div>
+            )}
+          </div>
+        )}
+      </header>
+
+      <div className="dterm-body">
+        <nav className="dterm-toc" aria-label="Contents">
+          {SECTIONS.map((s, i) => (
+            <a
+              key={s.titleKey}
+              href={`#${slug(i)}`}
+              className={`dterm-toc-item${active === i ? ' on' : ''}`}
+            >
+              <span className="dterm-toc-num">{num(i)}</span>
+              {t(s.titleKey)}
+            </a>
+          ))}
+        </nav>
+
+        <div className="dterm-sections">
+          {SECTIONS.map((s, i) => (
+            <section key={s.titleKey} id={slug(i)} className="dterm-section">
+              <div className="dterm-section-num">{num(i)}</div>
+              <h2 className="dterm-section-title">{t(s.titleKey)}</h2>
+              <p className="dterm-section-body">{t(s.bodyKey)}</p>
+            </section>
+          ))}
+
+          <footer className="dterm-foot">
+            <p>{t('DISCLAIMER_FOOTER_ACKNOWLEDGEMENT')}</p>
+            <p className="dterm-foot-meta">
+              <span>{t('DISCLAIMER_FOOTER_COPYRIGHT', { year: new Date().getFullYear() })}</span>
+              <Link href="/about">{t('DISCLAIMER_FOOTER_ABOUT_LINK')}</Link>
+            </p>
+          </footer>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
**Dev Team** · Refs #413. **First converted screen. The ledger has something to admit.**

## The risk row is two cells, not four — owner's decision

The design opens with `$412M · 24h · five venues`, `$18.4M largest single`, `under 90s cascade`. The app has a **rolling 15-minute Binance forceOrder aggregate for seven majors**. Three of the four cannot be produced at all.

**Option A, chosen by the owner:**

```
Liquidations · last 15m      Binance perps · N majors
Longs liquidated             of that total
```

**Smaller numbers, labels that say what they measure.** On the page whose entire purpose is telling users the truth about risk, printing a figure we cannot stand behind was the wrong trade — and it would have looked completely correct to anyone reviewing the screen.

**The row hides itself when the window is empty**, because `$0` on a risk-warning page reads as broken rather than calm. The long/short split is guarded against `0/0` for the same reason: `NaN% longs` on a legal page is worse than no row.

## Measured with the flag on

```
active TOC border    2px rgb(217,166,38)     amber, per README:165
section numbers      rgb(217,166,38)
grid                 264px + content
title                34px mono
sections             10, copy unchanged
```

## The mistake worth reading

**I spent four rounds debugging CSS that was correct.** Rules on disk, braces balanced, `--accent` resolving to `#d9a626` on the element — and `borderLeftWidth: 0px`.

The served stylesheet had `tnav-item` and **not** `dterm-toc-item`:

```
disk     324,659 bytes
served   260,262 bytes
node processes running   3
```

**Three dev servers. The one holding port 3000 predated the stash pop**, so it was compiling a globals.css from before the disclaimer block existed.

**That is the exact trap I wrote into HANDOVER §14 today** — *"a git checkout does NOT restart it"* — and I walked into a variant of it about six hours later. What caught it was your habit, not mine: **comparing the served bytes against the source instead of trusting the page.** Worth extending that entry: it is not only `checkout`, it is any stale process, and `taskkill` on one PID is not enough when three are running.

## How to test (QA)

1. **`/disclaimer` with no flag — unchanged.** The old three-column layout.
2. **`?design=terminal`** — numbered sections, contents rail, amber active item that follows scroll position.
3. **Click a rail item** — jumps to the section, `scroll-margin-top` keeps it clear of the nav.
4. **Mobile** — the rail becomes a horizontal scrolling strip with the active item underlined. **Unverified by me**, my viewport does not resize.
5. **The risk row** — likely absent on a quiet market. **I have never seen it render**; the 15-minute window was empty every time I looked. If you can catch it populated, that is the one thing nobody has seen.

## Risk level — **Low**

New component behind the flag; the existing page renders untouched by default. Gates: lint **0 errors / 140 warnings unchanged**, `tsc` clean, **427 tests**, build succeeds.
