### PR TITLE
fix(design): lower the gold tint alpha so secondary text keeps its margin

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -73,7 +73,20 @@
      rename is a separate change from a recolour. */
   --accent-solid: #d9a626;
   --accent-2:   #d9a626;
-  --accent-dim: rgba(217,166,38,0.12);
+  /* 0.09, not the blue's 0.12 (#419 knock-on).
+     Gold at the same alpha lifts a dark ground MORE than blue did, and --txt2
+     sits on these tints in panels across the app. Measured on --bg1 #06070a:
+
+         alpha   --txt2 on the tint
+         0.12      4.32   <- was 4.57 with blue: passing, then not
+         0.10      4.46
+         0.09      4.53   <- ships
+         0.07      4.66
+
+     The token that changed is the BACKGROUND, so the fix belongs here rather
+     than in --txt2, which 215 rules depend on. Gold text on the tint stays at
+     8.16:1, so nothing is lost at the other end. */
+  --accent-dim: rgba(217,166,38,0.09);
   --accent-bg:  rgba(217,166,38,0.07);
   --accent-bdr: rgba(217,166,38,0.22);
   /* What goes ON an accent fill. Flips with the theme because the accent does:


### PR DESCRIPTION
**Dev Team** · Diagnoses `#7a7e94`, the failure on `dev` neither of us had explained.

## It is `--txt2`, and the recolour moved the ground under it

`#7a7e94` is `--txt2`. It sits on accent-tinted panels across the app, and **gold at the same alpha lifts a dark ground more than blue did**:

```
--txt2 on --bg1 + a 12% tint
  blue   4.57    passing
  gold   4.32    failing
```

Measured across alphas on `--bg1 #06070a`:

```
0.12  4.32      0.10  4.46      0.09  4.53  <- ships      0.07  4.66
```

**The token that changed is the BACKGROUND**, so the fix belongs there — not in `--txt2`, which 215 rules depend on and whose own AA history is documented at its declaration. Gold text on the tint stays at **8.16:1**, so nothing is lost at the other end.

**This is a knock-on of my recolour, not pre-existing.** You confirmed it was absent from the baseline; I could not explain it at the time and said so.

## 🔴 A correction I owe you on the canvas

I wrote: *"byte-identical today, and it converts with the design."*

**That is true in dark theme only.** In light theme `--bg1` is `#FFFFFF`:

```
html/body before   #06070a   hardcoded dark, in BOTH themes
html/body after    var(--bg1) = #FFFFFF in light
```

**So light theme's page background changed from near-black to white.** I believe that is a fix — a light theme painting a dark canvas behind its content is wrong, and it would show on overscroll and on short pages — **but it is a visible change I told you would not happen**, and you reviewed the canvas edit on that basis.

**Worth a look during the re-run**, because "the light theme's background changed" is exactly the kind of thing that reads as a regression if nobody said it was coming.

## How to test (QA)

1. **`contrast.spec.ts` dark** — `#7a7e94` should clear. That is the assertion this PR exists for.
2. **Accent-tinted panels still read as tinted.** 0.12 → 0.09 is subtle but it is a real reduction; if a selected state now looks flat, say so and I will find the margin elsewhere.
3. **Light theme, any page, look at the canvas** — white behind the content, not dark. Per the correction above.

## Risk — **Low**

One alpha value. Gates: lint **0 errors / 131 warnings**, `tsc` clean, **428 tests**, build succeeds.

**Not verified:** the specific `/about` element. You have the route and token; I worked from the mechanism rather than the element, so if `#7a7e94` survives the re-run it is a call site with its own background and I will need the selector.