### PR TITLE
docs(qa): record the artifact discriminator and the settle-time audit

### DIFF
--- a/qa/STATUS.md
+++ b/qa/STATUS.md
@@ -94,6 +94,54 @@ gh issue list --state open
 
 ## Standing risks
 
+- **A design frame may not be authored — parts of it can be mouse drags.**
+  Measured 2026-08-15. "The frame wins over the README" assumed frames are
+  authored; `Monochrome Terminal.dc.html` has been edited in place, so parts of
+  it are not.
+
+  The discriminator is **a space after the colon in an inline style**:
+
+  ```
+  no space after colon :  7050   (authored)
+  space after colon    :    36   (editor)      0.51%
+  ```
+
+  Inside frame `1a` all 36 land on five lines, and they are exactly the values
+  that contradict their own siblings — a rail at `304px` where three sibling
+  frames say `352`, a verdict band `1142px` wide inside a `1440px` shell, a
+  hardcoded `height: 705px` on a flex column.
+
+  > **The frame wins, EXCEPT where a value carries the editor signature.** Then
+  > it is evidence of a drag and needs a decision, not a copy.
+
+  **I got this backwards first**, told dev their `304` rail was correct and the
+  README wrong, and had to retract it. The designer caught it.
+
+  **`design_handoff_liquidityhq_terminal/` is kept BECAUSE it is contaminated.**
+  It is the only positive control for the artifact detector. Do not tidy it away
+  as superseded — a scan of a clean file alone returns `0`, which is
+  indistinguishable from a detector that is not working.
+
+- **Settle times are adequate, measured — not a risk, recorded so nobody
+  re-derives it.** 2026-08-15, 250ms sampling on localhost:
+
+  ```
+  /           settles  500ms      shortest spec settle in the suite: 1500ms
+  /arena      settles  750ms      (a11y-auth)
+  /dashboard  settles 1000ms
+  ```
+
+  Everything has 50%+ headroom, most has 2-4x. **No spec measures a shell.**
+
+  What made it look risky: `/arena` at `domcontentloaded` is **719 characters**,
+  less than its own raw HTML, against 3,138 once settled. That is real, and it is
+  a measurement point nothing asserts at — every sweep waits after the goto.
+
+  **The caveat that stands: this is localhost.** The headroom is a ratio, not a
+  guarantee. If a settle-related flake ever appears, `a11y-auth` at 1500ms has
+  the least room and is where to look first.
+
+
 - **A QA spec branched from an UNMERGED dev branch merges that branch's app code
   with it.** Measured 2026-08-14: `test/contrast-names-the-site` was cut from
   `feature/gold-primary` so the spec could test the recolour. Merging the spec PR


### PR DESCRIPTION
## Summary

Two entries into `qa/STATUS.md` → Standing risks. Both are things the next person would otherwise re-derive, and one of them I got backwards first.

## 1. A design frame may not be authored

"The frame wins over the README" assumed frames are authored. Parts of `Monochrome Terminal.dc.html` are mouse drags:

```
no space after colon :  7050   (authored)
space after colon    :    36   (editor)      0.51%
```

All 36 cluster on **five lines** inside frame `1a`, and they are exactly the values that contradict their own siblings — a `304px` rail where three sibling frames say `352`, a `1142px` verdict band inside a `1440px` shell, a hardcoded `height: 705px` on a flex column.

> **The frame wins, EXCEPT where a value carries the editor signature.** Then it is evidence of a drag and needs a decision, not a copy.

**I told dev their 304px rail was correct and the README wrong, then retracted it.** The designer caught it.

It also records why the contaminated file is **kept**: it is the only positive control for the artifact detector. Scanning a clean file alone returns `0`, which is indistinguishable from a detector that is not working.

## 2. The settle-time audit — a negative result

After the #439 lifecycle work I wrote that settle times were unaudited and that a route 'needs somewhere between 0.7s and 15s'. That reads as a risk. **Measured at 250ms resolution, it is not one:**

```
/           settles  500ms      shortest spec settle in the suite: 1500ms
/arena      settles  750ms      (a11y-auth)
/dashboard  settles 1000ms
```

50%+ headroom everywhere, 2–4× mostly. **No spec measures a shell.**

What made it look risky — `/arena` at `domcontentloaded` being **719 characters**, less than its own raw HTML — is real, and is a measurement point nothing asserts at. Every sweep waits after the goto.

**The localhost caveat is recorded**, along with which spec has the least headroom if a settle-related flake ever appears.

## Why a negative result is worth a PR

Because I made the claim publicly, and an unretracted risk gets re-investigated by whoever reads it next. **The measurement that shows there is no problem is the artifact worth keeping.**

## How to test (QA)

Docs only — read the diff.

## Risk level

**Low.** No code, no spec behaviour changes.

---
**QA Team**