### PR TITLE
fix(layout): stop the consent script reporting itself as a hydration error

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -115,7 +115,32 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           Without it the FAB painted immediately, then the consent bar mounted
           and displaced it - which is how it got reported as "the FAB
           disappears". See body.consent-pending in globals.css. */}
-      <body className="consent-pending">
+      {/* suppressHydrationWarning, for the same reason <html> above has it, and
+          it is the class on THIS line that makes it necessary.
+
+          consent-pending is in the server markup, and the beforeInteractive
+          script below removes it before React hydrates - deliberately, that is
+          the whole point of #337. So a returning visitor hydrates against a
+          <body> whose class React did not write, and React reports it:
+
+            + Client   className="consent-pending"
+            - Server   className=""
+
+          "Server" there is the DOM as React FOUND it, not what the server sent.
+          The server did send consent-pending; the script had already taken it
+          off by the time React looked. Nothing is broken - React leaves the DOM
+          alone for an attribute mismatch, so the FAB correctly stays visible.
+
+          Suppressing it is not hiding the problem, it is the problem going
+          away: the warning fired on EVERY page load for every visitor who has
+          answered the consent bar, which is everyone after their first visit.
+          A console error that is wrong every time is worse than no error - it
+          trains you to scroll past the one that is real.
+
+          Scope is exactly right by accident of the API: suppressHydrationWarning
+          is one level deep, so this silences <body>'s own attributes and nothing
+          inside it. A genuine mismatch in the tree still reports. */}
+      <body className="consent-pending" suppressHydrationWarning>
         {/* beforeInteractive - injected into the initial server HTML and
             runs before hydration, so data-theme is correct before first
             paint (no flash of the wrong theme). Mirrors lib/theme.ts's


### PR DESCRIPTION
**Dev Team**

## Summary

`<body>` now carries `suppressHydrationWarning`, the same attribute `<html>`
above it has already had for the theme script. Kills a red console error that
fires on every page load for every returning visitor.

## What changed

One attribute in `app/layout.tsx`, plus the comment explaining why it is there.

## Why

Reported by the owner from `/disclaimer`, but it is not that page — it is every
page. #337 deliberately puts `consent-pending` in the server markup and removes
it from a `beforeInteractive` script, so React hydrates against a `<body>` whose
class it did not write and reports the difference:

```
+ Client   className="consent-pending"
- Server   className=""
```

"Server" there is the DOM **as React found it**, not what the server sent. The
server did send the class; the script had already taken it off. So the mechanism
is working exactly as designed and reporting itself as a bug.

Nothing was broken: React leaves the DOM alone for an attribute mismatch, so the
Ask AI FAB correctly stays visible. But a console error that is wrong every time
is worse than no error — it trains you to scroll past the one that is real.

`suppressHydrationWarning` is one level deep, so this silences `<body>`'s own
attributes and nothing inside it. A genuine mismatch anywhere in the tree still
reports.

Pre-existing on `dev` — confirmed the `<body>` line was last touched by c65e304
(the #337 work), not by any of the redesign branches.

## How to test (QA)

Not on `qa` yet — test the branch `fix/consent-class-hydration-warning`.

1. Load any page with devtools console open, having previously accepted or
   declined the cookie bar (i.e. a normal return visit).
   - Before: red `A tree hydrated but some attributes of the server rendered
     HTML didn't match...`, pointing at `app/layout.tsx (118:7) @ RootLayout`.
   - After: no such error.
2. Confirm the Ask AI FAB still appears bottom-right. That is the thing
   `consent-pending` exists to gate — if it vanished, this went wrong.
3. Clear site data, reload. The cookie bar should appear, and the FAB should
   stay hidden until you answer it. That is the first-visit half, unchanged.
4. Do the same on a phone viewport — #337 was originally a mobile measurement.

## Risk level

**Low.** One attribute, no behaviour change; React was already not patching this
up. The failure mode if I am wrong is the opposite of dangerous — a real
`<body>` attribute mismatch would go unreported — and that is bounded to `<body>`
itself, which only this one class is ever set on.
