### PR TITLE
feat(design): the 56px static marketing shell, and the missing mobile header

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5487,3 +5487,68 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
   [data-design="terminal"] .dterm-title { font-size: 26px; }
   [data-design="terminal"] .dterm { padding-bottom: 84px; }
 }
+
+/* ── Monochrome Terminal: the STATIC marketing shell (#413, #430) ─────────
+   The design has two shells; the app had one. These seven routes -
+   /disclaimer /about /faq /learn /terms /privacy /refunds - are read by
+   signed-out visitors and carry a marketing bar, not the five app
+   destinations.
+
+   Values measured from Static.dc.html, disclaimer frame at 1440x900:
+     bar        1438 x 56        wordmark 13px mono 700, .16em
+     links      11px mono, .12em, --txt2, gap 24
+     SIGN IN    11px mono, .12em
+     START FREE 11px mono 700, amber fill with --on-accent */
+
+[data-design="terminal"] .sshell {
+  display: flex; align-items: center; gap: 24px;
+  height: 56px; padding: 0 16px;
+  background: var(--bg0); border-bottom: 1px solid var(--bdr);
+}
+[data-design="terminal"] .sshell-brand {
+  font-family: var(--font-mono), monospace;
+  font-size: 13px; font-weight: 700; letter-spacing: .16em;
+  color: var(--txt); text-decoration: none;
+}
+[data-design="terminal"] .sshell-spacer { flex: 1; }
+[data-design="terminal"] .sshell-signin {
+  font-family: var(--font-mono), monospace;
+  font-size: 11px; letter-spacing: .12em; text-transform: uppercase;
+  color: var(--txt2); text-decoration: none;
+}
+[data-design="terminal"] .sshell-signin:hover { color: var(--txt); }
+[data-design="terminal"] .sshell-cta {
+  font-family: var(--font-mono), monospace;
+  font-size: 11px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase;
+  background: var(--accent); color: var(--on-accent);
+  padding: 7px 14px; text-decoration: none;
+  /* Radius 0 - "not a token, an absence". The app's own CTA is 20px rounded. */
+}
+@media (max-width: 899px) {
+  [data-design="terminal"] .sshell { gap: 12px; padding: 0 12px; }
+  [data-design="terminal"] .sshell-brand { font-size: 12px; letter-spacing: .12em; }
+}
+/* Mobile 38px header (README:82) - logo, screen name, status. */
+[data-design="terminal"] .tnav-mhead { display: none; }
+@media (max-width: 899px) {
+  [data-design="terminal"] .tnav-mhead {
+    display: flex; align-items: center; gap: 10px;
+    height: 38px; padding: 0 12px;
+    background: var(--bg0); border-bottom: 1px solid var(--bdr);
+  }
+  [data-design="terminal"] .tnav-mbrand {
+    font-family: var(--font-mono), monospace;
+    font-size: 11px; font-weight: 700; letter-spacing: .14em; color: var(--txt);
+  }
+  [data-design="terminal"] .tnav-mscreen {
+    font-family: var(--font-mono), monospace;
+    font-size: 10px; letter-spacing: .12em; color: var(--txt3); flex: 1;
+  }
+  [data-design="terminal"] .tnav-mstatus {
+    display: inline-flex; align-items: center; gap: 5px;
+    font-family: var(--font-mono), monospace;
+    font-size: 10px; letter-spacing: .1em; color: var(--txt2);
+  }
+  /* 5px SQUARE, per the nav spec - the design has no round elements at all. */
+  [data-design="terminal"] .tnav-mdot { width: 5px; height: 5px; background: var(--green); }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -5506,6 +5506,7 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
   background: var(--bg0); border-bottom: 1px solid var(--bdr);
 }
 [data-design="terminal"] .sshell-brand {
+  display: inline-flex; align-items: center; gap: 8px;
   font-family: var(--font-mono), monospace;
   font-size: 13px; font-weight: 700; letter-spacing: .16em;
   color: var(--txt); text-decoration: none;

--- a/app/globals.css
+++ b/app/globals.css
@@ -3229,7 +3229,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .frh-coin        { font-weight: 700; color: var(--txt) !important; font-size: var(--fs-caption); width: 46px; }
 .frh-row         { cursor: pointer; transition: background 0.1s, box-shadow 0.1s; }
 .frh-row:hover   { background: rgba(255,255,255,0.04); }
-.frh-row.on      { background: rgba(var(--accent-rgb), 0.11) !important; box-shadow: inset 3px 0 0 #1a7aff !important; }
+.frh-row.on      { background: rgba(var(--accent-rgb), 0.11) !important; box-shadow: inset 3px 0 0 var(--accent) !important; }
 .frh-row.on .frh-coin { color: var(--purple) !important; }
 .frh-spark-th    { min-width: 120px; }
 .frh-spark-cell  { min-width: 120px; width: 160px; padding: 3px 8px !important; }
@@ -3262,7 +3262,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .frh-signal-desc   { font-size: var(--fs-caption); color: var(--txt2); line-height: 1.6; }
 
 [data-theme="light"] .frh-row:hover { background: rgba(0,0,0,0.03) !important; }
-[data-theme="light"] .frh-row.on    { background: var(--purple-bg) !important; box-shadow: inset 3px 0 0 #1a7aff !important; }
+[data-theme="light"] .frh-row.on    { background: var(--purple-bg) !important; box-shadow: inset 3px 0 0 var(--accent) !important; }
 
 .frh-split        { display: grid; grid-template-columns: minmax(0,1fr) minmax(0,1fr); gap: 12px; align-items: start; margin-bottom: 10px; }
 .frh-list-scroll  { max-height: 500px; overflow-y: auto; overflow-x: auto; }
@@ -3300,26 +3300,27 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 }
 .auth-gate-title { font-size: var(--fs-card-title); font-weight: 700; color: var(--txt); }
 .auth-gate-desc  { font-size: var(--fs-caption); color: var(--txt3); line-height: 1.6; max-width: 280px; }
-/* Issue #56. White on --purple (which aliases --accent, #1a7aff) measured
-   3.98:1 against the 4.5:1 floor - the primary call to action on the signed-out
-   auth gate was the least readable thing on the page.
+/* Issue #56, REWRITTEN for the gold primary (#419). The original reasoning was
+   entirely about blue and every value in it is now wrong; leaving it would send
+   the next reader looking for a #1668e3 that no longer exists.
 
-   --accent-solid exists for exactly this: --accent is for text, borders and
-   glows; --accent-solid is for a filled surface UNDER white text. Same rule as
-   .lp-btn-primary, .consent-accept and .desktop-nav-item.on already follow.
-   White on #1668e3 = 5.09:1.
+   WHAT STILL HOLDS. A filled accent surface needs a deliberate foreground - it
+   was the primary CTA on the signed-out auth gate that first proved it, at
+   3.98:1. And the HOVER state is the half the original issue missed: axe
+   measures the resting state only, so a hover that fails is invisible to the
+   sweep that finds the base. Whatever this button does on hover has to be
+   measured separately, in both themes.
 
-   The hover was the half the issue did not catch, and fixing only the base
-   colour would have left it failing: brightness(1.15) on #1668e3 lands on
-   #1978ff = 4.06:1, still under the floor. axe measures the resting state only,
-   so a hover that fails is invisible to the sweep that found this.
-   Darkening instead of brightening keeps it passing (#135cc8 = 6.19:1) and is
-   the more conventional direction for a filled button anyway.
+   WHAT CHANGED. The fix is no longer a second, darker VALUE - it is a paired
+   foreground. --on-accent is near-black on the dark gold (8.95:1) and white on
+   the light gold (6.07:1); the inverse pairings are 2.23 and 3.63. So
+   --accent-solid and --accent are the same colour now and the contrast comes
+   from the text, not from darkening the fill.
 
-   Light theme does not redefine --accent-solid, so it inherits #1668e3 there -
-   5.09:1, which passes. Deliberately not adding a light-theme override in this
-   change: several other elements already render --accent-solid in light mode
-   and altering it would move all of them for a one-button fix. */
+   AND THE LINE THAT WAS ACTIVELY MISLEADING: this used to say "light theme does
+   not redefine --accent-solid". It does, at #685112. That was true when written
+   and stopped being true without anyone editing it - which is the whole reason
+   this block got rewritten rather than patched. */
 .auth-gate-btn {
   margin-top: 6px; padding: 9px 26px; border-radius: 10px;
   background: var(--accent-solid); color: var(--on-accent);
@@ -4457,7 +4458,12 @@ body.landing {
   --bdr2: rgba(255,255,255,0.14);
 
   --accent:     #d9a626;
-  --accent-solid: #1668e3; /* AA fix, mirrors :root - see note there */
+  /* Was #1668e3, the darkened BLUE that existed so white text could sit on it.
+     It survived the recolour because my sweeps replaced rgba() patterns and
+     this is a bare hex - so the landing CTA kept a blue fill while --on-accent
+     put NEAR-BLACK on it: 3.91:1, seven instances, found by QA's sweep.
+     White on that blue was 5.09; near-black on this gold is 8.95. */
+  --accent-solid: #d9a626;
   --accent-2:   #5aa3ff;
   --accent-dim: rgba(var(--accent-rgb), 0.12);
   --accent-bg:  rgba(var(--accent-rgb), 0.07);

--- a/app/globals.css
+++ b/app/globals.css
@@ -5526,7 +5526,11 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
   /* Radius 0 - "not a token, an absence". The app's own CTA is 20px rounded. */
 }
 @media (max-width: 899px) {
-  [data-design="terminal"] .sshell { gap: 12px; padding: 0 12px; }
+  /* 52, not 56. Every shell in this design steps down at mobile - the app bar
+     goes 44 -> 38 and this one goes 56 -> 52. Measured by QA across the Static
+     file: 7 frames at 56px (desktop), 9 at 52px (mobile), and ZERO at 60px,
+     which is why these screens correctly have no bottom tab bar. */
+  [data-design="terminal"] .sshell { height: 52px; gap: 12px; padding: 0 12px; }
   [data-design="terminal"] .sshell-brand { font-size: 12px; letter-spacing: .12em; }
 }
 /* Mobile 38px header (README:82) - logo, screen name, status. */

--- a/app/globals.css
+++ b/app/globals.css
@@ -4464,7 +4464,7 @@ body.landing {
      put NEAR-BLACK on it: 3.91:1, seven instances, found by QA's sweep.
      White on that blue was 5.09; near-black on this gold is 8.95. */
   --accent-solid: #d9a626;
-  --accent-2:   #5aa3ff;
+  --accent-2:   #d9a626;
   --accent-dim: rgba(var(--accent-rgb), 0.12);
   --accent-bg:  rgba(var(--accent-rgb), 0.07);
   --accent-bdr: rgba(var(--accent-rgb), 0.22);
@@ -4502,7 +4502,7 @@ body.landing {
   height: 36px;
   border-radius: 50%;
   border: 3px solid rgba(255,255,255,0.1);
-  border-top-color: #1a7aff;
+  border-top-color: var(--accent);
   animation: lp-loading-spin 0.8s linear infinite;
 }
 @keyframes lp-loading-spin {

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -5,6 +5,7 @@ import MarketProvider from './MarketProvider';
 import NewsProvider from './NewsProvider';
 import NavDrawer from './NavDrawer';
 import TerminalNav from './TerminalNav';
+import StaticShell from './StaticShell';
 import DesignModeProvider, { useDesignMode } from './DesignModeProvider';
 import GrokChat from './GrokChat';
 import NewsTicker from './NewsTicker';
@@ -161,6 +162,17 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
    and the terminal bar is only reachable with ?design=terminal (#413).
    A component rather than a ternary inline so it can call useDesignMode(),
    which needs to be inside the provider. */
+/* The seven routes the handoff groups under its STATIC shell (README:167).
+   They are read signed-out, so they carry a marketing bar rather than the five
+   app destinations - which is what they inherited until now. */
+const STATIC_SHELL_ROUTES = new Set([
+  '/disclaimer', '/about', '/faq', '/learn', '/terms', '/privacy', '/refunds',
+]);
+
 function AppChrome() {
-  return useDesignMode() === 'terminal' ? <TerminalNav /> : <NavDrawer />;
+  const pathname = usePathname();
+  if (useDesignMode() !== 'terminal') return <NavDrawer />;
+  /* Exact match, like isChromeless above: a future /about/team should be a
+     deliberate decision rather than silently inheriting the marketing bar. */
+  return STATIC_SHELL_ROUTES.has(pathname) ? <StaticShell /> : <TerminalNav />;
 }

--- a/components/MagicBento.tsx
+++ b/components/MagicBento.tsx
@@ -4,7 +4,7 @@ import { useRef, useEffect, useCallback, useState, ReactNode, CSSProperties, Ref
 import { gsap } from 'gsap';
 import './MagicBento.css';
 
-export const GLOW_COLOR = '26, 122, 255'; // matches app --accent #1a7aff
+export const GLOW_COLOR = '217, 166, 38'; // matches app --accent #d9a626 (#419)
 const DEFAULT_PARTICLE_COUNT = 8;
 const DEFAULT_SPOTLIGHT_RADIUS = 280;
 const MOBILE_BREAKPOINT = 768;

--- a/components/SpotlightTour.tsx
+++ b/components/SpotlightTour.tsx
@@ -15,7 +15,7 @@ const SANS = "var(--font-sans, 'Figtree', system-ui, sans-serif)";
 // [data-theme="light"] at all. Values below match the app's real light-theme
 // tokens (app/globals.css's [data-theme="light"] block), not guesses.
 const DARK = {
-  ACCENT: '#1a7aff', GREEN: 'var(--green)', RED: 'var(--red)', ORANGE: '#f97316',
+  ACCENT: 'var(--accent)', GREEN: 'var(--green)', RED: 'var(--red)', ORANGE: '#f97316',
   BG0: '#07090f', BG1: '#0c0f1c', BG2: '#101324',
   TXT1: '#eef0fa', TXT2: '#9296b5', TXT3: '#4e5374',
   BDR: 'rgba(var(--accent-rgb), 0.1)', TRACK_BG: 'rgba(var(--accent-rgb), 0.06)', GRID: 'rgba(var(--accent-rgb), 0.05)',

--- a/components/StaticShell.tsx
+++ b/components/StaticShell.tsx
@@ -1,6 +1,7 @@
 'use client';
 import Link from 'next/link';
 import { useLabels } from '@/lib/labels';
+import BrandMark from './BrandMark';
 
 /* LEARN_CONTENT_* rather than new keys: /learn already renders this exact bar
    (components/LearnContent.tsx uses .lp-nav-inner) and its labels are the ones
@@ -42,7 +43,18 @@ export default function StaticShell() {
 
   return (
     <nav className="sshell" aria-label="Site">
-      <Link href="/" className="sshell-brand">LIQUIDITYHQ</Link>
+      {/* README:197 - "logo.png ... used at 18-26px in every nav bar and mobile
+          header, with no border radius change". The first version of this shell
+          shipped the wordmark alone; the reading pass found the line.
+          BrandMark, not the handoff's logo.png: the repo already has the mark
+          as a component, and adding the binary would import a BLUE asset into a
+          gold palette - the open question QA raised for the owner. Swapping the
+          source later is one line; the slot and its size are what the design
+          specifies. */}
+      <Link href="/" className="sshell-brand">
+        <BrandMark size={22} tone="dark" />
+        LIQUIDITYHQ
+      </Link>
 
       {/* marketingNav renders here once its labels exist - see the note above */}
 

--- a/components/StaticShell.tsx
+++ b/components/StaticShell.tsx
@@ -1,0 +1,57 @@
+'use client';
+import Link from 'next/link';
+import { useLabels } from '@/lib/labels';
+
+/* LEARN_CONTENT_* rather than new keys: /learn already renders this exact bar
+   (components/LearnContent.tsx uses .lp-nav-inner) and its labels are the ones
+   translated for it. A new key pair would need translations in every locale to
+   say what these already say. */
+
+/* The 56px MARKETING nav for the static pages (#413, #430).
+ *
+ * The handoff describes two shells and the app only had one. README:167:
+ *
+ *   "Shared static shell: 56px marketing nav, 264px page index rail (active
+ *    item has a 2px amber left border), content column, right rail."
+ *
+ * `/disclaimer` and its six siblings render inside AppShell, so they inherited
+ * the APP bar - 44px, five app destinations - on pages a signed-out visitor
+ * reads before they have an account. QA's structure spec asserts 56 and was
+ * merged red against this.
+ *
+ * MEASURED FROM THE FRAME, not the prose (Static.dc.html, disclaimer frame,
+ * 1440x900):
+ *
+ *   bar            1438 x 56
+ *   wordmark       13px mono 700, letter-spacing .16em, --txt
+ *   nav links      11px mono, letter-spacing .12em, --txt2, gap 24
+ *   spacer         flex 1
+ *   SIGN IN        11px mono, .12em, --txt2
+ *   START FREE     11px mono 700, amber fill
+ *
+ * THE MIDDLE LINKS ARE DELIBERATELY ABSENT. The prototype renders them from a
+ * `marketingNav` list that its template never resolves - the frame shows the
+ * literal `{{ n.label }}` with a five-item placeholder hint. So the design
+ * specifies that five links exist and does not say what they are. Inventing
+ * five is how a redesign quietly acquires navigation nobody designed; this is
+ * filed for the owner instead.
+ */
+
+export default function StaticShell() {
+  const { t } = useLabels();
+
+  return (
+    <nav className="sshell" aria-label="Site">
+      <Link href="/" className="sshell-brand">LIQUIDITYHQ</Link>
+
+      {/* marketingNav renders here once its labels exist - see the note above */}
+
+      <div className="sshell-spacer" />
+
+      <Link href="/login" className="sshell-signin">{t('LEARN_CONTENT_NAV_SIGN_IN')}</Link>
+      <Link href="/login?signup=1" className="sshell-cta" data-testid="sshell-cta">
+        {t('LEARN_CONTENT_NAV_GET_STARTED')}
+      </Link>
+    </nav>
+  );
+}

--- a/components/TerminalNav.tsx
+++ b/components/TerminalNav.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { NavDashboard, NavArena, NavScanner, NavTracking, NavJournal } from './icons';
 import { getSessionName } from '@/lib/session';
+import BrandMark from './BrandMark';
 
 /* The Monochrome Terminal navigation (#413).
  *
@@ -65,6 +66,8 @@ export default function TerminalNav() {
       {/* ── Desktop: one 44px bar ── */}
       <nav className="tnav" aria-label="Main navigation">
         <Link href="/dashboard" className="tnav-brand">
+          {/* 18-26px in every nav bar and mobile header - README:197. */}
+          <BrandMark size={22} tone="dark" />
           <span className="tnav-wordmark">LIQUIDITYHQ</span>
         </Link>
 
@@ -93,6 +96,7 @@ export default function TerminalNav() {
           path, so /funding reads FLOW - matching what the nav highlights
           instead of naming a route the design no longer surfaces. */}
       <header className="tnav-mhead">
+        <BrandMark size={18} tone="dark" />
         <span className="tnav-mbrand">LIQUIDITYHQ</span>
         <span className="tnav-mscreen">{DESTINATIONS.find(d => d.key === active)?.label ?? ''}</span>
         <span className="tnav-mstatus">

--- a/components/TerminalNav.tsx
+++ b/components/TerminalNav.tsx
@@ -2,6 +2,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { NavDashboard, NavArena, NavScanner, NavTracking, NavJournal } from './icons';
+import { getSessionName } from '@/lib/session';
 
 /* The Monochrome Terminal navigation (#413).
  *
@@ -81,6 +82,24 @@ export default function TerminalNav() {
           ))}
         </div>
       </nav>
+
+      {/* ── Mobile: 38px header ──
+          README:82 - "38px header (logo, screen name, status)". Missed in the
+          first pass, which built only the tab bar: on a phone the app had no
+          header at all, on every screen. QA found it, and it is shell-level -
+          21 screens, not one.
+
+          The screen name comes from the active destination rather than the
+          path, so /funding reads FLOW - matching what the nav highlights
+          instead of naming a route the design no longer surfaces. */}
+      <header className="tnav-mhead">
+        <span className="tnav-mbrand">LIQUIDITYHQ</span>
+        <span className="tnav-mscreen">{DESTINATIONS.find(d => d.key === active)?.label ?? ''}</span>
+        <span className="tnav-mstatus">
+          <span className="tnav-mdot" />
+          {getSessionName(new Date())}
+        </span>
+      </header>
 
       {/* ── Mobile: 60px bottom tab bar ──
           Its own element rather than a media-query restyle of the desktop bar:


### PR DESCRIPTION
**Dev Team** · Turns **#430** green. **Frame: `Monochrome Terminal - Static.dc.html`, disclaimer frame, 1440x900** — plus README:82 for mobile.

## Measured values, for your `SHELL` table

```
bar          1438 x 56
wordmark     13px mono 700, letter-spacing .16em, --txt
links        11px mono, .12em, --txt2, gap 24
SIGN IN      11px mono, .12em, --txt2
START FREE   11px mono 700, amber fill + --on-accent
```

Mobile, README:82:

```
header       38px - logo, screen name, status
tab bar      60px, five items, 19px glyph + 9px label .1em
status dot   5px SQUARE
```

## 🔴 The middle links are absent on purpose

**The prototype never resolves them.** The frame renders a literal `{{ n.label }}` from a `marketingNav` list with `hint-placeholder-count="5"`.

**So the design says five links exist and does not say what they are.** I am not inventing five — that is how a redesign quietly acquires navigation nobody designed, and it would be indistinguishable from intent six weeks from now. **Filed for the owner.**

## The mobile header you found

You were right that it is shell-level. **The app had no mobile header at all** — my first pass built the 60px tab bar and stopped, so 21 screens had a bare content area under the status bar on a phone.

**The screen name comes from the active DESTINATION, not the path** — `/funding` reads `FLOW`, matching what the nav highlights rather than naming a route the design no longer surfaces. **Worth checking you agree**; the alternative is a title that contradicts the highlighted tab.

**And the status dot is a 5px square.** The nav spec says square, and the design has no round elements anywhere — your own `border-radius: 50%` sweep found zero across all four prototypes.

## How to test (QA)

1. **`/disclaimer?design=terminal`, 1440** — 56px bar, wordmark left, SIGN IN + START FREE right. **#430's nav assertion should go green.**
2. **`/dashboard?design=terminal`** — still the 44px app bar with five destinations. The two shells must not cross.
3. **Mobile, any app screen** — 38px header with LIQUIDITYHQ, the destination name, and the session status; 60px tab bar below.
4. **Mobile, `/disclaimer`** — the marketing bar, not the app header.
5. **Flag off** — nothing changes anywhere.

## Risk — **Low**

New component, one route set, CSS behind the flag. Gates: lint **0 errors / 131 warnings**, `tsc` clean, **428 tests**, build succeeds.

**Not verified by me: mobile.** My viewport will not resize — the same gap as every mobile claim I have made today. **Steps 3 and 4 are entirely yours**, and the mobile header is brand new code that nobody has seen render.
