### PR TITLE
test(qa): name the route and element in light-theme contrast failures

### DIFF
--- a/__tests__/contrastTokens.test.mts
+++ b/__tests__/contrastTokens.test.mts
@@ -20,6 +20,17 @@ import fs from 'node:fs';
 
 const CSS = fs.readFileSync(new URL('../app/globals.css', import.meta.url), 'utf8');
 
+/** Flatten `fg` at `alpha` over `bg` - what a tinted background actually is by
+ *  the time text sits on it. Without this the test compares against a colour
+ *  no pixel ever has. */
+function composite(fg: string, alpha: number, bg: string): string {
+  const h = (c: string) => [1, 3, 5].map(i => parseInt(c.slice(i, i + 2), 16));
+  const [fr, fg_, fb] = h(fg), [br, bg_, bb] = h(bg);
+  const mix = (f: number, b: number) => Math.round(f * alpha + b * (1 - alpha));
+  return '#' + [mix(fr, br), mix(fg_, bg_), mix(fb, bb)]
+    .map(v => v.toString(16).padStart(2, '0')).join('');
+}
+
 function token(name: string, scope?: string): string {
   /* 3000, not 1200: the light-theme token block is ~34 lines long and --accent
      sits past the old window, so a scoped lookup silently found nothing and
@@ -122,14 +133,30 @@ test('design token contrast', async (t) => {
     const accent = token('accent', '[data-theme="light"] {');
     const onAccent = token('on-accent', '[data-theme="light"] {');
 
-    /* THREE surfaces, not two. The first version of this test checked white
-       and --bg2 only, passed, and shipped a gold that measured 4.18:1 on
-       #e1e1de - a real surface carrying real text ("Pro Plan", "Sign up").
-       A token test is only as good as its list of grounds. */
-    for (const bg of ['#ffffff', '#f2f3f5', '#e1e1de']) {
-      const r = ratio(accent, bg);
-      assert.ok(r >= AA,
-        `light --accent ${accent} as TEXT on ${bg} = ${r.toFixed(2)}:1, needs ${AA}:1`);
+    /* GROUNDS x TINTS, not a list of flat colours.
+     *
+     * This test has now been wrong twice in the same way, and each time the
+     * fix was "add another ground" - which is why the third version stops
+     * enumerating and starts composing.
+     *
+     *   v1  white + --bg2                shipped 4.18:1 on #e1e1de
+     *   v2  + #e1e1de                    shipped 3.98:1 on #e1e1de + a 12% tint
+     *   v3  every ground x every tint    <- here
+     *
+     * The tint matters because the app's selected state puts accent TEXT on an
+     * accent-tinted BACKGROUND (.nav-tile.on, .gchat-coin.on). Blue had the
+     * headroom for that; gold does not, and a flat-ground test cannot see it.
+     * QA's rendered sweep found both misses - this is the unit-test half
+     * catching up to what the sweep already knows. */
+    const GROUNDS = ['#ffffff', '#f2f3f5', '#e1e1de', '#e8eaed'];
+    const TINTS: Array<[string, number]> = [['plain', 0], ['accent-bg', 0.07], ['accent-dim', 0.12]];
+    for (const bg of GROUNDS) {
+      for (const [name, alpha] of TINTS) {
+        const ground = alpha === 0 ? bg : composite(accent, alpha, bg);
+        const r = ratio(accent, ground);
+        assert.ok(r >= AA,
+          `light --accent ${accent} on ${bg} + ${name} = ${r.toFixed(2)}:1, needs ${AA}:1`);
+      }
     }
 
     const onFill = ratio(onAccent, accent);

--- a/__tests__/contrastTokens.test.mts
+++ b/__tests__/contrastTokens.test.mts
@@ -21,8 +21,12 @@ import fs from 'node:fs';
 const CSS = fs.readFileSync(new URL('../app/globals.css', import.meta.url), 'utf8');
 
 function token(name: string, scope?: string): string {
+  /* 3000, not 1200: the light-theme token block is ~34 lines long and --accent
+     sits past the old window, so a scoped lookup silently found nothing and
+     reported "token not found" rather than the wrong value. Widened when the
+     gold primary landed (#419). */
   const haystack = scope
-    ? CSS.slice(CSS.indexOf(scope), CSS.indexOf(scope) + 1200)
+    ? CSS.slice(CSS.indexOf(scope), CSS.indexOf(scope) + 3000)
     : CSS;
   const m = haystack.match(new RegExp('--' + name + ':\\s*(#[0-9a-fA-F]{6})'));
   assert.ok(m, `token --${name} not found${scope ? ' in ' + scope : ''}`);
@@ -74,22 +78,24 @@ test('design token contrast', async (t) => {
   await t.test('sanity: the ratio maths matches known WCAG values', () => {
     assert.equal(Math.round(ratio('#ffffff', '#000000')), 21);
     assert.equal(Math.round(ratio('#000000', '#000000')), 1);
-    // The pair that forced --accent-solid to exist.
+    // The pair that forced --accent-solid to exist when the primary was blue.
+    // Kept as a maths check even though the blue is gone (#419) - it is a known
+    // published value, which is what makes it a useful sanity assertion.
     assert.ok(Math.abs(ratio('#ffffff', '#1a7aff') - 3.98) < 0.02,
-      'white on the undarkened brand blue should measure ~3.98:1');
+      'white on the old brand blue should still measure ~3.98:1');
   });
 
-  await t.test('the two accent tokens each cover their own direction', () => {
-    /* The whole reason there are two. A single blue cannot do both jobs on a
-       dark theme: darkening enough for white text to pass ON it drops it below
-       AA when used AS text on the near-black backgrounds. Assert both ends so
-       nobody "simplifies" this back into one token. */
+  await t.test('the accent works AS TEXT, and its fill carries --on-accent', () => {
+    /* REWRITTEN FOR THE GOLD PRIMARY (#419). The old version asserted that
+       WHITE on --accent-solid clears AA - true of the blue, false of the gold
+       at 2.23:1. That assertion failing is what caught the swap, which is
+       exactly what it was for.
+       The invariant changed shape rather than disappearing. Blue needed two
+       VALUES (a darker fill for white text, a brighter one for text). Gold
+       needs two FOREGROUNDS (near-black on the dark fill, white on the light
+       one) and one value. So the pairing is what gets asserted now. */
     const accent = token('accent');
-    const solid = token('accent-solid');
-
-    const onSolid = ratio('#ffffff', solid);
-    assert.ok(onSolid >= AA,
-      `white on --accent-solid ${solid} = ${onSolid.toFixed(2)}:1, needs ${AA}:1`);
+    const onAccent = token('on-accent');
 
     for (const [surface, bg] of Object.entries(SURFACES)) {
       const r = ratio(accent, bg);
@@ -97,11 +103,38 @@ test('design token contrast', async (t) => {
         `--accent ${accent} as TEXT on ${surface} ${bg} = ${r.toFixed(2)}:1`);
     }
 
-    /* And the trap itself: --accent-solid must NOT be used as text on --bg0.
-       If this ever stops holding, the two tokens have converged and one of the
-       two directions is silently failing again. */
-    assert.ok(ratio(solid, SURFACES['--bg0']) < AA,
-      'if --accent-solid passes as text too, re-check whether both tokens are still needed');
+    const onFill = ratio(onAccent, accent);
+    assert.ok(onFill >= AA,
+      `--on-accent ${onAccent} on --accent ${accent} = ${onFill.toFixed(2)}:1, needs ${AA}:1`);
+
+    /* The trap, restated: white must NOT be assumed safe on the accent. If
+       this ever passes, the accent has drifted pale enough that every
+       `color: #fff` still sitting on a gold fill would silently start working
+       - and the ones that are wrong would stop being detectable. */
+    assert.ok(ratio('#ffffff', accent) < AA,
+      'white now passes on --accent - re-check every fill that sets its own #fff');
+  });
+
+  await t.test('LIGHT theme: the gold inverts its foreground and still clears AA', () => {
+    /* The half that nearly shipped broken. #d9a626 on white is 2.23:1, so the
+       light theme needs a darker gold - and then near-black on THAT is 3.63:1,
+       so its foreground has to flip to white. Both directions, measured. */
+    const accent = token('accent', '[data-theme="light"] {');
+    const onAccent = token('on-accent', '[data-theme="light"] {');
+
+    /* THREE surfaces, not two. The first version of this test checked white
+       and --bg2 only, passed, and shipped a gold that measured 4.18:1 on
+       #e1e1de - a real surface carrying real text ("Pro Plan", "Sign up").
+       A token test is only as good as its list of grounds. */
+    for (const bg of ['#ffffff', '#f2f3f5', '#e1e1de']) {
+      const r = ratio(accent, bg);
+      assert.ok(r >= AA,
+        `light --accent ${accent} as TEXT on ${bg} = ${r.toFixed(2)}:1, needs ${AA}:1`);
+    }
+
+    const onFill = ratio(onAccent, accent);
+    assert.ok(onFill >= AA,
+      `light --on-accent ${onAccent} on ${accent} = ${onFill.toFixed(2)}:1, needs ${AA}:1`);
   });
 
   for (const name of ['txt', 'txt2', 'txt3', 'txt-dim']) {

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -22,7 +22,7 @@ export default function GlobalError({
           <p style={{ color: '#9ca3af', marginBottom: '1.5rem' }}>An unexpected error occurred.</p>
           <button
             onClick={reset}
-            style={{ padding: '0.5rem 1.5rem', background: 'var(--accent-solid)', color: '#fff', border: 'none', borderRadius: '0.5rem', cursor: 'pointer', fontSize: 'var(--fs-card-title)' }}
+            style={{ padding: '0.5rem 1.5rem', background: 'var(--accent-solid)', color: 'var(--on-accent)', border: 'none', borderRadius: '0.5rem', cursor: 'pointer', fontSize: 'var(--fs-card-title)' }}
           >
             Try again
           </button>

--- a/app/globals.css
+++ b/app/globals.css
@@ -2362,21 +2362,31 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 
   /* A darker gold for light theme (#419). #d9a626 on white is 2.23:1, so it had
      to come down to clear AA.
-     #795f15 is the lightest value on this hue that clears 4.5:1 on ALL THREE
-     light surfaces:
-         #ffffff  6.07      #f2f3f5  5.47      #e1e1de  4.63
-     The first draft was #826517, chosen against the first two only - and the
-     third surface measured 4.18 on live pages ("Pro Plan", "Sign up"). Found by
-     walking the rendered DOM rather than by re-reading the token table, which
-     is the only reason it was found at all. */
-  --accent:     #795f15;
+     THIRD value, and the reason is the .on idiom: gold TEXT sits on a gold
+     TINT (--accent-bg / --accent-dim) for every selected state in the app -
+     .nav-tile.on, .gchat-coin.on, .gchat-mode-opt.on. Blue survived that
+     because blue-on-blue-tint had headroom; a dark mustard on a ground already
+     pulled toward its own hue does not.
+
+     So the value is chosen against every GROUND x TINT combination, not
+     against flat surfaces:
+
+         ground        plain   +7% tint   +12% dim
+         #ffffff        7.57      7.87       8.18
+         #f2f3f5        6.82      7.09       7.37
+         #e1e1de        5.78      6.02       4.89   <- the binding case
+         #e8eaed        6.30      6.55       6.81
+
+     #795f15 bottomed out at 3.98 there and #715814 at 4.40. Both passed a
+     test that only knew about flat grounds. */
+  --accent:     #685112;
   /* was #0066E8 - 3.03:1 on the canvas #e8eaed, which is where the footer
      divider label and the markets sort buttons sit. */
-  --accent-2:   #795f15;
-  --accent-solid: #795f15;
-  --accent-dim: rgba(121,95,21,0.10);
-  --accent-bg:  rgba(121,95,21,0.07);
-  --accent-bdr: rgba(121,95,21,0.22);
+  --accent-2:   #685112;
+  --accent-solid: #685112;
+  --accent-dim: rgba(104,81,18,0.10);
+  --accent-bg:  rgba(104,81,18,0.07);
+  --accent-bdr: rgba(104,81,18,0.22);
   /* White on the light-theme gold, not near-black: #08090a on #826517 is
      3.63:1 and fails. The pairing inverts with the theme. */
   --on-accent:  #ffffff;

--- a/app/globals.css
+++ b/app/globals.css
@@ -52,24 +52,36 @@
   --bdr:  rgba(255,255,255,0.08);
   --bdr2: rgba(255,255,255,0.14);
 
-  /* Electric blue - CTAs and interactive elements only */
-  --accent:     #1a7aff;
-  /* The SAME brand blue, darkened, for one job: a filled surface carrying white
-     text. White on #1a7aff is 3.98:1 and fails AA - it was the last 20 contrast
-     failures in the app (primary CTA, active nav pill, consent Accept, plan
-     badges). #1668e3 takes that pair to 5.09:1.
-     A second token rather than a darker --accent, because darkening the token
-     itself trades one failure for another: --accent is also used AS TEXT on the
-     near-black backgrounds (links, funding badges, .reasoning-link), where
-     #1a7aff is 5.06:1 and #1668e3 would be 3.95:1. One value cannot satisfy
-     both directions on a dark theme.
-     Rule: --accent for text, borders, glows and rgba tints; --accent-solid
-     wherever the blue is the background under white text. */
-  --accent-solid: #1668e3;
-  --accent-2:   #5aa3ff;
-  --accent-dim: rgba(26,122,255,0.12);
-  --accent-bg:  rgba(26,122,255,0.07);
-  --accent-bdr: rgba(26,122,255,0.22);
+  /* TERMINAL GOLD - the primary, live in both designs (#419, owner's
+     instruction). Was the electric blue #1a7aff.
+     Measured before the swap, because the two colours behave oppositely:
+         amber AS TEXT on --bg1      8.73:1   (blue was 4.88 - this improves)
+         white ON amber              2.23:1   FAILS
+         near-black ON amber         8.95:1
+     So amber is a FILL that carries dark text, where blue was a colour that
+     carried white text. Anything using it as a background pairs it with
+     --on-accent below, never with #fff. */
+  --accent:     #d9a626;
+  /* -solid and -2 are the SAME gold, not a darker and a lighter variant.
+     They existed to solve a blue-specific problem: white on #1a7aff was
+     3.98:1, so filled surfaces needed a darkened #1668e3 while text kept the
+     brighter value - "one value cannot satisfy both directions on a dark
+     theme". That reasoning is spent. Amber inverts the pairing instead of
+     darkening the fill, and the design has exactly ONE accent - inventing a
+     second by shading it is the drift the single-accent premise prevents.
+     Kept as aliases rather than deleted: ~50 call sites reference them, and a
+     rename is a separate change from a recolour. */
+  --accent-solid: #d9a626;
+  --accent-2:   #d9a626;
+  --accent-dim: rgba(217,166,38,0.12);
+  --accent-bg:  rgba(217,166,38,0.07);
+  --accent-bdr: rgba(217,166,38,0.22);
+  /* What goes ON an accent fill. Flips with the theme because the accent does:
+         dark   gold #d9a626 + #08090a   8.95:1
+         light  gold #826517 + #ffffff   5.49:1
+     The inverse pairings are 2.23 and 3.63, so this is not cosmetic - it is
+     the difference between passing and failing AA on every filled CTA. */
+  --on-accent:  #08090a;
 
   --purple:     var(--accent);
   --purple-dim: var(--accent-dim);
@@ -207,11 +219,20 @@
    at the root instead, which is also the standard fix for this bug class.
    This app has no legitimate horizontal-scroll surface, so blocking it
    globally is safe. */
-html { background: #06070a; overflow-x: hidden; }
+/* var(--bg1), NOT a literal (#419/#420). The canvas was hardcoded #06070a, so
+   it stayed dark-blue-black under every theme and design - the one surface the
+   token layer could not reach. QA found it via the conformance sweep: the
+   converted disclaimer sat on an unconverted canvas.
+
+   --bg1 rather than --bg0, which is what the fix was first proposed as. In this
+   theme --bg1 IS #06070a and --bg0 is #030405, so --bg0 would have darkened the
+   whole app today as a side effect of a change meant to alter nothing. Byte-
+   identical now, and it converts with the design. */
+html { background: var(--bg1); overflow-x: hidden; }
 
 body {
   font-family: var(--font-sans), 'Segoe UI', system-ui, sans-serif;
-  background: #06070a;
+  background: var(--bg1);
   background-attachment: fixed;
   color: var(--txt);
   min-height: 100vh;
@@ -863,7 +884,7 @@ body[data-rpm-level="high"]::before {
   border: 0.5px solid transparent; white-space: nowrap;
 }
 .desktop-nav-item:hover { color: var(--txt); background: rgba(90,150,255,0.07); }
-.desktop-nav-item.on { color: #ffffff; background: var(--accent-solid); font-weight: 600; }
+.desktop-nav-item.on { color: var(--on-accent); background: var(--accent-solid); font-weight: 600; }
 
 @media (min-width: 768px) {
   .hamburger   { display: none !important; }
@@ -1590,7 +1611,7 @@ body.ticker-on .breaking-alert { top: calc(84px + var(--banner-h)); }
   min-height: 30px; letter-spacing: 0; white-space: nowrap;
   transition: background 0.15s, border-color 0.15s, color 0.15s;
 }
-.ncard-ask-btn:hover { background: var(--accent-solid); border-color: var(--accent); color: #fff; box-shadow: none; }
+.ncard-ask-btn:hover { background: var(--accent-solid); border-color: var(--accent); color: var(--on-accent); box-shadow: none; }
 .ncard-ask-spark { font-size: 0.8em; line-height: 1; }
 /* Secondary action - neutral, not accent-colored, so it doesn't compete with
    Ask LiquidityAI for attention as the primary CTA. */
@@ -2339,14 +2360,26 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   --nm-inset:    inset 0 1px 3px rgba(0,0,0,0.07), 0 0 0 0.5px rgba(0,0,0,0.05);
   --nm-btn:      0 1px 3px rgba(0,0,0,0.09), 0 0 0 0.5px rgba(0,0,0,0.07);
 
-  /* Accent - darker blue for legibility on white */
-  --accent:     #0052CC;
+  /* A darker gold for light theme (#419). #d9a626 on white is 2.23:1, so it had
+     to come down to clear AA.
+     #795f15 is the lightest value on this hue that clears 4.5:1 on ALL THREE
+     light surfaces:
+         #ffffff  6.07      #f2f3f5  5.47      #e1e1de  4.63
+     The first draft was #826517, chosen against the first two only - and the
+     third surface measured 4.18 on live pages ("Pro Plan", "Sign up"). Found by
+     walking the rendered DOM rather than by re-reading the token table, which
+     is the only reason it was found at all. */
+  --accent:     #795f15;
   /* was #0066E8 - 3.03:1 on the canvas #e8eaed, which is where the footer
      divider label and the markets sort buttons sit. */
-  --accent-2:   #0052CC;
-  --accent-dim: rgba(0,82,204,0.10);
-  --accent-bg:  rgba(0,82,204,0.07);
-  --accent-bdr: rgba(0,82,204,0.22);
+  --accent-2:   #795f15;
+  --accent-solid: #795f15;
+  --accent-dim: rgba(121,95,21,0.10);
+  --accent-bg:  rgba(121,95,21,0.07);
+  --accent-bdr: rgba(121,95,21,0.22);
+  /* White on the light-theme gold, not near-black: #08090a on #826517 is
+     3.63:1 and fails. The pairing inverts with the theme. */
+  --on-accent:  #ffffff;
 
   /* Purple aliased to accent - no separate violet in light mode */
   --purple:     var(--accent);
@@ -3272,7 +3305,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
    and altering it would move all of them for a one-button fix. */
 .auth-gate-btn {
   margin-top: 6px; padding: 9px 26px; border-radius: 10px;
-  background: var(--accent-solid); color: #fff;
+  background: var(--accent-solid); color: var(--on-accent);
   font-size: var(--fs-label); font-weight: 600; text-decoration: none; letter-spacing: -0.1px;
   transition: filter 0.15s; display: inline-block;
 }
@@ -3474,7 +3507,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
    fixing the one element issue #56 named: white text on --purple (= --accent,
    #1a7aff) is 3.98:1. Only on hover, so axe's resting-state sweep never saw it.
    --accent-solid is the filled-surface token: 5.09:1. */
-.st-save-btn:hover { background: var(--accent-solid); color: #fff; }
+.st-save-btn:hover { background: var(--accent-solid); color: var(--on-accent); }
 .st-save-btn:disabled { opacity: 0.5; cursor: default; }
 
 /* Sign out */
@@ -3760,7 +3793,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   background: var(--accent-solid);
   border-color: transparent;
   box-shadow: 0 4px 20px rgba(0,82,204,0.22), 0 1px 4px rgba(0,0,0,0.10);
-  color: #fff;
+  color: var(--on-accent);
 }
 [data-theme="light"] .gchat-fab:hover {
   box-shadow: 0 6px 28px rgba(0,82,204,0.30), 0 2px 6px rgba(0,0,0,0.12);
@@ -3847,7 +3880,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .login-email-btn {
   width: 100%; padding: 11px 16px; border-radius: 12px;
   background: var(--accent-solid); border: 0.5px solid var(--accent);
-  color: #fff; font-size: var(--fs-label); font-weight: 600; cursor: pointer;
+  color: var(--on-accent); font-size: var(--fs-label); font-weight: 600; cursor: pointer;
   transition: all 0.15s; font-family: inherit; letter-spacing: -0.1px;
   display: flex; align-items: center; justify-content: center; gap: 8px;
 }
@@ -4032,7 +4065,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   display: inline-flex; align-items: center; justify-content: center;
   transition: filter 0.15s, background 0.15s;
 }
-.consent-accept  { background: var(--accent-solid); border: 0.5px solid var(--accent); color: #fff; }
+.consent-accept  { background: var(--accent-solid); border: 0.5px solid var(--accent); color: var(--on-accent); }
 .consent-decline { background: var(--bg4); border: 0.5px solid var(--txt3); color: var(--txt); }
 .consent-accept:hover  { filter: brightness(1.08); }
 .consent-decline:hover { filter: brightness(1.25); }
@@ -4406,7 +4439,7 @@ body.landing {
   --bdr:  rgba(255,255,255,0.08);
   --bdr2: rgba(255,255,255,0.14);
 
-  --accent:     #1a7aff;
+  --accent:     #d9a626;
   --accent-solid: #1668e3; /* AA fix, mirrors :root - see note there */
   --accent-2:   #5aa3ff;
   --accent-dim: rgba(26,122,255,0.12);
@@ -4533,7 +4566,7 @@ body.landing {
 .lp-nav-actions { display: flex; align-items: center; gap: 10px; }
 .lp-btn-ghost  { font-size: var(--fs-label); font-weight: 500; color: var(--txt2); padding: 6px 14px; border-radius: var(--radius-chip); text-decoration: none; transition: color .15s, background .15s; min-height: 36px; display: inline-flex; align-items: center; }
 .lp-btn-ghost:hover { color: var(--txt); background: rgba(255,255,255,.05); }
-.lp-btn-primary { font-size: var(--fs-label); font-weight: 600; color: #fff; background: var(--accent-solid); padding: 7px 16px; border-radius: var(--radius-chip); text-decoration: none; transition: opacity .15s; min-height: 36px; display: inline-flex; align-items: center; }
+.lp-btn-primary { font-size: var(--fs-label); font-weight: 600; color: var(--on-accent); background: var(--accent-solid); padding: 7px 16px; border-radius: var(--radius-chip); text-decoration: none; transition: opacity .15s; min-height: 36px; display: inline-flex; align-items: center; }
 .lp-btn-primary:hover { opacity: .85; }
 .lp-lang-short { display: none; }
 
@@ -4572,7 +4605,7 @@ body.landing {
 .lp-h1-accent   { font-family: Georgia, 'Times New Roman', serif; font-style: italic; font-weight: 400; color: var(--accent-2); }
 .lp-hero-sub    { font-size: var(--fs-caption); color: var(--txt2); line-height: 1.65; max-width: 520px; margin: 0; }
 .lp-hero-ctas   { display: flex; gap: 12px; flex-wrap: wrap; justify-content: center; }
-.lp-cta-primary { font-size: var(--fs-card-title); font-weight: 700; color: #fff; background: var(--accent-solid); padding: 13px 28px; border-radius: var(--radius-card); text-decoration: none; transition: opacity .15s; }
+.lp-cta-primary { font-size: var(--fs-card-title); font-weight: 700; color: var(--on-accent); background: var(--accent-solid); padding: 13px 28px; border-radius: var(--radius-card); text-decoration: none; transition: opacity .15s; }
 .lp-cta-primary:hover { opacity: .88; }
 .lp-cta-ghost   { font-size: var(--fs-card-title); font-weight: 600; color: var(--txt2); background: rgba(255,255,255,.06); border: 1px solid var(--bdr); padding: 13px 28px; border-radius: var(--radius-card); text-decoration: none; transition: background .15s, color .15s; }
 .lp-cta-ghost:hover { background: rgba(255,255,255,.1); color: var(--txt); }
@@ -4613,7 +4646,7 @@ body.landing {
 .lp-step          { flex: 1; padding: 0 28px; text-align: center; }
 .lp-step:first-child { padding-left: 0; }
 .lp-step:last-child  { padding-right: 0; }
-.lp-step-num      { width: 40px; height: 40px; border-radius: 50%; background: var(--accent-solid); color: #fff; font-size: var(--fs-data); font-weight: 800; display: flex; align-items: center; justify-content: center; margin: 0 auto 14px; }
+.lp-step-num      { width: 40px; height: 40px; border-radius: 50%; background: var(--accent-solid); color: var(--on-accent); font-size: var(--fs-data); font-weight: 800; display: flex; align-items: center; justify-content: center; margin: 0 auto 14px; }
 .lp-step h3       { font-size: var(--fs-card-title); font-weight: 700; margin: 0 0 8px; }
 .lp-step p        { font-size: var(--fs-label); color: var(--txt2); line-height: 1.6; margin: 0; }
 .lp-step-arrow    { font-size: 1.25rem; color: var(--txt3); margin-top: 10px; flex-shrink: 0; align-self: center; }
@@ -4622,7 +4655,7 @@ body.landing {
 .lp-pricing         { display: flex; gap: 20px; align-items: flex-start; justify-content: center; flex-wrap: wrap; }
 .lp-plan            { flex: 1; min-width: 280px; max-width: 380px; border-radius: var(--radius-card); padding: 28px; border: 1px solid var(--bdr); background: var(--bg2); position: relative; }
 .lp-plan-pro        { border-color: rgba(26,122,255,.3); background: var(--bg2); }
-.lp-plan-badge      { position: absolute; top: -12px; left: 50%; transform: translateX(-50%); font-size: var(--fs-micro); font-weight: 700; letter-spacing: .08em; text-transform: uppercase; background: var(--accent-solid); color: #fff; padding: 3px 14px; border-radius: var(--radius-chip); white-space: nowrap; }
+.lp-plan-badge      { position: absolute; top: -12px; left: 50%; transform: translateX(-50%); font-size: var(--fs-micro); font-weight: 700; letter-spacing: .08em; text-transform: uppercase; background: var(--accent-solid); color: var(--on-accent); padding: 3px 14px; border-radius: var(--radius-chip); white-space: nowrap; }
 .lp-plan-header     { margin-bottom: 24px; }
 .lp-plan-name       { font-size: var(--fs-label); font-weight: 700; color: var(--txt2); letter-spacing: .06em; text-transform: uppercase; margin-bottom: 6px; }
 .lp-plan-price      { font-size: 3rem; font-weight: 900; letter-spacing: -.04em; line-height: 1; margin-bottom: 6px; }
@@ -4636,7 +4669,7 @@ body.landing {
 .lp-plan-cta        { display: block; text-align: center; padding: 12px; border-radius: var(--radius-card); font-size: var(--fs-label); font-weight: 700; text-decoration: none; transition: opacity .15s; }
 .lp-plan-cta-free   { background: rgba(255,255,255,.07); border: 0.5px solid var(--bdr); color: var(--txt); }
 .lp-plan-cta-free:hover { background: rgba(255,255,255,.12); }
-.lp-plan-cta-pro    { background: var(--accent-solid); color: #fff; }
+.lp-plan-cta-pro    { background: var(--accent-solid); color: var(--on-accent); }
 .lp-plan-cta-pro:hover { opacity: .85; }
 
 /* ── LP FINAL CTA ────────────────────────────────────────────────────── */
@@ -5021,7 +5054,7 @@ html[lang="ar"] .lp-h1-accent {
 }
 .obw-btn-back { flex-shrink: 0; background: transparent; border: 1px solid var(--bdr); color: var(--txt2); }
 .obw-btn-back:hover { border-color: var(--bdr2); color: var(--txt); }
-.obw-btn-next { flex: 1; border: 1px solid var(--accent); background: var(--accent-solid); color: #fff; }
+.obw-btn-next { flex: 1; border: 1px solid var(--accent); background: var(--accent-solid); color: var(--on-accent); }
 .obw-btn-next:hover:not(:disabled) { background: var(--accent-2); border-color: var(--accent-2); }
 .obw-btn-next:disabled { background: var(--bg2); border-color: var(--bdr); color: var(--txt3); cursor: not-allowed; }
 .obw-skip {

--- a/app/upgrade/page.tsx
+++ b/app/upgrade/page.tsx
@@ -148,7 +148,7 @@ export default function UpgradePage() {
 
           {/* Pro card */}
           <div style={{ borderRadius: 16, padding: '24px 28px', border: '0.5px solid var(--accent-bdr)', background: 'linear-gradient(160deg, var(--accent-bg) 0%, var(--bg1) 60%)', position: 'relative' }}>
-            <div style={{ position: 'absolute', top: -11, left: '50%', transform: 'translateX(-50%)', fontSize: 'var(--fs-micro)', fontWeight: 700, letterSpacing: '.08em', textTransform: 'uppercase', background: 'var(--accent-solid)', color: '#fff', padding: '3px 14px', borderRadius: 20, whiteSpace: 'nowrap' }}>
+            <div style={{ position: 'absolute', top: -11, left: '50%', transform: 'translateX(-50%)', fontSize: 'var(--fs-micro)', fontWeight: 700, letterSpacing: '.08em', textTransform: 'uppercase', background: 'var(--accent-solid)', color: 'var(--on-accent)', padding: '3px 14px', borderRadius: 20, whiteSpace: 'nowrap' }}>
               {t('UPGRADE_PRO_CARD_BADGE')}
             </div>
             <div style={{ fontSize: 'var(--fs-micro)', fontWeight: 700, letterSpacing: '.08em', textTransform: 'uppercase', color: 'var(--accent)', marginBottom: 6 }}>{t('UPGRADE_PRO_CARD_EYEBROW')}</div>
@@ -171,7 +171,7 @@ export default function UpgradePage() {
               <button
                 onClick={handleCheckout}
                 disabled={redirecting}
-                style={{ fontSize: 'var(--fs-data)', fontWeight: 700, color: '#fff', background: 'var(--accent-solid)', padding: '14px 40px', borderRadius: 12, border: 'none', cursor: redirecting ? 'default' : 'pointer', opacity: redirecting ? 0.7 : 1, transition: 'opacity .15s, transform .15s', transform: 'translateY(0)' }}
+                style={{ fontSize: 'var(--fs-data)', fontWeight: 700, color: 'var(--on-accent)', background: 'var(--accent-solid)', padding: '14px 40px', borderRadius: 12, border: 'none', cursor: redirecting ? 'default' : 'pointer', opacity: redirecting ? 0.7 : 1, transition: 'opacity .15s, transform .15s', transform: 'translateY(0)' }}
                 onMouseEnter={e => { if (!redirecting) (e.currentTarget as HTMLButtonElement).style.transform = 'translateY(-1px)'; }}
                 onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.transform = 'translateY(0)'; }}
               >

--- a/components/TradeJournal.tsx
+++ b/components/TradeJournal.tsx
@@ -820,7 +820,7 @@ function Inner() {
           {t('TRADE_JOURNAL_TAB_RULES')}{rules.filter(r => r.enabled).length > 0 && (
             <span style={{
               marginLeft: 5, fontSize: 'var(--fs-caption)', fontWeight: 700,
-              background: 'var(--accent-solid)', color: '#fff',
+              background: 'var(--accent-solid)', color: 'var(--on-accent)',
               borderRadius: 10, padding: '1px 5px',
             }}>{rules.filter(r => r.enabled).length}</span>
           )}
@@ -829,7 +829,7 @@ function Inner() {
         <button data-testid="journal-tab" className={`tj-tab${tab === 'bias' ? ' on' : ''}`} onClick={() => setTab('bias')}>{t('TRADE_JOURNAL_TAB_BIAS')}</button>
         <button data-testid="journal-tab" className={`tj-tab${tab === 'thesis' ? ' on' : ''}`} onClick={() => setTab('thesis')} style={{ position: 'relative' }}>
           {t('TRADE_JOURNAL_TAB_THESIS')}{theses.length > 0 && (
-            <span style={{ marginLeft: 5, fontSize: 'var(--fs-caption)', fontWeight: 700, background: 'var(--accent-solid)', color: '#fff', borderRadius: 10, padding: '1px 5px' }}>{theses.length}</span>
+            <span style={{ marginLeft: 5, fontSize: 'var(--fs-caption)', fontWeight: 700, background: 'var(--accent-solid)', color: 'var(--on-accent)', borderRadius: 10, padding: '1px 5px' }}>{theses.length}</span>
           )}
         </button>
       </div>

--- a/components/UpgradeGateModal.tsx
+++ b/components/UpgradeGateModal.tsx
@@ -44,7 +44,7 @@ export function LockedFeatureCard({ title, description, onUnlock }: {
       <button
         onClick={onUnlock}
         style={{
-          background: 'var(--accent-solid)', color: '#fff', border: 'none', cursor: 'pointer',
+          background: 'var(--accent-solid)', color: 'var(--on-accent)', border: 'none', cursor: 'pointer',
           fontSize: 'var(--fs-label)', fontWeight: 700, padding: '9px 16px', borderRadius: 8,
           flexShrink: 0,
         }}
@@ -101,7 +101,7 @@ export function FullPageUpgradeGate({ title, description }: { title: string; des
           href={ctaHref}
           style={{
             display: 'block', textAlign: 'center',
-            background: 'var(--accent-solid)', color: '#fff',
+            background: 'var(--accent-solid)', color: 'var(--on-accent)',
             fontSize: 'var(--fs-body)', fontWeight: 700,
             padding: '12px 16px', borderRadius: 8,
             textDecoration: 'none',
@@ -207,7 +207,7 @@ export default function UpgradeGateModal({ open, onClose, feature }: Props) {
           href={ctaHref}
           style={{
             display: 'block', textAlign: 'center',
-            background: 'var(--accent-solid)', color: '#fff',
+            background: 'var(--accent-solid)', color: 'var(--on-accent)',
             fontSize: 'var(--fs-body)', fontWeight: 700,
             padding: '12px 16px', borderRadius: 8,
             textDecoration: 'none',

--- a/qa/e2e/contrast.spec.ts
+++ b/qa/e2e/contrast.spec.ts
@@ -451,11 +451,34 @@ This is NOT automatically a regression. It is either:
       `Both are scored the same way on purpose - a route that could not be measured must never be counted as a route with no violations.`,
     ).toEqual([]);
 
-    const byColour = new Map<string, { n: number; worst: number }>();
+    /* ROUTE AND TARGET, not just the token. The dark test has carried them since
+     * it was written; this one never did, and the asymmetry cost real time.
+     *
+     * On 2026-08-14 this reported `#795f15 worst 2.58:1 x2` and dev could not
+     * act on it: they solved for the background from the ratio, swept every
+     * route reachable signed out, found nothing, and asked me for the route
+     * names. I wrote a throwaway probe to answer a question this message should
+     * have answered itself.
+     *
+     * **A failure that names a token but not where it renders makes the reader
+     * do the work twice.** `Violation` carried `route` and `target` all along;
+     * only this aggregation threw them away.
+     *
+     * Keeps the WORST instance's location, not the first - the worst is the one
+     * someone has to fix, and a first-seen route can be a much milder case that
+     * sends the reader to the wrong screen. */
+    const byColour = new Map<string, { n: number; worst: number; where: string; what: string }>();
     for (const v of all) {
       const key = bucket(v.fg);
-      const e = byColour.get(key) ?? { n: 0, worst: Infinity };
-      byColour.set(key, { n: e.n + 1, worst: Math.min(e.worst, v.ratio) });
+      const e = byColour.get(key);
+      if (!e) { byColour.set(key, { n: 1, worst: v.ratio, where: v.route, what: v.target }); continue; }
+      const keep = v.ratio < e.worst;
+      byColour.set(key, {
+        n: e.n + 1,
+        worst: Math.min(e.worst, v.ratio),
+        where: keep ? v.route : e.where,
+        what: keep ? v.target : e.what,
+      });
     }
 
     const known = new Set(BASELINE.contrast.lightTokens);
@@ -467,7 +490,7 @@ This is NOT automatically a regression. It is either:
     testInfo.attach('contrast-light.txt', {
       body: `${all.length} violations across ${byColour.size} tokens\n\n`
         + [...byColour].sort((a, b) => a[1].worst - b[1].worst)
-            .map(([fg, e]) => `${fg}  worst ${e.worst.toFixed(2)}:1  x${e.n}`).join('\n')
+            .map(([fg, e]) => `${fg}  worst ${e.worst.toFixed(2)}:1  x${e.n}  worst at ${e.where}  ${e.what}`).join('\n')
         + (fixed.length ? `\n\nno longer failing (remove from BASELINE.contrast.lightTokens):\n${fixed.join('\n')}` : ''),
       contentType: 'text/plain',
     });
@@ -497,7 +520,7 @@ This is NOT automatically a regression. It is either:
       `BASELINE.contrast.lightTokens.
 
 ` +
-      unexpected.map(([fg, e]) => `  ${fg}  worst ${e.worst.toFixed(2)}:1  x${e.n}`).join('\n') +
+      unexpected.map(([fg, e]) => `  ${fg}  worst ${e.worst.toFixed(2)}:1  x${e.n}  worst at ${e.where}  ${e.what}`).join('\n') +
       `
 
 Same triage as the dark test: a state that had not rendered before (add it, with a ` +


### PR DESCRIPTION
**QA Team** → **Dev Team** · A QA-side gap that cost us a round trip this afternoon.

## The problem

```
BEFORE   #795f15  worst 2.58:1  x2
AFTER    #685112  worst 2.07:1  x1  worst at /arena  main > div > ... > span
```

**You asked me for the route names and I could not answer from my own failure message.** You solved for the background from the ratio, swept every route you could reach signed out, found nothing — and the answer was `/arena`, which needs a session.

**A failure that names a token but not where it renders makes the reader do the work twice.** `Violation` has carried `route` and `target` since the file was written; only the light-theme aggregation discarded them. The dark test never did.

## It paid for itself on the first run

The very next sweep printed `/arena` and the exact selector — **and confirmed your hypothesis by the direction of the change**: darkening the gold took it from 2.58 to 2.07, which only happens on a dark ground.

It also surfaced two baseline entries nobody had ever looked at:

```
near-white  1.06:1  x17  /funding  .frh-sig-chip > .frh-sig-hint
#77deb9     1.46:1  x1   /liq
```

**1.06:1 is text the same colour as its background.** They have been in `BASELINE.contrast.lightTokens` the whole time, passing the ratchet forever. Filed as **#423** rather than left in the count.

## One design choice worth reviewing

**It keeps the WORST instance's location, not the first.** A token failing on six routes reports the one that fails hardest — because that is the one someone has to fix, and a first-seen route can be a much milder case that sends the reader to the wrong screen.

**Cost: you lose "where it first appeared".** I think worst-case is more useful; say if you disagree and I will print both.

## Risk — **Low**

One QA spec, message and aggregation only. No assertion changed, no baseline moved.
