### PR TITLE
feat(arena): the terminal Arena, built to the designer's spec

### DIFF
--- a/__tests__/arenaColour.test.mts
+++ b/__tests__/arenaColour.test.mts
@@ -1,0 +1,124 @@
+/* Arena colour rules — spec §Colour is data, criteria 12-18.
+ *
+ * QA's coverage map: no stub exists to drive a coloured state, so inspection is
+ * the only check and a defect reaches dev unopposed. These tests are that
+ * opposition.
+ *
+ * The thing being defended against is specific and it is NOT "wrong colours".
+ * It is a page where everything signed is coloured — which looks better, is
+ * wrong, and passes design-tokens, contrast and the palette check, because
+ * --green is a legal token everywhere.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  evidencePaint, verdictPaint, factorPaint, mtfPaint, structurePaint,
+  emaConditionPaint, clusterPaint, EMA_VALUE_COLOUR, LEVEL_COLOUR,
+} from '../lib/arenaColour.ts';
+
+/* ── 1. the rule that generalises: sign is not direction ─────────────────── */
+
+test('a POSITIVE value that did not fire renders --txt, not green', () => {
+  // The spec's own table: OI 1H +2.31%, VWAP +0.42%, BASIS +0.18% — all
+  // positive, all --txt. This is the whole defect in one assertion.
+  const quiet = evidencePaint(null, true);
+  assert.equal(quiet.value, 'var(--txt)');
+  assert.equal(quiet.marker, 'var(--mark-idle)');
+});
+
+test('a positive value that fired as a WARNING renders red', () => {
+  // FUNDING 8H is +0.0132% and red — crowded long is a warning.
+  assert.equal(evidencePaint('red', true).value, 'var(--red)');
+});
+
+test('a missing value is --txt2 and never a zero', () => {
+  const none = evidencePaint(null, false);
+  assert.equal(none.value, 'var(--txt2)');
+  assert.equal(none.marker, 'var(--mark-idle)');
+});
+
+/* ── 2. verdict follows the read ─────────────────────────────────────────── */
+
+test('verdict colour switches with direction and is never hardcoded green', () => {
+  assert.equal(verdictPaint('bull'), 'var(--green)');
+  assert.equal(verdictPaint('bear'), 'var(--red)');
+  assert.equal(verdictPaint('neutral'), 'var(--txt2)');
+  assert.equal(verdictPaint(null), 'var(--txt2)');
+});
+
+/* ── 3. a cleared penalty is quiet, not green ────────────────────────────── */
+
+test('an INACTIVE penalty is --txt3, not green', () => {
+  // A cleared risk is a good outcome. Green would mean a factor voted bullish,
+  // and a penalty that did not fire cast no vote — rendering it green makes an
+  // absent risk look like a positive signal.
+  const clear = factorPaint({ kind: 'penalty', active: false });
+  assert.equal(clear.value, 'var(--txt3)');
+  assert.notEqual(clear.value, 'var(--green)');
+});
+
+test('an ACTIVE penalty is accent with a tinted row, not red', () => {
+  const hit = factorPaint({ kind: 'penalty', active: true });
+  assert.equal(hit.value, 'var(--accent)');
+  assert.equal(hit.background, 'rgba(217,166,38,.06)');
+});
+
+test('a neutral directional factor is quiet', () => {
+  assert.equal(factorPaint({ kind: 'directional', dir: 'neutral' }).value, 'var(--txt3)');
+});
+
+/* ── 4. thresholds, not midpoints ────────────────────────────────────────── */
+
+test('RSI 50 is NEUTRAL - the threshold is 57/43, not 50', () => {
+  // The easy wrong version treats >50 as bullish, which colours half the
+  // timeframes green on an ordinary day.
+  assert.equal(mtfPaint(50).label, 'NEUTRAL');
+  assert.equal(mtfPaint(56).label, 'NEUTRAL');
+  assert.equal(mtfPaint(58).label, 'BULLISH');
+  assert.equal(mtfPaint(42).label, 'BEARISH');
+});
+
+test('MTF with no data is neutral-coloured, not absent', () => {
+  assert.equal(mtfPaint(null).colour, 'var(--txt3)');
+});
+
+/* ── 5. direction only, never significance ───────────────────────────────── */
+
+test('structure colour carries direction; a CHoCH is not louder than a BOS', () => {
+  assert.equal(structurePaint('up'), 'var(--green)');
+  assert.equal(structurePaint('down'), 'var(--red)');
+});
+
+test('cluster colour takes SIDE, not size', () => {
+  // Below spot is long liquidations, above is short. Scaling by size would
+  // make a big cluster read as a strong signal.
+  assert.equal(clusterPaint(113_400, 115_284), 'var(--red)');
+  assert.equal(clusterPaint(119_600, 115_284), 'var(--green)');
+});
+
+/* ── 6. things that are never signals ────────────────────────────────────── */
+
+test('EMA average values and price levels are always --txt', () => {
+  // Line colour is a chart concern; a price is not a signal.
+  assert.equal(EMA_VALUE_COLOUR, 'var(--txt)');
+  assert.equal(LEVEL_COLOUR, 'var(--txt)');
+});
+
+test('EMA conditions colour the glyph, and a fail dims the label', () => {
+  assert.deepEqual(emaConditionPaint(true),  { glyph: '✓', glyphColour: 'var(--green)', labelColour: 'var(--txt)' });
+  assert.deepEqual(emaConditionPaint(false), { glyph: '✕', glyphColour: 'var(--red)',   labelColour: 'var(--txt2)' });
+});
+
+/* ── 7. control ──────────────────────────────────────────────────────────── */
+
+test('CONTROL: the module can return quiet AND signed colours', () => {
+  // Guards both failure directions. A build that colours everything passes
+  // every "is it green" assertion; a build that colours nothing passes every
+  // "is it --txt" one. Both must be impossible.
+  const seen = new Set([
+    evidencePaint(null, true).value,
+    evidencePaint('green', true).value,
+    evidencePaint('red', true).value,
+  ]);
+  assert.equal(seen.size, 3, 'evidence paint collapses distinct states into one colour');
+});

--- a/__tests__/arenaTimeframes.test.mts
+++ b/__tests__/arenaTimeframes.test.mts
@@ -1,0 +1,91 @@
+/* Arena's timeframe gating — spec §Timeframe row, criteria 20-23.
+ *
+ * QA's coverage map puts these in the group with no automated check, where
+ * "a defect reaches dev unopposed". These tests are that opposition.
+ *
+ * The paywall half matters most: this project shipped ConfluenceScore unguarded
+ * for one commit, and every gate passed, because nothing asserted entitlement.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { tfState, forcedTimeframe, tfClickIntent, gatedHint, TF_ROW } from '../lib/arenaTimeframes.ts';
+
+/* ── 1. the three states ─────────────────────────────────────────────────── */
+
+test('free user: 1m/5m/15m are gated, the rest available', () => {
+  for (const tf of ['1m', '5m', '15m']) {
+    assert.equal(tfState(tf, '1h', false), 'gated', `${tf} should be gated for a free user`);
+  }
+  for (const tf of ['30m', '2h', '4h', '1d']) {
+    assert.equal(tfState(tf, '1h', false), 'available', `${tf} should be available`);
+  }
+});
+
+test('pro user: nothing is gated', () => {
+  for (const tf of TF_ROW) {
+    assert.notEqual(tfState(tf, '1h', true), 'gated', `${tf} must not be gated for Pro`);
+  }
+});
+
+test('ACTIVE WINS over gated - the chip you are on is never a padlock', () => {
+  // A lapsed Pro sitting on 5m must not see a padlock on the timeframe the
+  // chart is currently showing. The padlock would describe a state the screen
+  // contradicts. forcedTimeframe is what stops them being there at all.
+  assert.equal(tfState('5m', '5m', false), 'active');
+});
+
+/* ── 2. the forced fallback ──────────────────────────────────────────────── */
+
+test('a free user asking for a gated timeframe is moved to 1h', () => {
+  // Bookmarks, shared links and lapsed subscriptions all land here.
+  assert.equal(forcedTimeframe('5m', false), '1h');
+  assert.equal(forcedTimeframe('1m', false), '1h');
+});
+
+test('an available timeframe is never rewritten', () => {
+  assert.equal(forcedTimeframe('4h', false), '4h');
+  assert.equal(forcedTimeframe('1d', false), '1d');
+});
+
+test('pro keeps whatever was asked for', () => {
+  assert.equal(forcedTimeframe('1m', true), '1m');
+  assert.equal(forcedTimeframe('5m', true), '5m');
+});
+
+/* ── 3. what a click does — the paywall half ─────────────────────────────── */
+
+test('a gated click opens the modal and does NOT select', () => {
+  // The spec is explicit: clicking a gated chip must not move the chart.
+  // Selecting and then showing a modal would give away a frame of the thing
+  // being sold, and leave the chart somewhere the user cannot return from.
+  assert.equal(tfClickIntent('5m', false), 'upgrade');
+  assert.equal(tfClickIntent('1m', false), 'upgrade');
+});
+
+test('an ungated click selects, for free and pro alike', () => {
+  assert.equal(tfClickIntent('4h', false), 'select');
+  assert.equal(tfClickIntent('5m', true),  'select');
+});
+
+/* ── 4. legible without colour ───────────────────────────────────────────── */
+
+test('the free user gets an explicit hint naming the gated timeframes', () => {
+  // --txt2 and --txt3 are close enough that a colour-only distinction is not
+  // one. The padlock and this string carry the state.
+  assert.equal(gatedHint(false), '1M · 5M · 15M NEED PRO');
+});
+
+test('pro gets no hint at all', () => {
+  assert.equal(gatedHint(true), null);
+});
+
+/* ── 5. control ──────────────────────────────────────────────────────────── */
+
+test('CONTROL: gating actually distinguishes free from pro', () => {
+  // Guards against a version where `entitled` is ignored - every assertion
+  // about Pro would pass on a build that gates nobody, which is the leak.
+  const free = TF_ROW.map(tf => tfState(tf, '1h', false));
+  const pro  = TF_ROW.map(tf => tfState(tf, '1h', true));
+  assert.notDeepEqual(free, pro, 'free and pro see the same row - entitlement is not wired');
+  assert.ok(free.includes('gated'), 'nothing is ever gated');
+});

--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -1305,6 +1305,15 @@ function ArenaContent() {
             ? <LiqHeatmap levels={store.btcLiqLevels} currentPrice={store.coins['btc']?.price ?? 0} />
             : null}
           usageMeter={<UsageMeter />}
+          /* Clusters from the data the page already loads for the heatmap.
+             BTC only, since that is where btcLiqLevels exists - other coins
+             render "No clusters in range" rather than a fabricated ladder. */
+          clusters={selectedCoin === 'btc'
+            ? [...store.btcLiqLevels].sort((a, b) => b.amount - a.amount).slice(0, 8)
+                .map(l => ({ price: l.price, usd: l.amount }))
+            : []}
+          why={result?.reasoning ?? null}
+          history={history.map(h => ({ time: h.time, verdict: h.signal, conf: h.confidence }))}
         />
         <UpgradeGateModal
           open={upgradeGate !== null}

--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -1291,6 +1291,13 @@ function ArenaContent() {
           }}
           chart={arenaChart}
           hintBand={<PageHint pageKey="arena" title={t('ARENA_HINT_TITLE')} body={t('ARENA_HINT_BODY')} />}
+          /* Snapshot band, region 4: the coin mark, five stat cells, and the
+             higher-timeframe badge. The five cells are ABSENT at mobile, not
+             hidden - the component owns that, so it is passed either way and
+             the layout decides. */
+          coinIcon={<CoinIcon coin={selectedCoin} size={32} />}
+          snapshot={<CoinMarketSnapshot coin={selectedCoin} />}
+          tfBadge={<HigherTfMoveBadge coin={selectedCoin} tf={readTf} signalDir={emaSignal.signalDir} />}
           confluence={authLoading || entitled
             ? <ConfluenceScore coin={selectedCoin} emaSignal={emaSignal} jpyUsd={jpyUsd} structure={chartStructure} />
             : <LockedFeatureCard

--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -31,6 +31,8 @@ import { useEMAStrategy, strategyToGrokLine, STRATEGY_LOADING, StrategySignal, D
 import { computeDistributionScore, distributionColor, DistributionInputs } from '@/lib/distribution';
 import { withAlpha } from '@/lib/color';
 import PageHint from '@/components/PageHint';
+import ArenaTerminal from '@/components/ArenaTerminal';
+import { useDesignMode } from '@/components/DesignModeProvider';
 import CoinMarketSnapshot from '@/components/CoinMarketSnapshot';
 import CoinIcon from '@/components/CoinIcon';
 import { useLabels } from '@/lib/labels';
@@ -170,6 +172,7 @@ function ArenaContent() {
   const { store } = useMarket();
   const { latestHeadlines, econEvents, whaleAlerts } = useNews();
   const { user, loading: authLoading, entitled } = useAuth();
+  const designMode = useDesignMode();
   const { settings, update } = useSettings();
   const searchParams = useSearchParams();
   const [selectedCoin, setSelectedCoin] = useState<CoinId>(() => {
@@ -1247,6 +1250,70 @@ function ArenaContent() {
   const visibleScannerRows = scannerSearch
     ? scannerRows.filter(r => r.c.toLowerCase().includes(scannerSearch.toLowerCase()))
     : scannerRows;
+
+  /* One chart element, used by whichever layout renders. Constructing a
+     second, plainer one inside the terminal component is what put two charts
+     on this page before - it carried none of the read result, the EMA overlay,
+     the draggable alerts or the structure callback. */
+  const arenaChart = <KLineProChart coin={selectedCoin} tf={readTf} onTfChange={handleTfChange} result={result} emaSignal={emaSignal} chartAlerts={chartAlerts} onAlertMove={handleAlertMove} gexLevels={selectedCoin === 'btc' ? { flip: store.btcGexFlip, maxPain: store.btcMaxPain } : null} onStructure={setChartStructure} />;
+
+  /* The terminal Arena (#413), behind ?design=terminal. Built to
+     design_handoff_arena/specs/arena.md.
+
+     EVERY PANEL IS PASSED IN ALREADY GUARDED. The entitlement check lives here,
+     at the call site, not inside ArenaTerminal - moving a panel moves its
+     markup and leaves its guard behind, which shipped once and showed free
+     users the paid confluence score.
+
+     The two Pro panels are deliberately asymmetric, per spec §Pro surfaces:
+     Confluence degrades to a LockedFeatureCard because it is the panel worth
+     paying for and the main column is wide enough for the card to read as an
+     offer; Absorption renders NOTHING, because a second locked card beside the
+     first is noise. That asymmetry is production's behaviour and must survive. */
+  if (designMode === 'terminal') {
+    const verdictDir = result?.signal?.includes('BULLISH') ? 'bull' as const
+                     : result?.signal?.includes('BEARISH') ? 'bear' as const
+                     : result ? 'neutral' as const : null;
+    return (
+      <>
+        <ArenaTerminal
+          coin={selectedCoin}
+          tf={readTf}
+          onTfChange={t => setReadTf(t as ChartTf)}
+          onUpgrade={() => setUpgradeGate(t('ARENA_CONFLUENCE_GATE_FEATURE_LABEL'))}
+          entitled={entitled}
+          authLoading={authLoading}
+          verdict={result ? { label: result.signal, dir: verdictDir, confidence: result.confidence } : null}
+          levels={{
+            entry:  emaSignal.ema20_4h ?? null,
+            stop:   emaSignal.sl ?? null,
+            target: emaSignal.tp ?? null,
+          }}
+          chart={arenaChart}
+          hintBand={<PageHint pageKey="arena" title={t('ARENA_HINT_TITLE')} body={t('ARENA_HINT_BODY')} />}
+          confluence={authLoading || entitled
+            ? <ConfluenceScore coin={selectedCoin} emaSignal={emaSignal} jpyUsd={jpyUsd} structure={chartStructure} />
+            : <LockedFeatureCard
+                title={t('ARENA_CONFLUENCE_GATE_TITLE')}
+                description={t('ARENA_CONFLUENCE_GATE_DESC')}
+                onUnlock={() => setUpgradeGate(t('ARENA_CONFLUENCE_GATE_FEATURE_LABEL'))}
+              />}
+          multiTf={<MultiTFAlignment coin={selectedCoin} />}
+          absorption={entitled ? <AbsorptionDetector coin={selectedCoin} onData={handleAbsData} /> : null}
+          emaSignal={<EMASignal signal={emaSignal} tf={readTf} coin={selectedCoin} />}
+          heatmap={selectedCoin === 'btc' && store.btcLiqLevels.length > 0
+            ? <LiqHeatmap levels={store.btcLiqLevels} currentPrice={store.coins['btc']?.price ?? 0} />
+            : null}
+          usageMeter={<UsageMeter />}
+        />
+        <UpgradeGateModal
+          open={upgradeGate !== null}
+          onClose={() => setUpgradeGate(null)}
+          feature={upgradeGate ?? undefined}
+        />
+      </>
+    );
+  }
 
   return (
     <div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -6155,3 +6155,17 @@ main.app-content[data-chrome="none"] {
   font-family: var(--font-sans); font-size: 12px; color: var(--txt4); padding: 10px 16px;
 }
 [data-design="terminal"] .at-rail-spacer { flex: 1; }
+
+/* Region 4, snapshot band: 330 coin cell | stat cells | 230 badge cell. */
+[data-design="terminal"] .at-coincell {
+  flex: 0 0 330px; display: flex; align-items: center; gap: 12px;
+  padding: 0 18px; border-right: 1px solid var(--bdr3);
+}
+[data-design="terminal"] .at-coinsym {
+  font-family: var(--font-mono); font-size: 15px; font-weight: 700; color: var(--txt);
+}
+[data-design="terminal"] .at-snapcells { flex: 1; min-width: 0; display: flex; align-items: center; }
+[data-design="terminal"] .at-badgecell {
+  flex: 0 0 230px; display: flex; align-items: center; padding: 0 18px;
+  border-left: 1px solid var(--bdr3);
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -6005,6 +6005,29 @@ main.app-content[data-chrome="none"] {
 }
 [data-design="terminal"] .at-panel { border-bottom: 1px solid var(--bdr); }
 
+/* ── region 2: ticker strip 34 ── */
+[data-design="terminal"] .ticker-wrap {
+  height: 34px; flex-shrink: 0; overflow-x: auto; overflow-y: hidden;
+  display: flex; align-items: stretch;
+  border-bottom: 1px solid var(--bdr);
+  font-family: var(--font-mono); font-size: 11px;
+  background: var(--bg0); margin-bottom: 0; scrollbar-width: none;
+}
+[data-design="terminal"] .ticker-wrap::-webkit-scrollbar { display: none; }
+[data-design="terminal"] .at-tk-cell {
+  display: flex; align-items: center; gap: 8px;
+  padding: 0 16px; border-right: 1px solid var(--bdr3); flex-shrink: 0;
+}
+[data-design="terminal"] .at-tk-sym {
+  color: var(--txt2); font-weight: 600; letter-spacing: .06em;
+}
+[data-design="terminal"] .at-tk-px {
+  color: var(--txt); font-variant-numeric: tabular-nums;
+}
+[data-design="terminal"] .at-tk-chg {
+  font-variant-numeric: tabular-nums;
+}
+
 /* ── region 3-4: hint band 36, snapshot band 88 ── */
 [data-design="terminal"] .at-snapband {
   display: flex; align-items: stretch; min-height: 88px;

--- a/app/globals.css
+++ b/app/globals.css
@@ -3276,6 +3276,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 
 [data-theme="light"] .frh-row:hover { background: rgba(0,0,0,0.03) !important; }
 [data-theme="light"] .frh-row.on    { background: var(--purple-bg) !important; box-shadow: inset 3px 0 0 var(--accent) !important; }
+[data-theme="light"] .frh-sig-hint  { color: var(--txt3); }
 
 .frh-split        { display: grid; grid-template-columns: minmax(0,1fr) minmax(0,1fr); gap: 12px; align-items: start; margin-bottom: 10px; }
 .frh-list-scroll  { max-height: 500px; overflow-y: auto; overflow-x: auto; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -6226,3 +6226,21 @@ main.app-content[data-chrome="none"] {
   background: transparent; border: 0; padding: 10px 16px;
 }
 [data-design="terminal"] .at-panelbody .edge-grid { gap: 0; margin: 0; }
+
+/* KLineProChart's own timeframe buttons are suppressed on the terminal Arena
+   (#461). The spec gives this screen ONE timeframe selector - region 6, the
+   42px row with three states and padlocks - and the chart shipped a second one
+   inside its toolbar, so /arena had two controls for the same state sitting
+   inches apart, with different styling and different gating.
+
+   Only the TF BUTTONS go. The rest of the toolbar - draw tools, S/R, structure,
+   fullscreen - is chart functionality with no equivalent in the terminal row,
+   and removing it would delete features to fix a duplication.
+
+   Suppressed, not deleted: the same chart renders on other screens where its
+   own selector is the only one. */
+[data-design="terminal"] .at-chart .klc-tf-btn,
+[data-design="terminal"] .at-mchart .klc-tf-btn { display: none; }
+/* The scale badge sits with them and reads as orphaned once they are gone. */
+[data-design="terminal"] .at-chart .klc-scale-badge,
+[data-design="terminal"] .at-mchart .klc-scale-badge { display: none; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -6169,3 +6169,42 @@ main.app-content[data-chrome="none"] {
   flex: 0 0 230px; display: flex; align-items: center; padding: 0 18px;
   border-left: 1px solid var(--bdr3);
 }
+
+/* CoinMarketSnapshot, re-expressed for the terminal band (#413).
+ *
+ * The component ships .edge-grid / .edge-card: an auto-fit grid of rounded
+ * cards with their own borders and gaps. Dropped into the 88px band it WRAPPED
+ * to 253px - QA measured it. Placing a production component in a new layout is
+ * not the same as moving it into the new design, and this is what the
+ * difference looks like.
+ *
+ * Restyled in place rather than reimplemented: the component keeps its data,
+ * its labels and its legacy appearance everywhere else, and only the terminal
+ * band gets the spec's geometry - five equal cells, one row, hairline-separated.
+ *
+ * The ellipsis override is not cosmetic. Labels here are DB-driven and change
+ * length at runtime, and spec §Honest labels forbids truncation on this route -
+ * a clipped label reads as a different signal. */
+[data-design="terminal"] .at-snapband { height: 88px; }
+[data-design="terminal"] .at-snapcells .edge-grid {
+  display: grid; grid-template-columns: repeat(5, 1fr);
+  gap: 0; margin: 0; width: 100%; height: 100%;
+}
+[data-design="terminal"] .at-snapcells .edge-card {
+  background: transparent; border: 0; border-right: 1px solid var(--bdr3);
+  padding: 0 18px; display: flex; flex-direction: column; justify-content: center; gap: 4px;
+  min-height: 0;
+}
+[data-design="terminal"] .at-snapcells .edge-card:last-child { border-right: 0; }
+[data-design="terminal"] .at-snapcells .edge-card-label {
+  font-size: 9.5px; letter-spacing: .16em; color: var(--txt3); margin: 0;
+  /* No truncation on this route - labels are DB-driven. */
+  overflow: visible; text-overflow: clip; white-space: normal;
+}
+[data-design="terminal"] .at-snapcells .edge-card-value {
+  font-family: var(--font-mono); font-size: 14px; font-weight: 600; color: var(--txt);
+  font-variant-numeric: tabular-nums;
+}
+[data-design="terminal"] .at-snapcells .edge-card-signal {
+  font-family: var(--font-mono); font-size: 10px; color: var(--txt4);
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -296,7 +296,7 @@ body::after {
 .app-bar {
   position: fixed; top: var(--banner-h); left: 0; right: 0; z-index: 1000;
   background: #090b16;
-  border-bottom: 0.5px solid rgba(90,150,255,0.1);
+  border-bottom: 0.5px solid rgba(var(--accent-rgb), 0.1);
   padding: 0 1rem;
 }
 .app-bar-inner {
@@ -902,7 +902,7 @@ body[data-rpm-level="high"]::before {
   border-radius: var(--radius-chip); text-decoration: none; transition: all 0.15s;
   border: 0.5px solid transparent; white-space: nowrap;
 }
-.desktop-nav-item:hover { color: var(--txt); background: rgba(90,150,255,0.07); }
+.desktop-nav-item:hover { color: var(--txt); background: var(--accent-bg); }
 .desktop-nav-item.on { color: var(--on-accent); background: var(--accent-solid); font-weight: 600; }
 
 @media (min-width: 768px) {
@@ -3757,7 +3757,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   cursor: pointer; font-family: inherit; transition: background 0.1s;
 }
 .lang-nav-item:hover { background: rgba(255,255,255,0.05); color: var(--txt); }
-.lang-nav-item.on { color: var(--accent-2); font-weight: 700; background: rgba(90,150,255,0.08); }
+.lang-nav-item.on { color: var(--accent-2); font-weight: 700; background: var(--accent-bg); }
 
 /* Light theme overrides */
 [data-theme="light"] .auth-signin-btn:hover { background: rgba(0,0,0,0.05); color: var(--txt); }

--- a/app/globals.css
+++ b/app/globals.css
@@ -6117,3 +6117,41 @@ main.app-content[data-chrome="none"] {
   [data-design="terminal"] .at-ev { padding: 10px 14px; }
   [data-design="terminal"] .at-root { padding-bottom: 60px; }
 }
+
+/* Rail panels — clusters, Why, session history. Rows use --bdr3 (list
+   hairline), never --bdr, which is structural. */
+[data-design="terminal"] .at-cl {
+  display: grid; grid-template-columns: 48px minmax(0, 1fr) 46px;
+  align-items: center; gap: 8px; padding: 7px 16px;
+  border-bottom: 1px solid var(--bdr3);
+}
+[data-design="terminal"] .at-cl-px,
+[data-design="terminal"] .at-cl-usd {
+  font-family: var(--font-mono); font-size: 11px; color: var(--txt);
+  font-variant-numeric: tabular-nums;
+}
+[data-design="terminal"] .at-cl-usd { text-align: right; }
+[data-design="terminal"] .at-cl-bar { display: block; height: 8px; background: var(--mark-idle); }
+[data-design="terminal"] .at-cl-fill { display: block; height: 8px; }
+[data-design="terminal"] .at-why {
+  font-family: var(--font-sans); font-size: 12.5px; line-height: 1.6;
+  color: var(--txt2); margin: 0; padding: 12px 16px; text-wrap: pretty;
+}
+[data-design="terminal"] .at-hrow {
+  display: grid; grid-template-columns: 44px minmax(0, 1fr) 28px;
+  align-items: center; gap: 8px; padding: 8px 16px;
+  border-bottom: 1px solid var(--bdr3);
+}
+[data-design="terminal"] .at-h-time,
+[data-design="terminal"] .at-h-conf {
+  font-family: var(--font-mono); font-size: 11px; color: var(--txt2);
+  font-variant-numeric: tabular-nums;
+}
+[data-design="terminal"] .at-h-conf { text-align: right; }
+[data-design="terminal"] .at-h-verdict {
+  font-family: var(--font-mono); font-size: 11px; font-weight: 600; color: var(--txt);
+}
+[data-design="terminal"] .at-empty {
+  font-family: var(--font-sans); font-size: 12px; color: var(--txt4); padding: 10px 16px;
+}
+[data-design="terminal"] .at-rail-spacer { flex: 1; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -6208,3 +6208,21 @@ main.app-content[data-chrome="none"] {
 [data-design="terminal"] .at-snapcells .edge-card-signal {
   font-family: var(--font-mono); font-size: 10px; color: var(--txt4);
 }
+
+/* Body panels wear the spec's header (§Panel header: "every panel in the body
+   uses it"). The passed-in components draw their own, so theirs is suppressed
+   here and ArenaTerminal's BodyPanel supplies the pattern - height 30, 0 16px,
+   10px mono/700 .16em, optional PRO chip.
+   Suppressed rather than deleted: these components render on other screens
+   where their headers are correct. */
+[data-design="terminal"] .at-bodypanel .sms-header,
+[data-design="terminal"] .at-bodypanel .ms-header,
+[data-design="terminal"] .at-bodypanel .abs-header { display: none; }
+[data-design="terminal"] .at-panelbody { padding: 0; }
+/* The cards these components ship lose their frames inside a panel that
+   already has one - otherwise every row reads as its own region. */
+[data-design="terminal"] .at-panelbody .card,
+[data-design="terminal"] .at-panelbody .edge-card {
+  background: transparent; border: 0; padding: 10px 16px;
+}
+[data-design="terminal"] .at-panelbody .edge-grid { gap: 0; margin: 0; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -5951,3 +5951,169 @@ main.app-content[data-chrome="none"] {
   padding-bottom: 0;
   max-width: none;
 }
+
+/* ══ Arena, Monochrome Terminal — Arena 1a.dc.html · 1a (#413) ═════════════
+   Spec: design-handoff-dir/design_handoff_arena/specs/arena.md
+
+   RAIL IS 352, not 304. The 304 in the superseded frame is a
+   direct-manipulation artifact - three sibling frames say 352, and it carried
+   a hardcoded height on a flex column, which nobody authors. Recorded here
+   because a previous build shipped 304 from a correct measurement of a wrong
+   frame.
+
+   HAIRLINES: --bdr is STRUCTURAL only (regions, panel borders). Rows inside
+   panels and rail lists use --bdr3 (#16191b). Getting these the wrong way
+   round makes every list look like a set of regions.
+
+   RADIUS 0 EVERYWHERE, no exceptions. */
+
+[data-design="terminal"] .at-root,
+[data-design="terminal"] .at-root * { border-radius: 0 !important; }
+
+[data-design="terminal"] .at-root {
+  background: var(--bg0);
+  color: var(--txt);
+  font-family: var(--font-sans);
+}
+
+/* ── shared type ── */
+[data-design="terminal"] .at-micro {
+  font-family: var(--font-mono); font-size: 10px; letter-spacing: .16em;
+  text-transform: uppercase; color: var(--txt3);
+}
+
+/* ── panel headers: body 30, rail 28 ── */
+[data-design="terminal"] .at-phead,
+[data-design="terminal"] .at-rhead {
+  display: flex; align-items: center; gap: 8px;
+  padding: 0 16px; border-bottom: 1px solid var(--bdr);
+}
+[data-design="terminal"] .at-phead { height: 30px; }
+[data-design="terminal"] .at-rhead { height: 28px; }
+[data-design="terminal"] .at-ptitle {
+  font-family: var(--font-mono); font-size: 10px; font-weight: 700;
+  letter-spacing: .16em; text-transform: uppercase; color: var(--txt2);
+}
+[data-design="terminal"] .at-pro {
+  font-family: var(--font-mono); font-size: 9px; font-weight: 700; letter-spacing: .12em;
+  background: var(--accent); color: var(--bg0); padding: 2px 5px;
+}
+[data-design="terminal"] .at-pspacer { flex: 1; }
+[data-design="terminal"] .at-pcount {
+  font-family: var(--font-mono); font-size: 10px; letter-spacing: .1em; color: var(--txt3);
+}
+[data-design="terminal"] .at-panel { border-bottom: 1px solid var(--bdr); }
+
+/* ── region 3-4: hint band 36, snapshot band 88 ── */
+[data-design="terminal"] .at-snapband {
+  display: flex; align-items: stretch; min-height: 88px;
+  border-bottom: 1px solid var(--bdr);
+}
+
+/* ── region 5: verdict ── */
+[data-design="terminal"] .at-verdict {
+  display: flex; align-items: stretch;
+  border-bottom: 1px solid var(--bdr); background: var(--bg1);
+}
+[data-design="terminal"] .at-vmain {
+  flex: 0 0 330px; padding: 16px; display: flex; flex-direction: column; gap: 6px;
+  border-right: 1px solid var(--bdr3);
+}
+[data-design="terminal"] .at-vlabel {
+  font-family: var(--font-mono); font-size: 34px; font-weight: 700; line-height: 1;
+}
+[data-design="terminal"] .at-vconf { display: flex; align-items: center; gap: 8px; }
+[data-design="terminal"] .at-vtrack {
+  flex: 1; max-width: 200px; height: 3px; background: var(--mark-idle); display: block;
+}
+[data-design="terminal"] .at-vfill { display: block; height: 3px; }
+[data-design="terminal"] .at-vnum {
+  font-family: var(--font-mono); font-size: 13px; font-weight: 700; color: var(--txt);
+}
+[data-design="terminal"] .at-vlevels { display: flex; flex: 1; }
+[data-design="terminal"] .at-vlevel {
+  flex: 1; padding: 16px; display: flex; flex-direction: column; gap: 5px;
+  border-right: 1px solid var(--bdr3);
+}
+[data-design="terminal"] .at-vlevelval {
+  font-family: var(--font-mono); font-size: 20px; font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── region 6: timeframe row, 42 ── */
+[data-design="terminal"] .at-tfrow {
+  display: flex; align-items: center; gap: 2px; height: 42px; padding: 0 16px;
+  border-bottom: 1px solid var(--bdr); overflow: hidden;
+}
+[data-design="terminal"] .at-tf {
+  display: inline-flex; align-items: center; gap: 6px; padding: 6px 12px;
+  cursor: pointer; background: transparent;
+  font-family: var(--font-mono); font-size: 11px; letter-spacing: .1em;
+}
+[data-design="terminal"] .at-tf-active {
+  background: var(--accent); color: var(--bg0); font-weight: 700; border: 1px solid var(--accent);
+}
+[data-design="terminal"] .at-tf-available { color: var(--txt2); border: 1px solid var(--bdr); }
+/* Gated is legible without colour - the padlock carries it. The border drops
+   to --bdr3 as a secondary cue, never the only one. */
+[data-design="terminal"] .at-tf-gated { color: var(--txt3); border: 1px solid var(--bdr3); }
+[data-design="terminal"] .at-tfhint {
+  margin-left: 10px;
+  font-family: var(--font-mono); font-size: 10px; letter-spacing: .1em; color: var(--txt3);
+}
+
+/* ── region 7: body, main + 352 rail ── */
+[data-design="terminal"] .at-body { display: flex; align-items: stretch; }
+[data-design="terminal"] .at-main {
+  flex: 1; min-width: 0; border-right: 1px solid var(--bdr);
+}
+[data-design="terminal"] .at-rail { flex: 0 0 352px; display: flex; flex-direction: column; }
+[data-design="terminal"] .at-chart { height: 430px; padding: 16px 62px 24px 16px; }
+/* The two paired rows: each half flex:1, divided by one structural hairline. */
+[data-design="terminal"] .at-pair { display: flex; align-items: stretch; border-bottom: 1px solid var(--bdr); }
+[data-design="terminal"] .at-pair > * { flex: 1; min-width: 0; }
+[data-design="terminal"] .at-pair > * + * { border-left: 1px solid var(--bdr); }
+
+/* ── evidence rows ── */
+[data-design="terminal"] .at-ev {
+  display: flex; align-items: center; gap: 11px;
+  padding: 10px 16px; border-bottom: 1px solid var(--bdr3);
+}
+[data-design="terminal"] .at-ev-mark { width: 2px; height: 18px; flex-shrink: 0; }
+[data-design="terminal"] .at-ev-label {
+  width: 78px; flex-shrink: 0;
+  font-family: var(--font-mono); font-size: 9.5px; letter-spacing: .1em;
+  text-transform: uppercase; color: var(--txt3);
+}
+[data-design="terminal"] .at-ev-val {
+  font-family: var(--font-mono); font-size: 12.5px; font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+/* No fixed width and no ellipsis anywhere on this route - labels are DB-driven
+   and change length at runtime (spec §Honest labels). */
+[data-design="terminal"] .at-ev-note {
+  margin-left: auto; text-align: right; font-size: 11px; color: var(--txt3);
+}
+
+/* ── mobile, below 768. A separate TREE - these rules style it, they do not
+      hide a desktop one. ── */
+@media (max-width: 767px) {
+  [data-design="terminal"] .at-msym {
+    display: flex; align-items: center; height: 44px; padding: 0 14px;
+    border-bottom: 1px solid var(--bdr);
+    font-family: var(--font-mono); font-size: 13px; font-weight: 700; color: var(--txt);
+  }
+  [data-design="terminal"] .at-verdict { flex-direction: column; }
+  [data-design="terminal"] .at-vmain { flex: 1 1 auto; border-right: 0; padding: 14px; }
+  [data-design="terminal"] .at-vlabel { font-size: 26px; }
+  [data-design="terminal"] .at-vlevels {
+    display: grid; grid-template-columns: 1fr 1fr 1fr; border-top: 1px solid var(--bdr3);
+  }
+  [data-design="terminal"] .at-vlevel { padding: 12px 14px; }
+  [data-design="terminal"] .at-vlevelval { font-size: 15px; }
+  [data-design="terminal"] .at-tfrow { height: 40px; padding: 0 14px; }
+  [data-design="terminal"] .at-tf { padding: 6px 10px; }
+  [data-design="terminal"] .at-mchart { height: 210px; }
+  [data-design="terminal"] .at-ev { padding: 10px 14px; }
+  [data-design="terminal"] .at-root { padding-bottom: 60px; }
+}

--- a/app/liq/page.tsx
+++ b/app/liq/page.tsx
@@ -486,7 +486,7 @@ export default function LiqPage() {
                 {(retailPos?.shortRatio ?? cd.bnShortRatio) != null && (
                   <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
                     <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)' }}>{t('LIQ_STAT_BINANCE_PERIOD', { period: retailPos ? RANGE_TO_PERIOD[range] : '5m' })}</span>
-                    <span style={{ fontSize: 'var(--fs-data)', fontWeight: 700, color: 'rgba(52,211,153,0.65)', fontVariantNumeric: 'tabular-nums' }}>
+                    <span style={{ fontSize: 'var(--fs-data)', fontWeight: 700, color: 'var(--green-2)', fontVariantNumeric: 'tabular-nums' }}>
                       {((retailPos?.shortRatio ?? cd.bnShortRatio!) * 100).toFixed(0)}%
                     </span>
                   </div>

--- a/components/ArenaTerminal.tsx
+++ b/components/ArenaTerminal.tsx
@@ -85,6 +85,25 @@ function PanelHead({ title, count, pro, rail }: { title: string; count?: string;
   );
 }
 
+/* Spec §Panel header: "every panel in the body uses it". The passed-in panels
+   are production components that draw their own headers, so the pattern is
+   applied HERE by wrapping them, and each component's own header is suppressed
+   in CSS under [data-design="terminal"].
+   Wrapping rather than restyling six internal structures: only three of the six
+   even have a targetable header class, and reimplementing the other three would
+   mean forking components that work. */
+function BodyPanel({ title, pro, count, children }: {
+  title: string; pro?: boolean; count?: string; children?: ReactNode;
+}) {
+  if (!children) return null;
+  return (
+    <section className="at-panel at-bodypanel">
+      <PanelHead title={title} pro={pro} count={count} />
+      <div className="at-panelbody">{children}</div>
+    </section>
+  );
+}
+
 function EvidenceList({ rows, mobile }: { rows: EvidenceRow[]; mobile: boolean }) {
   return (
     <>
@@ -208,11 +227,11 @@ export default function ArenaTerminal({
         {verdictBlock}
         <TimeframeRow tf={tf} onTfChange={onTfChange} onUpgrade={onUpgrade} entitled={entitled} mobile />
         <div className="at-mchart">{chart}</div>
-        {confluence}
-        {multiTf}
-        {structure}
-        {emaSignal}
-        {absorption}
+        <BodyPanel title="Confluence" pro>{confluence}</BodyPanel>
+        <BodyPanel title="Multi-timeframe">{multiTf}</BodyPanel>
+        <BodyPanel title="Market structure">{structure}</BodyPanel>
+        <BodyPanel title="EMA conditions">{emaSignal}</BodyPanel>
+        <BodyPanel title="Absorption" pro>{absorption}</BodyPanel>
         {evidencePanel}
       </div>
     );
@@ -236,14 +255,22 @@ export default function ArenaTerminal({
       <div className="at-body">
         <div className="at-main">
           <div className="at-chart">{chart}</div>
-          {confluence}
-          <div className="at-pair">{multiTf}{structure}</div>
+          <BodyPanel title="Confluence" pro>{confluence}</BodyPanel>
+          <div className="at-pair">
+            <BodyPanel title="Multi-timeframe">{multiTf}</BodyPanel>
+            <BodyPanel title="Market structure">{structure}</BodyPanel>
+          </div>
           {/* AbsorptionDetector is ABSENT for free users, so EMASignal takes
               the full width. Deliberately asymmetric with Confluence, which
               shows a locked card instead - spec §Pro surfaces. That asymmetry
               is production's behaviour and must survive. */}
-          <div className="at-pair">{emaSignal}{absorption}</div>
-          {heatmap}
+          <div className="at-pair">
+            <BodyPanel title="EMA conditions">{emaSignal}</BodyPanel>
+            {/* Absent for free users, so EMA takes the row - the null child
+                makes BodyPanel render nothing rather than an empty header. */}
+            <BodyPanel title="Absorption" pro>{absorption}</BodyPanel>
+          </div>
+          <BodyPanel title="Liquidation heatmap">{heatmap}</BodyPanel>
         </div>
 
         <aside className="at-rail">

--- a/components/ArenaTerminal.tsx
+++ b/components/ArenaTerminal.tsx
@@ -3,7 +3,7 @@ import { useMemo, type ReactNode } from 'react';
 import { useMarket, type CoinId } from '@/lib/marketStore';
 import { useMobileLayout, LANDING_MOBILE_QUERY } from '@/lib/useViewport';
 import { buildEvidence, firingCount, type EvidenceRow } from '@/lib/arenaEvidence';
-import { evidencePaint, verdictPaint, LEVEL_COLOUR, type VerdictDir } from '@/lib/arenaColour';
+import { evidencePaint, verdictPaint, clusterPaint, LEVEL_COLOUR, type VerdictDir } from '@/lib/arenaColour';
 import { TF_ROW, tfState, tfClickIntent, gatedHint } from '@/lib/arenaTimeframes';
 
 /* Arena in the Monochrome Terminal direction.
@@ -55,6 +55,13 @@ interface Props {
   absorption?:  ReactNode;
   heatmap?:     ReactNode;
   usageMeter?:  ReactNode;
+  /** Rail, in spec order: UsageMeter -> clusters -> Why -> evidence -> history.
+   *  All three are ABSENT on mobile, not hidden - the cluster ladder is what
+   *  makes the heatmap's colour-only magnitude readable, so §Accessibility
+   *  drops the heatmap at mobile rather than leave it unsupported. */
+  clusters?:    { price: number; usd: number }[];
+  why?:         string | null;
+  history?:     { time: string; verdict: string; conf: number | null }[];
   hintBand?:    ReactNode;
   snapshot?:    ReactNode;
   tfBadge?:     ReactNode;
@@ -138,7 +145,7 @@ function TimeframeRow({
 export default function ArenaTerminal({
   coin, tf, onTfChange, onUpgrade, entitled, authLoading, verdict, levels,
   chart, confluence, multiTf, structure, emaSignal, absorption, heatmap,
-  usageMeter, hintBand, snapshot, tfBadge,
+  usageMeter, hintBand, snapshot, tfBadge, clusters, why, history,
 }: Props) {
   const mobile = useMobileLayout(LANDING_MOBILE_QUERY);
   const { store } = useMarket();
@@ -150,6 +157,7 @@ export default function ArenaTerminal({
     cbPremium: null,      // no source wired - em dash, always. Never a zero.
   }), [c]);
 
+  const spot = c?.price ?? null;
   const { firing, neutral } = firingCount(rows);
   const vColour = verdictPaint(verdict?.dir ?? null);
 
@@ -232,7 +240,53 @@ export default function ArenaTerminal({
 
         <aside className="at-rail">
           {usageMeter}
+
+          {/* Cluster bars take SIDE, not size - below spot is long
+              liquidations, above is short. Scaling colour by size would make a
+              big cluster read as a strong signal. */}
+          <section className="at-panel">
+            <PanelHead title="Liquidation clusters" count={clusters?.length ? `${clusters.length}` : undefined} rail />
+            {clusters?.length
+              ? clusters.map(cl => {
+                  const max = Math.max(...clusters.map(x => x.usd), 1);
+                  return (
+                    <div key={cl.price} className="at-cl">
+                      <span className="at-cl-px">{(cl.price / 1000).toFixed(1)}k</span>
+                      <span className="at-cl-bar">
+                        <span
+                          className="at-cl-fill"
+                          style={{ width: `${(cl.usd / max) * 100}%`, background: clusterPaint(cl.price, spot ?? 0) }}
+                        />
+                      </span>
+                      <span className="at-cl-usd">${Math.round(cl.usd / 1e6)}M</span>
+                    </div>
+                  );
+                })
+              : <div className="at-empty">No clusters in range</div>}
+          </section>
+
+          <section className="at-panel">
+            <PanelHead title="Why" rail />
+            <p className="at-why">{why ?? 'No read has been generated for this instrument yet.'}</p>
+          </section>
+
           {evidencePanel}
+
+          <section className="at-panel">
+            <PanelHead title="Session history" count={history?.length ? `${history.length}` : undefined} rail />
+            {history?.length
+              ? history.map((h, i) => (
+                  <div key={`${h.time}-${i}`} className="at-hrow">
+                    <span className="at-h-time">{h.time}</span>
+                    <span className="at-h-verdict">{h.verdict}</span>
+                    <span className="at-h-conf">{h.conf ?? DASH}</span>
+                  </div>
+                ))
+              : <div className="at-empty">Nothing this session</div>}
+          </section>
+
+          {/* Flex spacer, per the spec's rail order. */}
+          <div className="at-rail-spacer" />
         </aside>
       </div>
 

--- a/components/ArenaTerminal.tsx
+++ b/components/ArenaTerminal.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useMemo, type ReactNode } from 'react';
-import { useMarket, type CoinId } from '@/lib/marketStore';
+import { useMarket, fmtPrice, type CoinId } from '@/lib/marketStore';
+import { COINS, COIN_DEC } from '@/lib/coins';
 import { useMobileLayout, LANDING_MOBILE_QUERY } from '@/lib/useViewport';
 import { buildEvidence, firingCount, type EvidenceRow } from '@/lib/arenaEvidence';
 import { evidencePaint, verdictPaint, clusterPaint, LEVEL_COLOUR, type VerdictDir } from '@/lib/arenaColour';
@@ -237,9 +238,30 @@ export default function ArenaTerminal({
     );
   }
 
+  const TICKER_COINS = COINS.slice(0, 8);
+
   /* ── DESKTOP ───────────────────────────────────────────────────────────── */
   return (
     <div className="at-root" data-layout="desktop">
+      {/* Region 2, 34px: price strip for 8 major coins. Desktop only — absent
+          at mobile per spec criterion 24. QA asserts .ticker-wrap height 34. */}
+      <div className="ticker-wrap">
+        {TICKER_COINS.map(id => {
+          const cd = store.coins[id];
+          const px = cd?.price ?? null;
+          const chg = cd?.change ?? null;
+          const col = chg == null ? 'var(--txt2)' : chg > 0 ? 'var(--green-2)' : chg < 0 ? 'var(--red)' : 'var(--txt2)';
+          return (
+            <div key={id} className="at-tk-cell">
+              <span className="at-tk-sym">{id.toUpperCase()}</span>
+              <span className="at-tk-px">{px != null ? fmtPrice(px, COIN_DEC[id]) : '—'}</span>
+              <span className="at-tk-chg" style={{ color: col }}>
+                {chg != null ? `${chg >= 0 ? '+' : ''}${chg.toFixed(2)}%` : '—'}
+              </span>
+            </div>
+          );
+        })}
+      </div>
       {hintBand}
       {/* Region 4, 88 tall: 330 coin cell (32x32 mark) | five stat cells |
           230 badge cell. The stat cells are absent at mobile, where the badge

--- a/components/ArenaTerminal.tsx
+++ b/components/ArenaTerminal.tsx
@@ -64,6 +64,7 @@ interface Props {
   history?:     { time: string; verdict: string; conf: number | null }[];
   hintBand?:    ReactNode;
   snapshot?:    ReactNode;
+  coinIcon?:    ReactNode;
   tfBadge?:     ReactNode;
 }
 
@@ -145,7 +146,7 @@ function TimeframeRow({
 export default function ArenaTerminal({
   coin, tf, onTfChange, onUpgrade, entitled, authLoading, verdict, levels,
   chart, confluence, multiTf, structure, emaSignal, absorption, heatmap,
-  usageMeter, hintBand, snapshot, tfBadge, clusters, why, history,
+  usageMeter, hintBand, snapshot, tfBadge, coinIcon, clusters, why, history,
 }: Props) {
   const mobile = useMobileLayout(LANDING_MOBILE_QUERY);
   const { store } = useMarket();
@@ -221,7 +222,14 @@ export default function ArenaTerminal({
   return (
     <div className="at-root" data-layout="desktop">
       {hintBand}
-      <div className="at-snapband">{snapshot}{tfBadge}</div>
+      {/* Region 4, 88 tall: 330 coin cell (32x32 mark) | five stat cells |
+          230 badge cell. The stat cells are absent at mobile, where the badge
+          becomes its own block instead. */}
+      <div className="at-snapband">
+        <div className="at-coincell">{coinIcon}<span className="at-coinsym">{coin.toUpperCase()}</span></div>
+        <div className="at-snapcells">{snapshot}</div>
+        <div className="at-badgecell">{tfBadge}</div>
+      </div>
       {verdictBlock}
       <TimeframeRow tf={tf} onTfChange={onTfChange} onUpgrade={onUpgrade} entitled={entitled} mobile={false} />
 

--- a/components/ArenaTerminal.tsx
+++ b/components/ArenaTerminal.tsx
@@ -83,7 +83,13 @@ function EvidenceList({ rows, mobile }: { rows: EvidenceRow[]; mobile: boolean }
       {rows.map(r => {
         const paint = evidencePaint(r.fire, r.value !== null);
         return (
-          <div key={r.label} className="at-ev">
+          /* data-fire so QA can assert the RENDERED colour matches what
+             arenaColour returns for the same input, rather than reading rows
+             by eye. Their check narrows from "judge the colour" to "compare
+             two values", which fails loudly instead of quietly.
+             `null` is written as the string "null" deliberately - an absent
+             attribute would be indistinguishable from a row that forgot it. */
+          <div key={r.label} className="at-ev" data-fire={String(r.fire)}>
             <span className="at-ev-mark" style={{ background: paint.marker }} />
             <span className="at-ev-label">{r.label}</span>
             <span className="at-ev-val" style={{ color: paint.value }}>{r.value ?? DASH}</span>

--- a/components/ArenaTerminal.tsx
+++ b/components/ArenaTerminal.tsx
@@ -1,0 +1,238 @@
+'use client';
+import { useMemo, type ReactNode } from 'react';
+import { useMarket, type CoinId } from '@/lib/marketStore';
+import { useMobileLayout, LANDING_MOBILE_QUERY } from '@/lib/useViewport';
+import { buildEvidence, firingCount, type EvidenceRow } from '@/lib/arenaEvidence';
+import { evidencePaint, verdictPaint, LEVEL_COLOUR, type VerdictDir } from '@/lib/arenaColour';
+import { TF_ROW, tfState, tfClickIntent, gatedHint } from '@/lib/arenaTimeframes';
+
+/* Arena in the Monochrome Terminal direction.
+ *
+ * SPEC:  design-handoff-dir/design_handoff_arena/specs/arena.md
+ * FRAME: Arena 1a.dc.html · 1a   (desktop 1440, mobile 390x844)
+ *
+ * NOTHING HERE COMES FROM feature/terminal-arena. That branch was closed
+ * unmerged: it built the rail at 304px, which is a direct-manipulation artifact
+ * in a superseded frame - three sibling frames say 352 - and it predates the
+ * extend rule, the no-duplication rule and the entitlement finding. This is a
+ * fresh build against the spec.
+ *
+ * COLOUR AND GATING ARE NOT DECIDED HERE. lib/arenaColour.ts and
+ * lib/arenaTimeframes.ts own them, with 25 tests between them, because QA's
+ * coverage map found no automated check for either - criteria 12-18 and 20-23
+ * both land in the group where a defect reaches dev unopposed. A component is
+ * the wrong place for a rule that nothing can assert.
+ *
+ * ONE TREE. The spec is explicit that this is the screen where two trees cost
+ * real resources: rendering both and hiding one means two KLineProChart
+ * instances and two candle subscriptions. That already shipped once. Criterion
+ * 24 tests by node count, criterion 25 counts chart instances.
+ *
+ * THE EVIDENCE LIST SHOWS 12, NOT THE FRAME'S 8. QA's ruling: the frame draws
+ * the mock's data, and the owner's extend rule was written for exactly this
+ * grid. Arena showing fewer signals than the marketing page would be backwards.
+ * If 12 rows overflow the rail, THE PANEL GROWS TALLER - owner's call, given in
+ * advance, so no build workaround is needed and none should be invented.
+ */
+
+interface Props {
+  coin:       CoinId;
+  tf:         string;
+  onTfChange: (tf: string) => void;
+  /** Opens UpgradeGateModal. A gated chip calls this and changes nothing else. */
+  onUpgrade:  () => void;
+  /** From the call site, never from inside a component - see §Pro surfaces. */
+  entitled:   boolean;
+  authLoading: boolean;
+  verdict:    { label: string; dir: VerdictDir; confidence: number | null } | null;
+  levels:     { entry: number | null; stop: number | null; target: number | null };
+  /** The panels this screen keeps, passed in so their guards stay at the call site. */
+  chart?:       ReactNode;
+  confluence?:  ReactNode;
+  multiTf?:     ReactNode;
+  structure?:   ReactNode;
+  emaSignal?:   ReactNode;
+  absorption?:  ReactNode;
+  heatmap?:     ReactNode;
+  usageMeter?:  ReactNode;
+  hintBand?:    ReactNode;
+  snapshot?:    ReactNode;
+  tfBadge?:     ReactNode;
+}
+
+const DASH = '—';
+
+const fmt = (n: number | null, dp = 0) =>
+  n === null ? DASH : n.toLocaleString('en-US', { minimumFractionDigits: dp, maximumFractionDigits: dp });
+
+/* Panel header — every body panel uses it. Height 30, rail headers 28. */
+function PanelHead({ title, count, pro, rail }: { title: string; count?: string; pro?: boolean; rail?: boolean }) {
+  return (
+    <div className={rail ? 'at-rhead' : 'at-phead'}>
+      <span className="at-ptitle">{title}</span>
+      {pro && <span className="at-pro">PRO</span>}
+      <span className="at-pspacer" />
+      {count && <span className="at-pcount">{count}</span>}
+    </div>
+  );
+}
+
+function EvidenceList({ rows, mobile }: { rows: EvidenceRow[]; mobile: boolean }) {
+  return (
+    <>
+      {rows.map(r => {
+        const paint = evidencePaint(r.fire, r.value !== null);
+        return (
+          <div key={r.label} className="at-ev">
+            <span className="at-ev-mark" style={{ background: paint.marker }} />
+            <span className="at-ev-label">{r.label}</span>
+            <span className="at-ev-val" style={{ color: paint.value }}>{r.value ?? DASH}</span>
+            {/* Note is ABSENT on mobile, not hidden - spec §Absent vs hidden. */}
+            {!mobile && <span className="at-ev-note">{r.note ?? ''}</span>}
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
+function TimeframeRow({
+  tf, onTfChange, onUpgrade, entitled, mobile,
+}: { tf: string; onTfChange: (t: string) => void; onUpgrade: () => void; entitled: boolean; mobile: boolean }) {
+  const hint = gatedHint(entitled);
+  return (
+    <div className="at-tfrow">
+      {TF_ROW.map(t => {
+        const state = tfState(t, tf, entitled);
+        return (
+          <button
+            key={t}
+            className={`at-tf at-tf-${state}`}
+            aria-pressed={state === 'active'}
+            onClick={() => (tfClickIntent(t, entitled) === 'upgrade' ? onUpgrade() : onTfChange(t))}
+          >
+            {/* The padlock carries the state. --txt2 and --txt3 are too close
+                for colour alone to be a distinction - spec §Timeframe row. */}
+            {state === 'gated' && (
+              <svg width={mobile ? 8 : 9} height={mobile ? 10 : 11} viewBox="0 0 9 11" fill="none"
+                   stroke="var(--txt3)" strokeWidth={1.2} aria-hidden="true">
+                <rect x="1" y="4.5" width="7" height="6" />
+                <path d="M2.75 4.5V3a1.75 1.75 0 0 1 3.5 0v1.5" />
+              </svg>
+            )}
+            {t.toUpperCase()}
+          </button>
+        );
+      })}
+      {hint && <span className="at-tfhint">{hint}</span>}
+    </div>
+  );
+}
+
+export default function ArenaTerminal({
+  coin, tf, onTfChange, onUpgrade, entitled, authLoading, verdict, levels,
+  chart, confluence, multiTf, structure, emaSignal, absorption, heatmap,
+  usageMeter, hintBand, snapshot, tfBadge,
+}: Props) {
+  const mobile = useMobileLayout(LANDING_MOBILE_QUERY);
+  const { store } = useMarket();
+  const c = store.coins[coin];
+
+  const rows = useMemo(() => buildEvidence({
+    coin: c,
+    spotPrice: c?.price ?? null,
+    cbPremium: null,      // no source wired - em dash, always. Never a zero.
+  }), [c]);
+
+  const { firing, neutral } = firingCount(rows);
+  const vColour = verdictPaint(verdict?.dir ?? null);
+
+  const verdictBlock = (
+    <div className="at-verdict">
+      <div className="at-vmain">
+        <span className="at-micro">Read · {coin.toUpperCase()} perp · {tf.toUpperCase()}</span>
+        <span className="at-vlabel" style={{ color: vColour }}>{verdict?.label ?? 'NO READ'}</span>
+        {/* No read -> confidence row ABSENT, panel keeps its height. */}
+        {verdict?.confidence != null && (
+          <span className="at-vconf">
+            <span className="at-vtrack">
+              <span className="at-vfill" style={{ width: `${verdict.confidence}%`, background: vColour }} />
+            </span>
+            <span className="at-vnum">{verdict.confidence}</span>
+            <span className="at-micro">CONF</span>
+          </span>
+        )}
+      </div>
+      {/* Prices, not signals - always --txt, em dash when absent. */}
+      <div className="at-vlevels">
+        {([['Entry', levels.entry], ['Stop', levels.stop], ['Target', levels.target]] as const).map(([l, v]) => (
+          <div key={l} className="at-vlevel">
+            <span className="at-micro">{l}</span>
+            <span className="at-vlevelval" style={{ color: LEVEL_COLOUR }}>{fmt(v)}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+
+  const evidencePanel = (
+    <section className="at-panel">
+      <PanelHead title="Evidence" count={`${firing} FIRING · ${neutral} NEUTRAL`} rail={!mobile} />
+      <EvidenceList rows={rows} mobile={mobile} />
+    </section>
+  );
+
+  /* ── MOBILE ────────────────────────────────────────────────────────────
+     Separate tree. The rail, the heatmap, the snapshot band's five cells and
+     the ticker do not EXIST here - criterion 24 counts nodes. */
+  if (mobile) {
+    return (
+      <div className="at-root" data-layout="mobile">
+        <div className="at-msym">{coin.toUpperCase()}</div>
+        {tfBadge}
+        {verdictBlock}
+        <TimeframeRow tf={tf} onTfChange={onTfChange} onUpgrade={onUpgrade} entitled={entitled} mobile />
+        <div className="at-mchart">{chart}</div>
+        {confluence}
+        {multiTf}
+        {structure}
+        {emaSignal}
+        {absorption}
+        {evidencePanel}
+      </div>
+    );
+  }
+
+  /* ── DESKTOP ───────────────────────────────────────────────────────────── */
+  return (
+    <div className="at-root" data-layout="desktop">
+      {hintBand}
+      <div className="at-snapband">{snapshot}{tfBadge}</div>
+      {verdictBlock}
+      <TimeframeRow tf={tf} onTfChange={onTfChange} onUpgrade={onUpgrade} entitled={entitled} mobile={false} />
+
+      <div className="at-body">
+        <div className="at-main">
+          <div className="at-chart">{chart}</div>
+          {confluence}
+          <div className="at-pair">{multiTf}{structure}</div>
+          {/* AbsorptionDetector is ABSENT for free users, so EMASignal takes
+              the full width. Deliberately asymmetric with Confluence, which
+              shows a locked card instead - spec §Pro surfaces. That asymmetry
+              is production's behaviour and must survive. */}
+          <div className="at-pair">{emaSignal}{absorption}</div>
+          {heatmap}
+        </div>
+
+        <aside className="at-rail">
+          {usageMeter}
+          {evidencePanel}
+        </aside>
+      </div>
+
+      {/* authLoading is read so the call site's guard shape stays visible here;
+          the panels themselves arrive already-guarded as props. */}
+      <span hidden data-entitled={entitled ? '1' : '0'} data-auth-loading={authLoading ? '1' : '0'} />
+    </div>
+  );
+}

--- a/lib/arenaColour.ts
+++ b/lib/arenaColour.ts
@@ -1,0 +1,161 @@
+/* Every colour decision on Arena, in one place (#413).
+ *
+ * Spec: design_handoff_arena/specs/arena.md §Colour is data.
+ *
+ * WHY A LIBRARY, AND WHY THIS ONE MATTERS MOST.
+ *
+ * QA mapped the spec's 31 criteria and found 11 automated and 20 not. Criteria
+ * 12-18 - colour as data - are in the group where "a defect reaches dev
+ * unopposed", because no stub exists to drive a coloured state and inspection
+ * is the only check. Pure functions with tests are the only opposition
+ * available.
+ *
+ * And this is the failure that hides best. From the spec:
+ *
+ *   "Colouring them green would look better, be wrong, and pass every
+ *    automated check - --green is a legal token."
+ *
+ * A fully-coloured Arena passes design-tokens.spec.ts, passes contrast, passes
+ * the palette check, and lies about every quiet signal on the screen. The only
+ * thing that catches it is a rule stated as data.
+ *
+ * THE ONE RULE THAT GENERALISES: direction is not the sign of the number.
+ * Crowded-long funding is +0.0132% and red. Overbought RSI is high and red. A
+ * cleared penalty is a good outcome rendered quiet, not green. Sign maps to
+ * colour in exactly one place on this route - the ticker - because a price
+ * change genuinely is directional.
+ */
+
+export type Token =
+  | 'var(--green)' | 'var(--red)' | 'var(--accent)'
+  | 'var(--txt)' | 'var(--txt2)' | 'var(--txt3)' | 'var(--mark-idle)';
+
+export interface Painted { value: Token; marker: Token; background?: string }
+
+const GREEN: Token = 'var(--green)';
+const RED:   Token = 'var(--red)';
+const TXT:   Token = 'var(--txt)';
+const TXT2:  Token = 'var(--txt2)';
+const TXT3:  Token = 'var(--txt3)';
+const IDLE:  Token = 'var(--mark-idle)';
+const ACC:   Token = 'var(--accent)';
+
+/* ── evidence rows ───────────────────────────────────────────────────────── */
+
+/** `fire` decides, never the sign. A missing value is --txt2, not a zero. */
+export function evidencePaint(fire: 'green' | 'red' | null, hasValue: boolean): Painted {
+  if (!hasValue)     return { value: TXT2,  marker: IDLE };
+  if (fire === 'green') return { value: GREEN, marker: GREEN };
+  if (fire === 'red')   return { value: RED,   marker: RED };
+  return { value: TXT, marker: IDLE };
+}
+
+/* ── verdict ─────────────────────────────────────────────────────────────── */
+
+export type VerdictDir = 'bull' | 'bear' | 'neutral' | null;
+
+/**
+ * The verdict string and its confidence fill.
+ *
+ * Green in the frame because the fixture is bullish. NOT a green element - the
+ * frame draws both variants so the switch is visible, and hardcoding green
+ * would lie on every bearish read while passing every check we own.
+ */
+export function verdictPaint(dir: VerdictDir): Token {
+  if (dir === 'bull') return GREEN;
+  if (dir === 'bear') return RED;
+  return TXT2;   // neutral, mixed, or no read
+}
+
+/* ── confluence factors ──────────────────────────────────────────────────── */
+
+export type FactorKind =
+  | { kind: 'directional'; dir: 'bull' | 'bear' | 'neutral' }
+  | { kind: 'penalty'; active: boolean };
+
+/**
+ * Colour is the VOTE, not the sign.
+ *
+ * A cleared penalty is a good outcome rendered QUIET. It is not green - green
+ * means a factor voted bullish, and a penalty that did not fire cast no vote.
+ * Getting that wrong makes an inactive risk look like a positive signal.
+ */
+export function factorPaint(f: FactorKind): Painted {
+  if (f.kind === 'penalty') {
+    return f.active
+      ? { value: ACC, marker: ACC, background: 'rgba(217,166,38,.06)' }
+      : { value: TXT3, marker: IDLE };
+  }
+  if (f.dir === 'bull') return { value: GREEN, marker: GREEN };
+  if (f.dir === 'bear') return { value: RED,   marker: RED };
+  return { value: TXT3, marker: IDLE };
+}
+
+/* ── multi-timeframe ─────────────────────────────────────────────────────── */
+
+export const MTF_BULL = 57;
+export const MTF_BEAR = 43;
+
+/** Thresholds, not sign: 50 is not bullish, 57 is. */
+export function mtfPaint(rsi: number | null): { label: string; colour: Token } {
+  if (rsi === null)      return { label: 'NO DATA', colour: TXT3 };
+  if (rsi > MTF_BULL)    return { label: 'BULLISH', colour: GREEN };
+  if (rsi < MTF_BEAR)    return { label: 'BEARISH', colour: RED };
+  return { label: 'NEUTRAL', colour: TXT3 };
+}
+
+/* ── market structure ────────────────────────────────────────────────────── */
+
+/**
+ * Colour carries DIRECTION only.
+ *
+ * A CHoCH is not more significant in colour than a BOS - the label carries
+ * significance, the colour carries which way. Colouring CHoCH differently
+ * would encode importance in a channel already used for direction.
+ */
+export function structurePaint(dir: 'up' | 'down'): Token {
+  return dir === 'up' ? GREEN : RED;
+}
+
+/* ── EMA conditions ──────────────────────────────────────────────────────── */
+
+export function emaConditionPaint(pass: boolean): { glyph: string; glyphColour: Token; labelColour: Token } {
+  return pass
+    ? { glyph: '✓', glyphColour: GREEN, labelColour: TXT }
+    : { glyph: '✕', glyphColour: RED,   labelColour: TXT2 };
+}
+
+/** The four EMA averages are ALWAYS --txt. Line colour is a chart concern. */
+export const EMA_VALUE_COLOUR: Token = TXT;
+
+/* ── clusters ────────────────────────────────────────────────────────────── */
+
+/**
+ * Cluster bars take SIDE, not size.
+ *
+ * Below spot is long liquidations (--red), above is short (--green). Scaling
+ * colour by size would make a big cluster look like a strong signal when what
+ * it encodes is which side gets liquidated.
+ */
+export function clusterPaint(clusterPrice: number, spot: number): Token {
+  return clusterPrice < spot ? RED : GREEN;
+}
+
+/* ── prices are never signals ────────────────────────────────────────────── */
+
+/** Entry / Stop / Target are --txt always. They are prices, not signals. */
+export const LEVEL_COLOUR: Token = TXT;
+
+/* ── the boundary ────────────────────────────────────────────────────────── */
+
+/**
+ * The only regions on this route permitted to render --green or --red.
+ *
+ * Exported so a test can assert the boundary rather than trusting each call
+ * site - the spec ends its colour section with exactly this list, and anything
+ * outside it rendering a signed colour is a defect.
+ */
+export const COLOUR_PERMITTED_REGIONS = [
+  'ticker', 'verdict', 'evidence', 'confluence',
+  'mtf', 'structure', 'ema-conditions', 'clusters',
+] as const;

--- a/lib/arenaTimeframes.ts
+++ b/lib/arenaTimeframes.ts
@@ -1,0 +1,76 @@
+/* Arena's timeframe row — three states, and what a click does (#413).
+ *
+ * Spec: design_handoff_arena/specs/arena.md §Timeframe row.
+ *
+ * WHY THIS IS A LIBRARY. Three reasons, and the third is the one that matters:
+ *
+ *   1. it decides what a user can reach, which is worth testing without a DOM
+ *   2. it is entitlement logic, and this project has already shipped a paywall
+ *      leak by moving markup and leaving its guard behind
+ *   3. QA's coverage map puts criteria 20-23 - the padlocks and the gated-click
+ *      behaviour - in the group where "a defect reaches dev unopposed", because
+ *      no automated check exists for them. Pure logic with tests is the only
+ *      opposition available.
+ *
+ * GATED MUST BE LEGIBLE WITHOUT COLOUR. --txt2 and --txt3 are close enough that
+ * a colour-only distinction is not one; the padlock glyph carries the state and
+ * the row ends with an explicit "1M · 5M · 15M NEED PRO". That is an
+ * accessibility requirement in the spec, not decoration - which is why the
+ * state is returned as a value here rather than being a CSS class decision.
+ */
+
+import { GATED_TFS, FREE_FALLBACK_TF } from './limits.ts';
+
+export type TfState = 'active' | 'available' | 'gated';
+
+/** Every timeframe the row offers, in the order the frame draws them. */
+export const TF_ROW = ['1m', '5m', '15m', '30m', '1h', '2h', '4h', '1d'] as const;
+export type Tf = typeof TF_ROW[number];
+
+const isGated = (tf: string): boolean => (GATED_TFS as readonly string[]).includes(tf);
+
+/**
+ * What state a chip is in.
+ *
+ * Order matters: ACTIVE WINS over gated. A Pro user on 5m who lets their
+ * subscription lapse should see the chip they are actually on rendered as
+ * active, not as a padlock next to a chart already showing that timeframe -
+ * the padlock would be describing a state the screen contradicts.
+ * `forcedTimeframe` below is what stops them being there in the first place.
+ */
+export function tfState(tf: string, current: string, entitled: boolean): TfState {
+  if (tf === current) return 'active';
+  if (!entitled && isGated(tf)) return 'gated';
+  return 'available';
+}
+
+/**
+ * The timeframe that should actually render, given who is asking.
+ *
+ * A free user landing on `/arena?tf=5m` - from a bookmark, a shared link, or a
+ * lapsed subscription - is moved to 1h rather than shown an empty chart or a
+ * paywall where a chart should be. Returns the input unchanged for anyone
+ * entitled, so this is safe to call unconditionally on every render.
+ */
+export function forcedTimeframe(requested: string, entitled: boolean): string {
+  if (entitled) return requested;
+  return isGated(requested) ? FREE_FALLBACK_TF : requested;
+}
+
+/**
+ * What a click on a chip should do.
+ *
+ * `'select'` changes the timeframe. `'upgrade'` opens UpgradeGateModal and
+ * changes NOTHING - the spec is explicit that a gated click must not move the
+ * chart. Returning an intent rather than performing it keeps the decision
+ * testable and stops the component owning the entitlement rule.
+ */
+export function tfClickIntent(tf: string, entitled: boolean): 'select' | 'upgrade' {
+  return !entitled && isGated(tf) ? 'upgrade' : 'select';
+}
+
+/** The trailing hint, or null when the user has nothing gated. */
+export function gatedHint(entitled: boolean): string | null {
+  if (entitled) return null;
+  return `${GATED_TFS.map(t => t.toUpperCase()).join(' · ')} NEED PRO`;
+}

--- a/qa/e2e/_shared.ts
+++ b/qa/e2e/_shared.ts
@@ -337,11 +337,8 @@ export const BASELINE = {
      * which is why it matters more than a normal contrast bug.
      */
     lightTokens: [
-      // Computed near-white blends on /funding chips collapse to one bucket -
-      // see bucket() in contrast.spec.ts. It is one defect, not N hexes.
-      'near-white',
       '#0052cc', '#22d3ee', '#3d8d76', '#4ade80', '#60a5fa', '#627eea',
-      '#76787b', '#77deb9', '#868890', '#868895', '#8f919c',
+      '#76787b', '#868890', '#868895', '#8f919c',
       '#94969d', '#98999d', '#989aa0', '#a2a4ab', '#a7a9af',
       '#c75050', '#c8891e', '#d4b483',
       '#f3ba2f', '#f472b6', '#f69f9f',


### PR DESCRIPTION
**Dev Team** · Arena, built to `design_handoff_arena/specs/arena.md`. Fresh — nothing from the closed #438.

## What is here

```
lib/arenaTimeframes.ts     11 tests   three chip states, forced fallback, click intent
lib/arenaColour.ts         14 tests   every colour decision on the route
components/ArenaTerminal.tsx          both trees, one rendered, data-fire per row
app/globals.css                       .at-* , 352 rail, 88 snapshot band
app/arena/page.tsx                    wired, every guard at the call site
```

471 tests, lint 0 errors, tsc clean, build succeeds.

## All 15 spec modules render

`PageHint` · `Tip` · `CoinIcon` · `CoinMarketSnapshot` · `HigherTfMoveBadge` · `KLineProChart` · `ConfluenceScore` · `MultiTFAlignment` · `MarketStructure` · `EMASignal` · `AbsorptionDetector` · `LiqHeatmap` · `UsageMeter` · `UpgradeGateModal` + `LockedFeatureCard`

Nothing from production dropped.

## The Pro asymmetry, deliberate and load-bearing

```
ConfluenceScore     free -> LockedFeatureCard, full main-column width, wired to the modal
AbsorptionDetector  free -> NOTHING
```

**Both are regressions if "tidied".** A second locked card looks more consistent and is wrong; deleting the first removes a conversion surface. Guards live at the call site because moving a panel moves its markup and leaves the guard behind — that shipped once.

## Answering QA's `.at-phead` question: it is a real gap, not a naming difference

`.at-phead` renders **nowhere on desktop**. The class exists and is used by exactly one panel — the evidence list, and only at mobile.

**Why:** the body panels arrive as props, and they are production components that draw their own headers. I gave them the spec's positions but not the spec's header pattern.

```
spec §Panel header    "every panel in the body uses it" - height 30, 0 16px,
                      title 10px mono/700 .16em, optional PRO chip, right count
built                 Confluence, MTF, Structure, EMA, Absorption, Heatmap all
                      keep their own headers
```

**So criteria 3 and the body half of 10 are NOT met.** Strike them as unmeasurable only if you agree they are out of scope for this PR; my read is they are in scope and unfinished. It is the same work as the snapshot band — restyle each panel's header inside `[data-design="terminal"]` — and I would rather do it as a follow-up than hold the PR, since it is six independent restyles and each one wants measuring.

## On the unfired colour branches — agreed, ship and record

The market is quiet, so the verdict reads `NO READ` and all 12 rows are `fire=null`. Criteria 9, 12 and 14 cannot be proven today.

**Agreed with your position.** The rule is unit-tested on all four branches, `arena-colour-obeys-lib` proves the component honours the lib for the branch that is live, and the residual risk is one branch of a tested function being miswired at the join. **A stub is the right fix and not worth holding Arena for.**

State it that way in the sign-off. **Do not imply full colour coverage.**

## How to test (QA)

1. `/arena` with **no flag** — unchanged. The regression that matters most.
2. `/arena?design=terminal` desktop: snapshot band **88**, rail **352**, chart **430**, timeframe row **42**, 12 evidence rows, exactly one chart.
3. Signed out: **1** locked card, **no** absorption panel, 3 gated chips with padlocks.
4. Mobile: rail, snapshot cells, cluster ladder and evidence notes **absent from the DOM**, not hidden.
5. `CB prem` renders an em dash. The string `Liq 24h` appears nowhere.

## Risk level

**Medium.** Largest screen in the app, behind a flag that is off by default. The panel-header gap above is known and named. Mobile geometry beyond node-existence is unmeasured on my side — Chrome will not resize below its minimum width.
