### PR TITLE
feat(design): terminal gold replaces the blue primary, live in both designs

### DIFF
--- a/__tests__/contrastTokens.test.mts
+++ b/__tests__/contrastTokens.test.mts
@@ -20,6 +20,17 @@ import fs from 'node:fs';
 
 const CSS = fs.readFileSync(new URL('../app/globals.css', import.meta.url), 'utf8');
 
+/** Flatten `fg` at `alpha` over `bg` - what a tinted background actually is by
+ *  the time text sits on it. Without this the test compares against a colour
+ *  no pixel ever has. */
+function composite(fg: string, alpha: number, bg: string): string {
+  const h = (c: string) => [1, 3, 5].map(i => parseInt(c.slice(i, i + 2), 16));
+  const [fr, fg_, fb] = h(fg), [br, bg_, bb] = h(bg);
+  const mix = (f: number, b: number) => Math.round(f * alpha + b * (1 - alpha));
+  return '#' + [mix(fr, br), mix(fg_, bg_), mix(fb, bb)]
+    .map(v => v.toString(16).padStart(2, '0')).join('');
+}
+
 function token(name: string, scope?: string): string {
   /* 3000, not 1200: the light-theme token block is ~34 lines long and --accent
      sits past the old window, so a scoped lookup silently found nothing and
@@ -122,14 +133,30 @@ test('design token contrast', async (t) => {
     const accent = token('accent', '[data-theme="light"] {');
     const onAccent = token('on-accent', '[data-theme="light"] {');
 
-    /* THREE surfaces, not two. The first version of this test checked white
-       and --bg2 only, passed, and shipped a gold that measured 4.18:1 on
-       #e1e1de - a real surface carrying real text ("Pro Plan", "Sign up").
-       A token test is only as good as its list of grounds. */
-    for (const bg of ['#ffffff', '#f2f3f5', '#e1e1de']) {
-      const r = ratio(accent, bg);
-      assert.ok(r >= AA,
-        `light --accent ${accent} as TEXT on ${bg} = ${r.toFixed(2)}:1, needs ${AA}:1`);
+    /* GROUNDS x TINTS, not a list of flat colours.
+     *
+     * This test has now been wrong twice in the same way, and each time the
+     * fix was "add another ground" - which is why the third version stops
+     * enumerating and starts composing.
+     *
+     *   v1  white + --bg2                shipped 4.18:1 on #e1e1de
+     *   v2  + #e1e1de                    shipped 3.98:1 on #e1e1de + a 12% tint
+     *   v3  every ground x every tint    <- here
+     *
+     * The tint matters because the app's selected state puts accent TEXT on an
+     * accent-tinted BACKGROUND (.nav-tile.on, .gchat-coin.on). Blue had the
+     * headroom for that; gold does not, and a flat-ground test cannot see it.
+     * QA's rendered sweep found both misses - this is the unit-test half
+     * catching up to what the sweep already knows. */
+    const GROUNDS = ['#ffffff', '#f2f3f5', '#e1e1de', '#e8eaed'];
+    const TINTS: Array<[string, number]> = [['plain', 0], ['accent-bg', 0.07], ['accent-dim', 0.12]];
+    for (const bg of GROUNDS) {
+      for (const [name, alpha] of TINTS) {
+        const ground = alpha === 0 ? bg : composite(accent, alpha, bg);
+        const r = ratio(accent, ground);
+        assert.ok(r >= AA,
+          `light --accent ${accent} on ${bg} + ${name} = ${r.toFixed(2)}:1, needs ${AA}:1`);
+      }
     }
 
     const onFill = ratio(onAccent, accent);

--- a/__tests__/contrastTokens.test.mts
+++ b/__tests__/contrastTokens.test.mts
@@ -21,8 +21,12 @@ import fs from 'node:fs';
 const CSS = fs.readFileSync(new URL('../app/globals.css', import.meta.url), 'utf8');
 
 function token(name: string, scope?: string): string {
+  /* 3000, not 1200: the light-theme token block is ~34 lines long and --accent
+     sits past the old window, so a scoped lookup silently found nothing and
+     reported "token not found" rather than the wrong value. Widened when the
+     gold primary landed (#419). */
   const haystack = scope
-    ? CSS.slice(CSS.indexOf(scope), CSS.indexOf(scope) + 1200)
+    ? CSS.slice(CSS.indexOf(scope), CSS.indexOf(scope) + 3000)
     : CSS;
   const m = haystack.match(new RegExp('--' + name + ':\\s*(#[0-9a-fA-F]{6})'));
   assert.ok(m, `token --${name} not found${scope ? ' in ' + scope : ''}`);
@@ -74,22 +78,24 @@ test('design token contrast', async (t) => {
   await t.test('sanity: the ratio maths matches known WCAG values', () => {
     assert.equal(Math.round(ratio('#ffffff', '#000000')), 21);
     assert.equal(Math.round(ratio('#000000', '#000000')), 1);
-    // The pair that forced --accent-solid to exist.
+    // The pair that forced --accent-solid to exist when the primary was blue.
+    // Kept as a maths check even though the blue is gone (#419) - it is a known
+    // published value, which is what makes it a useful sanity assertion.
     assert.ok(Math.abs(ratio('#ffffff', '#1a7aff') - 3.98) < 0.02,
-      'white on the undarkened brand blue should measure ~3.98:1');
+      'white on the old brand blue should still measure ~3.98:1');
   });
 
-  await t.test('the two accent tokens each cover their own direction', () => {
-    /* The whole reason there are two. A single blue cannot do both jobs on a
-       dark theme: darkening enough for white text to pass ON it drops it below
-       AA when used AS text on the near-black backgrounds. Assert both ends so
-       nobody "simplifies" this back into one token. */
+  await t.test('the accent works AS TEXT, and its fill carries --on-accent', () => {
+    /* REWRITTEN FOR THE GOLD PRIMARY (#419). The old version asserted that
+       WHITE on --accent-solid clears AA - true of the blue, false of the gold
+       at 2.23:1. That assertion failing is what caught the swap, which is
+       exactly what it was for.
+       The invariant changed shape rather than disappearing. Blue needed two
+       VALUES (a darker fill for white text, a brighter one for text). Gold
+       needs two FOREGROUNDS (near-black on the dark fill, white on the light
+       one) and one value. So the pairing is what gets asserted now. */
     const accent = token('accent');
-    const solid = token('accent-solid');
-
-    const onSolid = ratio('#ffffff', solid);
-    assert.ok(onSolid >= AA,
-      `white on --accent-solid ${solid} = ${onSolid.toFixed(2)}:1, needs ${AA}:1`);
+    const onAccent = token('on-accent');
 
     for (const [surface, bg] of Object.entries(SURFACES)) {
       const r = ratio(accent, bg);
@@ -97,11 +103,38 @@ test('design token contrast', async (t) => {
         `--accent ${accent} as TEXT on ${surface} ${bg} = ${r.toFixed(2)}:1`);
     }
 
-    /* And the trap itself: --accent-solid must NOT be used as text on --bg0.
-       If this ever stops holding, the two tokens have converged and one of the
-       two directions is silently failing again. */
-    assert.ok(ratio(solid, SURFACES['--bg0']) < AA,
-      'if --accent-solid passes as text too, re-check whether both tokens are still needed');
+    const onFill = ratio(onAccent, accent);
+    assert.ok(onFill >= AA,
+      `--on-accent ${onAccent} on --accent ${accent} = ${onFill.toFixed(2)}:1, needs ${AA}:1`);
+
+    /* The trap, restated: white must NOT be assumed safe on the accent. If
+       this ever passes, the accent has drifted pale enough that every
+       `color: #fff` still sitting on a gold fill would silently start working
+       - and the ones that are wrong would stop being detectable. */
+    assert.ok(ratio('#ffffff', accent) < AA,
+      'white now passes on --accent - re-check every fill that sets its own #fff');
+  });
+
+  await t.test('LIGHT theme: the gold inverts its foreground and still clears AA', () => {
+    /* The half that nearly shipped broken. #d9a626 on white is 2.23:1, so the
+       light theme needs a darker gold - and then near-black on THAT is 3.63:1,
+       so its foreground has to flip to white. Both directions, measured. */
+    const accent = token('accent', '[data-theme="light"] {');
+    const onAccent = token('on-accent', '[data-theme="light"] {');
+
+    /* THREE surfaces, not two. The first version of this test checked white
+       and --bg2 only, passed, and shipped a gold that measured 4.18:1 on
+       #e1e1de - a real surface carrying real text ("Pro Plan", "Sign up").
+       A token test is only as good as its list of grounds. */
+    for (const bg of ['#ffffff', '#f2f3f5', '#e1e1de']) {
+      const r = ratio(accent, bg);
+      assert.ok(r >= AA,
+        `light --accent ${accent} as TEXT on ${bg} = ${r.toFixed(2)}:1, needs ${AA}:1`);
+    }
+
+    const onFill = ratio(onAccent, accent);
+    assert.ok(onFill >= AA,
+      `light --on-accent ${onAccent} on ${accent} = ${onFill.toFixed(2)}:1, needs ${AA}:1`);
   });
 
   for (const name of ['txt', 'txt2', 'txt3', 'txt-dim']) {

--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -1255,7 +1255,7 @@ function ArenaContent() {
       <div style={{ padding: '1rem 0 0.75rem' }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4, flexWrap: 'wrap' }}>
           <div style={{ fontSize: 'var(--fs-section)', fontWeight: 700, color: 'var(--txt)', letterSpacing: '-0.3px' }}>{t('ARENA_PAGE_TITLE')}</div>
-          <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, padding: '3px 8px', borderRadius: 20, background: '#12233f', color: 'var(--accent-2)', border: '0.5px solid #2a4a7a', letterSpacing: '.05em' }}>{t('ARENA_LIVE_BADGE')}</span>
+          <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, padding: '3px 8px', borderRadius: 20, background: 'var(--accent-bg)', color: 'var(--accent)', border: '0.5px solid var(--accent-bdr)', letterSpacing: '.05em' }}>{t('ARENA_LIVE_BADGE')}</span>
         </div>
         <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)' }}>{t('ARENA_PAGE_SUBTITLE')}</div>
       </div>
@@ -1341,11 +1341,11 @@ function ArenaContent() {
           <span style={{
             display: 'inline-flex', alignItems: 'center', gap: 5,
             fontSize: 'var(--fs-caption)', fontWeight: 700, color: 'var(--accent-2)',
-            background: 'rgba(90,163,255,0.1)', padding: '2px 9px 2px 5px',
-            borderRadius: 20, border: '0.5px solid rgba(90,163,255,0.2)',
+            background: 'rgba(var(--accent-rgb), 0.1)', padding: '2px 9px 2px 5px',
+            borderRadius: 20, border: '0.5px solid rgba(var(--accent-rgb), 0.2)',
             flexShrink: 0,
           }}>
-            <CoinIcon coin={selectedCoin} size={16} color="#5aa3ff" bg="rgba(90,163,255,0.15)" />
+            <CoinIcon coin={selectedCoin} size={16} color="#5aa3ff" bg="rgba(var(--accent-rgb), 0.15)" />
             {selectedCoin.toUpperCase()}
           </span>
           {/* Spacer */}
@@ -1490,7 +1490,7 @@ function ArenaContent() {
                     width: '100%', display: 'grid',
                     gridTemplateColumns: '1fr 78px 44px 44px 72px 32px',
                     alignItems: 'center', padding: '7px 12px',
-                    background: isSelected ? 'rgba(90,163,255,0.08)' : 'transparent',
+                    background: isSelected ? 'rgba(var(--accent-rgb), 0.08)' : 'transparent',
                     border: 'none',
                     borderBottom: '0.5px solid var(--bdr)',
                     cursor: 'pointer', textAlign: 'left', transition: 'background 0.12s',
@@ -1633,7 +1633,7 @@ function ArenaContent() {
         {user && (
           <button
             className="arena-ask-grok-btn"
-            style={{ width: 'auto', marginBottom: 0, background: alertFormOpen ? 'rgba(26,122,255,0.15)' : undefined }}
+            style={{ width: 'auto', marginBottom: 0, background: alertFormOpen ? 'rgba(var(--accent-rgb), 0.15)' : undefined }}
             onClick={() => alertFormOpen ? setAlertFormOpen(false) : openAlertForm()}
             title={t('ARENA_SET_ALERT_TITLE')}
           >
@@ -1750,7 +1750,7 @@ function ArenaContent() {
                 onClick={saveArenaAlert}
                 disabled={alertSaving || !alertPrice}
                 style={{
-                  width: '100%', fontSize: 'var(--fs-body)', fontWeight: 700, color: '#fff',
+                  width: '100%', fontSize: 'var(--fs-body)', fontWeight: 700, color: 'var(--on-accent)',
                   background: 'var(--accent-solid)', border: 'none', borderRadius: 10, padding: '12px 18px',
                   cursor: alertSaving || !alertPrice ? 'default' : 'pointer',
                   opacity: alertSaving || !alertPrice ? 0.5 : 1, transition: 'opacity .15s',
@@ -1998,8 +1998,8 @@ function ArenaContent() {
                   const isBull = /bull|higher high|engulf.*bull|hammer|morning/i.test(p);
                   const isBear = /bear|lower high|engulf.*bear|shooting|evening|head.*shoulder|double top/i.test(p);
                   const col = isBull ? 'var(--green-2)' : isBear ? 'var(--red)' : '#1a7aff';
-                  const bg  = isBull ? 'rgba(52,211,153,0.08)' : isBear ? 'rgba(248,113,113,0.08)' : 'rgba(26,122,255,0.08)';
-                  const bdr = isBull ? 'rgba(52,211,153,0.25)' : isBear ? 'rgba(248,113,113,0.25)' : 'rgba(26,122,255,0.25)';
+                  const bg  = isBull ? 'rgba(52,211,153,0.08)' : isBear ? 'rgba(248,113,113,0.08)' : 'rgba(var(--accent-rgb), 0.08)';
+                  const bdr = isBull ? 'rgba(52,211,153,0.25)' : isBear ? 'rgba(248,113,113,0.25)' : 'rgba(var(--accent-rgb), 0.25)';
                   return (
                     <span key={i} style={{ fontSize: 'var(--fs-caption)', fontWeight: 600, padding: '3px 10px', borderRadius: 6, background: bg, color: col, border: `0.5px solid ${bdr}` }}>{p}</span>
                   );

--- a/app/backtest/page.tsx
+++ b/app/backtest/page.tsx
@@ -535,9 +535,9 @@ export default function BacktestPage() {
           onClick={runStrategyResearch}
           disabled={srRunning || !srPrompt.trim()}
           style={{
-            background: srRunning || !srPrompt.trim() ? 'rgba(255,255,255,0.06)' : 'rgba(26,122,255,0.12)',
+            background: srRunning || !srPrompt.trim() ? 'rgba(255,255,255,0.06)' : 'rgba(var(--accent-rgb), 0.12)',
             color: srRunning || !srPrompt.trim() ? 'var(--txt3)' : 'var(--accent)',
-            border: `1px solid ${srRunning || !srPrompt.trim() ? 'var(--bdr)' : 'rgba(26,122,255,0.35)'}`,
+            border: `1px solid ${srRunning || !srPrompt.trim() ? 'var(--bdr)' : 'rgba(var(--accent-rgb), 0.35)'}`,
             borderRadius: 8, padding: '10px 20px', fontSize: 'var(--fs-label)', fontWeight: 700,
             cursor: srRunning || !srPrompt.trim() ? 'default' : 'pointer',
           }}
@@ -616,9 +616,9 @@ export default function BacktestPage() {
                       });
                     }}
                     style={{
-                      background: psCopied ? 'rgba(52,211,153,0.12)' : 'rgba(26,122,255,0.10)',
+                      background: psCopied ? 'rgba(52,211,153,0.12)' : 'rgba(var(--accent-rgb), 0.10)',
                       color: psCopied ? 'var(--green-2)' : 'var(--accent)',
-                      border: `1px solid ${psCopied ? 'rgba(52,211,153,0.3)' : 'rgba(26,122,255,0.3)'}`,
+                      border: `1px solid ${psCopied ? 'rgba(52,211,153,0.3)' : 'rgba(var(--accent-rgb), 0.3)'}`,
                       borderRadius: 8, padding: '8px 16px', fontSize: 'var(--fs-caption)', fontWeight: 700, cursor: 'pointer',
                     }}
                   >
@@ -687,9 +687,9 @@ export default function BacktestPage() {
           onClick={runSMCSnapshot}
           disabled={smcRunning || !smcAsset.trim()}
           style={{
-            background: smcRunning || !smcAsset.trim() ? 'rgba(255,255,255,0.06)' : 'rgba(26,122,255,0.12)',
+            background: smcRunning || !smcAsset.trim() ? 'rgba(255,255,255,0.06)' : 'rgba(var(--accent-rgb), 0.12)',
             color: smcRunning || !smcAsset.trim() ? 'var(--txt3)' : 'var(--accent)',
-            border: `1px solid ${smcRunning || !smcAsset.trim() ? 'var(--bdr)' : 'rgba(26,122,255,0.35)'}`,
+            border: `1px solid ${smcRunning || !smcAsset.trim() ? 'var(--bdr)' : 'rgba(var(--accent-rgb), 0.35)'}`,
             borderRadius: 8, padding: '8px 16px', fontSize: 'var(--fs-label)', fontWeight: 700,
             cursor: smcRunning || !smcAsset.trim() ? 'default' : 'pointer',
           }}
@@ -763,9 +763,9 @@ export default function BacktestPage() {
           onClick={runTokenUnlock}
           disabled={ulRunning || !ulSymbol.trim()}
           style={{
-            background: ulRunning || !ulSymbol.trim() ? 'rgba(255,255,255,0.06)' : 'rgba(26,122,255,0.12)',
+            background: ulRunning || !ulSymbol.trim() ? 'rgba(255,255,255,0.06)' : 'rgba(var(--accent-rgb), 0.12)',
             color: ulRunning || !ulSymbol.trim() ? 'var(--txt3)' : 'var(--accent)',
-            border: `1px solid ${ulRunning || !ulSymbol.trim() ? 'var(--bdr)' : 'rgba(26,122,255,0.35)'}`,
+            border: `1px solid ${ulRunning || !ulSymbol.trim() ? 'var(--bdr)' : 'rgba(var(--accent-rgb), 0.35)'}`,
             borderRadius: 8, padding: '8px 16px', fontSize: 'var(--fs-label)', fontWeight: 700,
             cursor: ulRunning || !ulSymbol.trim() ? 'default' : 'pointer',
           }}

--- a/app/correlation/page.tsx
+++ b/app/correlation/page.tsx
@@ -83,7 +83,7 @@ function pearson(a: number[], b: number[]): number | null {
    identical green. Rescale 0.35→1.0 onto the full range with a power curve so
    0.6 reads faint and 0.95+ pops. */
 function cellBg(r: number | null, diag: boolean): string {
-  if (diag)    return 'rgba(26,122,255,0.22)';
+  if (diag)    return 'rgba(var(--accent-rgb), 0.22)';
   if (r == null) return 'rgba(255,255,255,0.03)';
   if (r > 0) {
     const t = Math.max(0, (r - 0.35) / 0.65);

--- a/app/funding/page.tsx
+++ b/app/funding/page.tsx
@@ -437,7 +437,7 @@ export default function FundingHistory() {
                   {t('FUNDING_CONTRARIAN_LONG_COUNT', { count: longSignals.length, plural: longSignals.length !== 1 ? 's' : '' })}
                 </Tip>
               </span>
-              <span style={{ fontSize: 'var(--fs-caption)', padding: '2px 7px', borderRadius: 10, background: 'rgba(26,122,255,0.10)', color: 'var(--accent)', border: '0.5px solid rgba(26,122,255,0.25)', fontWeight: 700 }}>
+              <span style={{ fontSize: 'var(--fs-caption)', padding: '2px 7px', borderRadius: 10, background: 'rgba(var(--accent-rgb), 0.10)', color: 'var(--accent)', border: '0.5px solid rgba(var(--accent-rgb), 0.25)', fontWeight: 700 }}>
                 <Tip iconColor="#1a7aff" text={t('FUNDING_CARRY_ARB_TIP')}>
                   {t('FUNDING_CARRY_ARB_COUNT', { count: arbs.length })}
                 </Tip>
@@ -469,7 +469,7 @@ export default function FundingHistory() {
                     </span>
                   )}
                   {carryArb && (
-                    <span style={{ fontSize: 'var(--fs-caption)', padding: '1px 5px', borderRadius: 3, background: 'rgba(26,122,255,0.10)', color: 'var(--accent)', fontWeight: 600, flexShrink: 0 }}>
+                    <span style={{ fontSize: 'var(--fs-caption)', padding: '1px 5px', borderRadius: 3, background: 'rgba(var(--accent-rgb), 0.10)', color: 'var(--accent)', fontWeight: 600, flexShrink: 0 }}>
                       {t('FUNDING_BADGE_ARB_LABEL')}
                     </span>
                   )}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -22,7 +22,7 @@ export default function GlobalError({
           <p style={{ color: '#9ca3af', marginBottom: '1.5rem' }}>An unexpected error occurred.</p>
           <button
             onClick={reset}
-            style={{ padding: '0.5rem 1.5rem', background: 'var(--accent-solid)', color: '#fff', border: 'none', borderRadius: '0.5rem', cursor: 'pointer', fontSize: 'var(--fs-card-title)' }}
+            style={{ padding: '0.5rem 1.5rem', background: 'var(--accent-solid)', color: 'var(--on-accent)', border: 'none', borderRadius: '0.5rem', cursor: 'pointer', fontSize: 'var(--fs-card-title)' }}
           >
             Try again
           </button>

--- a/app/globals.css
+++ b/app/globals.css
@@ -2362,21 +2362,31 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 
   /* A darker gold for light theme (#419). #d9a626 on white is 2.23:1, so it had
      to come down to clear AA.
-     #795f15 is the lightest value on this hue that clears 4.5:1 on ALL THREE
-     light surfaces:
-         #ffffff  6.07      #f2f3f5  5.47      #e1e1de  4.63
-     The first draft was #826517, chosen against the first two only - and the
-     third surface measured 4.18 on live pages ("Pro Plan", "Sign up"). Found by
-     walking the rendered DOM rather than by re-reading the token table, which
-     is the only reason it was found at all. */
-  --accent:     #795f15;
+     THIRD value, and the reason is the .on idiom: gold TEXT sits on a gold
+     TINT (--accent-bg / --accent-dim) for every selected state in the app -
+     .nav-tile.on, .gchat-coin.on, .gchat-mode-opt.on. Blue survived that
+     because blue-on-blue-tint had headroom; a dark mustard on a ground already
+     pulled toward its own hue does not.
+
+     So the value is chosen against every GROUND x TINT combination, not
+     against flat surfaces:
+
+         ground        plain   +7% tint   +12% dim
+         #ffffff        7.57      7.87       8.18
+         #f2f3f5        6.82      7.09       7.37
+         #e1e1de        5.78      6.02       4.89   <- the binding case
+         #e8eaed        6.30      6.55       6.81
+
+     #795f15 bottomed out at 3.98 there and #715814 at 4.40. Both passed a
+     test that only knew about flat grounds. */
+  --accent:     #685112;
   /* was #0066E8 - 3.03:1 on the canvas #e8eaed, which is where the footer
      divider label and the markets sort buttons sit. */
-  --accent-2:   #795f15;
-  --accent-solid: #795f15;
-  --accent-dim: rgba(121,95,21,0.10);
-  --accent-bg:  rgba(121,95,21,0.07);
-  --accent-bdr: rgba(121,95,21,0.22);
+  --accent-2:   #685112;
+  --accent-solid: #685112;
+  --accent-dim: rgba(104,81,18,0.10);
+  --accent-bg:  rgba(104,81,18,0.07);
+  --accent-bdr: rgba(104,81,18,0.22);
   /* White on the light-theme gold, not near-black: #08090a on #826517 is
      3.63:1 and fails. The pairing inverts with the theme. */
   --on-accent:  #ffffff;

--- a/app/globals.css
+++ b/app/globals.css
@@ -4559,7 +4559,18 @@ body.landing {
      #7c7c82 is 4.92:1 on #050505 and 4.73:1 on the #0a0c10 plan cards. */
   --txt3:   #7c7c82;
   --bdr:    rgba(255,255,255,0.07);
-  --accent: #1a7aff;
+  /* The landing page re-declares the accent to force the dark palette
+     regardless of saved theme - and that meant the :root swap to gold (#419)
+     did not reach it. Blue landing page, gold everywhere else, on the FIRST
+     page anyone sees.
+     Found by grepping for the old literal after the swap, not by looking:
+     the declaration uses single-space padding where :root uses aligned
+     columns, so a whitespace-sensitive replace walked straight past it.
+     Measured on this scope's own grounds: 9.15 on --bg0 #050505, 8.65 on
+     --bg1 #0e0e12, 8.79 on the #0a0c10 plan cards. */
+  --accent: #d9a626;
+  --accent-rgb: 217,166,38;
+  --on-accent: #08090a;
   display: flex; flex-direction: column; min-height: 100vh; color: var(--txt); background: var(--bg0); font-family: inherit;
   animation: lp-content-in 0.5s var(--ease-settle);
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -82,6 +82,12 @@
      The inverse pairings are 2.23 and 3.63, so this is not cosmetic - it is
      the difference between passing and failing AA on every filled CTA. */
   --on-accent:  #08090a;
+  /* The accent's CHANNELS, so a tint can follow the token instead of being
+     retyped as a literal. 51 hardcoded rgba(var(--accent-rgb), ...) in this file and 61
+     more in components did NOT move when --accent became gold (#422), leaving
+     gold text on blue tints - a defect the conformance sweep is blind to,
+     because both colours pass on their own. */
+  --accent-rgb: 217,166,38;
 
   --purple:     var(--accent);
   --purple-dim: var(--accent-dim);
@@ -822,7 +828,7 @@ body::after {
     border-radius: var(--radius-card); padding: 14px 18px; position: relative;
     min-width: 96px; transition: border-color 0.2s, box-shadow 0.2s, background 0.2s;
   }
-  .ticker-see-all:active { background: rgba(26,122,255,0.18); box-shadow: 0 0 28px rgba(26,122,255,0.22); }
+  .ticker-see-all:active { background: rgba(var(--accent-rgb), 0.18); box-shadow: 0 0 28px rgba(var(--accent-rgb), 0.22); }
   .ticker-see-all-count { display: block; font-size: 2rem; font-weight: 700; color: var(--txt); letter-spacing: -1.5px; line-height: 1; text-align: center; }
   .ticker-see-all-label { display: block; font-size: var(--fs-micro); font-weight: 800; color: var(--txt3); letter-spacing: .14em; text-transform: uppercase; text-align: center; margin-top: 3px; }
   .ticker-see-all-arrow { display: block; font-size: 0.6875rem; font-weight: 700; color: var(--purple); margin-top: 10px; letter-spacing: .01em; text-align: center; }
@@ -977,7 +983,7 @@ body[data-rpm-level="high"]::before {
    product on every page, so it should read as present, not compete with it. */
 .ticker-red    { border-bottom-color: rgba(248,113,113,0.25); }
 .ticker-amber  { border-bottom-color: rgba(251,191,36,0.22); }
-.ticker-purple { border-bottom-color: rgba(90,163,255,0.22); }
+.ticker-purple { border-bottom-color: rgba(var(--accent-rgb), 0.22); }
 
 .ticker-badge {
   flex-shrink: 0;
@@ -987,7 +993,7 @@ body[data-rpm-level="high"]::before {
 }
 .ticker-red    .ticker-badge { background: rgba(248,113,113,0.14); color: rgba(252,165,165,0.9); }
 .ticker-amber  .ticker-badge { background: rgba(251,191,36,0.14); color: rgba(253,211,77,0.9); }
-.ticker-purple .ticker-badge { background: rgba(90,163,255,0.14); color: rgba(90,163,255,0.9); }
+.ticker-purple .ticker-badge { background: rgba(var(--accent-rgb), 0.14); color: rgba(var(--accent-rgb), 0.9); }
 
 .ticker-sep {
   flex-shrink: 0; width: 0.5px; height: 14px; background: rgba(255,255,255,0.1);
@@ -1006,7 +1012,7 @@ body[data-rpm-level="high"]::before {
 }
 .ticker-red    .ticker-content span { color: rgba(252,165,165,0.88); }
 .ticker-amber  .ticker-content span { color: rgba(253,211,77,0.85); }
-.ticker-purple .ticker-content span { color: rgba(90,163,255,0.82); }
+.ticker-purple .ticker-content span { color: rgba(var(--accent-rgb), 0.82); }
 
 /* Dismiss control - hides the current batch until a newer alert arrives. */
 /* 30x22 previously, which fails WCAG 2.2 SC 2.5.8 (Target Size Minimum, 24x24).
@@ -1334,7 +1340,7 @@ body.ticker-on .breaking-alert { top: calc(84px + var(--banner-h)); }
   letter-spacing: .03em; margin-bottom: 0; transition: all 0.15s;
 }
 .arena-fire-btn:disabled { opacity: 0.35; cursor: not-allowed; }
-.arena-fire-btn:not(:disabled):hover { background: rgba(26,122,255,0.12); border-color: var(--accent); }
+.arena-fire-btn:not(:disabled):hover { background: rgba(var(--accent-rgb), 0.12); border-color: var(--accent); }
 .arena-fire-btn:not(:disabled):active { transform: scale(0.98); }
 /* Quick mode button - green tint */
 .arena-quick-btn { background: rgba(52,211,153,0.08) !important; border-color: rgba(52,211,153,0.3) !important; color: var(--green-2) !important; }
@@ -1430,7 +1436,7 @@ body.ticker-on .breaking-alert { top: calc(84px + var(--banner-h)); }
    toggles - not an inline link, so the text exception does not cover it. */
 .av-rail-collapse { display: flex; justify-content: space-between; align-items: center; width: 100%; min-height: 24px; padding: 3px 0; font-size: var(--fs-caption); color: var(--txt2); cursor: pointer; background: none; border: none; text-align: left; font-family: inherit; }
 .av-rail-collapse .chev { color: var(--txt3); }
-.arena-reasoning       { background: rgba(26,122,255,0.05); border: 0.5px solid var(--purple-bdr); border-radius: 12px; padding: 12px 14px; }
+.arena-reasoning       { background: rgba(var(--accent-rgb), 0.05); border: 0.5px solid var(--purple-bdr); border-radius: 12px; padding: 12px 14px; }
 .arena-reasoning-title { font-size: var(--fs-micro); font-weight: 700; letter-spacing: .08em; text-transform: uppercase; color: var(--purple); margin-bottom: 8px; }
 .arena-reasoning-text  { font-size: var(--fs-label); color: var(--txt2); line-height: 1.65; white-space: pre-wrap; }
 .arena-hist-item   { background: var(--bg1); border: 0.5px solid var(--bdr); border-radius: 12px; padding: 10px 14px; margin-bottom: 0; display: flex; justify-content: space-between; align-items: center; transition: background 0.12s, border-color 0.12s; }
@@ -1729,7 +1735,7 @@ body.ticker-on .breaking-alert { top: calc(84px + var(--banner-h)); }
 
 
 .tg-action-btn { font-size: var(--fs-label); font-weight: 700; padding: 8px 16px; border-radius: 8px; cursor: pointer; background: var(--accent-bg); color: var(--accent); border: 0.5px solid var(--accent-bdr); transition: all 0.15s; }
-.tg-action-btn:hover:not(:disabled) { background: rgba(26,122,255,0.12); border-color: var(--accent); }
+.tg-action-btn:hover:not(:disabled) { background: rgba(var(--accent-rgb), 0.12); border-color: var(--accent); }
 .tg-action-btn:disabled { opacity: 0.35; cursor: not-allowed; }
 .tg-btn-ok  { background: rgba(52,211,153,0.1); color: var(--green); border-color: rgba(52,211,153,0.3); }
 .tg-btn-err { background: rgba(248,113,113,0.1); color: var(--red);   border-color: rgba(248,113,113,0.3); }
@@ -1812,7 +1818,7 @@ body.ticker-on .breaking-alert { top: calc(84px + var(--banner-h)); }
   text-align: left; white-space: nowrap; transition: background 0.12s, color 0.12s;
 }
 .klc-draw-item:hover { background: rgba(255,255,255,0.06); color: var(--txt); }
-.klc-draw-item.on { color: var(--accent-2); background: rgba(90,163,255,0.1); }
+.klc-draw-item.on { color: var(--accent-2); background: rgba(var(--accent-rgb), 0.1); }
 .klc-draw-clear { color: var(--red); margin-top: 2px; border-top: 0.5px solid var(--bdr); border-radius: 0 0 5px 5px; }
 .klc-legend { display: flex; gap: 8px; align-items: center; }
 .klc-ws-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--txt3); flex-shrink: 0; }
@@ -1894,7 +1900,7 @@ body.ticker-on .breaking-alert { top: calc(84px + var(--banner-h)); }
   cursor: pointer; transition: opacity 0.15s, transform 0.15s, box-shadow 0.2s, background 0.2s, border-color 0.2s;
   display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 3px;
 }
-.gchat-fab:hover { box-shadow: 0 6px 32px rgba(0,0,0,0.9), 0 0 30px rgba(26,122,255,0.25); transform: scale(1.04); }
+.gchat-fab:hover { box-shadow: 0 6px 32px rgba(0,0,0,0.9), 0 0 30px rgba(var(--accent-rgb), 0.25); transform: scale(1.04); }
 /* AUTH-6/item #18 fix: the FAB used to swap to an ✕ glyph while the panel
    was open, duplicating the panel's own header ✕ - two close buttons on
    screen at once, worse when expanded since the FAB (bottom-right) reads
@@ -1923,7 +1929,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   width: 360px; height: 560px;
   background: var(--bg1); border: 0.5px solid var(--bdr);
   border-radius: var(--radius-card); display: flex; flex-direction: column; overflow: hidden;
-  box-shadow: 0 8px 48px rgba(0,0,0,0.9), 0 0 0 0.5px rgba(26,122,255,0.12);
+  box-shadow: 0 8px 48px rgba(0,0,0,0.9), 0 0 0 0.5px rgba(var(--accent-rgb), 0.12);
   transform: scale(0.92) translateY(16px); opacity: 0; pointer-events: none;
   transition: transform 0.3s cubic-bezier(0.34,1.56,0.64,1), opacity 0.2s,
               width 0.3s cubic-bezier(0.4,0,0.2,1), height 0.3s cubic-bezier(0.4,0,0.2,1),
@@ -1941,7 +1947,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   width: min(860px, calc(100vw - 32px));
   height: min(90vh, 760px);
   border-radius: var(--radius-card);
-  box-shadow: 0 24px 80px rgba(0,0,0,0.95), 0 0 0 0.5px rgba(26,122,255,0.14);
+  box-shadow: 0 24px 80px rgba(0,0,0,0.95), 0 0 0 0.5px rgba(var(--accent-rgb), 0.14);
   border-color: rgba(255,255,255,0.13);
   transform-origin: center center;
 }
@@ -1957,9 +1963,9 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .gchat-expanded .gchat-msgs   { padding: 14px 20px; gap: 14px; }
 
 /* Scrollbar visible in expanded mode */
-.gchat-expanded .gchat-msgs { scrollbar-width: thin; scrollbar-color: rgba(26,122,255,0.2) transparent; }
+.gchat-expanded .gchat-msgs { scrollbar-width: thin; scrollbar-color: rgba(var(--accent-rgb), 0.2) transparent; }
 .gchat-expanded .gchat-msgs::-webkit-scrollbar { display: block; width: 4px; }
-.gchat-expanded .gchat-msgs::-webkit-scrollbar-thumb { background: rgba(26,122,255,0.2); border-radius: 2px; }
+.gchat-expanded .gchat-msgs::-webkit-scrollbar-thumb { background: rgba(var(--accent-rgb), 0.2); border-radius: 2px; }
 
 @media (max-width: 420px) {
   /* `bottom` is deliberately NOT set here. Both this block and the
@@ -2095,9 +2101,9 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 
 /* ── History panel ── */
 .gchat-hist-view  { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
-.gchat-hist-list  { flex: 1; overflow-y: auto; padding: 6px 0; scrollbar-width: thin; scrollbar-color: rgba(26,122,255,0.15) transparent; }
+.gchat-hist-list  { flex: 1; overflow-y: auto; padding: 6px 0; scrollbar-width: thin; scrollbar-color: rgba(var(--accent-rgb), 0.15) transparent; }
 .gchat-hist-list::-webkit-scrollbar { display: block; width: 3px; }
-.gchat-hist-list::-webkit-scrollbar-thumb { background: rgba(26,122,255,0.18); border-radius: 2px; }
+.gchat-hist-list::-webkit-scrollbar-thumb { background: rgba(var(--accent-rgb), 0.18); border-radius: 2px; }
 .gchat-hist-empty { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; padding: 24px; }
 
 .gchat-hist-item { display: flex; align-items: center; gap: 10px; padding: 10px 14px; cursor: pointer; border-bottom: 0.5px solid var(--bdr); transition: background 0.1s; }
@@ -2121,16 +2127,16 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .gchat-followup-chip {
   font-size: var(--fs-caption); font-weight: 500;
   padding: 5px 11px; border-radius: 20px;
-  border: 0.5px solid rgba(26,122,255,0.22);
-  background: rgba(26,122,255,0.06);
+  border: 0.5px solid rgba(var(--accent-rgb), 0.22);
+  background: rgba(var(--accent-rgb), 0.06);
   color: var(--accent-2); cursor: pointer;
   white-space: normal; text-align: left; line-height: 1.35;
   transition: background 0.14s, border-color 0.14s, color 0.14s;
   animation: fadeInUp 0.15s ease;
 }
 .gchat-followup-chip:hover {
-  background: rgba(26,122,255,0.14);
-  border-color: rgba(26,122,255,0.45);
+  background: rgba(var(--accent-rgb), 0.14);
+  border-color: rgba(var(--accent-rgb), 0.45);
   color: #d4caff;
 }
 @keyframes fadeInUp { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
@@ -2161,7 +2167,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .liq-magnet-box-body { font-size: var(--fs-caption); font-weight: 600; line-height: 1.7; }
 
 .liq-card { background: var(--bg2); border: 0.5px solid var(--bdr); border-radius: var(--radius-card); overflow: hidden; margin-bottom: 12px; }
-.liq-insight-card { background: rgba(26,122,255,0.06); border: 0.5px solid rgba(26,122,255,0.2); border-radius: var(--radius-card); padding: 14px 16px; margin-bottom: 10px; }
+.liq-insight-card { background: rgba(var(--accent-rgb), 0.06); border: 0.5px solid rgba(var(--accent-rgb), 0.2); border-radius: var(--radius-card); padding: 14px 16px; margin-bottom: 10px; }
 .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
 
 /* ── Skeleton loading (shared by components/LoadingState.tsx + Skeleton.tsx) ──
@@ -2183,7 +2189,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .liq-section-hdr-long  { color: var(--red); background: rgba(248,113,113,0.06); border-top: 0.5px solid rgba(248,113,113,0.12); border-bottom: 0.5px solid rgba(248,113,113,0.12); }
 .liq-section-sub { font-size: var(--fs-caption); font-weight: 500; opacity: 0.75; text-transform: none; letter-spacing: 0; }
 
-.liq-current-bar { display: flex; align-items: center; gap: 10px; padding: 12px 14px; background: rgba(26,122,255,0.09); border-top: 1px solid rgba(26,122,255,0.28); border-bottom: 1px solid rgba(26,122,255,0.28); border-left: 3px solid var(--purple); margin: 2px 0; }
+.liq-current-bar { display: flex; align-items: center; gap: 10px; padding: 12px 14px; background: rgba(var(--accent-rgb), 0.09); border-top: 1px solid rgba(var(--accent-rgb), 0.28); border-bottom: 1px solid rgba(var(--accent-rgb), 0.28); border-left: 3px solid var(--purple); margin: 2px 0; }
 .liq-current-dot { width: 9px; height: 9px; border-radius: 50%; background: var(--purple); box-shadow: 0 0 8px var(--purple); flex-shrink: 0; animation: liq-pulse 2s infinite; }
 @keyframes liq-pulse { 0%,100%{box-shadow:0 0 6px var(--purple)} 50%{box-shadow:0 0 16px var(--purple),0 0 4px #fff4} }
 .liq-current-price { font-size: var(--fs-data); font-weight: 700; color: #fff; font-family: var(--font-mono), monospace; font-variant-numeric: tabular-nums; }
@@ -2304,7 +2310,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .gex-flip-row span { color: var(--txt3); font-weight: 600; }
 
 /* ── Macro Correlation Strip ── */
-.macro-strip { background: linear-gradient(135deg, rgba(26,122,255,0.06) 0%, rgba(20,90,220,0.03) 100%); border: 0.5px solid var(--bdr); border-radius: var(--radius-card); padding: 14px 16px 12px; margin-bottom: 8px; }
+.macro-strip { background: linear-gradient(135deg, rgba(var(--accent-rgb), 0.06) 0%, rgba(20,90,220,0.03) 100%); border: 0.5px solid var(--bdr); border-radius: var(--radius-card); padding: 14px 16px 12px; margin-bottom: 8px; }
 .macro-strip-title { font-size: var(--fs-micro); font-weight: 700; color: var(--txt3); text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 10px; }
 .macro-strip-row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; }
 .macro-item { background: var(--bg2); border: 0.5px solid var(--bdr); border-radius: 12px; padding: 10px 12px; display: flex; flex-direction: column; gap: 2px; }
@@ -2390,6 +2396,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   /* White on the light-theme gold, not near-black: #08090a on #826517 is
      3.63:1 and fails. The pairing inverts with the theme. */
   --on-accent:  #ffffff;
+  --accent-rgb: 104,81,18;
 
   /* Purple aliased to accent - no separate violet in light mode */
   --purple:     var(--accent);
@@ -2431,7 +2438,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 
   --glow-green:  0 0 16px rgba(4,120,87,0.12);
   --glow-red:    0 0 16px rgba(185,28,28,0.12);
-  --glow-purple: 0 0 16px rgba(0,82,204,0.12);
+  --glow-purple: 0 0 16px rgba(var(--accent-rgb), 0.12);
   --glow-amber:  0 0 16px rgba(180,83,9,0.12);
 }
 
@@ -2518,7 +2525,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 [data-theme="light"] .gex-hdr    { color: var(--txt3); }
 
 /* Current price bar in liq map */
-[data-theme="light"] .liq-current-bar   { background: rgba(0,82,204,0.06); }
+[data-theme="light"] .liq-current-bar   { background: rgba(var(--accent-rgb), 0.06); }
 [data-theme="light"] .liq-current-price { color: var(--txt); }
 [data-theme="light"] .liq-current-tag   { background: var(--purple-bg); color: var(--purple); border-color: var(--purple-bdr); }
 
@@ -2534,7 +2541,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 
 /* Macro strip warm gradient in light */
 [data-theme="light"] .macro-strip {
-  background: linear-gradient(135deg, rgba(29,78,216,0.05) 0%, rgba(0,82,204,0.05) 100%);
+  background: linear-gradient(135deg, rgba(29,78,216,0.05) 0%, rgba(var(--accent-rgb), 0.05) 100%);
 }
 
 /* ── SETUP SCANNER ──────────────────────────────────────────────────────── */
@@ -2684,7 +2691,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 }
 .liq-cascade-long  { background: rgba(248,113,113,0.10); border-top: 0.5px solid rgba(248,113,113,0.3); }
 .liq-cascade-short { background: rgba(52,211,153,0.10);  border-top: 0.5px solid rgba(52,211,153,0.3);  }
-.liq-cascade-mixed { background: rgba(26,122,255,0.10); border-top: 0.5px solid rgba(26,122,255,0.3); }
+.liq-cascade-mixed { background: rgba(var(--accent-rgb), 0.10); border-top: 0.5px solid rgba(var(--accent-rgb), 0.3); }
 .liq-cascade-icon  { font-size: 1.25rem; flex-shrink: 0; }
 .liq-cascade-body  { display: flex; flex-wrap: wrap; align-items: center; gap: 4px; }
 .liq-cascade-label { font-size: var(--fs-micro); font-weight: 800; letter-spacing: .06em; text-transform: uppercase; }
@@ -2737,7 +2744,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   padding: 1px 4px; border-radius: 3px; margin-right: 4px;
 }
 .liq-src-bn { background: rgba(240,165,0,0.15); color: #f0a500; }
-.liq-src-bb { background: rgba(90,163,255,0.15); color: var(--accent-2); }
+.liq-src-bb { background: rgba(var(--accent-rgb), 0.15); color: var(--accent-2); }
 
 @media (max-width: 480px) {
   .liqfeed-header { flex-wrap: wrap; gap: 2px 0; }
@@ -2772,7 +2779,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .ps-inp-tp:focus   { box-shadow: inset 0 0 0 1px rgba(52,211,153,.3); }
 .ps-presets { display: flex; gap: 6px; margin-top: 10px; flex-wrap: wrap; }
 .ps-preset  { flex: 0 0 auto; padding: 4px 12px; border-radius: 20px; border: 0.5px solid var(--bdr2); background: var(--bg3); color: var(--txt2); font-size: var(--fs-caption); font-weight: 600; cursor: pointer; }
-.ps-preset.on { background: rgba(26,122,255,.12); border-color: var(--purple-bdr); color: var(--purple); }
+.ps-preset.on { background: rgba(var(--accent-rgb), .12); border-color: var(--purple-bdr); color: var(--purple); }
 .ps-risk-line { font-size: var(--fs-caption); color: var(--txt3); margin-top: 8px; }
 /* Direction is a computed status, not a control - render it as a compact pill
    inside the results grid (not a full-width bar that reads as a button). */
@@ -2817,7 +2824,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .ps-live-btn    { display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; padding: 0 14px; border-radius: 10px;
   border: 0.5px solid var(--accent-bdr); background: var(--accent-bg); color: var(--accent); font-size: var(--fs-label); font-weight: 700;
   cursor: pointer; font-variant-numeric: tabular-nums; transition: background 0.15s, border-color 0.15s; }
-.ps-live-btn:hover { background: rgba(26,122,255,0.12); border-color: var(--accent); }
+.ps-live-btn:hover { background: rgba(var(--accent-rgb), 0.12); border-color: var(--accent); }
 .ps-live-dot    { width: 6px; height: 6px; border-radius: 50%; background: var(--green); box-shadow: 0 0 6px var(--green); flex-shrink: 0; }
 .ps-live-wait   { display: inline-flex; align-items: center; padding: 0 12px; font-size: var(--fs-caption); color: var(--txt3); white-space: nowrap; }
 .ps-results { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-bottom: 10px; }
@@ -2914,19 +2921,19 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .tj-tabs { display: flex; gap: 6px; margin-bottom: 14px; }
 .tj-tab  { flex: 1; padding: 9px 0; border-radius: 10px; border: 0.5px solid var(--bdr2); background: var(--bg2); color: var(--txt2); font-size: var(--fs-caption); font-weight: 600; cursor: pointer; transition: background .15s, color .15s; }
 .tj-tab:hover:not(.on) { background: var(--bg3); color: var(--txt); }
-.tj-tab.on { background: rgba(26,122,255,.12); border-color: var(--purple-bdr); color: var(--purple); }
+.tj-tab.on { background: rgba(var(--accent-rgb), .12); border-color: var(--purple-bdr); color: var(--purple); }
 .tj-card { background: var(--bg1); border: 0.5px solid var(--bdr); border-radius: var(--radius-card); padding: 14px; margin-bottom: 10px; }
 .tj-card-lbl { font-size: var(--fs-micro); font-weight: 600; letter-spacing: .08em; text-transform: uppercase; color: var(--txt3); margin-bottom: 10px; }
 .tj-coins { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 10px; }
 .tj-coin  { padding: 5px 10px; border-radius: 20px; border: 0.5px solid var(--bdr2); background: var(--bg2); color: var(--txt2); font-size: var(--fs-caption); font-weight: 600; cursor: pointer; }
-.tj-coin.on { background: rgba(26,122,255,.12); border-color: var(--purple-bdr); color: var(--purple); }
+.tj-coin.on { background: rgba(var(--accent-rgb), .12); border-color: var(--purple-bdr); color: var(--purple); }
 .tj-dir-row { display: flex; gap: 8px; margin-top: 4px; }
 .tj-dir-btn { flex: 1; padding: 9px; border-radius: 8px; border: 0.5px solid var(--bdr2); background: var(--bg2); color: var(--txt2); font-size: var(--fs-label); font-weight: 700; cursor: pointer; }
 .tj-dir-btn.tj-long  { background: var(--green-bg); border-color: var(--green-bdr); color: var(--green); }
 .tj-dir-btn.tj-short { background: var(--red-bg);   border-color: var(--red-bdr);   color: var(--red); }
 .tj-setups { display: flex; gap: 6px; flex-wrap: wrap; }
 .tj-setup-btn { padding: 5px 12px; border-radius: 20px; border: 0.5px solid var(--bdr2); background: var(--bg2); color: var(--txt2); font-size: var(--fs-caption); cursor: pointer; }
-.tj-setup-btn.on { background: rgba(26,122,255,.12); border-color: var(--purple-bdr); color: var(--purple); font-weight: 600; }
+.tj-setup-btn.on { background: rgba(var(--accent-rgb), .12); border-color: var(--purple-bdr); color: var(--purple); font-weight: 600; }
 .tj-price-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
 .tj-field { display: flex; flex-direction: column; }
 .tj-lbl   { font-size: var(--fs-caption); color: var(--txt2); margin-bottom: 5px; }
@@ -2937,9 +2944,9 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .tj-inp-tp:focus   { box-shadow: inset 0 0 0 1px rgba(52,211,153,.3); }
 .tj-autofill { font-size: var(--fs-caption); color: var(--green); margin-top: 8px; }
 .tj-notes { width: 100%; background: var(--bg2); border: 0.5px solid var(--bdr2); border-radius: 8px; padding: 10px; font-size: var(--fs-caption); color: var(--txt); resize: vertical; outline: none; font-family: inherit; box-sizing: border-box; }
-.tj-submit { width: 100%; padding: 13px; border-radius: var(--radius-card); border: 1px solid var(--purple); background: rgba(26,122,255,.22); color: #e4e7ff; font-size: var(--fs-label); font-weight: 700; cursor: pointer; margin-top: 4px; }
-.tj-submit:disabled { opacity: .35; cursor: not-allowed; border-color: var(--purple-bdr); background: rgba(26,122,255,.08); color: var(--purple); }
-.tj-submit:not(:disabled):hover { box-shadow: 0 0 16px rgba(26,122,255,.2); }
+.tj-submit { width: 100%; padding: 13px; border-radius: var(--radius-card); border: 1px solid var(--purple); background: rgba(var(--accent-rgb), .22); color: #e4e7ff; font-size: var(--fs-label); font-weight: 700; cursor: pointer; margin-top: 4px; }
+.tj-submit:disabled { opacity: .35; cursor: not-allowed; border-color: var(--purple-bdr); background: rgba(var(--accent-rgb), .08); color: var(--purple); }
+.tj-submit:not(:disabled):hover { box-shadow: 0 0 16px rgba(var(--accent-rgb), .2); }
 .tj-empty-state { text-align: center; padding: 3rem 0; color: var(--txt3); font-size: var(--fs-label); }
 /* Trade cards */
 .tj-trade { background: var(--bg1); border: 0.5px solid var(--bdr); border-radius: 12px; padding: 12px 14px; margin-bottom: 8px; border-left: 3px solid var(--bdr2); }
@@ -2961,7 +2968,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .tj-del-btn { width: 24px; height: 24px; border-radius: 50%; border: 0.5px solid var(--bdr); background: var(--bg3); color: var(--txt2); font-size: var(--fs-caption); cursor: pointer; display: flex; align-items: center; justify-content: center; }
 .tj-del-btn:hover { background: var(--red-bg); color: var(--red); border-color: var(--red-bdr); }
 .tj-edit-btn { width: 24px; height: 24px; border-radius: 50%; border: 0.5px solid var(--bdr); background: var(--bg3); color: var(--txt2); font-size: var(--fs-label); cursor: pointer; display: flex; align-items: center; justify-content: center; line-height: 1; }
-.tj-edit-btn:hover { background: rgba(26,122,255,.12); color: var(--purple); border-color: var(--purple-bdr); }
+.tj-edit-btn:hover { background: rgba(var(--accent-rgb), .12); color: var(--purple); border-color: var(--purple-bdr); }
 .tj-edit-form { margin-top: 10px; padding-top: 10px; border-top: 0.5px solid var(--bdr); }
 .tj-edit-row  { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 8px; }
 .tj-edit-field { display: flex; flex-direction: column; gap: 4px; }
@@ -3062,7 +3069,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 /* ── CONFLUENCE SCORER ──────────────────────────────────────────────────── */
 .cf-coins   { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 10px; }
 .cf-coin    { padding: 5px 10px; border-radius: 20px; border: 0.5px solid var(--bdr2); background: var(--bg2); color: var(--txt2); font-size: var(--fs-caption); font-weight: 600; cursor: pointer; transition: background .15s, color .15s; }
-.cf-coin.on { background: rgba(26,122,255,.12); border-color: var(--purple-bdr); color: var(--purple); }
+.cf-coin.on { background: rgba(var(--accent-rgb), .12); border-color: var(--purple-bdr); color: var(--purple); }
 .cf-dir-row { display: flex; gap: 8px; margin-bottom: 12px; }
 .cf-dir-btn { flex: 1; padding: 9px; border-radius: 10px; border: 0.5px solid var(--bdr2); background: var(--bg2); color: var(--txt2); font-size: var(--fs-label); font-weight: 700; cursor: pointer; transition: background .15s, color .15s, border-color .15s; }
 .cf-score-card { border: 0.5px solid; border-radius: var(--radius-card); padding: 14px 16px; margin-bottom: 10px; }
@@ -3075,13 +3082,13 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .cf-signal-body { flex: 1; display: flex; align-items: center; gap: 6px; }
 .cf-signal-label  { font-size: var(--fs-label); color: var(--txt2); }
 .cf-hit .cf-signal-label { color: var(--txt); }
-.cf-signal-strong { font-size: var(--fs-micro); font-weight: 700; padding: 1px 5px; border-radius: 4px; background: rgba(26,122,255,.12); color: var(--purple); border: 0.5px solid var(--purple-bdr); letter-spacing: .04em; text-transform: uppercase; }
+.cf-signal-strong { font-size: var(--fs-micro); font-weight: 700; padding: 1px 5px; border-radius: 4px; background: rgba(var(--accent-rgb), .12); color: var(--purple); border: 0.5px solid var(--purple-bdr); letter-spacing: .04em; text-transform: uppercase; }
 .cf-signal-detail { font-size: var(--fs-caption); color: var(--txt3); font-variant-numeric: tabular-nums; }
 .cf-detail-hit    { color: var(--green-2); font-weight: 600; }
 .cf-actions { display: flex; gap: 8px; }
 .cf-action-btn { flex: 1; padding: 12px; border-radius: 12px; font-size: var(--fs-label); font-weight: 700; cursor: pointer; transition: box-shadow .15s; }
-.cf-action-grok    { border: 0.5px solid var(--purple-bdr); background: rgba(26,122,255,.1); color: var(--purple); }
-.cf-action-grok:hover { box-shadow: 0 0 16px rgba(26,122,255,.2); }
+.cf-action-grok    { border: 0.5px solid var(--purple-bdr); background: rgba(var(--accent-rgb), .1); color: var(--purple); }
+.cf-action-grok:hover { box-shadow: 0 0 16px rgba(var(--accent-rgb), .2); }
 .cf-action-journal { border: 0.5px solid var(--green-bdr); background: var(--green-bg); color: var(--green); }
 .cf-action-journal:hover { box-shadow: 0 0 16px rgba(52,211,153,.15); }
 [data-theme="light"] .cf-signals { background: #fafafa; }
@@ -3167,7 +3174,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .mb-brief-card    { margin-bottom: 10px; }
 .mb-brief-header  { display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px; flex-wrap: wrap; gap: 8px; }
 .mb-brief-btn     { padding: 9px 16px; border-radius: 20px; font-size: var(--fs-caption); font-weight: 700; cursor: pointer; border: 0.5px solid var(--purple-bdr); background: var(--purple-bg); color: var(--purple); transition: all 0.15s; white-space: nowrap; min-height: 36px; display: inline-flex; align-items: center; }
-.mb-brief-btn:hover:not(:disabled) { background: rgba(26,122,255,0.18); }
+.mb-brief-btn:hover:not(:disabled) { background: rgba(var(--accent-rgb), 0.18); }
 .mb-brief-btn.loading  { opacity: 0.6; cursor: wait; }
 .mb-brief-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 .mb-brief-empty   { font-size: var(--fs-caption); color: var(--txt3); line-height: 1.6; }
@@ -3222,7 +3229,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .frh-coin        { font-weight: 700; color: var(--txt) !important; font-size: var(--fs-caption); width: 46px; }
 .frh-row         { cursor: pointer; transition: background 0.1s, box-shadow 0.1s; }
 .frh-row:hover   { background: rgba(255,255,255,0.04); }
-.frh-row.on      { background: rgba(26,122,255,0.11) !important; box-shadow: inset 3px 0 0 #1a7aff !important; }
+.frh-row.on      { background: rgba(var(--accent-rgb), 0.11) !important; box-shadow: inset 3px 0 0 #1a7aff !important; }
 .frh-row.on .frh-coin { color: var(--purple) !important; }
 .frh-spark-th    { min-width: 120px; }
 .frh-spark-cell  { min-width: 120px; width: 160px; padding: 3px 8px !important; }
@@ -3664,7 +3671,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   cursor: pointer; display: flex; align-items: center; justify-content: center;
   transition: all 0.15s;
 }
-.auth-avatar-btn:hover { background: rgba(26,122,255,0.16); border-color: var(--purple); }
+.auth-avatar-btn:hover { background: rgba(var(--accent-rgb), 0.16); border-color: var(--purple); }
 
 .auth-signin-btn {
   font-size: var(--fs-caption); font-weight: 600; color: var(--txt3);
@@ -3757,7 +3764,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 [data-theme="light"] .ticker-sep  { background: rgba(0,0,0,0.15); }
 [data-theme="light"] .ticker-red    { border-bottom-color: rgba(185,28,28,0.25); }
 [data-theme="light"] .ticker-amber  { border-bottom-color: rgba(180,83,9,0.25); }
-[data-theme="light"] .ticker-purple { border-bottom-color: rgba(0,82,204,0.25); }
+[data-theme="light"] .ticker-purple { border-bottom-color: rgba(var(--accent-rgb), 0.25); }
 /* Badge text was set to white here while the background stayed the
    dark-mode 0.14-alpha translucent tint (meant to sit on a near-black page) -
    on the light ticker's white background that read as barely-visible white-
@@ -3802,11 +3809,11 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 [data-theme="light"] .gchat-fab {
   background: var(--accent-solid);
   border-color: transparent;
-  box-shadow: 0 4px 20px rgba(0,82,204,0.22), 0 1px 4px rgba(0,0,0,0.10);
+  box-shadow: 0 4px 20px rgba(var(--accent-rgb), 0.22), 0 1px 4px rgba(0,0,0,0.10);
   color: var(--on-accent);
 }
 [data-theme="light"] .gchat-fab:hover {
-  box-shadow: 0 6px 28px rgba(0,82,204,0.30), 0 2px 6px rgba(0,0,0,0.12);
+  box-shadow: 0 6px 28px rgba(var(--accent-rgb), 0.30), 0 2px 6px rgba(0,0,0,0.12);
 }
 
 /* News cards - rgba(white) borders invisible in light mode */
@@ -4452,9 +4459,9 @@ body.landing {
   --accent:     #d9a626;
   --accent-solid: #1668e3; /* AA fix, mirrors :root - see note there */
   --accent-2:   #5aa3ff;
-  --accent-dim: rgba(26,122,255,0.12);
-  --accent-bg:  rgba(26,122,255,0.07);
-  --accent-bdr: rgba(26,122,255,0.22);
+  --accent-dim: rgba(var(--accent-rgb), 0.12);
+  --accent-bg:  rgba(var(--accent-rgb), 0.07);
+  --accent-bdr: rgba(var(--accent-rgb), 0.22);
 }
 
 /* Shared entrance curve - a considered "settle in" rather than the flatter
@@ -4664,7 +4671,7 @@ body.landing {
 /* ── LP PRICING ──────────────────────────────────────────────────────── */
 .lp-pricing         { display: flex; gap: 20px; align-items: flex-start; justify-content: center; flex-wrap: wrap; }
 .lp-plan            { flex: 1; min-width: 280px; max-width: 380px; border-radius: var(--radius-card); padding: 28px; border: 1px solid var(--bdr); background: var(--bg2); position: relative; }
-.lp-plan-pro        { border-color: rgba(26,122,255,.3); background: var(--bg2); }
+.lp-plan-pro        { border-color: rgba(var(--accent-rgb), .3); background: var(--bg2); }
 .lp-plan-badge      { position: absolute; top: -12px; left: 50%; transform: translateX(-50%); font-size: var(--fs-micro); font-weight: 700; letter-spacing: .08em; text-transform: uppercase; background: var(--accent-solid); color: var(--on-accent); padding: 3px 14px; border-radius: var(--radius-chip); white-space: nowrap; }
 .lp-plan-header     { margin-bottom: 24px; }
 .lp-plan-name       { font-size: var(--fs-label); font-weight: 700; color: var(--txt2); letter-spacing: .06em; text-transform: uppercase; margin-bottom: 6px; }
@@ -4742,7 +4749,7 @@ body.landing {
   content: '';
   display: block;
   height: 1px;
-  background: linear-gradient(90deg, var(--accent) 0%, rgba(26,122,255,0.25) 35%, transparent 70%);
+  background: linear-gradient(90deg, var(--accent) 0%, rgba(var(--accent-rgb), 0.25) 35%, transparent 70%);
   margin-bottom: 28px;
 }
 .pf-footer-top {

--- a/app/globals.css
+++ b/app/globals.css
@@ -52,24 +52,36 @@
   --bdr:  rgba(255,255,255,0.08);
   --bdr2: rgba(255,255,255,0.14);
 
-  /* Electric blue - CTAs and interactive elements only */
-  --accent:     #1a7aff;
-  /* The SAME brand blue, darkened, for one job: a filled surface carrying white
-     text. White on #1a7aff is 3.98:1 and fails AA - it was the last 20 contrast
-     failures in the app (primary CTA, active nav pill, consent Accept, plan
-     badges). #1668e3 takes that pair to 5.09:1.
-     A second token rather than a darker --accent, because darkening the token
-     itself trades one failure for another: --accent is also used AS TEXT on the
-     near-black backgrounds (links, funding badges, .reasoning-link), where
-     #1a7aff is 5.06:1 and #1668e3 would be 3.95:1. One value cannot satisfy
-     both directions on a dark theme.
-     Rule: --accent for text, borders, glows and rgba tints; --accent-solid
-     wherever the blue is the background under white text. */
-  --accent-solid: #1668e3;
-  --accent-2:   #5aa3ff;
-  --accent-dim: rgba(26,122,255,0.12);
-  --accent-bg:  rgba(26,122,255,0.07);
-  --accent-bdr: rgba(26,122,255,0.22);
+  /* TERMINAL GOLD - the primary, live in both designs (#419, owner's
+     instruction). Was the electric blue #1a7aff.
+     Measured before the swap, because the two colours behave oppositely:
+         amber AS TEXT on --bg1      8.73:1   (blue was 4.88 - this improves)
+         white ON amber              2.23:1   FAILS
+         near-black ON amber         8.95:1
+     So amber is a FILL that carries dark text, where blue was a colour that
+     carried white text. Anything using it as a background pairs it with
+     --on-accent below, never with #fff. */
+  --accent:     #d9a626;
+  /* -solid and -2 are the SAME gold, not a darker and a lighter variant.
+     They existed to solve a blue-specific problem: white on #1a7aff was
+     3.98:1, so filled surfaces needed a darkened #1668e3 while text kept the
+     brighter value - "one value cannot satisfy both directions on a dark
+     theme". That reasoning is spent. Amber inverts the pairing instead of
+     darkening the fill, and the design has exactly ONE accent - inventing a
+     second by shading it is the drift the single-accent premise prevents.
+     Kept as aliases rather than deleted: ~50 call sites reference them, and a
+     rename is a separate change from a recolour. */
+  --accent-solid: #d9a626;
+  --accent-2:   #d9a626;
+  --accent-dim: rgba(217,166,38,0.12);
+  --accent-bg:  rgba(217,166,38,0.07);
+  --accent-bdr: rgba(217,166,38,0.22);
+  /* What goes ON an accent fill. Flips with the theme because the accent does:
+         dark   gold #d9a626 + #08090a   8.95:1
+         light  gold #826517 + #ffffff   5.49:1
+     The inverse pairings are 2.23 and 3.63, so this is not cosmetic - it is
+     the difference between passing and failing AA on every filled CTA. */
+  --on-accent:  #08090a;
 
   --purple:     var(--accent);
   --purple-dim: var(--accent-dim);
@@ -207,11 +219,20 @@
    at the root instead, which is also the standard fix for this bug class.
    This app has no legitimate horizontal-scroll surface, so blocking it
    globally is safe. */
-html { background: #06070a; overflow-x: hidden; }
+/* var(--bg1), NOT a literal (#419/#420). The canvas was hardcoded #06070a, so
+   it stayed dark-blue-black under every theme and design - the one surface the
+   token layer could not reach. QA found it via the conformance sweep: the
+   converted disclaimer sat on an unconverted canvas.
+
+   --bg1 rather than --bg0, which is what the fix was first proposed as. In this
+   theme --bg1 IS #06070a and --bg0 is #030405, so --bg0 would have darkened the
+   whole app today as a side effect of a change meant to alter nothing. Byte-
+   identical now, and it converts with the design. */
+html { background: var(--bg1); overflow-x: hidden; }
 
 body {
   font-family: var(--font-sans), 'Segoe UI', system-ui, sans-serif;
-  background: #06070a;
+  background: var(--bg1);
   background-attachment: fixed;
   color: var(--txt);
   min-height: 100vh;
@@ -863,7 +884,7 @@ body[data-rpm-level="high"]::before {
   border: 0.5px solid transparent; white-space: nowrap;
 }
 .desktop-nav-item:hover { color: var(--txt); background: rgba(90,150,255,0.07); }
-.desktop-nav-item.on { color: #ffffff; background: var(--accent-solid); font-weight: 600; }
+.desktop-nav-item.on { color: var(--on-accent); background: var(--accent-solid); font-weight: 600; }
 
 @media (min-width: 768px) {
   .hamburger   { display: none !important; }
@@ -1590,7 +1611,7 @@ body.ticker-on .breaking-alert { top: calc(84px + var(--banner-h)); }
   min-height: 30px; letter-spacing: 0; white-space: nowrap;
   transition: background 0.15s, border-color 0.15s, color 0.15s;
 }
-.ncard-ask-btn:hover { background: var(--accent-solid); border-color: var(--accent); color: #fff; box-shadow: none; }
+.ncard-ask-btn:hover { background: var(--accent-solid); border-color: var(--accent); color: var(--on-accent); box-shadow: none; }
 .ncard-ask-spark { font-size: 0.8em; line-height: 1; }
 /* Secondary action - neutral, not accent-colored, so it doesn't compete with
    Ask LiquidityAI for attention as the primary CTA. */
@@ -2339,14 +2360,26 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   --nm-inset:    inset 0 1px 3px rgba(0,0,0,0.07), 0 0 0 0.5px rgba(0,0,0,0.05);
   --nm-btn:      0 1px 3px rgba(0,0,0,0.09), 0 0 0 0.5px rgba(0,0,0,0.07);
 
-  /* Accent - darker blue for legibility on white */
-  --accent:     #0052CC;
+  /* A darker gold for light theme (#419). #d9a626 on white is 2.23:1, so it had
+     to come down to clear AA.
+     #795f15 is the lightest value on this hue that clears 4.5:1 on ALL THREE
+     light surfaces:
+         #ffffff  6.07      #f2f3f5  5.47      #e1e1de  4.63
+     The first draft was #826517, chosen against the first two only - and the
+     third surface measured 4.18 on live pages ("Pro Plan", "Sign up"). Found by
+     walking the rendered DOM rather than by re-reading the token table, which
+     is the only reason it was found at all. */
+  --accent:     #795f15;
   /* was #0066E8 - 3.03:1 on the canvas #e8eaed, which is where the footer
      divider label and the markets sort buttons sit. */
-  --accent-2:   #0052CC;
-  --accent-dim: rgba(0,82,204,0.10);
-  --accent-bg:  rgba(0,82,204,0.07);
-  --accent-bdr: rgba(0,82,204,0.22);
+  --accent-2:   #795f15;
+  --accent-solid: #795f15;
+  --accent-dim: rgba(121,95,21,0.10);
+  --accent-bg:  rgba(121,95,21,0.07);
+  --accent-bdr: rgba(121,95,21,0.22);
+  /* White on the light-theme gold, not near-black: #08090a on #826517 is
+     3.63:1 and fails. The pairing inverts with the theme. */
+  --on-accent:  #ffffff;
 
   /* Purple aliased to accent - no separate violet in light mode */
   --purple:     var(--accent);
@@ -3272,7 +3305,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
    and altering it would move all of them for a one-button fix. */
 .auth-gate-btn {
   margin-top: 6px; padding: 9px 26px; border-radius: 10px;
-  background: var(--accent-solid); color: #fff;
+  background: var(--accent-solid); color: var(--on-accent);
   font-size: var(--fs-label); font-weight: 600; text-decoration: none; letter-spacing: -0.1px;
   transition: filter 0.15s; display: inline-block;
 }
@@ -3474,7 +3507,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
    fixing the one element issue #56 named: white text on --purple (= --accent,
    #1a7aff) is 3.98:1. Only on hover, so axe's resting-state sweep never saw it.
    --accent-solid is the filled-surface token: 5.09:1. */
-.st-save-btn:hover { background: var(--accent-solid); color: #fff; }
+.st-save-btn:hover { background: var(--accent-solid); color: var(--on-accent); }
 .st-save-btn:disabled { opacity: 0.5; cursor: default; }
 
 /* Sign out */
@@ -3760,7 +3793,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   background: var(--accent-solid);
   border-color: transparent;
   box-shadow: 0 4px 20px rgba(0,82,204,0.22), 0 1px 4px rgba(0,0,0,0.10);
-  color: #fff;
+  color: var(--on-accent);
 }
 [data-theme="light"] .gchat-fab:hover {
   box-shadow: 0 6px 28px rgba(0,82,204,0.30), 0 2px 6px rgba(0,0,0,0.12);
@@ -3847,7 +3880,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .login-email-btn {
   width: 100%; padding: 11px 16px; border-radius: 12px;
   background: var(--accent-solid); border: 0.5px solid var(--accent);
-  color: #fff; font-size: var(--fs-label); font-weight: 600; cursor: pointer;
+  color: var(--on-accent); font-size: var(--fs-label); font-weight: 600; cursor: pointer;
   transition: all 0.15s; font-family: inherit; letter-spacing: -0.1px;
   display: flex; align-items: center; justify-content: center; gap: 8px;
 }
@@ -4032,7 +4065,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   display: inline-flex; align-items: center; justify-content: center;
   transition: filter 0.15s, background 0.15s;
 }
-.consent-accept  { background: var(--accent-solid); border: 0.5px solid var(--accent); color: #fff; }
+.consent-accept  { background: var(--accent-solid); border: 0.5px solid var(--accent); color: var(--on-accent); }
 .consent-decline { background: var(--bg4); border: 0.5px solid var(--txt3); color: var(--txt); }
 .consent-accept:hover  { filter: brightness(1.08); }
 .consent-decline:hover { filter: brightness(1.25); }
@@ -4406,7 +4439,7 @@ body.landing {
   --bdr:  rgba(255,255,255,0.08);
   --bdr2: rgba(255,255,255,0.14);
 
-  --accent:     #1a7aff;
+  --accent:     #d9a626;
   --accent-solid: #1668e3; /* AA fix, mirrors :root - see note there */
   --accent-2:   #5aa3ff;
   --accent-dim: rgba(26,122,255,0.12);
@@ -4533,7 +4566,7 @@ body.landing {
 .lp-nav-actions { display: flex; align-items: center; gap: 10px; }
 .lp-btn-ghost  { font-size: var(--fs-label); font-weight: 500; color: var(--txt2); padding: 6px 14px; border-radius: var(--radius-chip); text-decoration: none; transition: color .15s, background .15s; min-height: 36px; display: inline-flex; align-items: center; }
 .lp-btn-ghost:hover { color: var(--txt); background: rgba(255,255,255,.05); }
-.lp-btn-primary { font-size: var(--fs-label); font-weight: 600; color: #fff; background: var(--accent-solid); padding: 7px 16px; border-radius: var(--radius-chip); text-decoration: none; transition: opacity .15s; min-height: 36px; display: inline-flex; align-items: center; }
+.lp-btn-primary { font-size: var(--fs-label); font-weight: 600; color: var(--on-accent); background: var(--accent-solid); padding: 7px 16px; border-radius: var(--radius-chip); text-decoration: none; transition: opacity .15s; min-height: 36px; display: inline-flex; align-items: center; }
 .lp-btn-primary:hover { opacity: .85; }
 .lp-lang-short { display: none; }
 
@@ -4572,7 +4605,7 @@ body.landing {
 .lp-h1-accent   { font-family: Georgia, 'Times New Roman', serif; font-style: italic; font-weight: 400; color: var(--accent-2); }
 .lp-hero-sub    { font-size: var(--fs-caption); color: var(--txt2); line-height: 1.65; max-width: 520px; margin: 0; }
 .lp-hero-ctas   { display: flex; gap: 12px; flex-wrap: wrap; justify-content: center; }
-.lp-cta-primary { font-size: var(--fs-card-title); font-weight: 700; color: #fff; background: var(--accent-solid); padding: 13px 28px; border-radius: var(--radius-card); text-decoration: none; transition: opacity .15s; }
+.lp-cta-primary { font-size: var(--fs-card-title); font-weight: 700; color: var(--on-accent); background: var(--accent-solid); padding: 13px 28px; border-radius: var(--radius-card); text-decoration: none; transition: opacity .15s; }
 .lp-cta-primary:hover { opacity: .88; }
 .lp-cta-ghost   { font-size: var(--fs-card-title); font-weight: 600; color: var(--txt2); background: rgba(255,255,255,.06); border: 1px solid var(--bdr); padding: 13px 28px; border-radius: var(--radius-card); text-decoration: none; transition: background .15s, color .15s; }
 .lp-cta-ghost:hover { background: rgba(255,255,255,.1); color: var(--txt); }
@@ -4613,7 +4646,7 @@ body.landing {
 .lp-step          { flex: 1; padding: 0 28px; text-align: center; }
 .lp-step:first-child { padding-left: 0; }
 .lp-step:last-child  { padding-right: 0; }
-.lp-step-num      { width: 40px; height: 40px; border-radius: 50%; background: var(--accent-solid); color: #fff; font-size: var(--fs-data); font-weight: 800; display: flex; align-items: center; justify-content: center; margin: 0 auto 14px; }
+.lp-step-num      { width: 40px; height: 40px; border-radius: 50%; background: var(--accent-solid); color: var(--on-accent); font-size: var(--fs-data); font-weight: 800; display: flex; align-items: center; justify-content: center; margin: 0 auto 14px; }
 .lp-step h3       { font-size: var(--fs-card-title); font-weight: 700; margin: 0 0 8px; }
 .lp-step p        { font-size: var(--fs-label); color: var(--txt2); line-height: 1.6; margin: 0; }
 .lp-step-arrow    { font-size: 1.25rem; color: var(--txt3); margin-top: 10px; flex-shrink: 0; align-self: center; }
@@ -4622,7 +4655,7 @@ body.landing {
 .lp-pricing         { display: flex; gap: 20px; align-items: flex-start; justify-content: center; flex-wrap: wrap; }
 .lp-plan            { flex: 1; min-width: 280px; max-width: 380px; border-radius: var(--radius-card); padding: 28px; border: 1px solid var(--bdr); background: var(--bg2); position: relative; }
 .lp-plan-pro        { border-color: rgba(26,122,255,.3); background: var(--bg2); }
-.lp-plan-badge      { position: absolute; top: -12px; left: 50%; transform: translateX(-50%); font-size: var(--fs-micro); font-weight: 700; letter-spacing: .08em; text-transform: uppercase; background: var(--accent-solid); color: #fff; padding: 3px 14px; border-radius: var(--radius-chip); white-space: nowrap; }
+.lp-plan-badge      { position: absolute; top: -12px; left: 50%; transform: translateX(-50%); font-size: var(--fs-micro); font-weight: 700; letter-spacing: .08em; text-transform: uppercase; background: var(--accent-solid); color: var(--on-accent); padding: 3px 14px; border-radius: var(--radius-chip); white-space: nowrap; }
 .lp-plan-header     { margin-bottom: 24px; }
 .lp-plan-name       { font-size: var(--fs-label); font-weight: 700; color: var(--txt2); letter-spacing: .06em; text-transform: uppercase; margin-bottom: 6px; }
 .lp-plan-price      { font-size: 3rem; font-weight: 900; letter-spacing: -.04em; line-height: 1; margin-bottom: 6px; }
@@ -4636,7 +4669,7 @@ body.landing {
 .lp-plan-cta        { display: block; text-align: center; padding: 12px; border-radius: var(--radius-card); font-size: var(--fs-label); font-weight: 700; text-decoration: none; transition: opacity .15s; }
 .lp-plan-cta-free   { background: rgba(255,255,255,.07); border: 0.5px solid var(--bdr); color: var(--txt); }
 .lp-plan-cta-free:hover { background: rgba(255,255,255,.12); }
-.lp-plan-cta-pro    { background: var(--accent-solid); color: #fff; }
+.lp-plan-cta-pro    { background: var(--accent-solid); color: var(--on-accent); }
 .lp-plan-cta-pro:hover { opacity: .85; }
 
 /* ── LP FINAL CTA ────────────────────────────────────────────────────── */
@@ -5021,7 +5054,7 @@ html[lang="ar"] .lp-h1-accent {
 }
 .obw-btn-back { flex-shrink: 0; background: transparent; border: 1px solid var(--bdr); color: var(--txt2); }
 .obw-btn-back:hover { border-color: var(--bdr2); color: var(--txt); }
-.obw-btn-next { flex: 1; border: 1px solid var(--accent); background: var(--accent-solid); color: #fff; }
+.obw-btn-next { flex: 1; border: 1px solid var(--accent); background: var(--accent-solid); color: var(--on-accent); }
 .obw-btn-next:hover:not(:disabled) { background: var(--accent-2); border-color: var(--accent-2); }
 .obw-btn-next:disabled { background: var(--bg2); border-color: var(--bdr); color: var(--txt3); cursor: not-allowed; }
 .obw-skip {

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -187,7 +187,7 @@ const SOURCE_COLORS: Record<string, string> = {
 const TYPE_CFG: Record<'red' | 'amber' | 'purple', { dot: string; labelKey: LabelKey; accentBg: string }> = {
   red:    { dot: 'var(--red)', labelKey: 'NEWS_TYPE_BADGE_BREAKING', accentBg: 'rgba(248,113,113,0.08)'  },
   amber:  { dot: 'var(--amber)', labelKey: 'NEWS_TYPE_BADGE_MACRO',    accentBg: 'rgba(251,191,36,0.07)'  },
-  purple: { dot: '#1a7aff', labelKey: 'NEWS_TYPE_BADGE_CRYPTO',   accentBg: 'rgba(26,122,255,0.07)' },
+  purple: { dot: '#1a7aff', labelKey: 'NEWS_TYPE_BADGE_CRYPTO',   accentBg: 'rgba(var(--accent-rgb), 0.07)' },
 };
 
 /* ── Market impact chip - first 6 words of note ── */

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -504,7 +504,7 @@ export default function SettingsPage() {
             onClick={handleTestPush}
             style={{
               width: '100%', padding: '9px 0', borderRadius: 8, marginBottom: 16,
-              background: testResult === 'sent' ? 'rgba(74,222,128,0.1)' : testResult === 'error' ? 'rgba(248,113,113,0.1)' : 'rgba(26,122,255,0.08)',
+              background: testResult === 'sent' ? 'rgba(74,222,128,0.1)' : testResult === 'error' ? 'rgba(248,113,113,0.1)' : 'rgba(var(--accent-rgb), 0.08)',
               border: `0.5px solid ${testResult === 'sent' ? 'rgba(74,222,128,0.3)' : testResult === 'error' ? 'rgba(248,113,113,0.3)' : 'var(--bdr)'}`,
               color: testResult === 'sent' ? 'var(--green)' : testResult === 'error' ? 'var(--red)' : 'var(--txt2)',
               fontSize: 'var(--fs-caption)', fontWeight: 600, cursor: 'pointer', transition: 'all 0.2s',

--- a/app/upgrade/page.tsx
+++ b/app/upgrade/page.tsx
@@ -148,7 +148,7 @@ export default function UpgradePage() {
 
           {/* Pro card */}
           <div style={{ borderRadius: 16, padding: '24px 28px', border: '0.5px solid var(--accent-bdr)', background: 'linear-gradient(160deg, var(--accent-bg) 0%, var(--bg1) 60%)', position: 'relative' }}>
-            <div style={{ position: 'absolute', top: -11, left: '50%', transform: 'translateX(-50%)', fontSize: 'var(--fs-micro)', fontWeight: 700, letterSpacing: '.08em', textTransform: 'uppercase', background: 'var(--accent-solid)', color: '#fff', padding: '3px 14px', borderRadius: 20, whiteSpace: 'nowrap' }}>
+            <div style={{ position: 'absolute', top: -11, left: '50%', transform: 'translateX(-50%)', fontSize: 'var(--fs-micro)', fontWeight: 700, letterSpacing: '.08em', textTransform: 'uppercase', background: 'var(--accent-solid)', color: 'var(--on-accent)', padding: '3px 14px', borderRadius: 20, whiteSpace: 'nowrap' }}>
               {t('UPGRADE_PRO_CARD_BADGE')}
             </div>
             <div style={{ fontSize: 'var(--fs-micro)', fontWeight: 700, letterSpacing: '.08em', textTransform: 'uppercase', color: 'var(--accent)', marginBottom: 6 }}>{t('UPGRADE_PRO_CARD_EYEBROW')}</div>
@@ -171,7 +171,7 @@ export default function UpgradePage() {
               <button
                 onClick={handleCheckout}
                 disabled={redirecting}
-                style={{ fontSize: 'var(--fs-data)', fontWeight: 700, color: '#fff', background: 'var(--accent-solid)', padding: '14px 40px', borderRadius: 12, border: 'none', cursor: redirecting ? 'default' : 'pointer', opacity: redirecting ? 0.7 : 1, transition: 'opacity .15s, transform .15s', transform: 'translateY(0)' }}
+                style={{ fontSize: 'var(--fs-data)', fontWeight: 700, color: 'var(--on-accent)', background: 'var(--accent-solid)', padding: '14px 40px', borderRadius: 12, border: 'none', cursor: redirecting ? 'default' : 'pointer', opacity: redirecting ? 0.7 : 1, transition: 'opacity .15s, transform .15s', transform: 'translateY(0)' }}
                 onMouseEnter={e => { if (!redirecting) (e.currentTarget as HTMLButtonElement).style.transform = 'translateY(-1px)'; }}
                 onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.transform = 'translateY(0)'; }}
               >

--- a/components/AccumulationTracker.tsx
+++ b/components/AccumulationTracker.tsx
@@ -128,7 +128,7 @@ export default function AccumulationTracker() {
                 border: `0.5px solid ${store.selectedCoin === r.id ? 'var(--accent-bdr)' : 'transparent'}`,
                 textAlign: 'left', transition: 'background .15s',
               }}
-              onMouseEnter={e => { if (store.selectedCoin !== r.id) e.currentTarget.style.background = 'rgba(26,122,255,0.05)'; }}
+              onMouseEnter={e => { if (store.selectedCoin !== r.id) e.currentTarget.style.background = 'rgba(var(--accent-rgb), 0.05)'; }}
               onMouseLeave={e => { if (store.selectedCoin !== r.id) e.currentTarget.style.background = 'transparent'; }}
             >
               <span style={{

--- a/components/EMASignal.tsx
+++ b/components/EMASignal.tsx
@@ -262,8 +262,8 @@ export default function EMASignal({ signal, tf = '4h', coin }: Props) {
             marginTop: 10,
             width: '100%',
             padding: '7px 0',
-            background: 'rgba(90,163,255,0.06)',
-            border: '0.5px solid rgba(90,163,255,0.2)',
+            background: 'rgba(var(--accent-rgb), 0.06)',
+            border: '0.5px solid rgba(var(--accent-rgb), 0.2)',
             borderRadius: 7,
             fontSize: 'var(--fs-caption)',
             fontWeight: 600,
@@ -272,8 +272,8 @@ export default function EMASignal({ signal, tf = '4h', coin }: Props) {
             letterSpacing: '.02em',
             transition: 'background 0.15s',
           }}
-          onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.background = 'rgba(90,163,255,0.12)'; }}
-          onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.background = 'rgba(90,163,255,0.06)'; }}
+          onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.background = 'rgba(var(--accent-rgb), 0.12)'; }}
+          onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.background = 'rgba(var(--accent-rgb), 0.06)'; }}
         >
           <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}>
             <svg width="12" height="12" viewBox="0 0 20 20" fill="none" aria-hidden="true"><path d="M10 1.5C10.4 5.2 11.8 6.6 15.5 7 11.8 7.4 10.4 8.8 10 12.5 9.6 8.8 8.2 7.4 4.5 7 8.2 6.6 9.6 5.2 10 1.5Z" fill="currentColor" /></svg>

--- a/components/HypothesisTracker.tsx
+++ b/components/HypothesisTracker.tsx
@@ -36,7 +36,7 @@ interface Evidence {
 }
 
 const STATUS_META: Record<string, { labelKey: LabelKey; col: string; bg: string }> = {
-  active:        { labelKey: 'HYPOTHESIS_TRACKER_STATUS_ACTIVE',       col: '#1a7aff', bg: 'rgba(26,122,255,0.12)' },
+  active:        { labelKey: 'HYPOTHESIS_TRACKER_STATUS_ACTIVE',       col: '#1a7aff', bg: 'rgba(var(--accent-rgb), 0.12)' },
   confirmed:     { labelKey: 'HYPOTHESIS_TRACKER_STATUS_CONFIRMED',    col: 'var(--green-2)', bg: 'rgba(52,211,153,0.12)' },
   disconfirmed:  { labelKey: 'HYPOTHESIS_TRACKER_STATUS_DISCONFIRMED', col: 'var(--red)', bg: 'rgba(248,113,113,0.12)' },
   expired:       { labelKey: 'HYPOTHESIS_TRACKER_STATUS_EXPIRED',      col: 'var(--txt-dim)', bg: 'rgba(148,163,184,0.10)' },
@@ -245,8 +245,8 @@ export default function HypothesisTracker() {
         <button
           onClick={() => setShowCreate(v => !v)}
           style={{
-            background: showCreate ? 'var(--bg2)' : 'rgba(26,122,255,0.2)',
-            border: '0.5px solid rgba(26,122,255,0.4)',
+            background: showCreate ? 'var(--bg2)' : 'rgba(var(--accent-rgb), 0.2)',
+            border: '0.5px solid rgba(var(--accent-rgb), 0.4)',
             borderRadius: 7,
             padding: '6px 12px',
             fontSize: 'var(--fs-caption)',
@@ -263,7 +263,7 @@ export default function HypothesisTracker() {
       {showCreate && (
         <div style={{
           background: 'var(--bg2)',
-          border: '0.5px solid rgba(26,122,255,0.3)',
+          border: '0.5px solid rgba(var(--accent-rgb), 0.3)',
           borderRadius: 10,
           padding: '14px',
           marginBottom: 14,
@@ -476,7 +476,7 @@ export default function HypothesisTracker() {
                       style={{
                         ...ghostBtnStyle,
                         color: isAnalyzing ? 'var(--txt3)' : 'var(--accent)',
-                        borderColor: 'rgba(26,122,255,0.3)',
+                        borderColor: 'rgba(var(--accent-rgb), 0.3)',
                         marginBottom: 14,
                         width: '100%',
                       }}
@@ -640,8 +640,8 @@ const ghostBtnStyle: React.CSSProperties = {
 };
 
 const primaryBtnStyle = (disabled: boolean): React.CSSProperties => ({
-  background: disabled ? 'rgba(26,122,255,0.1)' : 'rgba(26,122,255,0.2)',
-  border: '0.5px solid rgba(26,122,255,0.4)',
+  background: disabled ? 'rgba(var(--accent-rgb), 0.1)' : 'rgba(var(--accent-rgb), 0.2)',
+  border: '0.5px solid rgba(var(--accent-rgb), 0.4)',
   borderRadius: 6,
   padding: '6px 14px',
   fontSize: 'var(--fs-caption)',

--- a/components/KLineProChart.tsx
+++ b/components/KLineProChart.tsx
@@ -1742,7 +1742,7 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
       label: 'Setup Forming',
       detail: `Near ${nearSR.type} (${nearSR.touches} touches) · Squeeze ${sq.score}/100`,
       explanation: `Squeeze + ${nearSR.type} confluence (separate from the chart's own Buy/Sell signal) - the squeeze and the ${nearSR.type} level aren't lined up yet. Watch for direction confirmation - don't jump in early.`,
-      color: 'var(--accent)', bg: 'rgba(26,122,255,0.10)', bdr: 'rgba(26,122,255,0.28)',
+      color: 'var(--accent)', bg: 'rgba(var(--accent-rgb), 0.10)', bdr: 'rgba(var(--accent-rgb), 0.28)',
     };
   })();
 

--- a/components/MarketStructure.tsx
+++ b/components/MarketStructure.tsx
@@ -111,7 +111,7 @@ function evCol(ev: StructureEvent): string {
 }
 function evBg(ev: StructureEvent): string {
   return ev.type === 'CHoCH'
-    ? (ev.dir === 'bullish' ? 'rgba(26,122,255,0.10)' : 'rgba(248,113,113,0.10)')
+    ? (ev.dir === 'bullish' ? 'rgba(var(--accent-rgb), 0.10)' : 'rgba(248,113,113,0.10)')
     : (ev.dir === 'bullish' ? 'rgba(52,211,153,0.10)'  : 'rgba(248,113,113,0.10)');
 }
 

--- a/components/OnChainScore.tsx
+++ b/components/OnChainScore.tsx
@@ -165,8 +165,8 @@ export default function OnChainScore() {
           onClick={analyze}
           disabled={loading || !user}
           style={{
-            background: loading ? 'rgba(26,122,255,0.15)' : 'rgba(26,122,255,0.2)',
-            border: '0.5px solid rgba(26,122,255,0.4)',
+            background: loading ? 'rgba(var(--accent-rgb), 0.15)' : 'rgba(var(--accent-rgb), 0.2)',
+            border: '0.5px solid rgba(var(--accent-rgb), 0.4)',
             borderRadius: 6,
             padding: '5px 11px',
             fontSize: 'var(--fs-caption)',

--- a/components/PWAInstallPrompt.tsx
+++ b/components/PWAInstallPrompt.tsx
@@ -78,7 +78,7 @@ export default function PWAInstallPrompt() {
     }}>
       <span style={{
         flexShrink: 0, width: 34, height: 34, borderRadius: 10,
-        background: 'rgba(26,122,255,0.14)', border: '0.5px solid rgba(26,122,255,0.3)',
+        background: 'rgba(var(--accent-rgb), 0.14)', border: '0.5px solid rgba(var(--accent-rgb), 0.3)',
         display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--accent)',
       }}>
         <Download size={17} style={{ verticalAlign: 'baseline' }} />
@@ -97,7 +97,7 @@ export default function PWAInstallPrompt() {
             padding: '5px 11px',
             fontSize: 'var(--fs-caption)',
             fontWeight: 700,
-            color: '#fff',
+            color: 'var(--on-accent)',
             cursor: 'pointer',
             whiteSpace: 'nowrap',
           }}

--- a/components/PageHint.tsx
+++ b/components/PageHint.tsx
@@ -51,13 +51,13 @@ export default function PageHint({ pageKey, title, body }: Props) {
       display: 'flex',
       alignItems: 'flex-start',
       gap: 10,
-      background: 'rgba(26,122,255,0.07)',
-      border: '0.5px solid rgba(26,122,255,0.22)',
+      background: 'rgba(var(--accent-rgb), 0.07)',
+      border: '0.5px solid rgba(var(--accent-rgb), 0.22)',
       borderRadius: 10,
       padding: '10px 12px',
       marginBottom: 14,
     }}>
-      <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 800, color: 'var(--accent)', background: 'rgba(26,122,255,0.18)', borderRadius: '50%', width: 18, height: 18, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, letterSpacing: 0 }}>i</span>
+      <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 800, color: 'var(--accent)', background: 'rgba(var(--accent-rgb), 0.18)', borderRadius: '50%', width: 18, height: 18, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, letterSpacing: 0 }}>i</span>
       <div style={{ flex: 1, minWidth: 0 }}>
         <div style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: 'var(--accent)', marginBottom: 3 }}>{title}</div>
         <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', lineHeight: 1.55 }}>{body}</div>

--- a/components/SpotlightTour.tsx
+++ b/components/SpotlightTour.tsx
@@ -18,7 +18,7 @@ const DARK = {
   ACCENT: '#1a7aff', GREEN: 'var(--green)', RED: 'var(--red)', ORANGE: '#f97316',
   BG0: '#07090f', BG1: '#0c0f1c', BG2: '#101324',
   TXT1: '#eef0fa', TXT2: '#9296b5', TXT3: '#4e5374',
-  BDR: 'rgba(26,122,255,0.1)', TRACK_BG: 'rgba(26,122,255,0.06)', GRID: 'rgba(26,122,255,0.05)',
+  BDR: 'rgba(var(--accent-rgb), 0.1)', TRACK_BG: 'rgba(var(--accent-rgb), 0.06)', GRID: 'rgba(var(--accent-rgb), 0.05)',
   TG_BG: 'rgba(34,158,217,0.06)', TG_BDR: 'rgba(34,158,217,0.28)', TG_TXT: '#4db8e8',
   MODAL_SHADOW: '0 32px 80px rgba(0,0,0,0.7)',
 };
@@ -26,7 +26,7 @@ const LIGHT = {
   ACCENT: '#0052CC', GREEN: '#047857', RED: '#B91C1C', ORANGE: '#C2410C',
   BG0: '#F2F3F5', BG1: '#FFFFFF', BG2: '#F2F3F5',
   TXT1: '#111318', TXT2: '#44475A', TXT3: '#63656F',
-  BDR: 'rgba(0,82,204,0.14)', TRACK_BG: 'rgba(0,82,204,0.08)', GRID: 'rgba(0,82,204,0.08)',
+  BDR: 'rgba(var(--accent-rgb), 0.14)', TRACK_BG: 'rgba(var(--accent-rgb), 0.08)', GRID: 'rgba(var(--accent-rgb), 0.08)',
   TG_BG: 'rgba(34,158,217,0.08)', TG_BDR: 'rgba(34,158,217,0.35)', TG_TXT: '#0e7fae',
   MODAL_SHADOW: '0 20px 48px rgba(20,25,40,0.18)',
 };

--- a/components/TradeJournal.tsx
+++ b/components/TradeJournal.tsx
@@ -820,7 +820,7 @@ function Inner() {
           {t('TRADE_JOURNAL_TAB_RULES')}{rules.filter(r => r.enabled).length > 0 && (
             <span style={{
               marginLeft: 5, fontSize: 'var(--fs-caption)', fontWeight: 700,
-              background: 'var(--accent-solid)', color: '#fff',
+              background: 'var(--accent-solid)', color: 'var(--on-accent)',
               borderRadius: 10, padding: '1px 5px',
             }}>{rules.filter(r => r.enabled).length}</span>
           )}
@@ -829,7 +829,7 @@ function Inner() {
         <button data-testid="journal-tab" className={`tj-tab${tab === 'bias' ? ' on' : ''}`} onClick={() => setTab('bias')}>{t('TRADE_JOURNAL_TAB_BIAS')}</button>
         <button data-testid="journal-tab" className={`tj-tab${tab === 'thesis' ? ' on' : ''}`} onClick={() => setTab('thesis')} style={{ position: 'relative' }}>
           {t('TRADE_JOURNAL_TAB_THESIS')}{theses.length > 0 && (
-            <span style={{ marginLeft: 5, fontSize: 'var(--fs-caption)', fontWeight: 700, background: 'var(--accent-solid)', color: '#fff', borderRadius: 10, padding: '1px 5px' }}>{theses.length}</span>
+            <span style={{ marginLeft: 5, fontSize: 'var(--fs-caption)', fontWeight: 700, background: 'var(--accent-solid)', color: 'var(--on-accent)', borderRadius: 10, padding: '1px 5px' }}>{theses.length}</span>
           )}
         </button>
       </div>

--- a/components/TradeJournal.tsx
+++ b/components/TradeJournal.tsx
@@ -1559,9 +1559,9 @@ function Inner() {
                 onClick={runShadowAccount}
                 disabled={shadowLoading}
                 style={{
-                  background: shadowLoading ? 'rgba(255,255,255,0.06)' : 'rgba(26,122,255,0.12)',
+                  background: shadowLoading ? 'rgba(255,255,255,0.06)' : 'rgba(var(--accent-rgb), 0.12)',
                   color: shadowLoading ? 'var(--txt3)' : 'var(--accent)',
-                  border: `1px solid ${shadowLoading ? 'var(--bdr)' : 'rgba(26,122,255,0.35)'}`,
+                  border: `1px solid ${shadowLoading ? 'var(--bdr)' : 'rgba(var(--accent-rgb), 0.35)'}`,
                   borderRadius: 8, padding: '10px 20px', fontSize: 'var(--fs-label)', fontWeight: 700,
                   cursor: shadowLoading ? 'default' : 'pointer',
                 }}
@@ -1613,9 +1613,9 @@ function Inner() {
                 onClick={runBiasAnalysis}
                 disabled={biasLoading}
                 style={{
-                  background: biasLoading ? 'rgba(255,255,255,0.06)' : 'rgba(26,122,255,0.12)',
+                  background: biasLoading ? 'rgba(255,255,255,0.06)' : 'rgba(var(--accent-rgb), 0.12)',
                   color: biasLoading ? 'var(--txt3)' : 'var(--accent)',
-                  border: `1px solid ${biasLoading ? 'var(--bdr)' : 'rgba(26,122,255,0.35)'}`,
+                  border: `1px solid ${biasLoading ? 'var(--bdr)' : 'rgba(var(--accent-rgb), 0.35)'}`,
                   borderRadius: 8, padding: '10px 20px', fontSize: 'var(--fs-label)', fontWeight: 700,
                   cursor: biasLoading ? 'default' : 'pointer',
                 }}
@@ -1662,9 +1662,9 @@ function Inner() {
             <button
               onClick={() => setShowThesisForm(v => !v)}
               style={{
-                background: showThesisForm ? 'rgba(255,255,255,0.06)' : 'rgba(26,122,255,0.12)',
+                background: showThesisForm ? 'rgba(255,255,255,0.06)' : 'rgba(var(--accent-rgb), 0.12)',
                 color: showThesisForm ? 'var(--txt3)' : 'var(--accent)',
-                border: `1px solid ${showThesisForm ? 'var(--bdr)' : 'rgba(26,122,255,0.35)'}`,
+                border: `1px solid ${showThesisForm ? 'var(--bdr)' : 'rgba(var(--accent-rgb), 0.35)'}`,
                 borderRadius: 8, padding: '8px 16px', fontSize: 'var(--fs-caption)', fontWeight: 700, cursor: 'pointer', flexShrink: 0,
               }}
             >
@@ -1726,7 +1726,7 @@ function Inner() {
                 {thesisFormAssumptions.length < 5 && (
                   <button
                     onClick={() => setThesisFormAssumptions(a => [...a, ''])}
-                    style={{ fontSize: 'var(--fs-caption)', color: 'var(--accent)', background: 'transparent', border: '0.5px solid rgba(26,122,255,0.3)', borderRadius: 5, padding: '4px 10px', cursor: 'pointer' }}
+                    style={{ fontSize: 'var(--fs-caption)', color: 'var(--accent)', background: 'transparent', border: '0.5px solid rgba(var(--accent-rgb), 0.3)', borderRadius: 5, padding: '4px 10px', cursor: 'pointer' }}
                   >
                     {t('TRADE_JOURNAL_THESIS_ADD_ASSUMPTION_BUTTON')}
                   </button>
@@ -1745,8 +1745,8 @@ function Inner() {
                 disabled={!thesisFormSymbol.trim() || !thesisFormText.trim() || !thesisFormAssumptions.some(a => a.trim())}
                 style={{
                   display: 'block', marginTop: 14, width: '100%',
-                  background: 'rgba(26,122,255,0.12)', color: 'var(--accent)',
-                  border: '1px solid rgba(26,122,255,0.35)', borderRadius: 8,
+                  background: 'rgba(var(--accent-rgb), 0.12)', color: 'var(--accent)',
+                  border: '1px solid rgba(var(--accent-rgb), 0.35)', borderRadius: 8,
                   padding: '10px', fontSize: 'var(--fs-label)', fontWeight: 700, cursor: 'pointer',
                 }}
               >
@@ -1825,9 +1825,9 @@ function Inner() {
                       onClick={() => checkThesisHealth(thesis)}
                       disabled={isChecking}
                       style={{
-                        background: isChecking ? 'rgba(255,255,255,0.06)' : 'rgba(26,122,255,0.10)',
+                        background: isChecking ? 'rgba(255,255,255,0.06)' : 'rgba(var(--accent-rgb), 0.10)',
                         color: isChecking ? 'var(--txt3)' : 'var(--accent)',
-                        border: `0.5px solid ${isChecking ? 'var(--bdr)' : 'rgba(26,122,255,0.3)'}`,
+                        border: `0.5px solid ${isChecking ? 'var(--bdr)' : 'rgba(var(--accent-rgb), 0.3)'}`,
                         borderRadius: 6, padding: '5px 12px', fontSize: 'var(--fs-caption)', fontWeight: 700, cursor: isChecking ? 'default' : 'pointer',
                       }}
                     >

--- a/components/TrialBanner.tsx
+++ b/components/TrialBanner.tsx
@@ -28,8 +28,8 @@ export default function TrialBanner() {
   const urgent = daysLeft <= 3;
 
   const accent = urgent ? 'var(--amber)' : 'var(--accent)';
-  const bg     = urgent ? 'var(--amber-bg, rgba(251,191,36,0.08))' : 'var(--accent-bg, rgba(26,122,255,0.07))';
-  const bdr    = urgent ? 'var(--amber-bdr, rgba(251,191,36,0.22))' : 'var(--accent-bdr, rgba(26,122,255,0.22))';
+  const bg     = urgent ? 'var(--amber-bg, rgba(251,191,36,0.08))' : 'var(--accent-bg, rgba(var(--accent-rgb), 0.07))';
+  const bdr    = urgent ? 'var(--amber-bdr, rgba(251,191,36,0.22))' : 'var(--accent-bdr, rgba(var(--accent-rgb), 0.22))';
 
   return (
     <div

--- a/components/UpgradeGateModal.tsx
+++ b/components/UpgradeGateModal.tsx
@@ -44,7 +44,7 @@ export function LockedFeatureCard({ title, description, onUnlock }: {
       <button
         onClick={onUnlock}
         style={{
-          background: 'var(--accent-solid)', color: '#fff', border: 'none', cursor: 'pointer',
+          background: 'var(--accent-solid)', color: 'var(--on-accent)', border: 'none', cursor: 'pointer',
           fontSize: 'var(--fs-label)', fontWeight: 700, padding: '9px 16px', borderRadius: 8,
           flexShrink: 0,
         }}
@@ -101,7 +101,7 @@ export function FullPageUpgradeGate({ title, description }: { title: string; des
           href={ctaHref}
           style={{
             display: 'block', textAlign: 'center',
-            background: 'var(--accent-solid)', color: '#fff',
+            background: 'var(--accent-solid)', color: 'var(--on-accent)',
             fontSize: 'var(--fs-body)', fontWeight: 700,
             padding: '12px 16px', borderRadius: 8,
             textDecoration: 'none',
@@ -207,7 +207,7 @@ export default function UpgradeGateModal({ open, onClose, feature }: Props) {
           href={ctaHref}
           style={{
             display: 'block', textAlign: 'center',
-            background: 'var(--accent-solid)', color: '#fff',
+            background: 'var(--accent-solid)', color: 'var(--on-accent)',
             fontSize: 'var(--fs-body)', fontWeight: 700,
             padding: '12px 16px', borderRadius: 8,
             textDecoration: 'none',


### PR DESCRIPTION
**Dev Team** · Closes #419. **Live in both designs, not behind the flag.** Also fixes the canvas the owner asked for on #420.

## Your framing was inverted, and it changed the work

> Every one of those 93 rules is either "accent as background" (fine, swap the foreground) or "accent as text/border" (needs judging).

**Measured:** the accent is used as **`color` 32 times** and as **`background` twice**. So the text direction was the dominant one — and it is the one that *improves*:

```
amber AS TEXT on --bg1     8.73:1     blue was 4.88
near-black ON amber        8.95:1
white ON amber             2.23:1     FAILS
```

The failures were the two backgrounds plus every `--accent-solid` fill, which **always** paired with `#fff`. Those now take `var(--on-accent)`, in CSS and in the four components carrying inline styles.

## The light gold took two attempts, and the second one is the point

**`#826517` cleared white (5.49) and `--bg2` (4.95) and I nearly shipped it.** Walking the rendered DOM found it at **4.18:1** on `#e1e1de` — a third light surface carrying *"Pro Plan"* and *"Sign up"*.

```
#795f15    white 6.07    #f2f3f5 5.47    #e1e1de 4.63    <- ships
```

**`contrastTokens.test.mts` checked two grounds and passed.** It now checks three. **A token test is only as good as its list of surfaces**, and mine was short by exactly the one that had text on it.

## The canvas — and a correction to the proposed fix

```diff
- html { background: #06070a; }
+ html { background: var(--bg1); }
```

**Not `var(--bg0)`, which is what was proposed.** `#06070a` **is** `--bg1`; `--bg0` is `#030405`. Pointing the canvas at `--bg0` would have darkened the entire app today, as a side effect of a change meant to alter nothing. This way it is byte-identical now and converts with the design.

## Verified on the rendered page, both themes

```
dark    --accent #d9a626   fills carry #08090a at 8.95:1
light   --accent #795f15   17 accent-text elements, 0 below AA, lowest 4.60
canvas  rgb(6,7,10) unchanged
```

## How to test (QA)

1. **Both themes, every page** — gold where blue was: CTAs, active nav, links, badges, plan cards.
2. **No white-on-gold anywhere.** Dark theme fills carry near-black; light theme fills carry white. This is the one that fails silently if I missed a call site.
3. **The canvas is unchanged** in the current design — same `#06070a`. If the page background shifted, `--bg1` is wrong.
4. **Functionality, per the owner's standing requirement** — CTAs still navigate, the upgrade button still starts checkout, nav still routes. **A recolour cannot break a handler, but it can hide one**: check nothing became invisible against its background.
5. `contrast.spec.ts` — the real judge, across both themes.

## Risk level — **Medium**

Live change to every screen. Gates: lint **0 errors / 133 warnings — down from 140**, `tsc` clean, **428 tests**, build succeeds.

**Not verified:** every page. I measured `/upgrade` in both themes and reasoned from the token layer for the rest. **`contrast.spec.ts` across all 32 routes is the check I cannot run and you can** — if it is green in both themes, this is done; if not, it will name the exact element.
