### PR TITLE
feat(api): /api/egress-ip, the instrument #368 has been missing

### DIFF
--- a/app/api/egress-ip/route.ts
+++ b/app/api/egress-ip/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+/*
+ * What IP does this service call the outside world from?
+ *
+ * #368: `binance-futures` returned 418 on `qa` AND `staging` simultaneously,
+ * with no deploy and no test traffic, while the same endpoint answered 200 from
+ * a laptop. Binance rate-limits by IP, so the standing hypothesis is that
+ * Render's free-plan services share an egress IP and the quota is being spent
+ * by traffic that is not ours.
+ *
+ * That hypothesis has survived two attempts to test it and both failed for the
+ * same reason - no instrument:
+ *
+ *   compare the services' outbound IPs   Render's API does not expose it
+ *   prod as a paid control               prod predates /api/market/klines, 404
+ *   unban-time discriminator             polled at 60s, observed gap 60s -
+ *                                        the resolution equalled the effect
+ *
+ * This is the instrument. Two curls answer it permanently:
+ *
+ *   curl https://liquidity-hq-qa.onrender.com/api/egress-ip
+ *   curl https://liquidity-hq-staging.onrender.com/api/egress-ip
+ *
+ *   same ip  -> shared egress, and no cache tuning on our side fixes it
+ *   differs  -> the hypothesis is dead and the cause is ours after all
+ *
+ * WHY THIS IS NOT A LEAK. The egress IP is not a secret: every host we call
+ * already sees it, which is the entire premise of the bug. Binance knows it,
+ * Bybit knows it, and so does anyone running a service we fetch from. Exposing
+ * it here tells an attacker nothing they could not learn by receiving one
+ * request from us.
+ *
+ * It reports the IP and nothing else - no headers, no env, no region, no
+ * service name. /api/version already sets the precedent for a deliberately
+ * minimal public diagnostic.
+ *
+ * DELETE THIS WHEN #368 CLOSES. It exists to answer one question. A diagnostic
+ * with no removal condition becomes permanent surface area by accident - the
+ * same reasoning as the brand-mark exemption on #449.
+ */
+
+/* Two providers, because a single one being down would look exactly like a
+   failed measurement, and a failed measurement is not evidence either way -
+   which is the standing rule that the drift check already follows. */
+const ECHO_SERVICES = [
+  'https://api.ipify.org?format=json',
+  'https://ifconfig.co/json',
+];
+
+export async function GET() {
+  for (const url of ECHO_SERVICES) {
+    try {
+      const res = await fetch(url, {
+        cache: 'no-store',
+        signal: AbortSignal.timeout(4000),
+      });
+      if (!res.ok) continue;
+      const body = await res.json() as { ip?: string };
+      if (!body?.ip) continue;
+      return NextResponse.json({ ip: body.ip, via: new URL(url).host });
+    } catch {
+      /* try the next one - see the note above on failed measurements */
+    }
+  }
+
+  /* Explicitly "we could not measure", never a blank or a zero. A caller must
+     be able to tell "no answer" apart from "an answer that happens to differ". */
+  return NextResponse.json(
+    { ip: null, error: 'could not determine egress ip' },
+    { status: 503 },
+  );
+}


### PR DESCRIPTION
**Dev Team** · For #368.

## Summary

One route reporting the IP this service calls out from. No headers, no env, no region, no service name.

## Why

#368's hypothesis — Render free-plan services share an egress IP, so Binance's per-IP limit is spent by traffic that is not ours — **has survived two attempts to test it, both failing for the same reason: no instrument.**

```
compare outbound IPs        Render's API does not expose it
prod as a paid control      prod predates /api/market/klines, 404s
unban-time discriminator    polled at 60s, observed gap 60s
                            the resolution equalled the effect
```

Two curls settle it permanently:

```
curl https://liquidity-hq-qa.onrender.com/api/egress-ip
curl https://liquidity-hq-staging.onrender.com/api/egress-ip

same ip  -> shared egress; no cache tuning on our side fixes it
differs  -> hypothesis dead, cause is ours
```

## Not a leak

**The egress IP is not a secret — every host we call already sees it**, which is the premise of the bug. Binance knows it. So does anything else we fetch from. Exposing it here tells an attacker nothing they could not learn by receiving one request from us. `/api/version` sets the precedent for a minimal public diagnostic.

## Failed measurement ≠ measurement

Two echo providers, because one being down looks identical to a failed measurement. Total failure returns **503 with `ip: null`**, never a blank — so "could not measure" cannot be mistaken for "measured and differs". Same rule the drift check follows.

## Delete when #368 closes

Written into the file. A diagnostic with no removal condition becomes permanent surface area by accident — same reasoning as the brand-mark exemption.

## How to test (QA)

Branch `feature/egress-ip-probe`.

1. Locally: `curl localhost:3000/api/egress-ip` → `{"ip":"…","via":"api.ipify.org"}`. Verified, 200.
2. **The measurement that matters needs it deployed to `qa` and `staging`** — on localhost both would report the same machine and prove nothing.
3. Confirm it returns only `ip` and `via`.

## Deployment note

This is useless until deployed to **both** non-prod services. Promotion and deploy are mine to run; **say when you want it and I will promote and deploy**, then post both IPs on #368.

Not proposing prod — `starter` plan may differ, and that is a separate question the owner would need to weigh in on.

## Risk level

**Low.** New route, nothing else touched. Two outbound calls only when it is hit; not on any page path.