### PR TITLE
feat(dashboard): Monochrome Terminal — frame 2a

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -29,6 +29,7 @@ import { SkeletonBar } from '@/components/Skeleton';
 import { useLabels } from '@/lib/labels';
 import type { LabelKey } from '@/lib/labelKeys';
 import PerpSpotCard from '@/components/PerpSpotCard';
+import DeskTerminal from '@/components/DeskTerminal';
 
 const OI_TREND_META: Record<string, { txtKey: LabelKey; subKey: LabelKey; col: string }> = {
   strong_up:   { txtKey: 'OI_TREND_STRONG_UP_TXT',   subKey: 'OI_TREND_STRONG_UP_SUB',   col: 'var(--green)' },
@@ -496,17 +497,10 @@ function SelectedCoinCard() {
 }
 
 export default function Dashboard() {
-  const { t } = useLabels();
   const [showTour, setShowTour] = useState(false);
-  const rightRef = useRef<HTMLElement>(null);
-  const mainRef  = useRef<HTMLDivElement>(null);
-  const isMobile = useMobile();
 
   const { tourPending, clearTourPending } = useOnboarding();
 
-  // OnboardingGate flips tourPending right after a user finishes onboarding
-  // (from whatever page they were on) and routes here, since the spotlight
-  // tour targets dashboard-only DOM (data-spotlight-section, .mb-glow-card).
   useEffect(() => {
     if (tourPending) {
       setShowTour(true);
@@ -515,61 +509,11 @@ export default function Dashboard() {
   }, [tourPending, clearTourPending]);
 
   return (
-    <div className="dashboard-grid" data-spotlight-section>
+    <div data-design="terminal" data-spotlight-section>
       {showTour && <SpotlightTour onDone={() => setShowTour(false)} />}
       <SetupChecklist />
-      {/* Floating cascade toast - fixed-positioned, render once */}
       <CascadeAlertBanner />
-
-      <GlobalSpotlight gridRef={rightRef} cardSelector=".mb-glow-card" radius={260} disableAnimations={isMobile} />
-      <GlobalSpotlight gridRef={mainRef} cardSelector=".mb-glow-card" radius={320} disableAnimations={isMobile} />
-
-      {/* ── LEFT · the answers (answer-first order) ── */}
-      <div className="dash-main" ref={mainRef}>
-        {/* 1. Market Read - the verdict */}
-        <MarketRead />
-
-        {/* 2. Best Setup Today */}
-        <div id="tour-best-setup" className="mb-glow-card" style={{ borderRadius: 10 }}>
-          <div className="dash-section dash-section-hot" style={{ marginTop: 0 }}>{t('DASH_BEST_SETUP_TODAY_HEADER')}</div>
-          <SOTD />
-        </div>
-
-        {/* 3. Your coin - glance */}
-        <SelectedCoinCard />
-
-        {/* 4. Coin signals - selected coin detail */}
-        <div id="tour-coin-signals" className="mb-glow-card" style={{ borderRadius: 10 }}>
-          <CoinSignalsHeader />
-          <EdgeSignals />
-        </div>
-
-        {/* 5. Economic calendar preview + Market conditions gauge - full width
-            here instead of the narrow rail, side by side on desktop. */}
-        <div className="dash-conditions-row">
-          <EconCalendarWidget />
-          <MarketConditionsWidget />
-        </div>
-      </div>
-
-      {/* ── RIGHT · context (sticky rail on desktop, stacks below on mobile) ── */}
-      <aside className="dash-right" ref={rightRef}>
-        <CoinSidebar />
-        <MarketPulseStrip />
-        {/* Perps vs spot (#328) - "is this a real buyer or just futures traders".
-            Above the macro card because it is per-coin and follows the coin
-            selection, where the macro backdrop is the same whatever is picked. */}
-        <div className="macro-rail-card">
-          <PerpSpotCard />
-        </div>
-
-        {/* Macro backdrop - answers "what's the broad market doing", which nothing
-            else on the dashboard covers. Last in the rail so it never pushes the
-            per-coin essentials down on mobile. */}
-        <div className="macro-rail-card">
-          <GlobalMacroContext />
-        </div>
-      </aside>
+      <DeskTerminal />
     </div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -6269,3 +6269,185 @@ main.app-content[data-chrome="none"] {
 /* The scale badge sits with them and reads as orphaned once they are gone. */
 [data-design="terminal"] .at-chart .klc-scale-badge,
 [data-design="terminal"] .at-mchart .klc-scale-badge { display: none; }
+
+/* ══ Dashboard Terminal — frame 2A · #472 ═════════════════════════════════════
+   All values measured from Monochrome Terminal.dc.html · frame 2A at 1440px.
+   Class prefix: dk- (Desk Terminal). Tokens from lib/terminalTokens.ts.
+   IBM Plex Mono = var(--font-mono). IBM Plex Sans = var(--font-sans).
+   Radius 0 everywhere. Colour only where a signal fires.                     */
+
+[data-design="terminal"] .dk-root {
+  max-width: 1180px; margin: 0 auto; padding: 24px 24px 96px;
+}
+
+/* ── Market-read band ─── */
+[data-design="terminal"] .dk-band {
+  display: flex; align-items: stretch; gap: 1px;
+  background: var(--bdr3); margin-bottom: 1px;
+}
+[data-design="terminal"] .dk-band-verdict {
+  flex: 0 0 430px; background: var(--bg1); padding: 18px 20px;
+  display: flex; flex-direction: column; gap: 10px;
+}
+[data-design="terminal"] .dk-verdict-label {
+  font-family: var(--font-mono), monospace; font-size: 17px; font-weight: 700;
+  color: var(--txt); letter-spacing: .01em; line-height: 1.1;
+}
+[data-design="terminal"] .dk-verdict-label[data-band="good"] { color: var(--green); }
+[data-design="terminal"] .dk-verdict-label[data-band="weak"] { color: var(--red); }
+[data-design="terminal"] .dk-verdict-sub {
+  font-size: 12.5px; line-height: 1.6; color: var(--txt2); margin: 0;
+}
+[data-design="terminal"] .dk-pulse {
+  flex: 1; display: flex; gap: 1px; background: var(--bdr3);
+}
+[data-design="terminal"] .dk-pulse-cell {
+  flex: 1; background: var(--bg1); padding: 14px 16px;
+  display: flex; flex-direction: column; gap: 5px;
+}
+[data-design="terminal"] .dk-pulse-label {
+  font-family: var(--font-mono), monospace; font-size: 9px; font-weight: 600;
+  letter-spacing: .14em; text-transform: uppercase; color: var(--txt3);
+}
+[data-design="terminal"] .dk-pulse-value {
+  font-family: var(--font-mono), monospace; font-size: 20px; font-weight: 700;
+  color: var(--txt); line-height: 1; font-variant-numeric: tabular-nums;
+}
+[data-design="terminal"] .dk-pulse-sub {
+  font-size: 10px; color: var(--txt3); line-height: 1;
+}
+[data-design="terminal"] .dk-arena-btn {
+  align-self: center; flex-shrink: 0;
+  font-family: var(--font-mono), monospace; font-size: 11px; font-weight: 700;
+  letter-spacing: .12em; text-transform: uppercase; text-decoration: none;
+  background: var(--accent); color: var(--on-accent);
+  padding: 10px 20px; margin: 12px;
+  display: flex; align-items: center;
+  transition: opacity .12s;
+}
+[data-design="terminal"] .dk-arena-btn:hover { opacity: .85; }
+
+/* ── Body: 2-col grid ─── */
+[data-design="terminal"] .dk-body {
+  display: grid;
+  grid-template-columns: 1fr 280px;
+  gap: 1px; background: var(--bdr3);
+  align-items: start;
+}
+
+/* ── Coins table ─── */
+[data-design="terminal"] .dk-table-wrap {
+  background: var(--bg1); overflow: hidden;
+}
+[data-design="terminal"] .dk-table {
+  width: 100%; border-collapse: collapse;
+}
+[data-design="terminal"] .dk-th {
+  font-family: var(--font-mono), monospace; font-size: 9px; font-weight: 600;
+  letter-spacing: .14em; text-transform: uppercase; color: var(--txt3);
+  padding: 10px 12px 8px; text-align: left;
+  border-bottom: 1px solid var(--bdr2);
+  white-space: nowrap;
+}
+[data-design="terminal"] .dk-th-num { text-align: right; }
+[data-design="terminal"] .dk-tr {
+  border-bottom: 1px solid var(--bdr2); cursor: pointer;
+  transition: background .1s;
+}
+[data-design="terminal"] .dk-tr:last-child { border-bottom: none; }
+[data-design="terminal"] .dk-tr:hover { background: var(--mark-idle); }
+[data-design="terminal"] .dk-tr-sel { background: var(--bg2); }
+[data-design="terminal"] .dk-tr-sel .dk-td-coin { color: var(--accent); }
+[data-design="terminal"] .dk-td {
+  font-family: var(--font-mono), monospace; font-size: 12px; font-weight: 500;
+  color: var(--txt2); padding: 9px 12px; vertical-align: middle;
+  white-space: nowrap;
+}
+[data-design="terminal"] .dk-td-coin {
+  display: flex; align-items: center; gap: 7px; color: var(--txt);
+}
+[data-design="terminal"] .dk-coin-ticker { font-weight: 700; font-size: 12.5px; }
+[data-design="terminal"] .dk-td-num { text-align: right; }
+[data-design="terminal"] .dk-td-bar { padding-left: 8px; padding-right: 8px; }
+[data-design="terminal"] .dk-bar-track {
+  width: 48px; height: 4px; background: var(--bg3); overflow: hidden;
+}
+[data-design="terminal"] .dk-bar-fill { height: 100%; transition: width .3s; }
+[data-design="terminal"] .dk-td-sig {
+  font-size: 11px; max-width: 120px; overflow: hidden;
+  text-overflow: ellipsis; white-space: nowrap;
+}
+[data-design="terminal"] .dk-td-grade {
+  text-align: right; font-weight: 700; font-size: 12px;
+}
+[data-design="terminal"] .dk-all-markets {
+  display: block; padding: 9px 12px;
+  font-family: var(--font-mono), monospace; font-size: 10px; font-weight: 600;
+  letter-spacing: .1em; text-transform: uppercase;
+  color: var(--txt3); text-decoration: none;
+  border-top: 1px solid var(--bdr2);
+  transition: color .12s;
+}
+[data-design="terminal"] .dk-all-markets:hover { color: var(--txt); }
+
+/* ── Right rail ─── */
+[data-design="terminal"] .dk-rail {
+  background: var(--bg0); display: flex; flex-direction: column; gap: 1px;
+}
+[data-design="terminal"] .dk-rail-sec {
+  background: var(--bg1); padding: 14px 14px;
+}
+[data-design="terminal"] .dk-rail-head {
+  font-family: var(--font-mono), monospace; font-size: 9px; font-weight: 600;
+  letter-spacing: .14em; text-transform: uppercase; color: var(--txt3);
+  margin-bottom: 10px; padding-bottom: 8px; border-bottom: 1px solid var(--bdr2);
+}
+
+/* ── Macro backdrop rows ─── */
+[data-design="terminal"] .dk-macro-rows { display: flex; flex-direction: column; gap: 0; }
+[data-design="terminal"] .dk-macro-row {
+  display: flex; align-items: baseline; gap: 6px;
+  padding: 6px 0; border-bottom: 1px solid var(--bdr2);
+  font-family: var(--font-mono), monospace;
+}
+[data-design="terminal"] .dk-macro-row:last-child { border-bottom: none; }
+[data-design="terminal"] .dk-macro-label {
+  font-size: 9px; font-weight: 600; letter-spacing: .12em; text-transform: uppercase;
+  color: var(--txt3); flex: 0 0 64px;
+}
+[data-design="terminal"] .dk-macro-value {
+  font-size: 13px; font-weight: 700; font-variant-numeric: tabular-nums;
+  flex: 1; min-width: 0;
+}
+[data-design="terminal"] .dk-macro-chg {
+  font-size: 10px; font-weight: 500; flex-shrink: 0;
+}
+
+/* ── Rail SOTD overrides: tighten spacing inside the narrow rail ─── */
+[data-design="terminal"] .dk-rail-sec .sotd-wrap { font-size: 12px; }
+[data-design="terminal"] .dk-rail-sec .sotd-label { margin-bottom: 8px; }
+[data-design="terminal"] .dk-rail-sec .sotd-name { font-size: 13px; margin-bottom: 6px; }
+[data-design="terminal"] .dk-rail-sec .sotd-text { font-size: 12px; line-height: 1.55; }
+
+/* ── Rail econ calendar: hide its own header/footer in the rail context ─── */
+[data-design="terminal"] .dk-rail-sec .av-rail-panel { padding: 0; border: none; background: none; }
+[data-design="terminal"] .dk-rail-sec .av-rail-panel > div:first-child { display: none; }
+
+/* ── Mobile (≤899px) ─── */
+@media (max-width: 899px) {
+  [data-design="terminal"] .dk-root { padding: 12px 12px 84px; }
+  [data-design="terminal"] .dk-band { flex-direction: column; }
+  [data-design="terminal"] .dk-band-verdict { flex: none; }
+  [data-design="terminal"] .dk-pulse { flex-wrap: wrap; }
+  [data-design="terminal"] .dk-pulse-cell { flex: 1 1 45%; }
+  [data-design="terminal"] .dk-arena-btn { margin: 12px; align-self: flex-start; }
+  [data-design="terminal"] .dk-body { grid-template-columns: 1fr; }
+  [data-design="terminal"] .dk-table { font-size: 11px; }
+  [data-design="terminal"] .dk-td { padding: 7px 8px; }
+  [data-design="terminal"] .dk-th { padding: 8px 8px 6px; }
+  /* Hide funding + taker columns on mobile to fit */
+  [data-design="terminal"] .dk-th:nth-child(4),
+  [data-design="terminal"] .dk-th:nth-child(6),
+  [data-design="terminal"] .dk-td:nth-child(4),
+  [data-design="terminal"] .dk-td:nth-child(6) { display: none; }
+}

--- a/components/DeskTerminal.tsx
+++ b/components/DeskTerminal.tsx
@@ -1,0 +1,371 @@
+'use client';
+import { useMemo, useEffect, useState } from 'react';
+import Link from 'next/link';
+import {
+  useMarket, fmtPrice, computeCoinHealth, classifyFunding, COIN_DEC, FUNDING_TIP_KEY,
+} from '@/lib/marketStore';
+import type { CoinId } from '@/lib/marketStore';
+import { COINS } from '@/lib/coins';
+import { computeMarketRead } from '@/lib/marketRead';
+import { coinBadgeColor } from '@/lib/coinBadge';
+import CoinIcon from '@/components/CoinIcon';
+import { useLabels } from '@/lib/labels';
+import EconCalendarWidget from '@/components/EconCalendarWidget';
+import SOTD from '@/components/SOTD';
+import type { LabelKey } from '@/lib/labelKeys';
+
+/* Dashboard in the Monochrome Terminal direction.
+ *
+ * SPEC:  design-handoff-dir/design_handoff_liquidityhq_terminal/README.md#2A
+ * FRAME: Monochrome Terminal.dc.html · frame 2A (desktop 1440, mobile 390)
+ *
+ * CSS:   app/globals.css — [data-design="terminal"] .dk-* selector prefix.
+ *        No inline styles from the prototype. Token layer only.
+ *        IBM Plex Mono for numbers/labels, IBM Plex Sans for prose. Radius 0.
+ *        Colour only where a signal fires.
+ */
+
+const DASH = '—';
+const TABLE_COINS = 8;
+
+interface MacroCache {
+  dxy: number; dxyChg: number;
+  tnx: number; tnxChg: number;
+  gold: number; goldChg: number;
+}
+
+function useMacroCache(): MacroCache | null {
+  const [data, setData] = useState<MacroCache | null>(null);
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem('lhq_macro_context');
+      if (raw) {
+        const { ts, data: d } = JSON.parse(raw) as { ts: number; data: MacroCache };
+        if (Date.now() - ts < 2 * 60 * 60 * 1000) setData(d);
+      }
+    } catch { /* ignore */ }
+  }, []);
+  return data;
+}
+
+function useVolLabel(): string | null {
+  const [label, setLabel] = useState<string | null>(null);
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem('lhq_vol_regime');
+      if (raw) {
+        const parsed = JSON.parse(raw) as { ts: number; data?: { btc?: { label?: string } } };
+        if (Date.now() - parsed.ts < 4 * 60 * 60 * 1000 && parsed.data?.btc?.label) {
+          setLabel(parsed.data.btc.label);
+        }
+      }
+    } catch { /* ignore */ }
+  }, []);
+  return label;
+}
+
+function chgColor(chg: number | null, invert = false): string {
+  if (chg == null || Math.abs(chg) < 0.05) return 'var(--txt3)';
+  const pos = invert ? chg < 0 : chg > 0;
+  return pos ? 'var(--green)' : 'var(--red)';
+}
+function chgStr(chg: number | null): string {
+  if (chg == null) return DASH;
+  return (chg >= 0 ? '+' : '') + chg.toFixed(2) + '%';
+}
+function fmtNum(n: number | null, dp = 2): string {
+  if (n == null) return DASH;
+  return n.toLocaleString('en-US', { minimumFractionDigits: dp, maximumFractionDigits: dp });
+}
+
+/* Colour bands for scalar signals */
+function fngColor(fng: number | null): string {
+  if (fng == null) return 'var(--txt3)';
+  if (fng <= 25) return 'var(--red)';
+  if (fng <= 45) return 'var(--red-soft)';
+  if (fng <= 55) return 'var(--txt2)';
+  if (fng <= 75) return 'var(--green-soft)';
+  return 'var(--green)';
+}
+function altColor(alt: number | null): string {
+  if (alt == null) return 'var(--txt3)';
+  if (alt >= 75) return 'var(--green)';
+  if (alt >= 50) return 'var(--green-soft)';
+  if (alt >= 25) return 'var(--red-soft)';
+  return 'var(--red)';
+}
+function domColor(dom: number | null): string {
+  if (dom == null) return 'var(--txt3)';
+  if (dom >= 60) return 'var(--txt2)';
+  if (dom >= 48) return 'var(--txt)';
+  return 'var(--green)';
+}
+
+/* Coin signal — priority ordered, same logic as CoinSidebar */
+function coinSignal(
+  d: ReturnType<typeof useMarket>['store']['coins'][CoinId],
+  t: (k: LabelKey, vars?: Record<string, string | number>) => string,
+): { text: string; col: string } | null {
+  if (!d) return null;
+  const fr = d.fundingRate != null ? d.fundingRate * 100 : null;
+  if (fr != null && fr >= 0.04)  return { text: t('DASH_SIDEBAR_SIG_LONGS_OVERCROWDED'), col: 'var(--red)' };
+  if (fr != null && fr <= -0.02) return { text: t('DASH_SIDEBAR_SIG_SHORTS_SQUEEZED'),   col: 'var(--green)' };
+  if (d.cvdDivergence === 'bullish') return { text: t('DASH_SIDEBAR_SIG_SMART_BUYERS'),  col: 'var(--green)' };
+  if (d.cvdDivergence === 'bearish') return { text: t('DASH_SIDEBAR_SIG_SMART_SELLERS'), col: 'var(--red)' };
+  if (d.oiTrend === 'strong_up')     return { text: t('DASH_SIDEBAR_SIG_NEW_BUYERS'),    col: 'var(--green)' };
+  if (d.oiTrend === 'strong_down')   return { text: t('DASH_SIDEBAR_SIG_NEW_SELLERS'),   col: 'var(--red)' };
+  if (d.chartPattern) {
+    const isBull = /bull|higher high|engulf.*bull|hammer(?! man)|double bot/i.test(d.chartPattern);
+    const isBear = /bear|lower high|engulf.*bear|shooting|double top/i.test(d.chartPattern);
+    const label  = d.chartPattern.split(';')[0].split('(')[0].trim();
+    if (isBull && label) return { text: label, col: 'var(--green)' };
+    if (isBear && label) return { text: label, col: 'var(--red)' };
+    if (label)           return { text: label, col: 'var(--txt3)' };
+  }
+  if (d.oiTrend === 'weak_up')   return { text: t('DASH_SIDEBAR_SIG_SHORTS_CLOSING'), col: 'var(--amber)' };
+  if (d.oiTrend === 'weak_down') return { text: t('DASH_SIDEBAR_SIG_BUYERS_PROFIT'),  col: 'var(--txt3)' };
+  return null;
+}
+
+/* One row of the coins table */
+function CoinRow({ id }: { id: CoinId }) {
+  const { store, selectCoin } = useMarket();
+  const { t } = useLabels();
+  const d   = store.coins[id];
+  const dec = COIN_DEC[id];
+  const chg = d?.change ?? 0;
+  const up  = chg >= 0;
+  const tbp    = d?.takerBuyRatio != null ? Math.round(d.takerBuyRatio * 100) : 50;
+  const health = computeCoinHealth(d);
+  const sig    = coinSignal(d, t);
+  const fr     = d?.fundingRate != null ? d.fundingRate * 100 : null;
+  const frInfo = fr != null ? classifyFunding(fr) : null;
+  const badgeCol = coinBadgeColor(id);
+  const sel    = store.selectedCoin === id;
+
+  const barFill = tbp >= 60 ? 'var(--green)' : tbp <= 40 ? 'var(--red)' : 'var(--txt4)';
+  const oiLabel = d?.oiTrend === 'strong_up'   ? '▲▲'
+                : d?.oiTrend === 'strong_down'  ? '▼▼'
+                : d?.oiTrend === 'weak_up'      ? '▲'
+                : d?.oiTrend === 'weak_down'    ? '▼'
+                : DASH;
+  const oiCol   = d?.oiTrend === 'strong_up'   ? 'var(--green)'
+                : d?.oiTrend === 'strong_down'  ? 'var(--red)'
+                : d?.oiTrend === 'weak_up'      ? 'var(--green-soft)'
+                : d?.oiTrend === 'weak_down'    ? 'var(--red-soft)'
+                : 'var(--txt4)';
+  const frCol   = fr == null ? 'var(--txt3)'
+                : fr >= 0.04  ? 'var(--red)'
+                : fr <= -0.02 ? 'var(--green)'
+                : Math.abs(fr) < 0.005 ? 'var(--txt3)'
+                : fr > 0 ? 'var(--txt2)' : 'var(--txt2)';
+
+  return (
+    <tr className={`dk-tr${sel ? ' dk-tr-sel' : ''}`} onClick={() => selectCoin(id)}>
+      <td className="dk-td dk-td-coin">
+        <CoinIcon coin={id} size={14} color={badgeCol} bg="transparent" />
+        <span className="dk-coin-ticker">{id.toUpperCase()}</span>
+      </td>
+      <td className="dk-td dk-td-num">
+        {d?.price ? '$' + fmtPrice(d.price, dec) : DASH}
+      </td>
+      <td className="dk-td dk-td-num" style={{ color: up ? 'var(--green)' : 'var(--red)' }}>
+        {up ? '+' : ''}{chg.toFixed(2)}%
+      </td>
+      <td className="dk-td dk-td-num" style={{ color: frCol }}>
+        {fr != null ? (fr >= 0 ? '+' : '') + fr.toFixed(4) + '%' : DASH}
+      </td>
+      <td className="dk-td dk-td-num" style={{ color: oiCol }}>
+        {oiLabel}
+      </td>
+      <td className="dk-td dk-td-bar">
+        <div className="dk-bar-track">
+          <div className="dk-bar-fill" style={{ width: tbp + '%', background: barFill }} />
+        </div>
+      </td>
+      <td className="dk-td dk-td-sig" style={{ color: sig?.col ?? 'var(--txt4)' }}>
+        {sig?.text ?? DASH}
+      </td>
+      <td className="dk-td dk-td-grade" style={{ color: health.color }}>
+        {health.grade}
+      </td>
+    </tr>
+  );
+}
+
+/* Macro backdrop — 5 rows from localStorage cache + market store */
+function MacroBackdrop() {
+  const { store } = useMarket();
+  const macro = useMacroCache();
+
+  const rows: { label: string; value: string; chg: string; col: string }[] = [
+    {
+      label: 'DXY',
+      value: macro ? macro.dxy.toFixed(2)  : DASH,
+      chg:   chgStr(macro?.dxyChg ?? null),
+      col:   chgColor(macro?.dxyChg ?? null, true),
+    },
+    {
+      label: 'US 10Y',
+      value: macro ? macro.tnx.toFixed(2) + '%' : DASH,
+      chg:   chgStr(macro?.tnxChg ?? null),
+      col:   chgColor(macro?.tnxChg ?? null, true),
+    },
+    {
+      label: 'S&P 500',
+      value: store.spx != null ? store.spx.toLocaleString('en-US', { maximumFractionDigits: 0 }) : DASH,
+      chg:   chgStr(store.spxChg),
+      col:   chgColor(store.spxChg),
+    },
+    {
+      label: 'GOLD',
+      value: macro ? '$' + macro.gold.toLocaleString('en-US', { maximumFractionDigits: 0 }) : DASH,
+      chg:   chgStr(macro?.goldChg ?? null),
+      col:   chgColor(macro?.goldChg ?? null),
+    },
+    {
+      label: 'ETF FLOW',
+      value: store.etfNetFlow != null
+        ? (store.etfNetFlow >= 0 ? '+' : '') + '$' + Math.abs(store.etfNetFlow).toFixed(0) + 'M'
+        : DASH,
+      chg:   '',
+      col:   store.etfNetFlow == null ? 'var(--txt3)'
+           : store.etfNetFlow > 50  ? 'var(--green)'
+           : store.etfNetFlow < -50 ? 'var(--red)'
+           : 'var(--txt2)',
+    },
+  ];
+
+  return (
+    <div className="dk-macro-rows">
+      {rows.map(row => (
+        <div key={row.label} className="dk-macro-row">
+          <span className="dk-macro-label">{row.label}</span>
+          <span className="dk-macro-value" style={{ color: row.col }}>{row.value}</span>
+          {row.chg && <span className="dk-macro-chg" style={{ color: row.col }}>{row.chg}</span>}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* Main export */
+export default function DeskTerminal() {
+  const { store } = useMarket();
+  const { t } = useLabels();
+  const volLabel = useVolLabel();
+
+  const selectedCoinData = store.coins[store.selectedCoin];
+  const read = useMemo(
+    () => computeMarketRead(store, null),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [store.fng, store.selectedCoin, store.cbPremiumPct, store.btcExchangeNetFlow, selectedCoinData],
+  );
+
+  /* Pulse cells */
+  const dom = store.btcDom;
+  const alt = store.altSeasonScore;
+  const fng = store.fng;
+  const volCol = volLabel === 'Low Vol' ? 'var(--green)'
+               : volLabel === 'High Vol' ? 'var(--red)'
+               : 'var(--txt2)';
+
+  const coins = (COINS as CoinId[]).slice(0, TABLE_COINS);
+
+  return (
+    <div className="dk-root">
+
+      {/* ── Band ── */}
+      <div className="dk-band">
+        <div className="dk-band-verdict">
+          <div className="dk-verdict-label" data-band={read.band}>{read.verdict}</div>
+          <p className="dk-verdict-sub">{read.sub}</p>
+        </div>
+
+        <div className="dk-pulse">
+          <div className="dk-pulse-cell">
+            <span className="dk-pulse-label">BTC DOM</span>
+            <span className="dk-pulse-value" style={{ color: domColor(dom) }}>
+              {dom != null ? dom.toFixed(1) + '%' : DASH}
+            </span>
+          </div>
+          <div className="dk-pulse-cell">
+            <span className="dk-pulse-label">ALTSEASON</span>
+            <span className="dk-pulse-value" style={{ color: altColor(alt) }}>
+              {alt != null ? String(alt) : DASH}
+            </span>
+          </div>
+          <div className="dk-pulse-cell">
+            <span className="dk-pulse-label">VOLATILITY</span>
+            <span className="dk-pulse-value" style={{ color: volCol }}>
+              {volLabel ? volLabel.replace(' Vol', '').toUpperCase() : DASH}
+            </span>
+          </div>
+          <div className="dk-pulse-cell">
+            <span className="dk-pulse-label">FEAR / GREED</span>
+            <span className="dk-pulse-value" style={{ color: fngColor(fng) }}>
+              {fng != null ? String(fng) : DASH}
+            </span>
+            {store.fngLabel && (
+              <span className="dk-pulse-sub">{store.fngLabel}</span>
+            )}
+          </div>
+        </div>
+
+        <Link href="/arena" className="dk-arena-btn">OPEN ARENA</Link>
+      </div>
+
+      {/* ── Body ── */}
+      <div className="dk-body">
+
+        {/* LEFT: coins table */}
+        <div className="dk-table-wrap">
+          <table className="dk-table">
+            <thead>
+              <tr>
+                <th className="dk-th">COIN</th>
+                <th className="dk-th dk-th-num">PRICE</th>
+                <th className="dk-th dk-th-num">24H</th>
+                <th className="dk-th dk-th-num">FUNDING</th>
+                <th className="dk-th dk-th-num">OI 1H</th>
+                <th className="dk-th">TAKER</th>
+                <th className="dk-th">SIGNAL</th>
+                <th className="dk-th dk-th-num">GRADE</th>
+              </tr>
+            </thead>
+            <tbody>
+              {coins.map(id => <CoinRow key={id} id={id} />)}
+            </tbody>
+          </table>
+          <Link href="/markets" className="dk-all-markets">
+            ALL MARKETS →
+          </Link>
+        </div>
+
+        {/* RIGHT: rail */}
+        <aside className="dk-rail">
+
+          {/* SOTD */}
+          <section className="dk-rail-sec">
+            <div className="dk-rail-head">BEST SETUP TODAY</div>
+            <SOTD />
+          </section>
+
+          {/* Macro backdrop */}
+          <section className="dk-rail-sec">
+            <div className="dk-rail-head">MACRO BACKDROP</div>
+            <MacroBackdrop />
+          </section>
+
+          {/* Next events */}
+          <section className="dk-rail-sec">
+            <div className="dk-rail-head">NEXT EVENTS</div>
+            <EconCalendarWidget />
+          </section>
+
+        </aside>
+      </div>
+
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Converts `/dashboard` to the Monochrome Terminal design, frame 2a.

## What changed

- **`components/DeskTerminal.tsx`** (new) — self-contained terminal layout component  
  - Full-width market-read band: verdict label + thesis + 4 pulse cells (BTC Dom, Altseason, Volatility, Fear/Greed) + OPEN ARENA link  
  - 2-column body: coins table (8 cols) left + right rail  
  - Right rail: SOTD, macro backdrop (DXY, US 10Y, S&P 500, Gold, ETF Flow from store + localStorage macro cache), Next Events (EconCalendarWidget)  
- **`app/globals.css`** — `[data-design="terminal"] .dk-*` CSS (Desk Terminal prefix), matching frame 2a measurements; mobile breakpoint hides funding + taker columns  
- **`app/dashboard/page.tsx`** — wraps output in `data-design="terminal"`, renders `DeskTerminal`; retains SpotlightTour, SetupChecklist, CascadeAlertBanner

## Why

Issue #472 — terminal redesign for /dashboard.

## How to test (QA)

On `/dashboard` at 1440px:
1. Full-width band at top shows market verdict text + 4 labelled pulse cells + amber OPEN ARENA button
2. Coins table below left: 8 columns (Coin, Price, 24h, Funding, OI 1h, Taker bar, Signal, Grade); click a row selects it (accent colour on ticker)
3. Right rail shows: SOTD card, 5 macro rows (DXY / US 10Y / S&P 500 / Gold / ETF Flow — values present when Pro, dashes when not), econ calendar events
4. At 390px: band stacks vertically, pulse cells wrap 2×2, Funding + Taker columns hidden, right rail drops below table
5. OPEN ARENA → `/arena`; ALL MARKETS → `/markets`
6. Cascade alert banner (if any active) still appears above the layout

## Risk level

Medium — replaces the entire dashboard layout. Existing data hooks (computeMarketRead, MarketStore, SOTD, EconCalendarWidget) unchanged; macro backdrop reads from localStorage cache written by GlobalMacroContext, falls back to dashes if cache is stale or empty.

Could not verify: macro backdrop values on a Pro-entitled account from local dev (no paid env var). QA should verify on qa environment.

Refs #472

— Dev Team