### PR TITLE
test(qa): re-derive STRUCTURE from the frames, with provenance

### DIFF
--- a/qa/e2e/design-structure.spec.ts
+++ b/qa/e2e/design-structure.spec.ts
@@ -73,10 +73,25 @@ const SHELL = {
 
 /** Measured values from the handoff README, per route. */
 const STRUCTURE: Record<string, { title?: number; rail?: number; note: string }> = {
+  /* EVERY VALUE HERE IS MEASURED IN A FRAME, with its file and offset. A number
+   * without a provenance comment is a number nobody can re-check — and both
+   * entries in the first version of this table came from README prose, one of
+   * which was wrong.
+   *
+   * THE README IS NOT A SECOND SOURCE. Its own words: "Every value below was
+   * measured in the prototypes." So where it disagrees with a frame it is a bad
+   * copy, and two of its numbers have already been caught:
+   *
+   *     LEAN BULLISH   README 34px   frame  24px
+   *     DISCLAIMER     README 34px   frame  32px
+   *
+   * Both were 34. One value looks to have been copied across two screen entries.
+   * Assume a README number is wrong until measured, not right until contradicted.
+   */
   '/disclaimer': {
-    title: 34,
-    rail: 264,
-    note: 'README:172 numbered sections with a contents rail; grid 264px + content, 34px title',
+    title: 32,   // Static.dc.html @4606: font-size 32px, weight 700
+    rail: 264,   // Static.dc.html: width:264px, 6 occurrences
+    note: 'frame 3A, Monochrome Terminal - Static.dc.html. README:172 says 34px and is wrong.',
   },
 };
 


### PR DESCRIPTION
**QA Team** → **Dev Team** · **My spec was asserting a wrong number all day. Fixed, with provenance.**

```
README:172   "34px title"
FRAME 3A     32px, weight 700        Static.dc.html @4606
our render   34px
my spec      asserted 34
```

**Our build matched the README's error and my spec certified it.** A green run meant *"we copied the same mistake consistently"*.

## Second one in an hour, and both were 34

```
LEAN BULLISH   README 34px   frame 24px   yours, from the rendered DOM
DISCLAIMER     README 34px   frame 32px   mine, from the Static source
```

**One value looks to have been copied across two screen entries when the README was written.**

## The rule now in the file

> **Assume a README number is wrong until measured, not right until contradicted.**

Every value in `STRUCTURE` carries the file and offset it came from. **A number without a provenance comment is a number nobody can re-check** — which is exactly how the 34 survived.

## Risk — **Low**

One QA spec. It now fails on two real defects instead of passing on one wrong expectation.
