### PR TITLE
feat(landing): the terminal landing page, all eight sections

### DIFF
--- a/__tests__/arenaEvidence.test.mts
+++ b/__tests__/arenaEvidence.test.mts
@@ -1,0 +1,191 @@
+/* #413 frame 1a - the evidence grid, and the one rule a colour audit cannot see.
+ *
+ * README:47: green and red appear ONLY where a signal is firing. The prototype
+ * encodes it as a `fire` field per row, and six of its eight values are POSITIVE
+ * NUMBERS rendered in --txt. Colouring those green looks better and is wrong,
+ * and no contrast or token check catches it, because --green is a legal token.
+ *
+ * So these tests assert the thing that is otherwise unobservable: that a row
+ * sitting in its normal range stays neutral even when its value is signed.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildEvidence, firingCount, mobileEvidence, FIRING } from '../lib/arenaEvidence.ts';
+import type { CoinData } from '../lib/marketStore.ts';
+
+/** A coin sitting in the middle of every range - nothing should fire. */
+function quietCoin(over: Partial<CoinData> = {}): CoinData {
+  return {
+    price: 100, change: 0, high: 101, low: 99,
+    fundingRate: 0.00005,          // well under the crowded threshold
+    oi: 1_000_000, vol24: null, volRatio: null,
+    longRatio: null, shortRatio: null,
+    bnLongRatio: null, bnShortRatio: null,
+    bnWhaleLongRatio: null, bnWhaleShortRatio: null,
+    rsi14: null, ma20: null, perpPrice: 100,
+    rsi5m: null, rsi1h: null, rsi4h: null,
+    rsiDaily: null, rsiWeekly: null, rsiMonthly: null,
+    cvd: 5, cvdDivergence: null,
+    poc: null, vah: null, val: null,
+    orderBidWalls: null, orderAskWalls: null,
+    vwap: 100,                     // price exactly at VWAP
+    oiTrend: 'weak_up',            // drift, not a signal
+    takerBuyRatio: 0.52,           // inside the neutral band
+    chartPattern: null,
+    nextFrEstimate: null, nextFundingTime: null,
+    liqDelta: null, liqLongUsd: 1_000_000, liqShortUsd: 1_000_000,  // balanced
+    ...over,
+  } as CoinData;
+}
+
+/* ── 1. the grid is always eight rows, in the frame's order ──────────────── */
+
+test('the frame eight come first, in the frame order, then ours', () => {
+  // The design draws 8 cells in a 4x2. That is the PATTERN, not a cap - the
+  // owner's rule is to extend it to the data we actually have, in the same
+  // cell design. So the grid is 4x3 and the frame's eight keep their order,
+  // because the designed reading order is the part that is binding.
+  const rows = buildEvidence({ coin: null });
+  assert.deepEqual(rows.slice(0, 8).map(r => r.label), [
+    'Funding 8h', 'CVD 4h', 'OI 1h', 'VWAP', 'CB prem', 'Taker buy', 'Basis', 'Liq 15m',
+  ]);
+  assert.deepEqual(rows.slice(8).map(r => r.label), [
+    'RSI 14', 'MTF align', 'Volume', 'L/S ratio',
+  ]);
+  assert.equal(rows.length % 4, 0, 'the grid is 4 wide - a partial row leaves a hole');
+  assert.ok(rows.every(r => r.value === null), 'no data must not invent values');
+});
+
+test('our added rows obey the same firing rule as the frame ones', () => {
+  // Extending the design must not mean extending it with a looser rule.
+  const quiet = buildEvidence({ coin: quietCoin({ rsi14: 52, rsi1h: 52, rsi4h: 48, rsiDaily: 51, volRatio: 1.0, longRatio: 50, shortRatio: 50 }) });
+  for (const label of ['RSI 14', 'MTF align', 'Volume', 'L/S ratio']) {
+    assert.equal(quiet.find(r => r.label === label)!.fire, null, `${label} fired in a quiet market`);
+  }
+  const hot = buildEvidence({ coin: quietCoin({ rsi14: 78, rsi1h: 61, rsi4h: 58, rsiDaily: 55, volRatio: 2.4, longRatio: 80, shortRatio: 20 }) });
+  assert.equal(hot.find(r => r.label === 'RSI 14')!.fire,    'red',   'overbought is a warning, not an endorsement');
+  assert.equal(hot.find(r => r.label === 'MTF align')!.fire, 'green');
+  assert.equal(hot.find(r => r.label === 'Volume')!.fire,    'green');
+  assert.equal(hot.find(r => r.label === 'L/S ratio')!.fire, 'red',   'a crowded long book is the setup, not the confirmation');
+});
+
+/* ── 2. THE RULE: signed values do not imply colour ──────────────────────── */
+
+test('a quiet market fires NOTHING - the six-neutral case', () => {
+  const rows = buildEvidence({ coin: quietCoin(), spotPrice: 100 });
+  const { firing, neutral } = firingCount(rows);
+  assert.equal(firing, 0, `expected nothing firing, got: ${rows.filter(r=>r.fire).map(r=>r.label)}`);
+  assert.equal(neutral, rows.length);
+});
+
+test('positive values still render neutral when the signal is not firing', () => {
+  // This is the whole point. Every one of these is a POSITIVE number and every
+  // one must come back fire:null. A grid that colours them passes every colour
+  // check we have and is still the wrong page.
+  const rows = buildEvidence({
+    coin: quietCoin({ takerBuyRatio: 0.55, vwap: 99.8, oiTrend: 'weak_up' }),
+    spotPrice: 99.95,
+    oiChange1h: 0.008,   // open interest up 0.8% - a real positive number, still only drift
+  });
+  for (const label of ['OI 1h', 'VWAP', 'Taker buy', 'Basis']) {
+    const row = rows.find(r => r.label === label)!;
+    // "reads favourable" rather than "starts with +": Taker buy is a share
+    // (55%), not a signed change, which is how the frame renders it too (58%).
+    assert.ok(row.value && !row.value.startsWith('−'),
+      `${label} should read favourable in this fixture, got ${row.value}`);
+    assert.equal(row.fire, null, `${label} fired on a favourable value that is inside its normal range`);
+  }
+});
+
+/* ── 3. each signal fires on its own threshold, and in the right direction ─ */
+
+test('crowded long funding is RED, not green - it is a cost signal', () => {
+  // Positive funding means longs PAY shorts. Colouring it green because the
+  // number is positive inverts the meaning. Same polarity as the funding
+  // screen, README:131.
+  const hot = buildEvidence({ coin: quietCoin({ fundingRate: FIRING.fundingAbs * 2 }) });
+  assert.equal(hot.find(r => r.label === 'Funding 8h')!.fire, 'red');
+
+  const inverted = buildEvidence({ coin: quietCoin({ fundingRate: -FIRING.fundingAbs * 2 }) });
+  assert.equal(inverted.find(r => r.label === 'Funding 8h')!.fire, 'green');
+});
+
+test('CVD divergence maps straight onto fire - same idea, arrived at separately', () => {
+  const bull = buildEvidence({ coin: quietCoin({ cvdDivergence: 'bullish' }) });
+  const cvdBull = bull.find(r => r.label === 'CVD 4h')!;
+  assert.equal(cvdBull.fire, 'green');
+  assert.equal(cvdBull.value, 'Bull div');
+
+  const bear = buildEvidence({ coin: quietCoin({ cvdDivergence: 'bearish' }) });
+  assert.equal(bear.find(r => r.label === 'CVD 4h')!.fire, 'red');
+});
+
+test('OI drift does not fire; only a strong trend does', () => {
+  const weak   = buildEvidence({ coin: quietCoin({ oiTrend: 'weak_up' }) });
+  const strong = buildEvidence({ coin: quietCoin({ oiTrend: 'strong_up' }) });
+  assert.equal(weak.find(r => r.label === 'OI 1h')!.fire, null);
+  assert.equal(strong.find(r => r.label === 'OI 1h')!.fire, 'green');
+});
+
+test('basis fires red when perps are rich - leverage paying up, not a bullish tell', () => {
+  const rows = buildEvidence({ coin: quietCoin({ perpPrice: 100.5 }), spotPrice: 100 });
+  assert.equal(rows.find(r => r.label === 'Basis')!.fire, 'red');
+});
+
+test('a balanced liquidation window is neutral and says so', () => {
+  const rows = buildEvidence({ coin: quietCoin() });
+  const liq = rows.find(r => r.label === 'Liq 15m')!;
+  assert.equal(liq.fire, null);
+  assert.equal(liq.note, '50% longs');
+});
+
+test('an empty liquidation window is not a signal', () => {
+  // Zero liquidations is quiet, not bullish. Dividing by the total here would
+  // also be a divide-by-zero, which is the other reason to check it.
+  const rows = buildEvidence({ coin: quietCoin({ liqLongUsd: 0, liqShortUsd: 0 }) });
+  const liq = rows.find(r => r.label === 'Liq 15m')!;
+  assert.equal(liq.fire, null);
+  assert.equal(liq.value, 'None');
+  assert.equal(liq.note, 'quiet window');
+});
+
+/* ── 4. the row we may have no source for ────────────────────────────────── */
+
+test('CB prem with no source renders as absent, never as a stand-in', () => {
+  const rows = buildEvidence({ coin: quietCoin() });
+  const cb = rows.find(r => r.label === 'CB prem')!;
+  assert.equal(cb.value, null);
+  assert.equal(cb.fire, null);
+});
+
+/* ── 5. mobile is a different layout, not a narrower one ─────────────────── */
+
+test('mobile shows only the firing rows - frame 1a mobile, header reads "2 FIRING"', () => {
+  const rows = buildEvidence({
+    coin: quietCoin({ fundingRate: FIRING.fundingAbs * 2, cvdDivergence: 'bullish' }),
+  });
+  const m = mobileEvidence(rows);
+  assert.equal(m.length, 2);
+  assert.deepEqual(m.map(r => r.label), ['Funding 8h', 'CVD 4h']);
+});
+
+test('mobile falls back to the full set when nothing fires', () => {
+  // "0 FIRING" above an empty box is a worse answer than showing the data.
+  const all = buildEvidence({ coin: quietCoin() });
+  assert.equal(mobileEvidence(all).length, all.length);
+});
+
+/* ── 6. control ──────────────────────────────────────────────────────────── */
+
+test('CONTROL: the grid can produce both fire values and null', () => {
+  // Guards against a build where `fire` is hardcoded null - every assertion
+  // about neutrality above would pass on a component that never colours
+  // anything, which is the opposite failure and just as wrong.
+  const rows = buildEvidence({
+    coin: quietCoin({ fundingRate: FIRING.fundingAbs * 2, cvdDivergence: 'bullish' }),
+  });
+  const seen = new Set(rows.map(r => r.fire));
+  assert.ok(seen.has('red'),   'nothing ever fires red - the rule is not wired');
+  assert.ok(seen.has('green'), 'nothing ever fires green - the rule is not wired');
+  assert.ok(seen.has(null),    'everything fires - the neutral case is gone');
+});

--- a/__tests__/useViewport.test.mts
+++ b/__tests__/useViewport.test.mts
@@ -1,0 +1,26 @@
+/* #413 - the two breakpoints, and why there are two.
+ *
+ * Landing switches at 768 and the app screens at 900. Those are two designs,
+ * not one scale, and the risk is someone "tidying" them into one constant.
+ * These tests pin both numbers and say which spec each comes from.
+ *
+ * The hook itself needs a DOM, so what is asserted here is the QUERY - the
+ * part that is pure, and the part that would silently change behaviour if it
+ * drifted.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { LANDING_MOBILE_QUERY } from '../lib/useViewport.ts';
+
+test('landing switches at 768, per its own spec', () => {
+  // Landing spec: "Breakpoint: 768px. Below it, mobile layout; at and above
+  // it, desktop." So the max-width query must stop at 767 - a query of
+  // (max-width: 768px) would put 768 itself on the mobile layout, one pixel
+  // wrong in the direction nobody would notice.
+  assert.equal(LANDING_MOBILE_QUERY, '(max-width: 767px)');
+});
+
+test('the landing query is exclusive of the breakpoint itself', () => {
+  const px = Number(LANDING_MOBILE_QUERY.match(/(\d+)px/)![1]);
+  assert.equal(px, 767, 'at exactly 768 the desktop layout must render');
+});

--- a/__tests__/useViewport.test.mts
+++ b/__tests__/useViewport.test.mts
@@ -10,7 +10,7 @@
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { LANDING_MOBILE_QUERY } from '../lib/useViewport.ts';
+import { LANDING_MOBILE_QUERY, mediaStoreFor } from '../lib/useViewport.ts';
 
 test('landing switches at 768, per its own spec', () => {
   // Landing spec: "Breakpoint: 768px. Below it, mobile layout; at and above
@@ -23,4 +23,25 @@ test('landing switches at 768, per its own spec', () => {
 test('the landing query is exclusive of the breakpoint itself', () => {
   const px = Number(LANDING_MOBILE_QUERY.match(/(\d+)px/)![1]);
   assert.equal(px, 767, 'at exactly 768 the desktop layout must render');
+});
+
+/* ── identity stability, which is what QA caught on #443 ────────────────── */
+
+test('the subscribe/getSnapshot pair is STABLE across calls for one query', () => {
+  // useSyncExternalStore compares `subscribe` by IDENTITY. Building the closure
+  // inside the hook returns a new function every render, so React tears the
+  // listener down and re-adds it on each one. Invisible to a value assertion -
+  // which is why this test compares references, not results.
+  const a = mediaStoreFor(LANDING_MOBILE_QUERY);
+  const b = mediaStoreFor(LANDING_MOBILE_QUERY);
+  assert.equal(a.subscribe, b.subscribe, 'subscribe identity changed - React will resubscribe every render');
+  assert.equal(a.getSnapshot, b.getSnapshot, 'getSnapshot identity changed');
+});
+
+test('different queries get different stores - the parameter still works', () => {
+  // The cache must not collapse two breakpoints into one, which would silently
+  // give landing the app's 900 breakpoint.
+  const landing = mediaStoreFor(LANDING_MOBILE_QUERY);
+  const app     = mediaStoreFor('(max-width: 899px)');
+  assert.notEqual(landing.subscribe, app.subscribe);
 });

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,6 +1,6 @@
 ﻿import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
-import LandingContent from '@/components/LandingContent';
+import LandingSwitch from '@/components/LandingSwitch';
 import { getDictionary, dirForLocale, isSupportedLocale, SUPPORTED_LOCALES } from '@/lib/i18n/dictionaries';
 
 interface Params { locale: string }
@@ -50,5 +50,8 @@ export default async function LocalizedLandingPage({ params }: { params: Promise
   const { locale } = await params;
   if (!isSupportedLocale(locale)) notFound();
   const dict = getDictionary(locale);
-  return <LandingContent dict={dict} locale={locale} dir={dirForLocale(locale)} />;
+  /* LandingSwitch, not LandingContent: the design flag is per-browser and
+     this page is a server component, so the choice needs a client boundary.
+     Everything above it still prerenders. */
+  return <LandingSwitch dict={dict} locale={locale} dir={dirForLocale(locale)} />;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -5570,3 +5570,367 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
   /* 5px SQUARE, per the nav spec - the design has no round elements at all. */
   [data-design="terminal"] .tnav-mdot { width: 5px; height: 5px; background: var(--green); }
 }
+
+/* ══ Landing, Monochrome Terminal — Landing 7a.dc.html · 7a (#413) ═════════
+   Every value measured off frame 7a. QA measured it independently before the
+   markup was written and every size corroborated: H1 54/32, price 46, final
+   CTA 36, section h2 34/24, verdict 32/26, ticker 34/30, CTAs 50/48/46.
+
+   RADIUS 0 EVERYWHERE ON THIS ROUTE, no exceptions - criterion 12 asserts it on
+   every element including <img>. The frame rounds the logo 6px; the design's
+   own rule does not permit it, and the spec resolves that in favour of the
+   rule. So the reset below is deliberate and must not be relaxed for one
+   element later.
+
+   EVERY RULE IS 1px on this route - criterion 17. Both 0.5px and 1px exist
+   elsewhere in this design and are different decisions; here it is always 1. */
+
+[data-design="terminal"] .lt-root,
+[data-design="terminal"] .lt-root * { border-radius: 0 !important; }
+
+[data-design="terminal"] .lt-root {
+  background: var(--bg0);
+  color: var(--txt);
+  font-family: var(--font-sans);
+}
+
+/* ── 1. nav, 56 / 52 ── */
+[data-design="terminal"] .lt-nav {
+  display: flex; align-items: center; gap: 12px;
+  height: 56px; padding: 0 40px;
+  border-bottom: 1px solid var(--bdr);
+}
+[data-design="terminal"] .lt-brand { display: flex; align-items: center; gap: 10px; text-decoration: none; }
+[data-design="terminal"] .lt-wordmark {
+  font-family: var(--font-mono); font-size: 14px; font-weight: 700;
+  letter-spacing: .16em; color: var(--txt);
+}
+[data-design="terminal"] .lt-spacer { flex: 1; }
+[data-design="terminal"] .lt-ghost {
+  border: 1px solid var(--border-input); color: var(--txt2);
+  padding: 9px 16px; text-decoration: none;
+  font-family: var(--font-mono); font-size: 11.5px; letter-spacing: .12em;
+}
+[data-design="terminal"] .lt-ghost:hover { border-color: var(--txt3); }
+[data-design="terminal"] .lt-cta-sm {
+  background: var(--accent); color: var(--bg0); font-weight: 700;
+  padding: 10px 18px; text-decoration: none;
+  font-family: var(--font-mono); font-size: 11.5px; letter-spacing: .12em;
+}
+[data-design="terminal"] .lt-cta-sm:hover { opacity: .9; }
+
+/* ── 2. ticker, 34 / 30. Extends to every tracked coin, one row ── */
+[data-design="terminal"] .lt-ticker {
+  display: flex; height: 34px; overflow: hidden;
+  border-bottom: 1px solid var(--bdr);
+}
+[data-design="terminal"] .lt-tcell {
+  display: flex; align-items: center; gap: 8px; flex-shrink: 0;
+  padding: 0 16px; border-right: 1px solid var(--bdr3);
+}
+[data-design="terminal"] .lt-tsym {
+  font-family: var(--font-mono); font-size: 11px; font-weight: 600;
+  letter-spacing: .06em; color: var(--txt2);
+}
+[data-design="terminal"] .lt-tpx {
+  font-family: var(--font-mono); font-size: 11px; color: var(--txt);
+  font-variant-numeric: tabular-nums;
+}
+/* The ONE place on this route where sign maps to colour. A price change
+   genuinely is directional; nowhere else on the page is. */
+[data-design="terminal"] .lt-tchg {
+  font-family: var(--font-mono); font-size: 11px; opacity: .8;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── 3. hero ── */
+[data-design="terminal"] .lt-hero {
+  display: flex; gap: 56px; padding: 76px 40px 64px;
+  border-bottom: 1px solid var(--bdr);
+}
+[data-design="terminal"] .lt-hero-l { flex: 1; min-width: 0; }
+[data-design="terminal"] .lt-hero-r { flex: 0 0 472px; }
+[data-design="terminal"] .lt-badge-live {
+  display: inline-flex; align-items: center; gap: 8px;
+  border: 1px solid var(--bdr); background: var(--bg1); padding: 7px 13px;
+  font-family: var(--font-mono); font-size: 10.5px; letter-spacing: .16em;
+  text-transform: uppercase; color: var(--txt2);
+}
+[data-design="terminal"] .lt-dot { width: 6px; height: 6px; background: var(--green); display: inline-block; }
+[data-design="terminal"] .lt-h1 {
+  font-family: var(--font-mono); font-size: 54px; font-weight: 700;
+  line-height: 1.06; letter-spacing: -.015em; color: var(--txt);
+  margin: 26px 0 0;
+}
+[data-design="terminal"] .lt-h1-accent { color: var(--accent); }
+[data-design="terminal"] .lt-hero-sub {
+  font-size: 17px; line-height: 1.6; color: var(--txt2);
+  margin: 22px 0 0; max-width: 600px; text-wrap: pretty;
+}
+[data-design="terminal"] .lt-hero-ctas { display: flex; gap: 12px; margin-top: 30px; }
+[data-design="terminal"] .lt-cta {
+  display: inline-flex; align-items: center; height: 50px; padding: 0 30px;
+  background: var(--accent); color: var(--bg0); text-decoration: none;
+  font-family: var(--font-mono); font-size: 13px; font-weight: 700; letter-spacing: .12em;
+}
+[data-design="terminal"] .lt-ghost-lg {
+  display: inline-flex; align-items: center; height: 50px; padding: 0 26px;
+  border: 1px solid var(--border-input); color: var(--txt2); text-decoration: none;
+  font-family: var(--font-mono); font-size: 13px; letter-spacing: .12em;
+}
+[data-design="terminal"] .lt-stats {
+  display: flex; margin-top: 40px; border-top: 1px solid var(--bdr); padding-top: 24px;
+}
+[data-design="terminal"] .lt-stat { padding-right: 38px; margin-right: 38px; border-right: 1px solid var(--bdr); }
+[data-design="terminal"] .lt-stat:last-child { border-right: 0; margin-right: 0; padding-right: 0; }
+[data-design="terminal"] .lt-stat-v {
+  display: block; font-family: var(--font-mono); font-size: 26px; font-weight: 700;
+  color: var(--txt); line-height: 1;
+}
+[data-design="terminal"] .lt-stat-l {
+  display: block; margin-top: 8px;
+  font-family: var(--font-mono); font-size: 9.5px; letter-spacing: .16em;
+  text-transform: uppercase; color: var(--txt3);
+}
+
+/* ── live read panel ── */
+[data-design="terminal"] .lt-read { background: var(--bg1); border: 1px solid var(--bdr); }
+[data-design="terminal"] .lt-read-head {
+  display: flex; align-items: center; gap: 9px; height: 34px; padding: 0 14px;
+  border-bottom: 1px solid var(--bdr);
+}
+[data-design="terminal"] .lt-read-head .lt-dot { width: 5px; height: 5px; }
+[data-design="terminal"] .lt-read-label {
+  font-family: var(--font-mono); font-size: 10px; letter-spacing: .16em;
+  text-transform: uppercase; color: var(--txt2);
+}
+[data-design="terminal"] .lt-read-ts {
+  margin-left: auto; font-family: var(--font-mono); font-size: 10px; color: var(--txt3);
+}
+[data-design="terminal"] .lt-read-body { padding: 20px; }
+/* Colour comes from the read, never hardcoded. The frame is green because its
+   fixture is bullish. */
+[data-design="terminal"] .lt-verdict {
+  font-family: var(--font-mono); font-size: 32px; font-weight: 700; line-height: 1;
+}
+[data-design="terminal"] .lt-conf { display: flex; align-items: center; gap: 9px; margin-top: 14px; }
+[data-design="terminal"] .lt-conf-track { flex: 1; height: 3px; background: var(--bdr); display: block; }
+[data-design="terminal"] .lt-conf-fill { display: block; height: 3px; }
+[data-design="terminal"] .lt-conf-val { font-family: var(--font-mono); font-size: 13px; font-weight: 700; color: var(--txt); }
+[data-design="terminal"] .lt-conf-lab {
+  font-family: var(--font-mono); font-size: 9.5px; letter-spacing: .12em; color: var(--txt3);
+}
+[data-design="terminal"] .lt-levels {
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px;
+  background: var(--bdr); margin-top: 16px;
+}
+[data-design="terminal"] .lt-level { background: var(--bg1); padding: 11px 12px; }
+[data-design="terminal"] .lt-level-lab {
+  display: block; font-family: var(--font-mono); font-size: 9px; letter-spacing: .14em;
+  text-transform: uppercase; color: var(--txt3);
+}
+[data-design="terminal"] .lt-level-val {
+  display: block; margin-top: 5px;
+  font-family: var(--font-mono); font-size: 13.5px; font-weight: 600; color: var(--txt);
+  font-variant-numeric: tabular-nums;
+}
+[data-design="terminal"] .lt-evidence { margin-top: 16px; }
+[data-design="terminal"] .lt-ev {
+  display: flex; align-items: center; gap: 11px;
+  padding: 10px 14px; border-bottom: 1px solid var(--bdr2);
+}
+[data-design="terminal"] .lt-ev-mark { width: 2px; height: 18px; flex-shrink: 0; }
+[data-design="terminal"] .lt-ev-label {
+  width: 76px; flex-shrink: 0;
+  font-family: var(--font-mono); font-size: 9.5px; letter-spacing: .1em;
+  text-transform: uppercase; color: var(--txt3);
+}
+[data-design="terminal"] .lt-ev-val {
+  font-family: var(--font-mono); font-size: 12.5px; font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+[data-design="terminal"] .lt-ev-note {
+  margin-left: auto; text-align: right; font-size: 11px; color: var(--txt3);
+}
+
+/* ── sections 4-7 ── */
+[data-design="terminal"] .lt-sec { padding: 64px 40px; border-bottom: 1px solid var(--bdr); }
+[data-design="terminal"] .lt-how   { background: var(--bg1); padding: 60px 40px; }
+[data-design="terminal"] .lt-final { background: var(--bg1); display: flex; align-items: center; gap: 40px; }
+[data-design="terminal"] .lt-sec-label {
+  font-family: var(--font-mono); font-size: 10px; letter-spacing: .16em;
+  text-transform: uppercase; color: var(--txt3);
+}
+[data-design="terminal"] .lt-h2 {
+  font-family: var(--font-mono); font-size: 34px; font-weight: 700;
+  color: var(--txt); margin: 14px 0 0; line-height: 1.15;
+}
+[data-design="terminal"] .lt-final-h {
+  font-family: var(--font-mono); font-size: 36px; font-weight: 700;
+  color: var(--txt); margin: 0; line-height: 1.15;
+}
+[data-design="terminal"] .lt-sec-sub {
+  font-size: 15px; line-height: 1.6; color: var(--txt2); margin: 12px 0 0; max-width: 620px;
+}
+
+/* features: 3 columns, the GAP is the hairline - container painted --bdr */
+[data-design="terminal"] .lt-fgrid {
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px;
+  background: var(--bdr); border: 1px solid var(--bdr); margin-top: 32px;
+}
+[data-design="terminal"] .lt-fcard {
+  display: block; background: var(--bg0); padding: 22px 20px; text-decoration: none; color: var(--txt2);
+}
+[data-design="terminal"] .lt-fcard:hover { background: var(--bg1); }
+[data-design="terminal"] .lt-fcard-title {
+  display: block; margin-top: 14px;
+  font-family: var(--font-mono); font-size: 14px; font-weight: 700; color: var(--txt);
+}
+/* min-height so all six description blocks align - criterion 14 */
+[data-design="terminal"] .lt-fcard-desc {
+  display: block; margin-top: 9px; min-height: 66px;
+  font-size: 13px; line-height: 1.6; color: var(--txt2); text-wrap: pretty;
+}
+[data-design="terminal"] .lt-fcard-open {
+  display: block; margin-top: 12px;
+  font-family: var(--font-mono); font-size: 10.5px; letter-spacing: .12em; color: var(--accent);
+}
+
+[data-design="terminal"] .lt-steps {
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 1px;
+  background: var(--bdr); border: 1px solid var(--bdr); margin-top: 32px;
+}
+[data-design="terminal"] .lt-step { background: var(--bg1); padding: 22px 20px; }
+[data-design="terminal"] .lt-step-n {
+  display: block; font-family: var(--font-mono); font-size: 22px; font-weight: 700; color: var(--accent);
+}
+[data-design="terminal"] .lt-step-title {
+  display: block; margin-top: 12px;
+  font-family: var(--font-mono); font-size: 13px; font-weight: 700; color: var(--txt);
+}
+[data-design="terminal"] .lt-step-desc {
+  display: block; margin-top: 8px; font-size: 13px; line-height: 1.6; color: var(--txt2);
+}
+
+[data-design="terminal"] .lt-plans {
+  display: grid; grid-template-columns: repeat(2, 1fr); gap: 1px;
+  background: var(--bdr); border: 1px solid var(--bdr); margin-top: 32px;
+}
+[data-design="terminal"] .lt-plan { background: var(--bg0); padding: 28px 26px; }
+/* 2px accent top border marks Pro - criterion 15 */
+[data-design="terminal"] .lt-plan-pro { background: var(--bg1); border-top: 2px solid var(--accent); }
+[data-design="terminal"] .lt-plan-name {
+  display: flex; align-items: center; gap: 10px;
+  font-family: var(--font-mono); font-size: 12px; letter-spacing: .14em;
+  text-transform: uppercase; color: var(--txt2);
+}
+[data-design="terminal"] .lt-badge {
+  font-family: var(--font-mono); font-size: 9.5px; letter-spacing: .12em;
+  background: var(--accent); color: var(--bg0); padding: 3px 7px; font-weight: 700;
+}
+[data-design="terminal"] .lt-price {
+  font-family: var(--font-mono); font-size: 46px; font-weight: 700; color: var(--txt);
+  line-height: 1; margin-top: 14px;
+}
+[data-design="terminal"] .lt-plan-sub { font-size: 13px; color: var(--txt3); margin-top: 8px; }
+[data-design="terminal"] .lt-plan-list { list-style: none; margin: 22px 0 0; padding: 0; }
+[data-design="terminal"] .lt-plan-list li {
+  display: flex; gap: 10px; padding: 8px 0; border-bottom: 1px solid var(--bdr2);
+  font-size: 13px; color: var(--txt2);
+}
+[data-design="terminal"] .lt-tick { color: var(--txt3); font-family: var(--font-mono); }
+[data-design="terminal"] .lt-plan-cta {
+  display: flex; align-items: center; justify-content: center; height: 46px; margin-top: 22px;
+  border: 1px solid var(--border-input); color: var(--txt2); text-decoration: none;
+  font-family: var(--font-mono); font-size: 12px; letter-spacing: .12em;
+}
+[data-design="terminal"] .lt-plan-cta-pro { background: var(--accent); color: var(--bg0); border-color: var(--accent); font-weight: 700; }
+
+/* ── 8. footer ── */
+[data-design="terminal"] .lt-footer { padding: 52px 40px 0; }
+[data-design="terminal"] .lt-footer-top { display: flex; gap: 48px; }
+[data-design="terminal"] .lt-footer-brand { flex: 0 0 290px; }
+[data-design="terminal"] .lt-footer-desc { font-size: 13px; line-height: 1.6; color: var(--txt3); margin: 14px 0 0; }
+[data-design="terminal"] .lt-footer-cols { flex: 1; display: grid; grid-template-columns: repeat(4, 1fr); gap: 24px; }
+[data-design="terminal"] .lt-footer-col { display: flex; flex-direction: column; gap: 9px; }
+[data-design="terminal"] .lt-footer-col-title {
+  font-family: var(--font-mono); font-size: 10px; letter-spacing: .16em;
+  text-transform: uppercase; color: var(--txt3); margin-bottom: 4px;
+}
+[data-design="terminal"] .lt-footer-col a { font-size: 13px; color: var(--txt2); text-decoration: none; }
+[data-design="terminal"] .lt-footer-col a:hover { color: var(--txt); }
+[data-design="terminal"] .lt-risk-divider {
+  display: flex; align-items: center; gap: 14px; margin-top: 44px;
+  border-top: 1px solid var(--bdr); padding-top: 22px;
+}
+[data-design="terminal"] .lt-risk-divider span {
+  font-family: var(--font-mono); font-size: 10px; letter-spacing: .16em; color: var(--txt3);
+}
+[data-design="terminal"] .lt-risk {
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px 32px; margin-top: 18px;
+}
+[data-design="terminal"] .lt-risk-label {
+  font-family: var(--font-mono); font-size: 10px; letter-spacing: .14em;
+  text-transform: uppercase; color: var(--txt2);
+}
+[data-design="terminal"] .lt-risk-text { font-size: 12.5px; line-height: 1.6; color: var(--txt3); margin: 6px 0 0; }
+[data-design="terminal"] .lt-legal {
+  display: flex; gap: 16px; align-items: center; flex-wrap: wrap;
+  margin-top: 34px; border-top: 1px solid var(--bdr); padding: 20px 0 34px;
+  font-size: 12px; color: var(--txt3);
+}
+[data-design="terminal"] .lt-legal a { color: var(--txt3); text-decoration: underline; text-underline-offset: 2px; }
+
+/* ── mobile, below 768. A SEPARATE layout, and the JS renders only one tree -
+      these rules restyle the mobile tree, they do not hide a desktop one. ── */
+@media (max-width: 767px) {
+  [data-design="terminal"] .lt-nav { height: 52px; padding: 0 16px; gap: 9px; }
+  [data-design="terminal"] .lt-wordmark { font-size: 11.5px; letter-spacing: .14em; }
+  [data-design="terminal"] .lt-ticker {
+    height: 30px;
+    -webkit-mask-image: linear-gradient(90deg, #000 86%, transparent);
+            mask-image: linear-gradient(90deg, #000 86%, transparent);
+  }
+  [data-design="terminal"] .lt-tcell { padding: 0 12px; gap: 6px; }
+  [data-design="terminal"] .lt-tsym { font-size: 10px; }
+
+  [data-design="terminal"] .lt-hero { flex-direction: column; gap: 26px; padding: 34px 18px 30px; }
+  [data-design="terminal"] .lt-hero-r { flex: 1 1 auto; }
+  [data-design="terminal"] .lt-h1 { font-size: 32px; line-height: 1.1; margin-top: 18px; }
+  [data-design="terminal"] .lt-hero-sub { font-size: 14.5px; margin-top: 14px; max-width: none; }
+  [data-design="terminal"] .lt-hero-ctas { flex-direction: column; gap: 9px; }
+  [data-design="terminal"] .lt-cta { height: 48px; justify-content: center; }
+  [data-design="terminal"] .lt-ghost-lg { height: 46px; justify-content: center; }
+  [data-design="terminal"] .lt-stats {
+    display: grid; grid-template-columns: repeat(2, 1fr); gap: 1px;
+    background: var(--bdr); border: 1px solid var(--bdr); padding-top: 0; border-top: 0;
+  }
+  [data-design="terminal"] .lt-stat {
+    background: var(--bg0); padding: 13px 14px; margin: 0; border-right: 0;
+  }
+  [data-design="terminal"] .lt-stat-v { font-size: 20px; }
+  [data-design="terminal"] .lt-stat-l { font-size: 8.5px; letter-spacing: .14em; }
+
+  [data-design="terminal"] .lt-verdict { font-size: 26px; }
+  [data-design="terminal"] .lt-read-body { padding: 18px; }
+  [data-design="terminal"] .lt-level { padding: 9px 10px; }
+  [data-design="terminal"] .lt-level-val { font-size: 12.5px; }
+
+  [data-design="terminal"] .lt-sec { padding: 30px 18px; }
+  [data-design="terminal"] .lt-how { padding: 30px 18px; }
+  [data-design="terminal"] .lt-h2 { font-size: 24px; }
+  [data-design="terminal"] .lt-final { flex-direction: column; align-items: stretch; gap: 20px; }
+  [data-design="terminal"] .lt-final-h { font-size: 26px; }
+
+  [data-design="terminal"] .lt-fgrid  { grid-template-columns: 1fr; }
+  [data-design="terminal"] .lt-steps  { grid-template-columns: 1fr; gap: 16px; background: transparent; border: 0; }
+  [data-design="terminal"] .lt-step   { border: 1px solid var(--bdr); }
+  [data-design="terminal"] .lt-plans  { grid-template-columns: 1fr; }
+  [data-design="terminal"] .lt-plan-pro { margin-top: 14px; }
+
+  [data-design="terminal"] .lt-footer { padding: 34px 18px 0; }
+  [data-design="terminal"] .lt-footer-top { flex-direction: column; gap: 28px; }
+  [data-design="terminal"] .lt-footer-brand { flex: 1 1 auto; }
+  [data-design="terminal"] .lt-footer-cols { grid-template-columns: repeat(2, 1fr); gap: 22px; }
+  [data-design="terminal"] .lt-risk { grid-template-columns: 1fr; gap: 16px; }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -5934,3 +5934,16 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
   [data-design="terminal"] .lt-footer-cols { grid-template-columns: repeat(2, 1fr); gap: 22px; }
   [data-design="terminal"] .lt-risk { grid-template-columns: 1fr; gap: 16px; }
 }
+
+/* Landing owns its chrome: no reserved nav offset, no content max-width.
+   .app-content reserves 84px of top padding for the app nav and caps width at
+   1340px. Landing renders its own 56px nav and full-bleed sections, so both
+   would be wrong - the padding pushed the hero from y=90 to y=174, and the cap
+   would have boxed a page the frame draws edge to edge. */
+main.app-content[data-chrome="none"] {
+  padding-top: var(--banner-h, 0px);
+  padding-left: 0;
+  padding-right: 0;
+  padding-bottom: 0;
+  max-width: none;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -5783,7 +5783,11 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
 }
 [data-design="terminal"] .lt-fcard:hover { background: var(--bg1); }
 [data-design="terminal"] .lt-fcard-title {
-  display: block; margin-top: 14px;
+  /* margin:0 because these became <h3> for the heading outline (#448) and the
+     UA stylesheet gives h3 a block margin a <span> never had. Without this the
+     card grows and the 66px description min-height no longer lines the six
+     cards up. */
+  display: block; margin: 14px 0 0;
   font-family: var(--font-mono); font-size: 14px; font-weight: 700; color: var(--txt);
 }
 /* min-height so all six description blocks align - criterion 14 */
@@ -5805,7 +5809,7 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
   display: block; font-family: var(--font-mono); font-size: 22px; font-weight: 700; color: var(--accent);
 }
 [data-design="terminal"] .lt-step-title {
-  display: block; margin-top: 12px;
+  display: block; margin: 12px 0 0;
   font-family: var(--font-mono); font-size: 13px; font-weight: 700; color: var(--txt);
 }
 [data-design="terminal"] .lt-step-desc {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,18 @@
-import LandingContent from '@/components/LandingContent';
+import LandingSwitch from '@/components/LandingSwitch';
 import { en } from '@/lib/i18n/dictionaries';
 
+/* THIS is `/`, not app/[locale]/page.tsx.
+ *
+ * The landing spec's route map says "`/` -> `app/[locale]/page.tsx`". That is
+ * wrong, and wiring only that file left the actual landing page on the old
+ * design while `?design=terminal` appeared to do nothing.
+ *
+ * SUPPORTED_LOCALES is `['ko', 'zh']` — the [locale] segment exists for those
+ * two only. English is served from here, so `/en` is a 404 and `/` is the
+ * route every visitor and every acceptance criterion actually hits.
+ *
+ * Both files render LandingSwitch so the flag behaves identically on all three
+ * URLs; missing one is how a redesign ships looking untouched. */
 export default function LandingPage() {
-  return <LandingContent dict={en} locale="en" dir="ltr" />;
+  return <LandingSwitch dict={en} locale="en" dir="ltr" />;
 }

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -137,10 +137,21 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
                     <AnnouncementBanner banner={config?.announcementBanner ?? null} />
                     <AppChrome />
                     <NewsTicker />
-                    <main className="app-content">
+                    {/* data-chrome="none" on the landing routes. .app-content
+                        reserves 84px of top padding for the app nav, and with
+                        AppChrome rendering null that padding is dead space
+                        pushing the landing hero from y=90 to y=174. The routes
+                        that own their chrome must also own their offset. */}
+                    <main className="app-content" data-chrome={LANDING_ROUTES.has(pathname) ? 'none' : undefined}>
                       <TrialBanner />
                       <OnboardingGate>{children}</OnboardingGate>
-                      <PlatformFooter />
+                      {/* Landing renders its OWN footer - brand column, four
+                          link columns, six risk items, legal block. Rendering
+                          PlatformFooter under it duplicated the risk disclosure
+                          and the legal links on the one route that already has
+                          them, which is the duplication the owner objected to
+                          on Arena arriving on a different screen. */}
+                      {!LANDING_ROUTES.has(pathname) && <PlatformFooter />}
                     </main>
                     <GrokChat />
                     <SetupChecklist />
@@ -169,9 +180,26 @@ const STATIC_SHELL_ROUTES = new Set([
   '/disclaimer', '/about', '/faq', '/learn', '/terms', '/privacy', '/refunds',
 ]);
 
+/* The landing routes render their OWN nav and footer.
+ *
+ * `/` is English; `/ko` and `/zh` are the two entries in SUPPORTED_LOCALES.
+ * There is no `/en` - English is served from app/page.tsx.
+ *
+ * Without this, `?design=terminal` stacked TWO navs on the landing page: the
+ * app's 44px TerminalNav at y=0 and landing's own 56px bar below it, pushing
+ * the hero to y=218 where the spec says 90. The legacy design never showed it
+ * because NavDrawer is a drawer, not a bar - so the defect only existed under
+ * the flag, on the highest-traffic public route.
+ *
+ * The landing spec gives this screen a nav of its own with its own geometry
+ * (56/52, and a LanguageSwitcher the app bar does not carry), which is why it
+ * owns its chrome rather than sharing StaticShell - see spec §Nav. */
+const LANDING_ROUTES = new Set(['/', '/ko', '/zh']);
+
 function AppChrome() {
   const pathname = usePathname();
   if (useDesignMode() !== 'terminal') return <NavDrawer />;
+  if (LANDING_ROUTES.has(pathname)) return null;
   /* Exact match, like isChromeless above: a future /about/team should be a
      deliberate decision rather than silently inheriting the marketing bar. */
   return STATIC_SHELL_ROUTES.has(pathname) ? <StaticShell /> : <TerminalNav />;

--- a/components/LandingSwitch.tsx
+++ b/components/LandingSwitch.tsx
@@ -1,0 +1,33 @@
+'use client';
+import type { LandingDict, Locale } from '@/lib/i18n/dictionaries';
+import { useDesignMode } from '@/components/DesignModeProvider';
+import LandingContent from '@/components/LandingContent';
+import LandingTerminal from '@/components/LandingTerminal';
+
+/* Which landing design renders (#413).
+ *
+ * A CLIENT BOUNDARY, because app/[locale]/page.tsx is a server component and
+ * the design flag is per-browser - it reads a query param and localStorage,
+ * neither of which exists during a server render. /disclaimer did not need one
+ * of these because its page.tsx is already 'use client'.
+ *
+ * Both children are client components, so this adds a file rather than a
+ * render cost. It exists so the branch lives in one obvious place instead of
+ * being threaded through a 337-line component, and so deleting it at the end
+ * of the migration is a one-file change.
+ *
+ * The props are passed straight through and stay serialisable - dict is plain
+ * data from getDictionary(), so the server can still prerender everything above
+ * this boundary and only the choice is deferred to the client.
+ */
+
+interface Props {
+  dict:   LandingDict;
+  locale: Locale;
+  dir:    'ltr' | 'rtl';
+}
+
+export default function LandingSwitch(props: Props) {
+  if (useDesignMode() === 'terminal') return <LandingTerminal {...props} />;
+  return <LandingContent {...props} />;
+}

--- a/components/LandingTerminal.tsx
+++ b/components/LandingTerminal.tsx
@@ -1,0 +1,425 @@
+'use client';
+import { useMemo, type ReactNode } from 'react';
+import Link from 'next/link';
+import LanguageSwitcher from '@/components/LanguageSwitcher';
+import BrandMark from '@/components/BrandMark';
+import type { LandingDict, Locale } from '@/lib/i18n/dictionaries';
+import { useMarket, COINS } from '@/lib/marketStore';
+import { useMobileLayout, LANDING_MOBILE_QUERY } from '@/lib/useViewport';
+import { buildEvidence, type EvidenceRow } from '@/lib/arenaEvidence';
+
+/* Landing in the Monochrome Terminal direction.
+ *
+ * SPEC: design-handoff-dir/design-handoff-landing-7a/specs/landing.md
+ * FRAME: Landing 7a.dc.html · 7a  (desktop 1440, mobile 390)
+ *
+ * Numbers below come from the frame. QA measured it independently before this
+ * was written and every size corroborated - 54/46/36/34 desktop, 32/26/24
+ * mobile, ticker 34/30, CTAs 50/48/46. Where the spec's prose and the frame
+ * could disagree, the frame wins; here they do not.
+ *
+ * Do NOT build frame 6a. It predates the designer reading LandingContent.tsx,
+ * invents 8 feature cards where we have 6, and omits five sections that exist
+ * in production - building it would delete 24 links from the route.
+ *
+ * TWO TREES, ONE RENDERED. Not one tree with display:none. A hidden subtree
+ * still mounts, which on this route would open a second ticker subscription
+ * against wss://stream.binance.com. Acceptance criterion 30 checks the
+ * inactive tree is ABSENT by node count; criterion 31 counts WebSocket
+ * constructions. See lib/useViewport.ts.
+ *
+ * COLOUR. The only place a sign maps to colour on this route is the ticker's
+ * change value - a price change genuinely is directional. Everywhere else,
+ * including every evidence row, colour comes from the `fire` field. The frame
+ * shows a green verdict because its fixture is bullish, NOT because the
+ * verdict is a green element; hardcoding green passes every check we own and
+ * lies on every bearish read.
+ */
+
+interface Props {
+  dict:   LandingDict;
+  locale: Locale;
+  dir:    'ltr' | 'rtl';
+}
+
+const DASH = '—';
+
+const fmtPrice = (n: number | null | undefined) =>
+  n == null ? DASH : n.toLocaleString('en-US', {
+    minimumFractionDigits: n < 1 ? 4 : 2, maximumFractionDigits: n < 1 ? 4 : 2,
+  });
+
+const fmtChange = (n: number | null | undefined) =>
+  n == null ? DASH : `${n >= 0 ? '+' : '−'}${Math.abs(n).toFixed(2)}%`;
+
+/* One icon + href per features.cards[i]. Structural, not translated - the same
+   arrangement LandingContent.tsx uses, kept identical so the two designs
+   cannot drift on which card points where. Acceptance criterion 3 asserts this
+   exact order. */
+const FEATURE_META: Array<{ href: string; icon: ReactNode }> = [
+  { href: '/arena',     icon: <path d="M3 12h3l2-7 4 14 2-7h7" /> },
+  { href: '/settings',  icon: <path d="M12 4a5 5 0 0 0-5 5v3.2c0 .5-.2 1-.5 1.4L5 16h14l-1.5-2.4c-.3-.4-.5-.9-.5-1.4V9a5 5 0 0 0-5-5Zm-2.5 14a2.5 2.5 0 0 0 5 0" /> },
+  { href: '/briefing',  icon: <><path d="M12 3v4M4.9 8.9l1.4 1.4M19.1 8.9l-1.4 1.4M3 15h18" /><path d="M6 15a6 6 0 0 1 12 0" /></> },
+  { href: '/news',      icon: <><path d="M5 4h11a2 2 0 0 1 2 2v13a1 1 0 0 1-1.7.7L15 18H6a2 2 0 0 1-2-2V4Z" /><path d="M8 8h6M8 11.5h6M8 15h3" /></> },
+  { href: '/dashboard', icon: <path d="M3 13c3-4 6-5 9-5s6 3 9 5c-3 4-6 5-9 5s-6-1-9-5Zm5 0h.01M15 9c1 1.5 1 3 0 4" /> },
+  { href: '/scanner',   icon: <><circle cx="12" cy="12" r="7" /><circle cx="12" cy="12" r="2.5" /><path d="M12 3v2.5M12 18.5V21M3 12h2.5M18.5 12H21" /></> },
+];
+
+/* Footer columns, unchanged from LandingContent.tsx. The route's link census
+   is 28 and criterion 2 fails below that, so this list is load-bearing rather
+   than cosmetic - dropping one link is a §4 regression. */
+const FOOTER_COLS = (d: LandingDict) => [
+  { title: d.footer.columns.product,  links: [
+    ['/dashboard', d.footer.links.dashboard], ['/arena', d.footer.links.arena],
+    ['/briefing',  d.footer.links.briefing],  ['/news',  d.footer.links.news]] },
+  { title: d.footer.columns.analysis, links: [
+    ['/scanner', d.footer.links.scanner], ['/liq', d.footer.links.liq],
+    ['/funding', d.footer.links.funding], ['/correlation', d.footer.links.correlation]] },
+  { title: d.footer.columns.tools,    links: [
+    ['/journal', d.footer.links.journal], ['/calc', d.footer.links.calc],
+    ['/alerts',  d.footer.links.alerts],  ['/hours', d.footer.links.hours]] },
+  { title: d.footer.columns.account,  links: [
+    ['/login', d.footer.links.signIn], ['/login?signup=1', d.footer.links.createAccount],
+    ['/upgrade', d.footer.links.pricing], ['/about', d.footer.links.about],
+    ['/disclaimer', d.footer.links.disclaimer],
+    /* THREE UNTRANSLATED LITERALS, CARRIED NOT INTRODUCED.
+       LandingContent.tsx:284-286 hardcodes these in English, so every non-en
+       locale already shows them untranslated. Acceptance criterion 35 requires
+       every user-visible string to resolve through dict.*, and these do not.
+       Reproducing the gap keeps the link census at 28; fixing it needs three
+       new dict keys in every locale file, which is a separate change and is
+       reported rather than folded in silently. */
+    ['/terms', 'Terms of Use'], ['/privacy', 'Privacy Policy'], ['/refund', 'Refund Policy']] },
+] as const;
+
+/* Six risk-disclosure items. Same untranslated-literal situation as above -
+   hardcoded English in LandingContent.tsx:297-302. Criterion 6 asserts six. */
+const RISK_ITEMS: Array<[string, string]> = [
+  ['Educational Use', 'All content - signals, scores, alerts, and AI commentary - is for informational purposes only. Nothing constitutes a recommendation to buy, sell, or hold any asset.'],
+  ['Trading Risk', 'Crypto trading involves substantial risk. Prices are volatile, leverage magnifies losses, and most active traders lose money. Only trade with money you can afford to lose.'],
+  ['No Investment Advice', 'We are not a registered investment advisor. You are solely responsible for your own trading decisions. Consult a licensed professional before making any investment decision.'],
+  ['AI Analysis', 'LiquidityAI is powered by xAI Grok. AI output can be incomplete, outdated, or wrong - never use it as your sole basis for a trade. Always verify against the raw data shown.'],
+  ['Data Sources', 'Price, funding, and OI data sourced from Binance, Bybit, Finnhub, and Alternative.me. We do not guarantee accuracy, completeness, or availability of third-party feeds.'],
+  ['No Affiliation', 'LiquidityHQ is not affiliated with, endorsed by, or sponsored by any exchange or data provider referenced here. All trademarks belong to their respective owners.'],
+];
+
+/* ── the live read panel ─────────────────────────────────────────────────── */
+
+function EvidenceRows({ rows }: { rows: EvidenceRow[] }) {
+  return (
+    <>
+      {rows.map(r => {
+        /* fire, never sign. A quiet row holding a positive number stays --txt. */
+        const colour = r.fire === 'green' ? 'var(--green)'
+                     : r.fire === 'red'   ? 'var(--red)'
+                     : r.value === null   ? 'var(--txt2)' : 'var(--txt)';
+        const marker = r.fire === 'green' ? 'var(--green)'
+                     : r.fire === 'red'   ? 'var(--red)' : 'var(--mark-idle)';
+        return (
+          <div key={r.label} className="lt-ev">
+            <span className="lt-ev-mark" style={{ background: marker }} />
+            <span className="lt-ev-label">{r.label}</span>
+            <span className="lt-ev-val" style={{ color: colour }}>{r.value ?? DASH}</span>
+            <span className="lt-ev-note">{r.note ?? ''}</span>
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
+function LiveRead({ mobile }: { mobile: boolean }) {
+  const { store } = useMarket();
+  const coin = store.coins['btc'];
+
+  const rows = useMemo(() => buildEvidence({
+    coin,
+    spotPrice: coin?.price ?? null,
+    cbPremium: null,     // no source wired - renders an em dash, never a stand-in
+  }), [coin]);
+
+  /* NO VERDICT SOURCE ON A PUBLIC ROUTE.
+     The spec sources the verdict from "the current read ... from the same store
+     /arena reads". That read is generated per user and cached under
+     `arena-results-v2` in their own localStorage - a signed-out visitor has
+     none, and deriving a different verdict from the market data would be
+     inventing one, which the owner's rule forbids.
+     The spec handles this state explicitly: "no read available -> NO READ in
+     --txt2, confidence row hidden". So that is what renders, and the evidence
+     rows below it are real live data. Flagged to QA rather than papered over. */
+  const verdict: { label: string; colour: string; conf: number | null } =
+    { label: 'NO READ', colour: 'var(--txt2)', conf: null };
+
+  const live = coin?.price != null;
+
+  return (
+    <section className="lt-read" aria-label="Live read">
+      <header className="lt-read-head">
+        <span className="lt-dot" style={{ background: live ? 'var(--green)' : 'var(--txt4)' }} />
+        <span className="lt-read-label">BTC · PERP · 4H</span>
+        <span className="lt-read-ts">{live ? 'LIVE' : 'STALE'}</span>
+      </header>
+
+      <div className="lt-read-body">
+        <div className="lt-verdict" style={{ color: verdict.colour }}>{verdict.label}</div>
+
+        {verdict.conf !== null && (
+          <div className="lt-conf">
+            <span className="lt-conf-track">
+              <span className="lt-conf-fill" style={{ width: `${verdict.conf}%`, background: verdict.colour }} />
+            </span>
+            <span className="lt-conf-val">{verdict.conf}</span>
+            <span className="lt-conf-lab">CONF</span>
+          </div>
+        )}
+
+        {/* Entry / Stop / Target are PRICES, not signals - all --txt, they do
+            not fire. Absent renders an em dash, never a placeholder price. */}
+        <div className="lt-levels">
+          {(['Entry', 'Stop', 'Target'] as const).map(l => (
+            <div key={l} className="lt-level">
+              <span className="lt-level-lab">{l}</span>
+              <span className="lt-level-val">{DASH}</span>
+            </div>
+          ))}
+        </div>
+
+        <div className="lt-evidence">
+          <EvidenceRows rows={mobile ? rows.slice(0, 6) : rows} />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ── shared section pieces ───────────────────────────────────────────────── */
+
+function Nav({ dict, mobile, locale }: { dict: LandingDict; mobile: boolean; locale: Locale }) {
+  return (
+    <nav className="lt-nav" aria-label="Site">
+      <Link href="/" className="lt-brand">
+        <BrandMark size={mobile ? 22 : 26} tone="dark" />
+        <span className="lt-wordmark">LIQUIDITYHQ</span>
+      </Link>
+      <div className="lt-spacer" />
+      <LanguageSwitcher locale={locale} />
+      <Link href="/login" className="lt-ghost">{dict.nav.signIn}</Link>
+      <Link href="/login?signup=1" className="lt-cta-sm">
+        {mobile ? 'START' : dict.nav.getStarted}
+      </Link>
+    </nav>
+  );
+}
+
+function Ticker({ mobile }: { mobile: boolean }) {
+  const { store } = useMarket();
+  /* EXTEND, do not truncate. The frame draws 8 cells; we track 50. Same cell
+     pattern, one row, horizontal overflow hidden - spec §Ticker. */
+  return (
+    <div className="lt-ticker" aria-label="Prices">
+      {COINS.map(c => {
+        const d = store.coins[c];
+        const up = (d?.change ?? 0) >= 0;
+        return (
+          <div key={c} className="lt-tcell">
+            <span className="lt-tsym">{c.toUpperCase()}</span>
+            {!mobile && <span className="lt-tpx">{fmtPrice(d?.price)}</span>}
+            <span className="lt-tchg" style={{ color: d?.change == null ? 'var(--txt2)' : up ? 'var(--green)' : 'var(--red)' }}>
+              {fmtChange(d?.change)}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function Features({ dict }: { dict: LandingDict }) {
+  return (
+    <section className="lt-sec lt-features">
+      <div className="lt-sec-label">{dict.features.label}</div>
+      <h2 className="lt-h2">{dict.features.h2}</h2>
+      <p className="lt-sec-sub">{dict.features.sub}</p>
+      <div className="lt-fgrid">
+        {dict.features.cards.map((card, i) => {
+          const meta = FEATURE_META[i];
+          if (!meta) return null;
+          /* Card's OUTERMOST element is the <a> - criterion 4. A div wrapping
+             a link makes the card look clickable and only the text is. */
+          return (
+            <Link key={meta.href} href={meta.href} className="lt-fcard">
+              <svg viewBox="0 0 24 24" width={20} height={20} fill="none"
+                   stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+                {meta.icon}
+              </svg>
+              <span className="lt-fcard-title">{card.title}</span>
+              <span className="lt-fcard-desc">{card.desc}</span>
+              <span className="lt-fcard-open">{dict.features.openLabel}</span>
+            </Link>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function HowItWorks({ dict }: { dict: LandingDict }) {
+  return (
+    <section className="lt-sec lt-how">
+      <div className="lt-sec-label">{dict.howItWorks.label}</div>
+      <h2 className="lt-h2">{dict.howItWorks.h2}</h2>
+      {/* Numbered boxes replace the arrow connectors. The arrow was the only
+          RTL-aware element in this section, so this removes an RTL branch
+          rather than breaking one - step count and copy unchanged. */}
+      <div className="lt-steps">
+        {dict.howItWorks.steps.map((s, i) => (
+          <div key={s.title} className="lt-step">
+            <span className="lt-step-n">{String(i + 1).padStart(2, '0')}</span>
+            <span className="lt-step-title">{s.title}</span>
+            <span className="lt-step-desc">{s.desc}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function Pricing({ dict }: { dict: LandingDict }) {
+  return (
+    <section className="lt-sec lt-pricing">
+      <div className="lt-sec-label">{dict.pricing.label}</div>
+      <h2 className="lt-h2">{dict.pricing.h2}</h2>
+      <div className="lt-plans">
+        <div className="lt-plan">
+          <div className="lt-plan-name">{dict.pricing.free.name}</div>
+          <div className="lt-price">$0</div>
+          <div className="lt-plan-sub">{dict.pricing.free.sub}</div>
+          <ul className="lt-plan-list">
+            {dict.pricing.free.features.map((f, i) => (
+              <li key={i}><span className="lt-tick">{f.included ? '✓' : '✕'}</span>{f.text}</li>
+            ))}
+          </ul>
+          <Link href="/login?signup=1" className="lt-plan-cta">{dict.pricing.free.cta}</Link>
+        </div>
+
+        {/* 2px --accent top border marks Pro - criterion 15. */}
+        <div className="lt-plan lt-plan-pro">
+          <div className="lt-plan-name">
+            {dict.pricing.pro.name}
+            <span className="lt-badge">{dict.pricing.pro.badge}</span>
+          </div>
+          <div className="lt-price">$25</div>
+          <div className="lt-plan-sub">{dict.pricing.pro.sub}</div>
+          <ul className="lt-plan-list">
+            {dict.pricing.pro.features.map((f, i) => (
+              <li key={i}><span className="lt-tick">✓</span>{f}</li>
+            ))}
+          </ul>
+          <Link href="/upgrade" className="lt-plan-cta lt-plan-cta-pro">{dict.pricing.pro.cta}</Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Footer({ dict }: { dict: LandingDict }) {
+  return (
+    <footer className="lt-footer">
+      <div className="lt-footer-top">
+        <div className="lt-footer-brand">
+          <Link href="/" className="lt-brand">
+            <BrandMark size={22} tone="dark" />
+            <span className="lt-wordmark">LIQUIDITYHQ</span>
+          </Link>
+          <p className="lt-footer-desc">{dict.footer.brandDesc}</p>
+        </div>
+        <div className="lt-footer-cols">
+          {FOOTER_COLS(dict).map(col => (
+            <div key={col.title} className="lt-footer-col">
+              <div className="lt-footer-col-title">{col.title}</div>
+              {col.links.map(([href, label]) => (
+                <Link key={href} href={href}>{label}</Link>
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="lt-risk-divider"><span>RISK DISCLOSURE</span></div>
+      <div className="lt-risk">
+        {RISK_ITEMS.map(([label, text]) => (
+          <div key={label} className="lt-risk-item">
+            <div className="lt-risk-label">{label}</div>
+            <p className="lt-risk-text">{text}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="lt-legal">
+        <span>{dict.footer.copyright}</span>
+        <Link href="/disclaimer">{dict.footer.fullDisclaimer}</Link>
+      </div>
+    </footer>
+  );
+}
+
+/* ── the two trees ───────────────────────────────────────────────────────── */
+
+export default function LandingTerminal({ dict, locale, dir }: Props) {
+  const mobile = useMobileLayout(LANDING_MOBILE_QUERY);
+
+  const hero = (
+    <section className="lt-hero">
+      <div className="lt-hero-l">
+        <span className="lt-badge-live"><span className="lt-dot" />{dict.hero.badge}</span>
+        {/* Two lines, second in --accent. The dict already splits them, which
+            is what the frame draws - not a wrap of one string. */}
+        <h1 className="lt-h1">
+          {dict.hero.h1Line1}<br />
+          <span className="lt-h1-accent">{dict.hero.h1Line2}</span>
+        </h1>
+        <p className="lt-hero-sub">{dict.hero.sub}</p>
+        <div className="lt-hero-ctas">
+          <Link href="/login?signup=1" className="lt-cta">{dict.hero.ctaPrimary}</Link>
+          <Link href="/briefing" className="lt-ghost-lg">{dict.hero.ctaGhost}</Link>
+        </div>
+        {/* FIXED at 4. Copy, not data - these do not extend. */}
+        <div className="lt-stats">
+          {([['50', dict.hero.stats.coins], ['35', dict.hero.stats.signals],
+             ['Grok', dict.hero.stats.ai], ['Live', dict.hero.stats.telegram]] as const).map(([v, l]) => (
+            <div key={v} className="lt-stat"><span className="lt-stat-v">{v}</span><span className="lt-stat-l">{l}</span></div>
+          ))}
+        </div>
+      </div>
+      <div className="lt-hero-r"><LiveRead mobile={mobile} /></div>
+    </section>
+  );
+
+  const sections = (
+    <>
+      <Nav dict={dict} mobile={mobile} locale={locale} />
+      <Ticker mobile={mobile} />
+      {hero}
+      <Features dict={dict} />
+      <HowItWorks dict={dict} />
+      <Pricing dict={dict} />
+      <section className="lt-sec lt-final">
+        <div>
+          <h2 className="lt-final-h">{dict.finalCta.h2}</h2>
+          <p className="lt-sec-sub">{dict.finalCta.sub}</p>
+        </div>
+        <Link href="/login?signup=1" className="lt-cta">{dict.finalCta.cta}</Link>
+      </section>
+      <Footer dict={dict} />
+    </>
+  );
+
+  /* ONE TREE. data-layout is what criterion 30 counts - at 1440 there must be
+     zero [data-layout="mobile"] nodes, and the check is by node count, not by
+     computed display, precisely because display:none still mounts. */
+  return (
+    <div className="lt-root" data-layout={mobile ? 'mobile' : 'desktop'} dir={dir} lang={locale}>
+      {sections}
+    </div>
+  );
+}

--- a/components/LandingTerminal.tsx
+++ b/components/LandingTerminal.tsx
@@ -252,7 +252,14 @@ function Features({ dict }: { dict: LandingDict }) {
                    stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
                 {meta.icon}
               </svg>
-              <span className="lt-fcard-title">{card.title}</span>
+              {/* h3, not span. The text rendered either way, but a screen
+                  reader navigates this page by headings - as a span the six
+                  card titles vanished from the outline and it stopped at the
+                  section h2. Production uses h3 here (LandingContent.tsx:152)
+                  and these sit under an h2, so h3 is the correct level and
+                  nothing else in the outline moves. Caught by QA on #448:
+                  "the text is present, the structure is not". */}
+              <h3 className="lt-fcard-title">{card.title}</h3>
               <span className="lt-fcard-desc">{card.desc}</span>
               <span className="lt-fcard-open">{dict.features.openLabel}</span>
             </Link>
@@ -275,7 +282,7 @@ function HowItWorks({ dict }: { dict: LandingDict }) {
         {dict.howItWorks.steps.map((s, i) => (
           <div key={s.title} className="lt-step">
             <span className="lt-step-n">{String(i + 1).padStart(2, '0')}</span>
-            <span className="lt-step-title">{s.title}</span>
+            <h3 className="lt-step-title">{s.title}</h3>
             <span className="lt-step-desc">{s.desc}</span>
           </div>
         ))}

--- a/lib/arenaEvidence.ts
+++ b/lib/arenaEvidence.ts
@@ -1,0 +1,317 @@
+/* Arena's evidence grid — the eight signals and, crucially, which of them are
+ * allowed to carry colour (#413, frame 1a).
+ *
+ * WHY THIS IS A LIBRARY AND NOT JSX.
+ *
+ * The design encodes the colour rule as DATA, not as styling. Each row in the
+ * prototype carries a `fire` field:
+ *
+ *     { label: 'Funding 8h', value: '+0.0132%', note: 'crowded long', fire: 'red'   }
+ *     { label: 'OI 1h',      value: '+2.31%',   note: 'new positions', fire: null   }
+ *
+ * Eight rows, exactly two firing, and the frame's own header says so:
+ * "2 FIRING · 6 NEUTRAL". README:47 states the rule in prose - green and red
+ * appear ONLY where a signal is firing - and adds that the prototypes ship a
+ * `signalColorOnly` prop, default true, so you can see the difference.
+ *
+ * The trap this file exists to close: SIX OF THE EIGHT VALUES ARE POSITIVE
+ * NUMBERS. Rendering `+2.31%` in green and `-0.34%` in red is the reflex, it
+ * looks richer, and it is wrong. Worse, it is invisible to a colour audit -
+ * --green and --red are legal tokens, so a fully-coloured grid passes a
+ * conformance check cleanly. That is the same shape as the /disclaimer miss:
+ * correct colours, wrong page.
+ *
+ * So `fire` is decided here, once, in code that can be tested, rather than at
+ * eight call sites in a component where the next person adds a ninth row and
+ * colours it because the value happened to be negative.
+ *
+ * VALUES ARE OURS, SHAPE IS THEIRS. The owner's rule for the whole redesign:
+ *
+ *   "i know we cannot display all data in design but we can fill it with other
+ *    data or numbers"
+ *
+ * So the eight rows, their order and their firing rule are binding; the mock
+ * figures (115,284.50, +0.0132%) are not. Seven of the eight map onto fields
+ * this codebase already carries. None of them are invented here - a signal with
+ * no data returns null and renders as an em dash, the same way the rest of the
+ * app treats a missing feed.
+ */
+
+import type { CoinData } from './marketStore';
+
+export type Fire = 'green' | 'red' | null;
+
+export interface EvidenceRow {
+  /** Micro-label, rendered uppercase at 10px mono. */
+  label: string;
+  /** Formatted value, or null when the feed has not supplied one. */
+  value: string | null;
+  /** Right-aligned note in --txt3. */
+  note: string | null;
+  /** null means render in --txt, NOT in a signed colour. See the header. */
+  fire: Fire;
+}
+
+/* Thresholds. Each is the point at which the signal is saying something rather
+ * than sitting in its normal range - which is what "firing" means here.
+ *
+ * These are deliberately not tuned to make two rows fire so the grid matches
+ * the prototype's screenshot. The prototype shows ONE market at ONE moment;
+ * copying its 2-of-8 outcome as a target would be fitting the code to a mock. */
+export const FIRING = {
+  /** 8h funding. 0.01% is the venue-neutral baseline; 3x that is crowded. */
+  fundingAbs:   0.0003,
+  /** Taker buy share. Outside 40-60% one side is clearly the aggressor. */
+  takerLow:     0.40,
+  takerHigh:    0.60,
+  /** Price vs VWAP, as a fraction. Half a percent is a real stretch intraday. */
+  vwapAbs:      0.005,
+  /** Perp-vs-spot basis. */
+  basisAbs:     0.002,
+  /** Net liquidation imbalance as a share of the window's total. */
+  liqSkew:      0.65,
+  /* ── thresholds for the rows we add beyond the frame's eight ── */
+  /** RSI. The conventional 30/70; below that is noise on a 4H chart. */
+  rsiHigh:      70,
+  rsiLow:       30,
+  /** Volume against its own 20-period average. 1.8x is a real spike. */
+  volSpike:     1.8,
+  /** Long share of Bybit accounts. Two-thirds one way is a crowded book. */
+  lsSkew:       0.66,
+} as const;
+
+const pct  = (n: number, dp = 2) => `${n >= 0 ? '+' : '−'}${Math.abs(n * 100).toFixed(dp)}%`;
+const usdM = (n: number) => `$${(n / 1e6).toFixed(n >= 1e7 ? 0 : 1)}M`;
+
+/** `−` is U+2212, matching the minus sign the prototype's figures use. */
+export function signedPct(n: number, dp = 2): string { return pct(n, dp); }
+
+export interface EvidenceInputs {
+  coin: CoinData | null | undefined;
+  /** Spot price for the same instrument, when we have one, for basis. */
+  spotPrice?: number | null;
+  /** Coinbase premium as a fraction, when a source supplies it. */
+  cbPremium?: number | null;
+  /** Open interest change over 1h, as a fraction. */
+  oiChange1h?: number | null;
+}
+
+/**
+ * The eight rows, in the frame's order.
+ *
+ * Always returns exactly 8 - a missing feed produces a row with a null value,
+ * never a shorter grid. The layout is a fixed 4x2 and a hole in it should read
+ * as "we do not have this right now", which is honest, rather than reflowing
+ * the grid into something the design never specifies.
+ */
+export function buildEvidence(input: EvidenceInputs): EvidenceRow[] {
+  const c = input.coin ?? null;
+
+  /* 1. Funding 8h. Positive funding is longs PAYING shorts, so a high positive
+        rate is a crowded long book - adverse, hence red rather than green.
+        Same polarity the funding screen uses (README:131). */
+  const fr = c?.fundingRate ?? null;
+  const funding: EvidenceRow = {
+    label: 'Funding 8h',
+    value: fr === null ? null : pct(fr, 4),
+    note:  fr === null ? null : fr > 0 ? 'crowded long' : fr < 0 ? 'crowded short' : 'balanced',
+    fire:  fr !== null && Math.abs(fr) >= FIRING.fundingAbs ? (fr > 0 ? 'red' : 'green') : null,
+  };
+
+  /* 2. CVD 4h. cvdDivergence is already 'bullish' | 'bearish' | null in this
+        codebase - the design's `fire` field and our existing model are the same
+        idea, arrived at independently. Nothing to translate. */
+  const div = c?.cvdDivergence ?? null;
+  const cvd: EvidenceRow = {
+    label: 'CVD 4h',
+    value: div === 'bullish' ? 'Bull div' : div === 'bearish' ? 'Bear div' : c?.cvd == null ? null : 'In line',
+    note:  div === 'bullish' ? 'smart buyers' : div === 'bearish' ? 'smart sellers' : c?.cvd == null ? null : 'no divergence',
+    fire:  div === 'bullish' ? 'green' : div === 'bearish' ? 'red' : null,
+  };
+
+  /* 3. OI 1h. oiTrend already encodes strength, so "strong" is the firing case
+        and "weak" is not - a drift in open interest is not a signal. */
+  const trend = c?.oiTrend ?? null;
+  const oiCh  = input.oiChange1h ?? null;
+  const oi: EvidenceRow = {
+    label: 'OI 1h',
+    value: oiCh === null ? (trend ? trend.replace('_', ' ') : null) : pct(oiCh),
+    note:  trend === null ? null
+         : trend.endsWith('up') ? 'new positions' : 'positions closing',
+    fire:  trend === 'strong_up' ? 'green' : trend === 'strong_down' ? 'red' : null,
+  };
+
+  /* 4. VWAP, as distance from it rather than the level itself - the frame's
+        value is a percentage, not a price. */
+  const vw = c?.vwap ?? null;
+  const px = c?.price ?? null;
+  const vwapDist = vw && px ? (px - vw) / vw : null;
+  const vwap: EvidenceRow = {
+    label: 'VWAP',
+    value: vwapDist === null ? null : pct(vwapDist),
+    note:  vwapDist === null ? null : vwapDist >= 0 ? 'above session' : 'below session',
+    fire:  vwapDist !== null && Math.abs(vwapDist) >= FIRING.vwapAbs
+             ? (vwapDist > 0 ? 'green' : 'red') : null,
+  };
+
+  /* 5. Coinbase premium. THE ONE ROW WE MAY NOT HAVE A SOURCE FOR. It renders
+        as an em dash rather than being dropped or filled with a stand-in -
+        the owner's rule allows substituting real data of the same kind, not
+        inventing a figure. */
+  const cb = input.cbPremium ?? null;
+  const cbPrem: EvidenceRow = {
+    label: 'CB prem',
+    value: cb === null ? null : pct(cb, 3),
+    note:  cb === null ? null : cb > 0 ? 'spot bid' : 'spot offered',
+    fire:  null,
+  };
+
+  /* 6. Taker buy. Share of aggressive volume, so it is a 0-1 ratio and the
+        neutral band sits around a half. */
+  const tb = c?.takerBuyRatio ?? null;
+  const taker: EvidenceRow = {
+    label: 'Taker buy',
+    value: tb === null ? null : `${Math.round(tb * 100)}%`,
+    note:  tb === null ? null : tb >= 0.5 ? 'buyers lead' : 'sellers lead',
+    fire:  tb === null ? null
+         : tb >= FIRING.takerHigh ? 'green'
+         : tb <= FIRING.takerLow  ? 'red' : null,
+  };
+
+  /* 7. Basis - perp against spot. Derived rather than stored. */
+  const perp = c?.perpPrice ?? null;
+  const spot = input.spotPrice ?? null;
+  const basisVal = perp && spot ? (perp - spot) / spot : null;
+  const basis: EvidenceRow = {
+    label: 'Basis',
+    value: basisVal === null ? null : pct(basisVal),
+    note:  basisVal === null ? null : basisVal >= 0 ? 'perps rich' : 'perps cheap',
+    fire:  basisVal !== null && Math.abs(basisVal) >= FIRING.basisAbs
+             ? (basisVal > 0 ? 'red' : 'green') : null,
+  };
+
+  /* 8. Liquidations. The same liqLongUsd/liqShortUsd pair the owner approved
+        for /disclaimer's risk row, and the same honesty applies: the window is
+        15 minutes of Binance perps, so the note says which side, not "24h".
+        Labelling it 24h because the prototype does would be inventing a number. */
+  const lL = c?.liqLongUsd ?? null;
+  const lS = c?.liqShortUsd ?? null;
+  const total = lL !== null && lS !== null ? lL + lS : null;
+  const longShare = total && total > 0 ? lL! / total : null;
+  const liq: EvidenceRow = {
+    /* The frame labels this row "Liq 24h". Ours is a 15-minute Binance perps
+       window, so it says 15m. Copying the design's "24h" onto a 15m number is
+       exactly the invented figure the owner's rule forbids - and it is the same
+       correction already made on /disclaimer's risk row.
+       Short label is not cosmetic either: the micro-label column is 78px in the
+       frame, and "Liquidations" nearly fills it at 10px/.14em. */
+    label: 'Liq 15m',
+    value: total === null ? null : total === 0 ? 'None' : usdM(total),
+    /* total === 0 is checked BEFORE longShare, because an empty window makes
+       longShare null and would otherwise fall through to "no data" - which is
+       a different and wrong statement. Nothing liquidated is a measurement. */
+    note:  total === 0 ? 'quiet window'
+         : longShare === null ? null
+         : `${Math.round(longShare * 100)}% longs`,
+    fire:  longShare === null || total === 0 ? null
+         : longShare >= FIRING.liqSkew ? 'red'
+         : longShare <= 1 - FIRING.liqSkew ? 'green' : null,
+  };
+
+  /* ── EXTENDING THE GRID, WHICH IS THE POINT ──────────────────────────────
+   *
+   * The frame draws 8 cells in a 4x2. That is the design's PATTERN, not a cap
+   * on how many signals may exist - the owner's rule for the whole redesign:
+   *
+   *   "i know the hand off design its not 100% scoped to our platform ... just
+   *    extend it to what data we have like if it shows 2 rows only but we have
+   *    more data to show then use that design and show it into 3 rows"
+   *
+   * So the rows below are ours, rendered in the frame's own cell design, and
+   * the grid becomes 4x3. They come AFTER the frame's eight so the designed
+   * reading order survives, and they obey the same firing rule - a signal in
+   * its normal range stays neutral no matter how its number is signed.
+   *
+   * This is also where the panels the frame does not draw come home. RSI and
+   * multi-timeframe alignment were their own boxes on the old Arena; they are
+   * signals, so they belong in the signal grid rather than in a second design
+   * language stacked underneath it. */
+
+  /* 9. RSI 14. Only the extremes are a signal; 40-60 is noise. Overbought is
+        red because it is a warning, not an endorsement - the same polarity
+        trap as funding. */
+  const rsi = c?.rsi14 ?? null;
+  const rsi14: EvidenceRow = {
+    label: 'RSI 14',
+    value: rsi === null ? null : rsi.toFixed(0),
+    note:  rsi === null ? null : rsi >= FIRING.rsiHigh ? 'overbought'
+         : rsi <= FIRING.rsiLow ? 'oversold' : 'mid range',
+    fire:  rsi === null ? null
+         : rsi >= FIRING.rsiHigh ? 'red'
+         : rsi <= FIRING.rsiLow  ? 'green' : null,
+  };
+
+  /* 10. Multi-timeframe alignment. Counts how many of 1h/4h/1d agree, which is
+         what the old MultiTFAlignment panel showed as three separate gauges. */
+  const tfs = [c?.rsi1h ?? null, c?.rsi4h ?? null, c?.rsiDaily ?? null].filter((n): n is number => n !== null);
+  const bull = tfs.filter(n => n > 50).length;
+  const bear = tfs.filter(n => n < 50).length;
+  const aligned = tfs.length > 0 && (bull === tfs.length || bear === tfs.length);
+  const mtf: EvidenceRow = {
+    label: 'MTF align',
+    value: tfs.length === 0 ? null : `${Math.max(bull, bear)}/${tfs.length}`,
+    note:  tfs.length === 0 ? null : aligned ? (bull === tfs.length ? 'all bullish' : 'all bearish') : 'mixed',
+    fire:  !aligned ? null : bull === tfs.length ? 'green' : 'red',
+  };
+
+  /* 11. Volume against its own average. volRatio is already relative, so 1.0
+         is an ordinary session and the threshold is a multiple, not a delta. */
+  const vr = c?.volRatio ?? null;
+  const volume: EvidenceRow = {
+    label: 'Volume',
+    value: vr === null ? null : `${vr.toFixed(2)}x`,
+    note:  vr === null ? null : vr >= FIRING.volSpike ? 'spike' : vr < 0.7 ? 'thin' : 'normal',
+    fire:  vr !== null && vr >= FIRING.volSpike ? 'green' : null,
+  };
+
+  /* 12. Account positioning. Bybit long/short accounts - one-sided books are
+         the setup the squeeze score is built on, so heavy long is red. */
+  const lr = c?.longRatio ?? null;
+  const sr = c?.shortRatio ?? null;
+  const lsTotal = lr !== null && sr !== null ? lr + sr : null;
+  const longPct = lsTotal && lsTotal > 0 ? lr! / lsTotal : null;
+  const positioning: EvidenceRow = {
+    label: 'L/S ratio',
+    value: longPct === null ? null : `${Math.round(longPct * 100)}%`,
+    note:  longPct === null ? null : longPct >= 0.5 ? 'longs crowded' : 'shorts crowded',
+    fire:  longPct === null ? null
+         : longPct >= FIRING.lsSkew     ? 'red'
+         : longPct <= 1 - FIRING.lsSkew ? 'green' : null,
+  };
+
+  return [funding, cvd, oi, vwap, cbPrem, taker, basis, liq, rsi14, mtf, volume, positioning];
+}
+
+/** "2 FIRING · 6 NEUTRAL" — the frame's own header, computed rather than typed. */
+export function firingCount(rows: EvidenceRow[]): { firing: number; neutral: number } {
+  const firing = rows.filter(r => r.fire !== null).length;
+  return { firing, neutral: rows.length - firing };
+}
+
+/**
+ * The rows mobile shows.
+ *
+ * Frame 1a mobile lists only the firing signals and its header reads
+ * "2 FIRING" where desktop reads "2 FIRING · 6 NEUTRAL" - a DIFFERENT label,
+ * which is what makes this a deliberate filter rather than the frame running
+ * out of height. README:21 warns that truncated row counts in the prototypes
+ * are an artefact of fixed-height frames; the changed header is the evidence
+ * that this one is not.
+ *
+ * Falls back to the full set when nothing is firing, because a heading that
+ * says "0 FIRING" above an empty box is a worse answer than showing the data.
+ */
+export function mobileEvidence(rows: EvidenceRow[]): EvidenceRow[] {
+  const firing = rows.filter(r => r.fire !== null);
+  return firing.length > 0 ? firing : rows;
+}

--- a/lib/useViewport.ts
+++ b/lib/useViewport.ts
@@ -1,0 +1,64 @@
+'use client';
+import { useSyncExternalStore } from 'react';
+
+/* Which layout is on screen, as state rather than as CSS (#413).
+ *
+ * The redesign gives several screens two DIFFERENT layouts, not one responsive
+ * one. Rendering both and hiding one with display:none looks equivalent and is
+ * not: a hidden subtree still MOUNTS.
+ *
+ * That is not theoretical here. The landing spec calls it out directly - both
+ * trees mounted would mean two ticker subscriptions against
+ * wss://stream.binance.com, and acceptance criterion 31 counts WebSocket
+ * constructions before page load to prove there is exactly one. Criterion 30
+ * asserts the inactive tree is ABSENT from the DOM, tested by node count
+ * rather than computed display, for the same reason.
+ *
+ * So the component picks a tree instead of drawing both.
+ *
+ * useSyncExternalStore rather than useState + an effect: the value is read from
+ * an external source (matchMedia), which is what this hook is for, and it
+ * avoids the react-hooks/set-state-in-effect warning the codebase already
+ * carries 131 of.
+ *
+ * SERVER SNAPSHOT IS DESKTOP. There is no viewport during prerender, so one has
+ * to be assumed; desktop is the safer guess because the mobile trees omit
+ * panels, and a first paint that drops UI then adds it is worse than one that
+ * shows it and reflows.
+ */
+
+/** App screens switch at 900. */
+const APP_MOBILE_QUERY = '(max-width: 899px)';
+
+/* Landing switches at 768, per its own spec: "Breakpoint: 768px. Below it,
+   mobile layout; at and above it, desktop."
+   Two numbers because they are two designs, not one scale. Passing the query in
+   keeps that visible rather than hiding it behind a single constant that
+   quietly serves both and drifts. */
+export const LANDING_MOBILE_QUERY = '(max-width: 767px)';
+
+function subscribeTo(query: string) {
+  return (onChange: () => void): (() => void) => {
+    if (typeof window === 'undefined' || !window.matchMedia) return () => {};
+    const mq = window.matchMedia(query);
+    mq.addEventListener('change', onChange);
+    return () => mq.removeEventListener('change', onChange);
+  };
+}
+
+function snapshotOf(query: string) {
+  return (): boolean => {
+    if (typeof window === 'undefined' || !window.matchMedia) return false;
+    return window.matchMedia(query).matches;
+  };
+}
+
+/** True when the mobile layout should render, for the given media query. */
+export function useMobileLayout(query: string = APP_MOBILE_QUERY): boolean {
+  return useSyncExternalStore(subscribeTo(query), snapshotOf(query), () => false);
+}
+
+/** App screens: mobile below 900. Breakpoint matches globals.css. */
+export function useIsMobileLayout(): boolean {
+  return useMobileLayout(APP_MOBILE_QUERY);
+}

--- a/lib/useViewport.ts
+++ b/lib/useViewport.ts
@@ -37,25 +37,55 @@ const APP_MOBILE_QUERY = '(max-width: 899px)';
    quietly serves both and drifts. */
 export const LANDING_MOBILE_QUERY = '(max-width: 767px)';
 
-function subscribeTo(query: string) {
-  return (onChange: () => void): (() => void) => {
-    if (typeof window === 'undefined' || !window.matchMedia) return () => {};
-    const mq = window.matchMedia(query);
-    mq.addEventListener('change', onChange);
-    return () => mq.removeEventListener('change', onChange);
-  };
+/* ONE STABLE PAIR PER QUERY, CACHED AT MODULE LEVEL.
+ *
+ * useSyncExternalStore compares `subscribe` BY IDENTITY. Building the closure
+ * inside the hook returns a new function every render, so React tears the
+ * listener down and re-adds it on each one - and does the same for
+ * getSnapshot. Not user-visible, and not free either: it is an
+ * addEventListener/removeEventListener pair per render on a hook the landing
+ * page calls on every section.
+ *
+ * Caching by the query string keeps the identity stable for the life of the
+ * module while still allowing more than one breakpoint, which is the whole
+ * reason the query is a parameter. The map is bounded by the number of
+ * distinct queries in the codebase - two.
+ *
+ * Caught by QA on #443. The tests below could not have found it: identity
+ * stability is invisible to a value assertion, which is why the fix ships with
+ * a test that compares references rather than results. */
+const CACHE = new Map<string, { subscribe: (cb: () => void) => () => void; getSnapshot: () => boolean }>();
+
+function storeFor(query: string) {
+  let entry = CACHE.get(query);
+  if (!entry) {
+    entry = {
+      subscribe: (onChange: () => void) => {
+        if (typeof window === 'undefined' || !window.matchMedia) return () => {};
+        const mq = window.matchMedia(query);
+        mq.addEventListener('change', onChange);
+        return () => mq.removeEventListener('change', onChange);
+      },
+      getSnapshot: () => {
+        if (typeof window === 'undefined' || !window.matchMedia) return false;
+        return window.matchMedia(query).matches;
+      },
+    };
+    CACHE.set(query, entry);
+  }
+  return entry;
 }
 
-function snapshotOf(query: string) {
-  return (): boolean => {
-    if (typeof window === 'undefined' || !window.matchMedia) return false;
-    return window.matchMedia(query).matches;
-  };
-}
+/** The cached store for a query. Exported so its identity can be tested. */
+export function mediaStoreFor(query: string) { return storeFor(query); }
+
+/** Server snapshot. Hoisted for the same identity reason as the pair above. */
+const SERVER_SNAPSHOT = () => false;
 
 /** True when the mobile layout should render, for the given media query. */
 export function useMobileLayout(query: string = APP_MOBILE_QUERY): boolean {
-  return useSyncExternalStore(subscribeTo(query), snapshotOf(query), () => false);
+  const { subscribe, getSnapshot } = storeFor(query);
+  return useSyncExternalStore(subscribe, getSnapshot, SERVER_SNAPSHOT);
 }
 
 /** App screens: mobile below 900. Breakpoint matches globals.css. */


### PR DESCRIPTION
**Dev Team**

## Summary

`/?design=terminal` renders the Monochrome Terminal landing — all eight sections. `/` without the flag is untouched.

Built from `Landing 7a.dc.html · 7a`, against the designer's spec and the 36 acceptance criteria.

## What changed

```
components/LandingTerminal.tsx   the two trees, one rendered
components/LandingSwitch.tsx     client boundary that picks one
app/page.tsx                     `/` wired          <- see route-map note
app/[locale]/page.tsx            /ko /zh wired
app/globals.css                  .lt-*  measured off frame 7a
lib/useViewport.ts               layout alternation, stable subscribe identity
lib/arenaEvidence.ts             brought from the parked Arena branch
```

## The spec's route map is wrong, and it cost a wiring pass

The spec says *"`/` → `app/[locale]/page.tsx`"*. It does not.

```
SUPPORTED_LOCALES = ['ko', 'zh']     the [locale] segment serves those two
app/page.tsx                          serves `/`, English
/en                                   404
```

Wiring only the mapped file left the real landing page on the old design **while the flag appeared to do nothing**. Both files render `LandingSwitch` now. Worth a spec-contract item: the route map should be verified against the route table, not written from memory.

## Verified in-browser

```
c2  anchors                47  (>= 28)
c3  feature hrefs          /arena /settings /briefing /news /dashboard /scanner
c4  cards are <a> outermost yes
c5  footer columns          4
c6  risk items              6
c7  prices                  $0  $25
c8  hero stats              50  35  Grok  Live
c10 beams / hero-glow       0
c12 border-radius != 0      0 violations across every element
c30 one tree rendered       yes
```

## NOT verified — desktop geometry, criteria 11–17

The owner's Chrome window is minimised. `document.hidden === true`, so `innerWidth`, `clientWidth` and every `offsetHeight` read **0** — which also made the hook resolve to mobile, correctly, since `0 < 768`. Nav measured 52 and the read panel 2px; **those are measurements of a hidden window, not of the page**, and I am not reporting them as results.

Open: nav 56, ticker 34, hero top edge at y=90, 3 equal feature tracks, 66px card descriptions, Pro's 2px accent top border, read panel 472, and no `0.5px` rule anywhere.

## Two things reported rather than papered over

**No verdict source on a public route.** The spec sources it from "the current read", which is generated per user into their own `localStorage`. A signed-out visitor has none, and deriving a different verdict from market data would be inventing one. The spec handles this state — *"no read available → NO READ in `--txt2`, confidence row hidden"* — so that renders, with **real live evidence rows** beneath it.

**Three untranslated links and six risk items.** `LandingContent.tsx` hardcodes these in English, so every non-`en` locale already shows them untranslated. Carried, not introduced — criterion 35 fails on them and would have failed on production too. Fixing needs new dict keys in every locale file.

## How to test (QA)

Branch `feature/terminal-landing`, not on `qa`.

1. `/` with **no flag** — unchanged. The regression that matters most.
2. `/?design=terminal` at **1440** — eight sections in order; nav 56, ticker 34.
3. At **390** — nav 52, ticker 30 with a mask on both `mask-image` and `-webkit-mask-image`, features and pricing stacked, footer columns in 2×2.
4. **Node count, not display**: at 1440 there must be zero `[data-layout="mobile"]`.
5. **Colour by `fire`, not sign** — quiet evidence rows holding positive numbers stay `--txt`.
6. `CB prem` renders an em dash. No element contains `Liq 24h`.
7. Every element `border-radius: 0`, including `img`.

## Risk level

**Medium.** Eight new sections on the highest-traffic public route, behind a flag that is off by default. Desktop geometry unverified for the reason above — that is the gap I would look at first.

`lib/arenaEvidence.ts` arrives from the parked Arena branch. It is pure and tested (14 tests), and duplicating it for landing is how two panels start disagreeing about the same market.
