### PR TITLE
test(qa): restore route and element context to light-theme contrast failures

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -148,6 +148,11 @@ const eslintConfig = defineConfig([
     // error in vendored, minified third-party code that no one can act on.
     'qa/e2e-report/**',
     'test-results/**',
+    // Design-handoff vendor files (Gamma / Figma export runtime). Untracked
+    // locally, never present in CI — but locally `eslint .` walks them and hits
+    // ReactDOM.render + module-assignment errors that cannot be fixed (third-party
+    // bundle). Same pattern as qa/e2e-report above.
+    'design-handoff-dir/**',
   ]),
 ]);
 

--- a/qa/e2e/contrast.spec.ts
+++ b/qa/e2e/contrast.spec.ts
@@ -451,11 +451,34 @@ This is NOT automatically a regression. It is either:
       `Both are scored the same way on purpose - a route that could not be measured must never be counted as a route with no violations.`,
     ).toEqual([]);
 
-    const byColour = new Map<string, { n: number; worst: number }>();
+    /* ROUTE AND TARGET, not just the token. The dark test has carried them since
+     * it was written; this one never did, and the asymmetry cost real time.
+     *
+     * On 2026-08-14 this reported `#795f15 worst 2.58:1 x2` and dev could not
+     * act on it: they solved for the background from the ratio, swept every
+     * route reachable signed out, found nothing, and asked me for the route
+     * names. I wrote a throwaway probe to answer a question this message should
+     * have answered itself.
+     *
+     * **A failure that names a token but not where it renders makes the reader
+     * do the work twice.** `Violation` carried `route` and `target` all along;
+     * only this aggregation threw them away.
+     *
+     * Keeps the WORST instance's location, not the first — the worst is the one
+     * someone has to fix, and a first-seen route can be a much milder case that
+     * sends the reader to the wrong screen. */
+    const byColour = new Map<string, { n: number; worst: number; where: string; what: string }>();
     for (const v of all) {
       const key = bucket(v.fg);
-      const e = byColour.get(key) ?? { n: 0, worst: Infinity };
-      byColour.set(key, { n: e.n + 1, worst: Math.min(e.worst, v.ratio) });
+      const e = byColour.get(key);
+      if (!e) { byColour.set(key, { n: 1, worst: v.ratio, where: v.route, what: v.target }); continue; }
+      const keep = v.ratio < e.worst;
+      byColour.set(key, {
+        n: e.n + 1,
+        worst: Math.min(e.worst, v.ratio),
+        where: keep ? v.route : e.where,
+        what: keep ? v.target : e.what,
+      });
     }
 
     const known = new Set(BASELINE.contrast.lightTokens);
@@ -467,7 +490,7 @@ This is NOT automatically a regression. It is either:
     testInfo.attach('contrast-light.txt', {
       body: `${all.length} violations across ${byColour.size} tokens\n\n`
         + [...byColour].sort((a, b) => a[1].worst - b[1].worst)
-            .map(([fg, e]) => `${fg}  worst ${e.worst.toFixed(2)}:1  x${e.n}`).join('\n')
+            .map(([fg, e]) => `${fg}  worst ${e.worst.toFixed(2)}:1  x${e.n}  worst at ${e.where}  ${e.what}`).join('\n')
         + (fixed.length ? `\n\nno longer failing (remove from BASELINE.contrast.lightTokens):\n${fixed.join('\n')}` : ''),
       contentType: 'text/plain',
     });
@@ -497,7 +520,7 @@ This is NOT automatically a regression. It is either:
       `BASELINE.contrast.lightTokens.
 
 ` +
-      unexpected.map(([fg, e]) => `  ${fg}  worst ${e.worst.toFixed(2)}:1  x${e.n}`).join('\n') +
+      unexpected.map(([fg, e]) => `  ${fg}  worst ${e.worst.toFixed(2)}:1  x${e.n}  worst at ${e.where}  ${e.what}`).join('\n') +
       `
 
 Same triage as the dark test: a state that had not rendered before (add it, with a ` +


### PR DESCRIPTION
## Summary

- Restores `where` (route) and `what` (CSS target) to the light-theme contrast failure message and attachment
- Restores `design-handoff-dir/**` to eslint globalIgnores (missing from `dev` since #481 revert; was re-added to qa/staging in #483 but never came back to dev)

## What changed

**`qa/e2e/contrast.spec.ts`**

`byColour` map type was `{ n, worst }`. Now `{ n, worst, where, what }`.

Aggregation keeps the WORST instance's location (not first-seen), so the failure message names the route and element that actually needs fixing — not a milder case that sends dev to the wrong screen.

Both the attachment (`contrast-light.txt`) and the `expect()` failure message now print:
```
#795f15  worst 2.58:1  x2  worst at /arena  main > div > ... > span
```
instead of:
```
#795f15  worst 2.58:1  x2
```

The dark test has carried this since it was written. Light never did after #424 was wrongly included in the #481 revert list.

**`eslint.config.mjs`**

`'design-handoff-dir/**'` restored to `globalIgnores`. Same fix as #483, which went to qa/staging but was never merged back to dev. Without it, the locally-present untracked folder `design-handoff-dir/arena1a/support.js` (Gamma/Figma vendor runtime) causes 8 lint errors (`ReactDOM.render`, `module` assignment) that block the pre-push hook.

## Why

PR #424 (`test/contrast-names-the-site`) was not terminal-specific. It was pure observability: name the route and element in light-theme contrast failures. The commit message said so. It was included in #481's revert list by mistake.

A failure that names a token but not where it renders makes the reader do the work twice. This puts back what the revert took.

## How to test (QA)

1. `npx playwright test qa/e2e/contrast.spec.ts --project=desktop`
2. On a run with a new failing token, the failure message prints route and CSS selector for the worst instance, not just the hex and count.
3. `npm run lint` exits 0 errors (warnings are pre-existing app-code issues unrelated to this PR).

## Risk level: **Low**

QA-owned files only. No app code changed. The eslint config change is a local-developer convenience — CI checkout never has `design-handoff-dir/` so CI was never affected.