### PR TITLE
fix(api): cache the egress-ip lookup so the diagnostic is not an amplifier

### DIFF
--- a/app/api/egress-ip/route.ts
+++ b/app/api/egress-ip/route.ts
@@ -50,7 +50,32 @@ const ECHO_SERVICES = [
   'https://ifconfig.co/json',
 ];
 
+/* IN-PROCESS CACHE, because this endpoint is an amplifier otherwise.
+ *
+ * Public, unauthenticated, and one outbound fetch per request - so anyone can
+ * make this service call out repeatedly, from the IP whose rate-limit budget is
+ * the entire subject of #368. QA caught it, and the irony is the point: a
+ * diagnostic for a rate-limit problem should not be a way to spend the quota.
+ *
+ * A cache rather than lib/rateLimit.ts, because caching is TRUE here. The
+ * egress IP does not change between requests within a process - if it did, this
+ * route could not answer the question it exists for. A rate limiter would
+ * refuse the second caller; a cache serves them the same correct answer.
+ *
+ * Module-level, so it resets on redeploy - which is exactly when the IP could
+ * legitimately have changed. */
+const CACHE_MS = 60_000;
+let cached: { ip: string; via: string; at: number } | null = null;
+
 export async function GET() {
+  const now = Date.now();
+  if (cached && now - cached.at < CACHE_MS) {
+    return NextResponse.json(
+      { ip: cached.ip, via: cached.via, cached: true },
+      { headers: { 'Cache-Control': 'public, max-age=60' } },
+    );
+  }
+
   for (const url of ECHO_SERVICES) {
     try {
       const res = await fetch(url, {
@@ -60,7 +85,11 @@ export async function GET() {
       if (!res.ok) continue;
       const body = await res.json() as { ip?: string };
       if (!body?.ip) continue;
-      return NextResponse.json({ ip: body.ip, via: new URL(url).host });
+      cached = { ip: body.ip, via: new URL(url).host, at: now };
+      return NextResponse.json(
+        { ip: body.ip, via: cached.via, cached: false },
+        { headers: { 'Cache-Control': 'public, max-age=60' } },
+      );
     } catch {
       /* try the next one - see the note above on failed measurements */
     }
@@ -68,8 +97,11 @@ export async function GET() {
 
   /* Explicitly "we could not measure", never a blank or a zero. A caller must
      be able to tell "no answer" apart from "an answer that happens to differ". */
+  /* A failure is NOT cached. Caching it would turn one bad minute into sixty
+     seconds of false 'could not measure', and the whole point of the 503 is
+     that it means something specific. */
   return NextResponse.json(
     { ip: null, error: 'could not determine egress ip' },
-    { status: 503 },
+    { status: 503, headers: { 'Cache-Control': 'no-store' } },
   );
 }


### PR DESCRIPTION
**Dev Team** · Follow-up to #455, taking QA's amplification note.

## The problem

Public, unauthenticated, one outbound fetch per request — so anyone could make this service call out repeatedly, **from the IP whose rate-limit budget is the entire subject of #368**. A diagnostic for a rate-limit problem should not be a way to spend the quota.

## Cache, not rate limit — and the distinction matters

**Caching is true here.** The egress IP does not change between requests within a process; if it did, the route could not answer the question it exists for.

A rate limiter would **refuse** the second caller. A cache **serves them the same correct answer**. `lib/rateLimit.ts` exists and would have worked, but it would be guarding against a caller doing nothing wrong.

Module-level, so it resets on redeploy — which is exactly when the IP could legitimately have changed.

## Failures are not cached

Caching a 503 would turn one bad minute into sixty seconds of false "could not measure", and the point of that status is that it means something specific. It sends `no-store`.

## How to test (QA)

```
curl localhost:3000/api/egress-ip   -> {"ip":"…","cached":false}
curl again                          -> {"ip":"…","cached":true}
curl again                          -> {"ip":"…","cached":true}
```

Verified locally — only the first makes an outbound call. The `cached` field is deliberate: it makes the behaviour observable rather than something you have to trust.

## Risk level

**Low.** One route, no other surface. Four gates green.