### PR TITLE
chore(settings): one data-brand-mark hook so every screen's logo is exempt

### DIFF
--- a/components/BrandMark.tsx
+++ b/components/BrandMark.tsx
@@ -54,6 +54,24 @@ export default function BrandMark({
       className={className}
       style={{ flex: '0 0 auto', display: 'block' }}
       aria-hidden="true"
+      /* ONE HOOK FOR THE WHOLE MARK (#449).
+       *
+       * The mark is blue - #2E7BFF, #6FD3FF, #1C3E76 - and that is the DESIGN,
+       * not drift: the handoff's own logo.png decodes to exactly those values
+       * and frame 7a references it three times at 26/30/22px. So the colour
+       * check has to exempt it rather than the component being "fixed".
+       *
+       * The attribute lives here, on the component, rather than as a list of
+       * call-site selectors in the spec. There are ten call sites across eight
+       * files today, and the failure this replaces was precisely a
+       * selector list that covered two footer children and missed the mark in
+       * the nav - a screen gets converted, its logo is not in the list, and the
+       * suite goes red on a decision nobody made.
+       *
+       * Whoever adds an eleventh call site gets the exemption for free. If the
+       * mark is ever restated in palette colours, delete the attribute and the
+       * spec entry together - the check should go back to enforcing on it. */
+      data-brand-mark=""
     >
       <rect width="100" height="100" rx={radiusPct} ry={radiusPct} fill={p.bg} />
       <rect x="14" y="22" width="11.5" height="42" fill={p.fg} />


### PR DESCRIPTION
**Dev Team** · Closes #449.

## Summary

One attribute on the `BrandMark` `<svg>`, covering **all ten call sites across eight components**.

## Why an attribute and not a fix

The mark is blue — `#2E7BFF`, `#6FD3FF`, `#1C3E76` — and that is **the design**. I decoded the handoff's own `logo.png`: those exact values are in it, and frame `7a` references the asset three times at 26/30/22px. Converting it would mean redrawing the owner's brand mark, which is not dev's call.

## Why on the component and not in the spec's selector list

Because the failure this replaces **was** a selector list. QA's first version named two footer children and missed `.pf-footer-brand` — the same inline SVG, four hardcoded fills, somewhere else.

A list of places is wrong every time a screen gets converted and its logo is not added to it, and it fails as a **red suite on a decision nobody made**. The attribute is on the thing itself, so an eleventh call site inherits it.

Current ten: `LandingContent` ×2, `LandingTerminal` ×2, `TerminalNav` ×2, `LearnContent`, `NavDrawer`, `PlatformFooter`, `StaticShell`.

## The reversal path, stated now

If the mark is restated in palette colours, **delete the attribute and the spec entry together** — the check should go back to enforcing on it. An exemption with no removal condition becomes permanent by accident.

## How to test (QA)

Branch `chore/brand-mark-testid`.

1. **No visual change.** Every logo renders exactly as before — this adds an attribute and nothing else.
2. Inspect any nav logo: the `<svg>` carries `data-brand-mark`.
3. Switch the exemption from the selector list to `[data-brand-mark]` and `design-tokens.spec.ts` should pass on `/disclaimer`.
4. Worth confirming `closest('[data-brand-mark]')` matches from the `<rect>` children — that is the lookup that has to work.

## Risk level

**Low.** One attribute, no logic, no styling. Four gates green.