### PR TITLE
test(qa): assert colour counts from the frame data, not the stylesheet

### DIFF
--- a/qa/e2e/design-structure.spec.ts
+++ b/qa/e2e/design-structure.spec.ts
@@ -106,6 +106,38 @@ const COLOUR_COUNTS: Record<string, { total: number; coloured: number; note: str
     note: "evidence grid: fire 'red' on Funding 8h, 'green' on CVD 4h, null on the other six. "
         + "The frame states it in its own header: '2 FIRING · 6 NEUTRAL'.",
   },
+
+  /* The four below are extracted and ready, but have NO header stating the
+   * count the way Arena's grid does. The assertion matches on that header, so
+   * these need a container selector before they can run — they are recorded
+   * here so the numbers are not re-derived, and each entry says what is still
+   * missing rather than pretending it is wired.
+   *
+   * Deliberately not guessing a selector: a wrong one silently measures the
+   * whole page and passes. */
+  '/dashboard': {
+    total: 4, coloured: 1,
+    note: 'pulse cells: BTC dominance / Altseason / Volatility are col TXT; only '
+        + "Fear & greed is conditional (mono ? RED : TXT, and mono ships true). "
+        + 'NEEDS A CONTAINER SELECTOR - no count header on this screen.',
+  },
+  '/liq': {
+    total: 4, coloured: 2,
+    note: "stat cells: Liquidated 24h and Largest single are TXT; Nearest cluster is "
+        + "hard RED; Cascade risk is conditional. NEEDS A CONTAINER SELECTOR.",
+  },
+  '/disclaimer': {
+    total: 4, coloured: 3,
+    note: "stat band: Liquidations 24h / Longs liquidated / Largest single are #f0524d; "
+        + "Typical cascade is #8b8f94. I described this as 'four red cells' from a "
+        + "screenshot and the data says three. NEEDS A CONTAINER SELECTOR.",
+  },
+  '/hours': {
+    total: 4, coloured: 4,
+    note: 'all four coloured, and that is consistent rather than an exception: '
+        + 'expectancy is DIRECTIONAL, which is the same reason the heat grid earns '
+        + 'green/red while Fear & greed does not. NEEDS A CONTAINER SELECTOR.',
+  },
 };
 
 /** Cells whose computed colour is --green or --red, inside a container. */
@@ -215,7 +247,10 @@ test.describe('design structure', () => {
         .toEqual([]);
     });
 
-    const colours = COLOUR_COUNTS[route];
+    /* Only Arena has a header stating its own count, which is what the grid is
+     * matched on. The other entries are recorded data waiting for a container
+     * selector - running them now would measure the whole page and pass. */
+    const colours = route === '/arena' ? COLOUR_COUNTS[route] : undefined;
     if (colours) {
       test(`${route} colours exactly the cells the frame colours`, async ({ page }) => {
         await seedTerminal(page);

--- a/qa/e2e/design-structure.spec.ts
+++ b/qa/e2e/design-structure.spec.ts
@@ -80,6 +80,37 @@ const STRUCTURE: Record<string, { title?: number; rail?: number; note: string }>
   },
 };
 
+/* ── COLOUR IS DATA, AND THIS IS THE ASSERTION MY COLOUR SPEC CANNOT MAKE ─────
+ *
+ * Every coloured cell in this design carries its colour as a FIELD, not as a
+ * styling decision. Extracted from all four prototype files:
+ *
+ *     Arena evidence grid   8 rows, `fire: 'red' | 'green' | null`, exactly 2 set
+ *     Desk pulse cells      4 cells, `col`, 3 are TXT and 1 conditional
+ *     Liq stat cells        4 cells, 2 TXT, 1 hard RED, 1 conditional
+ *     Disclaimer stat band  4 cells, 3 red, 1 --txt2
+ *     Trading hours stats   4 cells, all coloured - expectancy IS directional
+ *
+ * **An implementation that colours every row produces something that looks
+ * richer and is wrong — and `design-tokens.spec.ts` passes it cleanly**, because
+ * `--green` and `--red` are legal tokens wherever they appear. That is the exact
+ * shape of the `/disclaimer` failure: correct colours, wrong page.
+ *
+ * So the count of coloured cells is asserted here, from the frame's own data.
+ * The VALUES are not asserted — the owner's rule is that shape is binding and
+ * numbers may come from our feeds.
+ */
+const COLOUR_COUNTS: Record<string, { total: number; coloured: number; note: string }> = {
+  '/arena': {
+    total: 8, coloured: 2,
+    note: "evidence grid: fire 'red' on Funding 8h, 'green' on CVD 4h, null on the other six. "
+        + "The frame states it in its own header: '2 FIRING · 6 NEUTRAL'.",
+  },
+};
+
+/** Cells whose computed colour is --green or --red, inside a container. */
+const FIRING = ['rgb(63, 185, 80)', 'rgb(240, 82, 77)'];
+
 async function seedTerminal(page: Page) {
   await page.addInitScript((k) => {
     try { localStorage.setItem(k, 'terminal'); } catch { /* private mode */ }
@@ -183,6 +214,52 @@ test.describe('design structure', () => {
         `Rounded corners on a converted screen mean it was restyled rather than rebuilt.`)
         .toEqual([]);
     });
+
+    const colours = COLOUR_COUNTS[route];
+    if (colours) {
+      test(`${route} colours exactly the cells the frame colours`, async ({ page }) => {
+        await seedTerminal(page);
+        await gotoGuarded(page, `${route}?design=terminal`);
+        await page.waitForTimeout(3500);
+
+        const got = await page.evaluate((firing) => {
+          /* The evidence grid is the only 4x2 block of label+value cells on the
+           * screen. Matched on the header the frame states rather than a class
+           * name, so a refactor of the markup does not silently skip this. */
+          const header = [...document.querySelectorAll('*')]
+            .find(e => /\d+\s*FIRING/i.test(e.textContent ?? '') && e.children.length < 4);
+          const grid = header?.closest('section, div')?.parentElement ?? document.querySelector('main');
+          if (!grid) return null;
+          const cells = [...grid.querySelectorAll('*')].filter(e => {
+            const t = (e.textContent ?? '').trim();
+            return t.length > 0 && t.length < 40 && e.children.length === 0;
+          });
+          const coloured = cells.filter(e => firing.includes(getComputedStyle(e).color));
+          return { headerText: (header?.textContent ?? '').trim().slice(0, 40), coloured: coloured.length };
+        }, FIRING);
+
+        expect(got, `${route}: could not find the evidence grid. It is matched on the ` +
+          `"N FIRING" header the frame states, so either that header is missing or the ` +
+          `grid moved. Nothing below is measurable.`).not.toBeNull();
+
+        /* THE HEADER MUST AGREE WITH THE CELLS. The frame prints the count in
+         * its own header, so the app can be internally inconsistent - a header
+         * saying 2 above a grid colouring 8 is worse than either alone, and it
+         * is the failure a human reviewer would skim past. */
+        expect(got!.headerText,
+          `${route}: the grid header reads "${got!.headerText}" and the frame states ` +
+          `"${colours.coloured} FIRING". ${colours.note}`)
+          .toContain(String(colours.coloured));
+
+        expect(got!.coloured,
+          `${route}: ${got!.coloured} cells render in --green or --red; the frame colours ` +
+          `exactly ${colours.coloured} of ${colours.total}. ${colours.note}
+` +
+          `Colouring every row looks richer and is wrong - and design-tokens.spec.ts ` +
+          `passes it, because both colours are legal tokens wherever they appear.`)
+          .toBe(colours.coloured);
+      });
+    }
 
     const spec = STRUCTURE[route];
     if (!spec) continue;


### PR DESCRIPTION
**QA Team** → **Dev Team** · **The assertion my colour spec structurally cannot make. Ready before you need it — inert until `/arena` joins the ledger.**

## What it asserts

```
/arena   8 evidence rows, exactly 2 coloured
         and the grid's own 'N FIRING' header must agree with the cells
```

## Why it exists

**Every coloured cell in this design carries its colour as a field**, across all four files:

```
Arena evidence grid   fire: 'red' | 'green' | null      2 of 8
Desk pulse cells      col                                1 of 4 conditional
Liq stat cells        col                                1 hard RED, 1 conditional
Disclaimer stat band  col                                3 red, 1 --txt2
Trading hours stats   col                                4 of 4 - expectancy is directional
```

**`design-tokens.spec.ts` cannot catch a fully-coloured grid.** Both `--green` and `--red` are legal tokens wherever they appear, so eight coloured rows pass conformance cleanly — and look *better*. **Same shape as `/disclaimer`: correct colours, wrong page.**

## Two design choices worth reviewing

**Matched on the `N FIRING` header, not a class name.** The frame prints the count in its own header, so that string is part of the design rather than an implementation detail. A markup refactor cannot silently skip the check.

**The header is asserted against the cells too.** A header reading `2 FIRING` above a grid colouring eight is worse than either error alone — and it is exactly what a human reviewer skims past.

## Not asserted: the values

Owner's rule — **shape is binding, numbers may come from our feeds.** `+0.0132%` is not checked; `8 rows, 2 firing` is.

## Risk — **Low**

One QA spec, inert until a route with a `COLOUR_COUNTS` entry is converted.