### PR TITLE
fix(markets): remove double arrow on OPEN ARENA button

### DIFF
--- a/app/markets/page.tsx
+++ b/app/markets/page.tsx
@@ -492,7 +492,7 @@ export default function MarketsPage() {
               {/* Action */}
               <div style={{ textAlign: 'right' }} className="mkt3-desktop-col">
                 <button className="mkt3-arena-btn" onClick={e => { e.stopPropagation(); goToArena(id); }}>
-                  {t('MARKETS_OPEN_ARENA')} →
+                  {t('MARKETS_OPEN_ARENA')}
                 </button>
               </div>
 


### PR DESCRIPTION
## Summary

Fixes #478 — removes hardcoded ` →` suffix added in PR #476.

## What changed

Removed ` →` appended in JSX to `{t('MARKETS_OPEN_ARENA')}`. The translation value already contains the arrow (`"OPEN ARENA →"` in `labelDefaults.en.json:733`), causing double-arrow rendering.

## Why

PR #476 introduced `{t('MARKETS_OPEN_ARENA')} →` — the suffix was redundant.

## How to test (QA)

1. Navigate to `/markets` on `qa` after this lands
2. Each row's action column must show **OPEN ARENA →** (single arrow, not double)

## Risk level

Low — one character removed, no logic change.

— Dev Team