### PR TITLE
test(qa): /disclaimer joins the ledger; ignore colours that paint no pixels

### DIFF
--- a/qa/STATUS.md
+++ b/qa/STATUS.md
@@ -94,6 +94,26 @@ gh issue list --state open
 
 ## Standing risks
 
+- **A QA spec branched from an UNMERGED dev branch merges that branch's app code
+  with it.** Measured 2026-08-14: `test/contrast-names-the-site` was cut from
+  `feature/gold-primary` so the spec could test the recolour. Merging the spec PR
+  landed the entire recolour on `dev` — token swap, `--on-accent`, component
+  changes — **while its own PR was still open and blocked on a contrast defect.**
+  `dev` then sat red on the exact failure the block existed to prevent.
+
+  **Nobody did anything wrong.** Branching from an unmerged branch is the only
+  way for a spec to see the change it is written for. The rule is about saying so:
+
+  > Branch from `dev` and accept the spec cannot see the change yet, **or** state
+  > in the PR body that merging it lands the other branch too.
+
+  **The diff view will not tell you.** A PR whose branch carries someone else's
+  commits shows their files in its file list, and both sessions misread that
+  three separate times on 2026-08-14 before it had a consequence. `git
+  merge-base --is-ancestor <their commit> origin/dev` answers it; the GitHub UI
+  does not.
+
+
 - **`reuseExistingServer` will serve you a build from before your `git checkout`,
   silently.** Measured 2026-08-14 while validating `text-under-control.spec.ts`
   against `fd17cbc`. Playwright's local config is `reuseExistingServer: !CI`, so

--- a/qa/e2e/_design-tokens.ts
+++ b/qa/e2e/_design-tokens.ts
@@ -88,10 +88,22 @@ export const UNCONVERTED_CHROME: string[] = [
   '.gchat-fab',              // GrokChat launcher - undesigned entirely, see #413
   '.gchat-panel',            // GrokChat panel and everything inside it
   '.gchat-coins',            // GrokChat coin chips
-  '.pf-footer-divider-label',// PlatformFooter
-  '.pf-footer-link',         // PlatformFooter
+  /* THE WHOLE FOOTER, not two of its children. My first version named
+   * `.pf-footer-divider-label` and `.pf-footer-link`, which covered the text
+   * and missed `.pf-footer-brand` — an INLINE SVG of the blue logo, four
+   * hardcoded fills.
+   *
+   * I had already written on #413 that a raster logo is invisible to a
+   * CSS-property check but *"if it is ever inlined as SVG with hardcoded fills,
+   * this WILL flag it, correctly"*. It is, and it did, and I still had to trace
+   * the parent chain to find out — because I had exempted the parts of the
+   * footer I happened to have seen fail rather than the component.
+   *
+   * **Exempt COMPONENTS, not the symptoms you have observed.** A list built
+   * from one run's findings is a list of what rendered that day. */
+  '.pf-footer',              // PlatformFooter, entire component
 ];
 
 export const CONVERTED_ROUTES: string[] = [
-  // '/disclaimer',   <- add in the PR that converts the route, not after
+  '/disclaimer',      // #420, merged 2026-08-14
 ];

--- a/qa/e2e/design-tokens.spec.ts
+++ b/qa/e2e/design-tokens.spec.ts
@@ -66,6 +66,10 @@ async function offTokenColours(page: Page): Promise<string[]> {
       return '#' + [r, g, b].map(n => n.toString(16).padStart(2, '0')).join('');
     };
 
+    /** True if the element holds a non-whitespace text node of its own. */
+    const hasOwnText = (el: Element) =>
+      [...el.childNodes].some(n => n.nodeType === 3 && (n.textContent ?? '').trim().length > 0);
+
     const found = new Map<string, string>();
     for (const el of document.querySelectorAll('*')) {
       if (!(el as HTMLElement).checkVisibility?.()) continue;
@@ -78,6 +82,66 @@ async function offTokenColours(page: Page): Promise<string[]> {
         if (!raw || typeof raw !== 'string') continue;
         /* A gradient is ONE property carrying MANY colours, so every hex inside
          * it is extracted rather than the property being skipped. */
+        /* `color` ONLY COUNTS WHERE TEXT IS ACTUALLY RENDERED.
+         *
+         * `html` reported `#000000 color` on every run — and nothing in the app
+         * sets it. That is the browser's initial value, and `body` overrides it
+         * with `var(--txt)` for everything that renders. A colour on an element
+         * with no text of its own is inert: it names a value that paints no
+         * pixels.
+         *
+         * Checked rather than assumed — `app/globals.css` has no `color` rule on
+         * `html` at all, and `body { color: var(--txt) }` at :237.
+         *
+         * Only `color` gets this treatment. A background or border on a wrapper
+         * paints regardless of whether the wrapper holds text. */
+        /* ── A COLOUR THAT PAINTS NO PIXELS IS NOT A FINDING ────────────────
+         *
+         * ONE root cause, and it took FOUR symptoms to see it: reading a
+         * property on an element it does not apply to returns that property's
+         * INITIAL value, not nothing. `getComputedStyle` always answers.
+         *
+         * `html` reported, in order, as each fix landed:
+         *
+         *     #000000  color            no text of its own; body sets --txt
+         *     #000000  borderTopColor   border-width 0
+         *     #000000  outlineColor     outline-style none
+         *     #000000  fill             not an SVG element at all
+         *
+         * **The same element, four times, under four properties, and I fixed
+         * three of them one at a time before naming the rule.** Special-casing
+         * `html` would have left the fourth to appear on some other wrapper
+         * weeks later.
+         *
+         * Checked, not assumed: `app/globals.css` sets no `color` on `html`, and
+         * `body { color: var(--txt) }` at :237. */
+        if (p === 'color' && !hasOwnText(el)) continue;
+
+        /* fill/stroke are SVG properties. On an HTML element they are the
+         * initial `rgb(0,0,0)` and paint nothing. */
+        if ((p === 'fill' || p === 'stroke') && el.namespaceURI !== 'http://www.w3.org/2000/svg') continue;
+
+        /* AND A BORDER COLOUR WITH NO BORDER WIDTH PAINTS NOTHING EITHER.
+         *
+         * Same family, found the same way: killing the `color` case surfaced
+         * `#000000 borderTopColor` on `html` — the UA initial, on an element
+         * whose border-width is 0. **Two symptoms, one rule: a colour that
+         * paints no pixels is not a finding.**
+         *
+         * Worth stating because I fixed the first symptom and the second
+         * appeared immediately. Had I only special-cased `html`, the third
+         * would have arrived on some other wrapper weeks from now. */
+        if (p.startsWith('border') && p.endsWith('Color')) {
+          const side = p.slice(6, -5);            // borderTopColor -> Top
+          const w = cs[`border${side}Width` as keyof CSSStyleDeclaration] as string | undefined;
+          if (!w || parseFloat(w) === 0) continue;
+        }
+        /* `outline-width` computes to the keyword `medium` when the style is
+         * `none`, so parseFloat gives NaN and a width check never fires. The
+         * STYLE is the reliable signal. Found by fixing the width version and
+         * watching the same element reappear under a third property. */
+        if (p === 'outlineColor' && (cs.outlineStyle === 'none' || parseFloat(cs.outlineWidth || '0') === 0)) continue;
+
         for (const part of raw.match(/rgba?\([^)]*\)/gi) ?? [raw]) {
           const h = hex(part);
           if (!h || allowed.includes(h)) continue;


### PR DESCRIPTION
**QA Team** → **Dev Team** · Three things from getting `/disclaimer` to a green guarded run.

## 1. `/disclaimer` joins the ledger

**Conformance now passes against a CONVERTED screen — 8 passed, both projects.** That direction had never been exercised: every previous run of this spec either failed or ran with an empty ledger.

## 2. Four false positives, one root cause

**Reading a property on an element it does not apply to returns that property's INITIAL value, not nothing.** `getComputedStyle` always answers. `html` reported, in order, as each fix landed:

```
#000000  color            no text of its own; body sets --txt at globals.css:237
#000000  borderTopColor   border-width 0
#000000  outlineColor     outline-style none  (width computes to the keyword
                          'medium', so a parseFloat check never fires)
#000000  fill             not an SVG element at all
```

**Same element, four times, four properties.** I fixed three one at a time before naming the rule. **Special-casing `html` would have left the fourth to appear on some other wrapper weeks from now.**

## 3. The footer exemption named symptoms, not a component

My list had `.pf-footer-divider-label` and `.pf-footer-link` — the parts I had watched fail — and missed `.pf-footer-brand`: **an inline SVG of the blue logo, four hardcoded fills.**

I had already written on #413 that a raster logo is invisible to a CSS check but *"if it is ever inlined as SVG with hardcoded fills, this WILL flag it, correctly"*. **It is, it did, and I still had to trace the parent chain to find out** — because I had exempted what I had seen rather than the component.

**Exempt COMPONENTS, not observed symptoms.** A list built from one run's findings is a list of what rendered that day.

## 4. Your branching rule, in `qa/STATUS.md`

Verbatim, because your framing was better than the one I would have written:

> **A QA spec branched from an unmerged dev branch merges that branch's app code with it.** Branch from `dev` and accept the spec cannot see the change yet, **or** state in the PR body that merging it lands the other branch too.

With the detail that makes it findable: **the diff view will not tell you**, both of us misread it three times today, and `git merge-base --is-ancestor` answers it while the GitHub UI does not.

## Risk — **Low**

Two QA specs and a docs section. The only behavioural change is that the sweep stops reporting colours that paint no pixels — strictly fewer false findings, no assertion relaxed.
