### PR TITLE
chore(settings): restore design-handoff-dir eslint globalIgnore

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -148,6 +148,11 @@ const eslintConfig = defineConfig([
     // error in vendored, minified third-party code that no one can act on.
     'qa/e2e-report/**',
     'test-results/**',
+    // design-handoff-dir contains vendored design-tool runtime bundles (support.js,
+    // ~1,200 lines). Lint correctly flags ReactDOM.render and module assignment but
+    // neither can be fixed — they are third-party files. Ignore was first added in
+    // b38a9b1 and removed by mistake during the #481 terminal revert.
+    'design-handoff-dir/**',
   ]),
 ]);
 


### PR DESCRIPTION
## Summary

Restores one line removed by mistake in #481 (terminal revert).

## What changed

Re-added `'design-handoff-dir/**'` to `globalIgnores` in `eslint.config.mjs`.

## Why

The revert removed the ignore that was intentionally added in `b38a9b1`. `design-handoff-dir/` contains vendored design-tool runtime files (`support.js`, ~1,200 lines). Lint correctly flags a `ReactDOM.render` call and a `module` assignment, but both are in a third-party bundle that cannot be edited. Without the ignore, `npm run lint` exits with 2 errors and the pre-push hook blocks every push.

## How to test (QA)

1. On `qa` branch locally: `npm run lint` — expect **0 errors**.
2. Attempt to push any branch — hook should not block on `design-handoff-dir/` errors.

## Risk level

Low — one-line restoration of a previously intentional ignore entry. No application code changed.

Closes #482

— Dev Team
