### PR TITLE
feat(chart): wire Spot Absorption to PerpSpotCard (#361)

### DIFF
--- a/components/PerpSpotCard.tsx
+++ b/components/PerpSpotCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useMarket } from '@/lib/marketStore';
-import { usePerpSpot } from '@/lib/usePerpSpot';
+import { usePerpSpot, useAbsorption } from '@/lib/usePerpSpot';
 
 /* Perps vs spot (#328) - "is there a real buyer, or is the pump just futures?"
  *
@@ -39,6 +39,7 @@ export default function PerpSpotCard() {
   // Shared with the Arena prompts and the chart signal (#340) - one fetch, one
   // reading, so the card and the AI cannot disagree on screen.
   const reading = usePerpSpot(coin);
+  const absorption = useAbsorption(coin);
 
   if (!reading) return null;
 
@@ -95,6 +96,21 @@ export default function PerpSpotCard() {
       <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt2)', lineHeight: 1.55 }}>
         {reading.explanation}
       </div>
+
+      {absorption?.available && (
+        <>
+          <div style={{ borderTop: '0.5px solid var(--bdr)', margin: '10px 0' }} />
+          <div style={{
+            fontSize: 'var(--fs-micro)', fontWeight: 700, textTransform: 'uppercase',
+            letterSpacing: '0.08em', color: 'var(--txt3)', marginBottom: 4,
+          }}>
+            Spot Absorption
+          </div>
+          <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt2)', lineHeight: 1.55 }}>
+            {absorption.observation}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/lib/perpSpot.ts
+++ b/lib/perpSpot.ts
@@ -346,7 +346,7 @@ export function computeAbsorption(
    * of 68% vs 34% (the owner's example, 34pp) clears it comfortably. */
   const observation =
     delta >= 20
-      ? `Spot buying absorbing futures selling — ${sp}% taker-buy on spot against ${pp}% on perps.`
+      ? `Spot buying absorbing futures selling — ${sp}% taker-buy on spot against ${pp}% on perps. Someone is taking the other side of the forced sales.`
       : delta <= -20
       ? `Futures buyers leading spot — ${pp}% taker-buy on perps against ${sp}% on spot.`
       : `Spot and perps moving together — ${sp}% taker-buy on spot, ${pp}% on perps.`;


### PR DESCRIPTION
## Summary
Wires `useAbsorption(coin)` into `PerpSpotCard`, completing the UI half of #361.

## What changed
- **`components/PerpSpotCard.tsx`**: Imports `useAbsorption` alongside `usePerpSpot`. Adds a conditional "Spot Absorption" section below the existing perp/spot reading — hairline divider, micro uppercase label, observation string. Hidden when `available: false`.

## Why
Data layer (PR #487) landed in `dev` and verified on `qa`. This is the display step — ships the `observation` string to the user per the #361 spec wording.

## How to test (QA)
On the `qa` environment after promotion:
1. Navigate to any page that renders `PerpSpotCard` (Dashboard or Arena, coin selector visible).
2. Select a coin with a Binance spot pair (BTC, ETH, SOL).
3. `PerpSpotCard` should show a **Spot Absorption** section below the "Futures Activity vs Normal" reading, separated by a hairline. Text should be one of:
   - `"Spot buying absorbing futures selling — X% taker-buy on spot against Y% on perps."`
   - `"Futures buyers leading spot — Y% taker-buy on perps against X% on spot."`
   - `"Spot and perps moving together — X% taker-buy on spot, Y% on perps."`
4. Select a coin **without** a Binance spot pair (if any exist in the selector). Spot Absorption section should not appear.
5. Open DevTools → Network → confirm still exactly **two** klines fetches per coin (no extra fetch from the absorption hook).

## Risk level
Low — additive display only. Existing perp/spot display unchanged. `useAbsorption` shares the same `fetchEntry` as `usePerpSpot` — no new network calls. Hidden by default when data unavailable.

— Dev Team
