### PR TITLE
chore(settings): add data-testid to LockedFeatureCard for the entitlement gate

### DIFF
--- a/components/UpgradeGateModal.tsx
+++ b/components/UpgradeGateModal.tsx
@@ -23,7 +23,21 @@ export function LockedFeatureCard({ title, description, onUnlock }: {
 }) {
   const { t } = useLabels();
   return (
-    <div style={{
+    /* data-testid so the paywall can be COUNTED per screen (#441).
+     *
+     * The entitlement check lives at each CALL SITE, not in this component, so
+     * moving a panel into the redesign moves its markup and leaves its guard
+     * behind. That happened on /arena: ConfluenceScore shipped unguarded for
+     * one commit and tsc, eslint, build and 442 tests all passed, because
+     * nothing in the codebase asserts "this screen locks as much as production
+     * does".
+     *
+     * The alternatives were both worse. Matching the card's TEXT binds a spec
+     * to whatever the labels table says today, in one locale. Matching the
+     * gradient binds it to styling the redesign is actively changing - so the
+     * check would break on the very commit it exists to catch. An explicit
+     * hook survives both. */
+    <div data-testid="locked-feature" style={{
       background: 'linear-gradient(180deg, var(--bg2), var(--bg1))',
       border: '0.5px solid var(--bdr)',
       borderRadius: 'var(--radius-card, 12px)',


### PR DESCRIPTION
**Dev Team** · Closes #441.

## Summary

One attribute on `LockedFeatureCard` so QA's `entitlement-survives-redesign.spec.ts` has something stable to count.

## Why

Directly downstream of the paywall leak I reported on #438: the entitlement check lives at each **call site**, not inside the guarded component, so moving a panel into the redesign moves its markup and leaves its guard behind. `tsc`, `eslint`, `build` and 442 tests all passed while `ConfluenceScore` was unguarded.

QA ruled out matching the card's text (binds to the labels table, one locale) and its gradient (binds to styling the redesign is changing — it would break on the commit it exists to catch).

This is the **counterpart** to the no-lost-UI census, not a duplicate: the census compares sets and only sees what went missing, and a dropped paywall *adds* a panel. That is why it read `94 buttons` on both sides while the leak was live.

## How to test (QA)

Branch `chore/locked-feature-testid`.

1. `/arena` signed out or free — the Confluence upsell card renders exactly as before. **Nothing visual changes.**
2. Inspect it: root carries `data-testid="locked-feature"`.
3. Every other `LockedFeatureCard` call site gets the hook too, since it is on the component.

## Risk level

**Low.** One attribute, no logic, no styling. tsc clean.