### PR TITLE
feat(chart): spot/perp taker-buy absorption signal (#361)

### DIFF
--- a/lib/perpSpot.ts
+++ b/lib/perpSpot.ts
@@ -34,6 +34,9 @@ export interface OHLCVLike {
   time: number;
   /** Quote-asset volume - USDT, comparable between spot and perp. */
   quoteVolume: number;
+  /** Taker-buy quote-asset volume (USDT). Binance kline index 10.
+   *  Optional: absent on Bybit and on older cached rows. */
+  takerBuyQuoteVolume?: number;
 }
 
 export type PerpSpotLean = 'spot' | 'perp' | 'normal' | 'unknown';
@@ -266,4 +269,87 @@ export function perpScorePenalty(lean: PerpSpotLean): number {
  */
 export function perpNoticeTone(lean: PerpSpotLean): 'caution' | 'neutral' {
   return lean === 'perp' || lean === 'unknown' ? 'caution' : 'neutral';
+}
+
+/* ── Spot absorption of futures liquidations (#361) ──────────────────────────
+ *
+ * When futures traders are force-sold (liquidations), perp taker-buy drops —
+ * sellers dominate. If spot taker-buy is simultaneously HIGH, real buyers are
+ * absorbing those forced sales. That divergence is the signal.
+ *
+ * Uses the taker-buy QUOTE volume (Binance kline index 10) so both feeds are
+ * USDT-denominated and comparable. The observation threshold (20pp delta) is
+ * an internal calibration value, not an owner-blessed number — record here
+ * so it is visible rather than buried in a constant. */
+
+const ABSORPTION_WINDOW = 4; // last 4 closed hourly bars
+
+export interface AbsorptionReading {
+  /** Average taker-buy % on spot over the last ABSORPTION_WINDOW bars. */
+  spotTakerPct: number | null;
+  /** Average taker-buy % on perp over the last ABSORPTION_WINDOW bars. */
+  perpTakerPct: number | null;
+  /** False when taker-buy data is missing (Bybit coins, old cache rows). */
+  available: boolean;
+  /** Ready-to-display observation. No forecast — numbers and direction only. */
+  observation: string;
+}
+
+/**
+ * Cross taker-buy % between spot and perp feeds.
+ *
+ * Requires `takerBuyQuoteVolume` on both feeds — returns `available: false`
+ * for any coin without it (Bybit, or rows fetched before the field was added).
+ * Never fabricates: an absent reading is an explicit "unknown", not a quiet 50%.
+ */
+export function computeAbsorption(
+  spot: readonly OHLCVLike[],
+  perp: readonly OHLCVLike[],
+  intervalMs = 3_600_000,
+  nowMs = Date.now(),
+): AbsorptionReading {
+  const unavailable: AbsorptionReading = {
+    spotTakerPct: null, perpTakerPct: null,
+    available: false,
+    observation: 'Taker-buy data unavailable for this coin.',
+  };
+
+  if (spot.length === 0 || perp.length === 0) return unavailable;
+
+  const closedSpot = dropForming(spot, intervalMs, nowMs);
+  const closedPerp = dropForming(perp, intervalMs, nowMs);
+
+  const perpByTime = new Map(closedPerp.map(c => [c.time, c]));
+  const paired: Array<{ spotPct: number; perpPct: number }> = [];
+
+  for (const s of closedSpot) {
+    const p = perpByTime.get(s.time);
+    if (!p) continue;
+    if (s.takerBuyQuoteVolume == null || p.takerBuyQuoteVolume == null) continue;
+    if (s.quoteVolume <= 0 || p.quoteVolume <= 0) continue;
+    paired.push({
+      spotPct: (s.takerBuyQuoteVolume / s.quoteVolume) * 100,
+      perpPct:  (p.takerBuyQuoteVolume  / p.quoteVolume)  * 100,
+    });
+  }
+
+  if (paired.length < MIN_BARS) return unavailable;
+
+  const window = paired.slice(-ABSORPTION_WINDOW);
+  const spotPct = window.reduce((s, x) => s + x.spotPct, 0) / window.length;
+  const perpPct = window.reduce((s, x) => s + x.perpPct, 0) / window.length;
+  const sp = Math.round(spotPct);
+  const pp = Math.round(perpPct);
+  const delta = sp - pp;
+
+  /* 20pp threshold is internal — not an owner-blessed number. A spot-led gap
+   * of 68% vs 34% (the owner's example, 34pp) clears it comfortably. */
+  const observation =
+    delta >= 20
+      ? `Spot buying absorbing futures selling — ${sp}% taker-buy on spot against ${pp}% on perps.`
+      : delta <= -20
+      ? `Futures buyers leading spot — ${pp}% taker-buy on perps against ${sp}% on spot.`
+      : `Spot and perps moving together — ${sp}% taker-buy on spot, ${pp}% on perps.`;
+
+  return { spotTakerPct: spotPct, perpTakerPct: perpPct, available: true, observation };
 }

--- a/lib/usePerpSpot.ts
+++ b/lib/usePerpSpot.ts
@@ -1,7 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { BINANCE_SYMS } from './coins';
-import { computePerpSpot, type PerpSpotReading } from './perpSpot';
+import { computePerpSpot, computeAbsorption, type PerpSpotReading, type AbsorptionReading } from './perpSpot';
 
 /* One source for the perps-vs-spot reading (#340).
  *
@@ -21,9 +21,9 @@ const BARS = 168;   // 7 days of hourly bars - enough for a stable median
 
 type Kline = [number, string, string, string, string, string, number, string, ...unknown[]];
 
-interface Entry { reading: PerpSpotReading; fetchedAt: number }
+interface Entry { reading: PerpSpotReading; absorption: AbsorptionReading; fetchedAt: number }
 const cache = new Map<string, Entry>();
-const inflight = new Map<string, Promise<PerpSpotReading>>();
+const inflight = new Map<string, Promise<Entry>>();
 
 async function fetchBars(source: 'binance' | 'binance-futures', symbol: string) {
   const r = await fetch(
@@ -32,69 +32,95 @@ async function fetchBars(source: 'binance' | 'binance-futures', symbol: string) 
   );
   if (!r.ok) throw new Error(`${source} ${r.status}`);
   const rows = (await r.json()) as Kline[];
-  // Index 7 is quote-asset volume (USDT) - comparable across the two venues in
-  // a way base volume is not. Index 0 is the bar's open time.
-  return rows.map(k => ({ time: k[0], quoteVolume: parseFloat(k[7]) }));
+  // Index 7: quote-asset volume (USDT). Index 10: taker-buy quote volume (#361).
+  return rows.map(k => ({
+    time: k[0],
+    quoteVolume: parseFloat(k[7] as string),
+    takerBuyQuoteVolume: parseFloat(k[10] as string),
+  }));
 }
 
 /**
- * Read perps-vs-spot for a coin. Never throws; an unmeasurable state is a
- * value, not an exception.
- *
- * Single-flight per coin: five surfaces mounting at once must not become five
- * pairs of upstream calls. Same reasoning as #201 on the klines route.
+ * Fetch both readings for a coin in one network round-trip.
+ * Never throws — an unmeasurable state is a value, not an exception.
+ * Single-flight per coin so five surfaces do not become five pairs of calls.
  */
-export async function readPerpSpot(coin: string): Promise<PerpSpotReading> {
+async function fetchEntry(coin: string): Promise<Entry> {
+  const now = Date.now();
   const hit = cache.get(coin);
-  // Valid until the hour turns, matching the bar interval the reading is built
-  // from - a fresh fetch inside the same hour returns the same closed bar.
-  if (hit && Math.floor(hit.fetchedAt / HOUR) === Math.floor(Date.now() / HOUR)) {
-    return hit.reading;
-  }
+  if (hit && Math.floor(hit.fetchedAt / HOUR) === Math.floor(now / HOUR)) return hit;
   const running = inflight.get(coin);
   if (running) return running;
 
   const sym = BINANCE_SYMS[coin];
-  const job = (async (): Promise<PerpSpotReading> => {
-    // No Binance spot pair means the question cannot be answered for this coin.
-    // computePerpSpot([], []) is the explicit "cannot tell" reading - never a
-    // number derived from the perp side alone.
-    if (!sym) return computePerpSpot([], []);
+  const job = (async (): Promise<Entry> => {
+    if (!sym) {
+      const empty = computePerpSpot([], []);
+      return { reading: empty, absorption: computeAbsorption([], []), fetchedAt: Date.now() };
+    }
     try {
       const [spot, perp] = await Promise.all([
         fetchBars('binance', sym), fetchBars('binance-futures', sym),
       ]);
-      return computePerpSpot(spot, perp, HOUR, Date.now());
+      const t = Date.now();
+      return {
+        reading:   computePerpSpot(spot, perp, HOUR, t),
+        absorption: computeAbsorption(spot, perp, HOUR, t),
+        fetchedAt: t,
+      };
     } catch {
-      return computePerpSpot([], []);   // a failed fetch is not a quiet market
+      const empty = computePerpSpot([], []);
+      return { reading: empty, absorption: computeAbsorption([], []), fetchedAt: Date.now() };
     }
   })();
 
   inflight.set(coin, job);
   try {
-    const reading = await job;
-    cache.set(coin, { reading, fetchedAt: Date.now() });
-    return reading;
+    const entry = await job;
+    cache.set(coin, entry);
+    return entry;
   } finally {
     inflight.delete(coin);
   }
 }
 
-/** React binding. Re-reads when the hour turns, since the bar has changed. */
+export async function readPerpSpot(coin: string): Promise<PerpSpotReading> {
+  return (await fetchEntry(coin)).reading;
+}
+
+export async function readAbsorption(coin: string): Promise<AbsorptionReading> {
+  return (await fetchEntry(coin)).absorption;
+}
+
+function useHourTick(): number {
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const id = setTimeout(() => setTick(t => t + 1), HOUR - (Date.now() % HOUR) + 3_000);
+    return () => clearTimeout(id);
+  }, [tick]);
+  return tick;
+}
+
+/** React binding for perps-vs-spot. Re-reads when the hour turns. */
 export function usePerpSpot(coin: string): PerpSpotReading | null {
   const [reading, setReading] = useState<PerpSpotReading | null>(null);
-  const [tick, setTick] = useState(0);
-
+  const tick = useHourTick();
   useEffect(() => {
     let cancelled = false;
     readPerpSpot(coin).then(r => { if (!cancelled) setReading(r); });
     return () => { cancelled = true; };
   }, [coin, tick]);
+  return reading;
+}
 
+/** React binding for spot/perp absorption. Shares the same fetch as usePerpSpot. */
+export function useAbsorption(coin: string): AbsorptionReading | null {
+  const [reading, setReading] = useState<AbsorptionReading | null>(null);
+  const tick = useHourTick();
   useEffect(() => {
-    const id = setTimeout(() => setTick(t => t + 1), HOUR - (Date.now() % HOUR) + 3_000);
-    return () => clearTimeout(id);
-  }, [tick]);
-
+    let cancelled = false;
+    readAbsorption(coin).then(r => { if (!cancelled) setReading(r); });
+    return () => { cancelled = true; };
+  }, [coin, tick]);
   return reading;
 }


### PR DESCRIPTION
## Summary
Adds `computeAbsorption` to detect spot buyers absorbing futures liquidations by comparing taker-buy % across venues.

## What changed
- **`lib/perpSpot.ts`**: New `AbsorptionReading` interface and `computeAbsorption()`. Uses 4-bar rolling window of closed hourly bars. Computes `takerBuyQuoteVolume / quoteVolume` on both spot and perp, pairs bars by timestamp, returns percentages + plain-language `observation` string. Falls through to `available: false` when data is missing.
- **`lib/usePerpSpot.ts`**: Refactored to `fetchEntry()` internal that computes both readings in one fetch. Added `readAbsorption(coin)` async function and `useAbsorption(coin)` React hook. Cache and inflight dedup cover both readings — five components mounting share one pair of upstream calls, not two.

## Why
Issue #361 — signal when spot buying absorbs forced futures liquidations. Binance kline index 10 = taker-buy quote volume (USDT); index 7 = total quote volume. Spot taker-buy % >> perp taker-buy % = real buyers stepping in against forced selling.

## How to test (QA)
On the `qa` environment after promotion:
1. Open browser DevTools → Network tab, filter for `klines`.
2. Navigate to any coin with a Binance pair (BTC, ETH).
3. Confirm **exactly two** klines fetches fire per coin — one `source=binance`, one `source=binance-futures`. A second pair would mean the cache is broken.
4. In the browser console: `await import('/lib/usePerpSpot').then(m => m.readAbsorption('BTC'))`. Expect `{ available: true, spotTakerPct: <number>, perpTakerPct: <number>, observation: "<string>" }`.
5. For a coin without a Binance pair, expect `available: false` with observation `"Taker-buy data unavailable for this coin."`.

Note: `useAbsorption` and `readAbsorption` are exported but not wired to any UI surface yet — that is the next step per #361. This PR delivers the data layer only.

## Risk level
Low — additive only. `usePerpSpot` and `readPerpSpot` unchanged from callers' perspective; internal refactor only. No new API routes. No DB changes. Existing `AbsorptionDetector` component uses different data (15m candles, base volume) and is unaffected.

— Dev Team
