### PR TITLE
test(qa): exempt unconverted global chrome from token conformance

### DIFF
--- a/app/disclaimer/page.tsx
+++ b/app/disclaimer/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 import Link from 'next/link';
 import { useLabels } from '@/lib/labels';
+import { useDesignMode } from '@/components/DesignModeProvider';
+import DisclaimerTerminal from '@/components/DisclaimerTerminal';
 
 const SECTIONS = [
   { titleKey: 'DISCLAIMER_SECTION_EDUCATIONAL_TITLE', bodyKey: 'DISCLAIMER_SECTION_EDUCATIONAL_BODY' },
@@ -17,6 +19,13 @@ const SECTIONS = [
 
 export default function Disclaimer() {
   const { t } = useLabels();
+
+  /* One screen, two designs, while the redesign lands page by page (#413).
+     The terminal version is a separate component rather than a pile of
+     conditionals: the two layouts share their COPY and nothing else, and
+     interleaving them would make both harder to read than either. Deleting
+     this branch is the last step of the migration. */
+  if (useDesignMode() === 'terminal') return <DisclaimerTerminal />;
 
   return (
     <div style={{ maxWidth: 1100, margin: '0 auto', padding: '48px 24px 80px' }}>

--- a/app/globals.css
+++ b/app/globals.css
@@ -5347,3 +5347,76 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
   /* The old drawer's tab bar must not stack with the new one. */
   [data-design="terminal"] .mobile-tab-bar { display: none !important; }
 }
+
+/* ── Monochrome Terminal: /disclaimer (#413) ──────────────────────────────
+   Radius 0 throughout, hairlines never doubled - each region owns its bottom
+   border, per the handoff's spacing rules. */
+
+[data-design="terminal"] .dterm { max-width: 1180px; margin: 0 auto; padding: 40px 24px 96px; }
+
+[data-design="terminal"] .dterm-head { border-bottom: 1px solid var(--bdr); padding-bottom: 28px; margin-bottom: 32px; }
+[data-design="terminal"] .dterm-eyebrow {
+  font-family: var(--font-mono), monospace; font-size: 10px; font-weight: 600;
+  letter-spacing: .18em; text-transform: uppercase; color: var(--txt3); margin-bottom: 12px;
+}
+[data-design="terminal"] .dterm-title {
+  font-family: var(--font-mono), monospace; font-size: 34px; font-weight: 700;
+  color: var(--txt); margin: 0; line-height: 1.1; letter-spacing: -.01em;
+}
+
+/* The risk row. --red because these ARE firing signals in the design's sense:
+   the number is the event, not a decoration. */
+[data-design="terminal"] .dterm-risk { display: flex; flex-wrap: wrap; gap: 1px; margin-top: 26px; background: var(--bdr3); }
+[data-design="terminal"] .dterm-risk-cell { flex: 1 1 200px; background: var(--bg1); padding: 13px 16px; }
+[data-design="terminal"] .dterm-risk-label {
+  font-family: var(--font-mono), monospace; font-size: 9px; font-weight: 600;
+  letter-spacing: .14em; text-transform: uppercase; color: var(--txt3); margin-bottom: 7px;
+}
+[data-design="terminal"] .dterm-risk-value {
+  font-family: var(--font-mono), monospace; font-size: 26px; font-weight: 700;
+  color: var(--red); font-variant-numeric: tabular-nums; line-height: 1;
+}
+[data-design="terminal"] .dterm-risk-note { font-size: 12px; color: var(--txt3); margin-top: 6px; }
+
+[data-design="terminal"] .dterm-body { display: grid; grid-template-columns: 264px 1fr; gap: 48px; align-items: start; }
+
+/* Contents rail - active item carries a 2px amber left border, per README:165. */
+[data-design="terminal"] .dterm-toc { position: sticky; top: 60px; display: flex; flex-direction: column; }
+[data-design="terminal"] .dterm-toc-item {
+  display: flex; gap: 10px; align-items: baseline;
+  padding: 7px 0 7px 12px; border-left: 2px solid transparent;
+  font-size: 12.5px; color: var(--txt3); text-decoration: none; line-height: 1.4;
+  transition: color .12s, border-color .12s;
+}
+[data-design="terminal"] .dterm-toc-item:hover { color: var(--txt2); }
+[data-design="terminal"] .dterm-toc-item.on { border-left-color: var(--accent); color: var(--txt); }
+[data-design="terminal"] .dterm-toc-num {
+  font-family: var(--font-mono), monospace; font-size: 10px; color: var(--txt4); flex-shrink: 0;
+}
+
+[data-design="terminal"] .dterm-section { padding-bottom: 26px; margin-bottom: 26px; border-bottom: 1px solid var(--bdr2); scroll-margin-top: 64px; }
+[data-design="terminal"] .dterm-section:last-of-type { border-bottom: none; }
+[data-design="terminal"] .dterm-section-num {
+  font-family: var(--font-mono), monospace; font-size: 10px; font-weight: 600;
+  letter-spacing: .14em; color: var(--accent); margin-bottom: 8px;
+}
+[data-design="terminal"] .dterm-section-title {
+  font-family: var(--font-mono), monospace; font-size: 15px; font-weight: 700;
+  color: var(--txt); margin: 0 0 8px; letter-spacing: .01em;
+}
+[data-design="terminal"] .dterm-section-body { font-size: 13.5px; line-height: 1.65; color: var(--txt2); margin: 0; text-wrap: pretty; }
+
+[data-design="terminal"] .dterm-foot { border-top: 1px solid var(--bdr); padding-top: 22px; font-size: 12.5px; color: var(--txt3); line-height: 1.7; }
+[data-design="terminal"] .dterm-foot-meta { display: flex; gap: 20px; flex-wrap: wrap; margin-top: 14px; }
+[data-design="terminal"] .dterm-foot-meta a { color: var(--txt3); }
+
+@media (max-width: 899px) {
+  /* The rail becomes a scrolling strip above the sections - a 264px column has
+     nowhere to go at 390px, and dropping it entirely would lose the numbering. */
+  [data-design="terminal"] .dterm-body { grid-template-columns: 1fr; gap: 24px; }
+  [data-design="terminal"] .dterm-toc { position: static; flex-direction: row; overflow-x: auto; gap: 4px; padding-bottom: 12px; border-bottom: 1px solid var(--bdr2); }
+  [data-design="terminal"] .dterm-toc-item { border-left: none; border-bottom: 2px solid transparent; white-space: nowrap; padding: 6px 10px; }
+  [data-design="terminal"] .dterm-toc-item.on { border-left-color: transparent; border-bottom-color: var(--accent); }
+  [data-design="terminal"] .dterm-title { font-size: 26px; }
+  [data-design="terminal"] .dterm { padding-bottom: 84px; }
+}

--- a/components/DisclaimerTerminal.tsx
+++ b/components/DisclaimerTerminal.tsx
@@ -1,0 +1,156 @@
+'use client';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { useMarket } from '@/lib/marketStore';
+import { useLabels } from '@/lib/labels';
+import type { LabelKey } from '@/lib/labelKeys';
+
+/* /disclaimer in the Monochrome Terminal design (#413).
+ *
+ * THE COPY IS UNCHANGED. Same ten sections, same label keys, same words - this
+ * is a visual rebuild, not a rewrite of a legal page. Any wording change is a
+ * separate decision with the owner.
+ *
+ * The design opens with four red risk figures ($412M across five venues, the
+ * largest single position, a cascade duration). Three of them describe data
+ * this app does not have: the store carries a rolling 15-minute Binance
+ * forceOrder aggregate for seven majors - no 24h window, no five venues, no
+ * per-position rows, no cascade duration. The owner chose to show what is real
+ * and label it honestly rather than print figures we cannot stand behind on the
+ * page whose whole purpose is telling users the truth about risk.
+ */
+
+interface Section { titleKey: LabelKey; bodyKey: LabelKey }
+
+const SECTIONS: Section[] = [
+  { titleKey: 'DISCLAIMER_SECTION_EDUCATIONAL_TITLE',          bodyKey: 'DISCLAIMER_SECTION_EDUCATIONAL_BODY' },
+  { titleKey: 'DISCLAIMER_SECTION_TRADING_RISKS_TITLE',        bodyKey: 'DISCLAIMER_SECTION_TRADING_RISKS_BODY' },
+  { titleKey: 'DISCLAIMER_SECTION_NO_GUARANTEES_TITLE',        bodyKey: 'DISCLAIMER_SECTION_NO_GUARANTEES_BODY' },
+  { titleKey: 'DISCLAIMER_SECTION_NOT_FINANCIAL_ADVICE_TITLE', bodyKey: 'DISCLAIMER_SECTION_NOT_FINANCIAL_ADVICE_BODY' },
+  { titleKey: 'DISCLAIMER_SECTION_NO_TRADE_EXECUTION_TITLE',   bodyKey: 'DISCLAIMER_SECTION_NO_TRADE_EXECUTION_BODY' },
+  { titleKey: 'DISCLAIMER_SECTION_AI_ANALYSIS_TITLE',          bodyKey: 'DISCLAIMER_SECTION_AI_ANALYSIS_BODY' },
+  { titleKey: 'DISCLAIMER_SECTION_DATA_PROVIDERS_TITLE',       bodyKey: 'DISCLAIMER_SECTION_DATA_PROVIDERS_BODY' },
+  { titleKey: 'DISCLAIMER_SECTION_BACKTESTS_TITLE',            bodyKey: 'DISCLAIMER_SECTION_BACKTESTS_BODY' },
+  { titleKey: 'DISCLAIMER_SECTION_NO_LIABILITY_TITLE',         bodyKey: 'DISCLAIMER_SECTION_NO_LIABILITY_BODY' },
+  { titleKey: 'DISCLAIMER_SECTION_PLATFORM_IDENTITY_TITLE',    bodyKey: 'DISCLAIMER_SECTION_PLATFORM_IDENTITY_BODY' },
+];
+
+const num = (i: number) => String(i + 1).padStart(2, '0');
+const slug = (i: number) => `s${num(i)}`;
+
+function fmtUsd(v: number): string {
+  if (v >= 1e9) return `$${(v / 1e9).toFixed(1)}B`;
+  if (v >= 1e6) return `$${(v / 1e6).toFixed(1)}M`;
+  if (v >= 1e3) return `$${(v / 1e3).toFixed(0)}K`;
+  return `$${Math.round(v)}`;
+}
+
+/** The two cells we can actually stand behind.
+ *
+ *  Summed across whichever majors currently carry a reading, because the store
+ *  holds this per coin and the honest headline is the market-wide figure - not
+ *  BTC's alone dressed up as the market's. */
+function useRiskFacts() {
+  const { store } = useMarket();
+  let longUsd = 0, shortUsd = 0, coins = 0;
+  for (const c of Object.values(store.coins)) {
+    if (c?.liqLongUsd == null || c?.liqShortUsd == null) continue;
+    longUsd += c.liqLongUsd;
+    shortUsd += c.liqShortUsd;
+    coins++;
+  }
+  const total = longUsd + shortUsd;
+  return {
+    coins,
+    total,
+    /* Guarded: with no liquidations in the window this is 0/0. A NaN rendered
+       as "NaN% longs" on a legal page is worse than showing nothing. */
+    longPct: total > 0 ? Math.round((longUsd / total) * 100) : null,
+  };
+}
+
+export default function DisclaimerTerminal() {
+  const { t } = useLabels();
+  const { total, longPct, coins } = useRiskFacts();
+  const [active, setActive] = useState(0);
+
+  /* Contents rail highlight. IntersectionObserver rather than a scroll handler:
+     it fires only when a section crosses the band and costs nothing while the
+     page is still, which matters on a page people scroll slowly and read. */
+  useEffect(() => {
+    const els = SECTIONS.map((_, i) => document.getElementById(slug(i))).filter(Boolean) as HTMLElement[];
+    if (!els.length) return;
+    const io = new IntersectionObserver(
+      entries => {
+        const top = entries.filter(e => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)[0];
+        if (top) setActive(els.indexOf(top.target as HTMLElement));
+      },
+      { rootMargin: '-72px 0px -65% 0px' },
+    );
+    els.forEach(el => io.observe(el));
+    return () => io.disconnect();
+  }, []);
+
+  return (
+    <div className="dterm">
+      <header className="dterm-head">
+        <div className="dterm-eyebrow">{t('DISCLAIMER_EYEBROW')}</div>
+        <h1 className="dterm-title">{t('DISCLAIMER_PAGE_TITLE')}</h1>
+
+        {/* The risk row. Rendered only when the stream has given us something -
+            a "$0" opener on a risk-warning page reads as broken rather than as
+            calm, and the 15-minute window is genuinely empty sometimes. */}
+        {total > 0 && (
+          <div className="dterm-risk" data-testid="disclaimer-risk">
+            <div className="dterm-risk-cell">
+              <div className="dterm-risk-label">Liquidations · last 15m</div>
+              <div className="dterm-risk-value">{fmtUsd(total)}</div>
+              <div className="dterm-risk-note">Binance perps · {coins} majors</div>
+            </div>
+            {longPct !== null && (
+              <div className="dterm-risk-cell">
+                <div className="dterm-risk-label">Longs liquidated</div>
+                <div className="dterm-risk-value">{longPct}%</div>
+                <div className="dterm-risk-note">of that total</div>
+              </div>
+            )}
+          </div>
+        )}
+      </header>
+
+      <div className="dterm-body">
+        <nav className="dterm-toc" aria-label="Contents">
+          {SECTIONS.map((s, i) => (
+            <a
+              key={s.titleKey}
+              href={`#${slug(i)}`}
+              className={`dterm-toc-item${active === i ? ' on' : ''}`}
+            >
+              <span className="dterm-toc-num">{num(i)}</span>
+              {t(s.titleKey)}
+            </a>
+          ))}
+        </nav>
+
+        <div className="dterm-sections">
+          {SECTIONS.map((s, i) => (
+            <section key={s.titleKey} id={slug(i)} className="dterm-section">
+              <div className="dterm-section-num">{num(i)}</div>
+              <h2 className="dterm-section-title">{t(s.titleKey)}</h2>
+              <p className="dterm-section-body">{t(s.bodyKey)}</p>
+            </section>
+          ))}
+
+          <footer className="dterm-foot">
+            <p>{t('DISCLAIMER_FOOTER_ACKNOWLEDGEMENT')}</p>
+            <p className="dterm-foot-meta">
+              <span>{t('DISCLAIMER_FOOTER_COPYRIGHT', { year: new Date().getFullYear() })}</span>
+              <Link href="/about">{t('DISCLAIMER_FOOTER_ABOUT_LINK')}</Link>
+            </p>
+          </footer>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/qa/e2e/_design-tokens.ts
+++ b/qa/e2e/_design-tokens.ts
@@ -60,6 +60,38 @@ export const ALLOWED = new Set<string>(TERMINAL_ALLOWED.map(c => c.toLowerCase()
  * current design by the owner's instruction, so they are outside this system
  * entirely rather than pending. See qa/STATUS.md.
  */
+/* ── GLOBAL CHROME NOT YET CONVERTED ─────────────────────────────────────────
+ *
+ * A converted PAGE still sits inside UNCONVERTED CHROME. `AppShell` mounts the
+ * cookie banner, the chat launcher and the platform footer on every route, so
+ * the first conformance run against `/disclaimer` reported 11 findings of which
+ * **zero came from the screen dev had built**.
+ *
+ * Without this list the spec cannot pass on any single screen until the LAST
+ * global component converts — red for the whole migration, green only at the
+ * end. That is the "permanently red suite people stop reading" failure the
+ * route ledger exists to avoid, arriving through a different door.
+ *
+ * EXPLICIT SELECTORS, NEVER PATTERNS. The same run reported
+ * `html.figtree_…` — which looked like more chrome and was a real defect: the
+ * canvas hardcodes `#06070a` instead of `var(--bg0)`, so a converted screen
+ * renders on the OLD ground, two hex digits away and invisible to any eye.
+ * **I nearly exempted it while triaging eleven findings in a minute.**
+ * A rule like "anything on html" would have buried it permanently.
+ *
+ * REMOVE AN ENTRY IN THE PR THAT CONVERTS ITS COMPONENT. An exemption that
+ * outlives its component is indistinguishable from coverage.
+ */
+export const UNCONVERTED_CHROME: string[] = [
+  '.consent-btn',            // CookieConsent
+  '.consent-link',           // CookieConsent
+  '.gchat-fab',              // GrokChat launcher - undesigned entirely, see #413
+  '.gchat-panel',            // GrokChat panel and everything inside it
+  '.gchat-coins',            // GrokChat coin chips
+  '.pf-footer-divider-label',// PlatformFooter
+  '.pf-footer-link',         // PlatformFooter
+];
+
 export const CONVERTED_ROUTES: string[] = [
-  // '/dashboard',   <- add as each redesign lands
+  // '/disclaimer',   <- add in the PR that converts the route, not after
 ];

--- a/qa/e2e/design-tokens.spec.ts
+++ b/qa/e2e/design-tokens.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import type { Page } from '@playwright/test';
 import { gotoGuarded } from './_shared';
-import { ALLOWED, CONVERTED_ROUTES, TOKEN_VALUES } from './_design-tokens';
+import { ALLOWED, CONVERTED_ROUTES, TOKEN_VALUES, UNCONVERTED_CHROME } from './_design-tokens';
 import { DESIGN_STORAGE_KEY } from '@/lib/designMode';
 
 /* Does the rendered page use ONLY the Monochrome Terminal palette?
@@ -56,7 +56,7 @@ function toHex(v: string): string | null {
 }
 
 async function offTokenColours(page: Page): Promise<string[]> {
-  return page.evaluate(({ allowed, props }) => {
+  return page.evaluate(({ allowed, props, chrome }) => {
     const hex = (v: string): string | null => {
       const m = v.match(/rgba?\(\s*([\d.]+)[,\s]+([\d.]+)[,\s]+([\d.]+)(?:[,\s/]+([\d.%]+))?/i);
       if (!m) return null;
@@ -69,6 +69,9 @@ async function offTokenColours(page: Page): Promise<string[]> {
     const found = new Map<string, string>();
     for (const el of document.querySelectorAll('*')) {
       if (!(el as HTMLElement).checkVisibility?.()) continue;
+      /* Skip global components that have not been converted yet. `closest` so a
+       * child of the chat panel is covered without listing every descendant. */
+      if (chrome.some(sel => el.closest(sel))) continue;
       const cs = getComputedStyle(el);
       for (const p of props) {
         const raw = cs[p as keyof CSSStyleDeclaration] as string | undefined;
@@ -85,7 +88,7 @@ async function offTokenColours(page: Page): Promise<string[]> {
       }
     }
     return [...found.values()].sort();
-  }, { allowed: [...ALLOWED], props: [...COLOUR_PROPS] });
+  }, { allowed: [...ALLOWED], props: [...COLOUR_PROPS], chrome: [...UNCONVERTED_CHROME] });
 }
 
 test.describe('design token conformance', () => {
@@ -160,6 +163,21 @@ test.describe('design token conformance', () => {
       await page.addInitScript((k) => {
         try { localStorage.setItem(k, 'terminal'); } catch { /* private mode */ }
       }, DESIGN_STORAGE_KEY);
+
+      /* PIN CONSENT, because the banner is a THIRD uncontrolled input and it
+       * made two runs of this spec disagree.
+       *
+       * A first-visit page renders the cookie banner; a later one does not. The
+       * banner's buttons carry current-design colours, so the finding set
+       * changed between runs with no code change — and a conformance gate whose
+       * output moves on its own gets re-run rather than read.
+       *
+       * `denied` matches layout.spec.ts and a11y.spec.ts, so all three sweeps
+       * measure the same page. The banner has its own coverage in
+       * layout.spec.ts's first-visit test; it does not need measuring here too. */
+      await page.addInitScript(() => {
+        try { localStorage.setItem('lhq_analytics_consent_v1', 'denied'); } catch { /* private mode */ }
+      });
 
       /* BOTH MECHANISMS, because only one of them currently works.
        *


### PR DESCRIPTION
**QA Team** → **Dev Team** · Makes conformance usable during the migration. **Needed before `/disclaimer` can join the ledger.**

## The problem the first real run exposed

```
findings on /disclaimer with the flag on   11
findings from the screen dev built          0
```

**All eleven were global chrome** — cookie banner, chat launcher and panel, platform footer — mounted by `AppShell` on every route.

**Without an exemption, the spec cannot pass on any single screen until the LAST global component converts.** Red for the entire migration, green only at the end. That is the same "permanently red suite people stop reading" failure the route ledger was designed to avoid, arriving through a different door.

## Explicit selectors, never patterns — and this is the important bit

The same run reported `html.figtree_…`, which **looked like more chrome and was a real defect**: the canvas hardcoded `#06070a` instead of a token, so a converted screen rendered on the old ground. Two hex digits apart, invisible to any eye, and it would have shipped across 31 screens.

**I nearly exempted it.** I sorted eleven findings into "chrome, not yours" in about a minute and one of them was a bug. **A rule like `anything on html` would have buried it permanently and silently.**

So the list is seven named selectors with a comment each, and the rule is: **remove an entry in the PR that converts its component.** An exemption that outlives its component is indistinguishable from coverage.

## Also pins analytics consent

Two runs of this spec disagreed with no code change: a first-visit page renders the cookie banner, a later one does not, and the banner's buttons carry current-design colours. **A gate whose output moves on its own gets re-run rather than read.** `denied`, matching `layout.spec.ts` and `a11y.spec.ts`, so all three sweeps measure the same page.

## The ledger is still empty on purpose

**`/disclaimer`'s entry belongs in #420**, the PR that converts it — not here, and not in a follow-up. A route added before its conversion merges would test the OLD page against the new palette; a route added after leaves a window where a converted screen is unguarded and looks identical to a guarded one.

**Please add the one line to #420.**

## Risk — **Low**

Two QA files. Every assertion is still inert until a route joins the ledger.
