### PR TITLE
fix(markets): add data-coin-mark to coin colour mark span

### DIFF
--- a/app/markets/page.tsx
+++ b/app/markets/page.tsx
@@ -130,7 +130,7 @@ export default function MarketsPage() {
         const col = coinBadgeColor(id);
         return (
           <div className="mkt3-coin-cell">
-            <span className="mkt3-coin-mark" style={{ background: col }} />
+            <span className="mkt3-coin-mark" data-coin-mark style={{ background: col }} />
             <span className="mkt3-coin-sym">{id.toUpperCase()}</span>
           </div>
         );


### PR DESCRIPTION
## Summary

One-attribute follow-up to #476 (frame 3a).

## What changed

Added `data-coin-mark` to the `<span className="mkt3-coin-mark">` element in `/markets`.

## Why

`coinBadgeColor()` returns off-palette hex (e.g. BTC `#F7931A`). Without an exemption, the contrast conformance spec flags every coin row as a violation. `data-coin-mark` lets the spec exclude that element — same pattern already used for `data-brand-mark` on BrandMark.

## How to test (QA)

1. After arming `/markets` in `CONVERTED_ROUTES`, run the contrast spec
2. Coin mark spans (`[data-coin-mark]`) must be skipped — no false positives on brand colours
3. All other elements on `/markets` must pass WCAG AA as normal

## Risk level

Low — single attribute addition, no visual or behavioural change.

— Dev Team