### PR TITLE
fix(disclaimer): title font-size 42px → 32px (frame 3a)

### DIFF
--- a/app/disclaimer/page.tsx
+++ b/app/disclaimer/page.tsx
@@ -29,7 +29,7 @@ export default function Disclaimer() {
         }}>
           {t('DISCLAIMER_EYEBROW')}
         </div>
-        <h1 style={{ fontSize: '2.625rem', fontWeight: 800, color: 'var(--txt)', margin: 0, lineHeight: 1.1 }}>
+        <h1 style={{ fontSize: '2rem', fontWeight: 800, color: 'var(--txt)', margin: 0, lineHeight: 1.1 }}>
           {t('DISCLAIMER_PAGE_TITLE')}
         </h1>
       </div>


### PR DESCRIPTION
## Summary

Fixes /disclaimer page title: was 42px (2.625rem), frame 3a specifies 32px (2rem).

## What changed

- `app/disclaimer/page.tsx:32` — inline `fontSize` changed from `2.625rem` to `2rem`

## Why

Frame 3a specifies 32px. The page shipped at 42px. Previous measurement reported 34px but QA re-measured 2026-08-27 and found 42px (the inline style, not the CSS rule that was measured before).

## How to test (QA)

1. Open `/disclaimer` signed in or out
2. Inspect the page `h1` — computed font-size must be 32px (2rem)
3. Run `npx playwright test qa/e2e/design-structure.spec.ts --project=desktop -g "measured structure"` — must pass (was failing at 34, now at 32)

## Risk level

Low — one inline style value on a single static page, no logic, no data path.

Closes #445

— Dev Team