### PR TITLE
fix(settings): three contrast failures from QA gate sweep

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -46,7 +46,7 @@
      blue-grey, because these sites also carry the "neutral / no signal"
      semantic that sits beside --green and --red (squeeze direction, funding
      bias, EMA pass state) and should not read as tinted. */
-  --txt-dim: #8a8a8a;
+  --txt-dim: #909090;
 
   /* Borders - neutral white hairline, no indigo tint */
   --bdr:  rgba(255,255,255,0.08);
@@ -1484,7 +1484,7 @@ body.ticker-on .breaking-alert { top: calc(84px + var(--banner-h)); }
 .tp { background: var(--purple-bg); color: var(--purple); border: 0.5px solid var(--purple-bdr); }
 .pbox { background: var(--purple-bg); border: 0.5px solid var(--purple-bdr); border-radius: var(--radius-card); padding: 10px 14px; margin-bottom: 10px; }
 .pt   { font-size: var(--fs-caption); font-weight: 700; color: var(--purple); margin-bottom: 3px; }
-.pb   { font-size: var(--fs-label); color: var(--txt2); line-height: 1.5; }
+.pb   { font-size: var(--fs-label); color: var(--txt); line-height: 1.5; }
 .rb   { font-size: var(--fs-label); color: var(--red-soft); line-height: 1.5; }
 .div  { border-top: 0.5px solid var(--bdr); margin: 8px 0; }
 .row  { display: flex; gap: 12px; align-items: flex-start; }
@@ -2319,6 +2319,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .gex-bar-fill    { position: absolute; left: 0; top: 0; bottom: 0; border-radius: 3px; transition: width 0.6s cubic-bezier(.4,0,.2,1); }
 .gex-value       { font-size: var(--fs-data); font-weight: 700; text-align: right; }
 .gex-insight     { padding: 10px 14px; font-size: var(--fs-caption); color: rgba(255,255,255,0.65); line-height: 1.65; border-bottom: 1px solid rgba(255,255,255,0.06); }
+[data-theme="light"] .gex-insight { color: var(--txt2); border-bottom-color: rgba(0,0,0,0.06); }
 .gex-flip-row    { padding: 6px 14px 8px; font-size: var(--fs-caption); color: var(--txt3); display: flex; gap: 12px; flex-wrap: wrap; }
 .gex-flip-row span { color: var(--txt3); font-weight: 600; }
 


### PR DESCRIPTION
## Summary
- Fix 1.07:1 `.gex-insight` near-white text on `/liq` light theme (#467)
- Fix 4.47:1 `.pb` pbox body text on `/about` dark (#466)
- Fix 4.37:1 `--txt-dim` on `/funding` dark (#466)

## What changed
`app/globals.css` — three targeted edits:
1. `--txt-dim: #8a8a8a` → `#909090` (root dark default; still neutral grey r=g=b; light override `#5E5E5E` unchanged)
2. `.pb { color: var(--txt2) }` → `color: var(--txt)` — pbox body text now uses full-contrast token on the gold-tinted `--accent-bg` surface
3. Added `[data-theme="light"] .gex-insight { color: var(--txt2); border-bottom-color: rgba(0,0,0,0.06); }` after the `.gex-insight` rule — overrides near-white in light mode; dark mode unchanged

## Why
QA contrast sweep (commit `729c1f2`) flagged three WCAG AA failures across `/liq`, `/about`, and `/funding`. All three surfaces failed in the 1.07–4.47 range; AA minimum is 4.5:1.

## How to test (QA)
1. Checkout `qa` after promotion, open `/liq` in light mode → `.gex-insight` rows (insight labels on the GEX chart) must be legible dark text, not near-white
2. Open `/about` dark mode → pbox body text (the callout paragraphs) must be clearly readable
3. Open `/funding` dark mode → neutral-rate funding cells (shown in dim grey) must clear AA contrast
4. Run `npm run test` → `contrastTokens.test.mts` must pass (all 11 assertions)
5. Run `contrast.spec.ts` sweep against `qa` build → `#7a7e94`, `#8a8a8a`/`#909090` and near-white entries in `BASELINE.contrast` should no longer fire; QA may remove those allowlist entries once confirmed

## Risk level
Low — CSS-only, no logic change. `--txt-dim` lightened by one step (neutral). Two token substitutions on bounded surfaces. Unit test covers all token pairs.

## Screenshots
See issues #466 and #467 for pre-fix measurements.