### PR TITLE
feat(dashboard): Monochrome Terminal — Desk 2a (#413)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5280,6 +5280,15 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
   --mark-idle:    #22262a;  /* signal marker when not firing */
   --border-input: #2a2e32;  /* input and secondary-button border */
 
+  /* Radius: 0 everywhere in terminal mode. The comment above already states
+     this intent; these override the root tokens so CSS classes that reference
+     var(--radius-card) etc. produce 0 without needing per-class rules. */
+  --radius-data: 0;
+  --radius-card: 0;
+  --radius-chip: 0;
+  --radius-pill: 0;
+  --radius-sharp: 0;
+
   /* Undocumented in the README, real in the prototypes: the FLAT cell of the
      hours expectancy grid (|expectancy| < 0.12), with its own legend swatch.
      Close to --mark-idle and deliberately not equal to it. */
@@ -6188,3 +6197,16 @@ main.app-content[data-chrome="none"] {
 /* The scale badge sits with them and reads as orphaned once they are gone. */
 [data-design="terminal"] .at-chart .klc-scale-badge,
 [data-design="terminal"] .at-mchart .klc-scale-badge { display: none; }
+
+/* ── Dashboard (Desk 2a) terminal overrides (#413) ─────────────────────────
+   Hardcoded pixel radii that the token override (--radius-card: 0) cannot
+   reach because they are literal px values in the shared class definitions.
+   Each rule is one class, one property: no cascade, no specificity surprise. */
+[data-design="terminal"] .edge-card     { border-radius: 0; }
+[data-design="terminal"] .scc-card      { border-radius: 0; }
+[data-design="terminal"] .macro-rail-card { border-radius: 0; border: 1px solid var(--bdr); }
+[data-design="terminal"] .mr            { border-radius: 0; }
+[data-design="terminal"] .cascade-dismiss { border-radius: 0; }
+[data-design="terminal"] .csb2-sig      { border-radius: 0; }
+[data-design="terminal"] .csb2-bar-track,
+[data-design="terminal"] .csb2-bar-fill { border-radius: 0; }

--- a/components/DashboardTerminal.tsx
+++ b/components/DashboardTerminal.tsx
@@ -1,10 +1,20 @@
 'use client';
+/* Monochrome Terminal rendering of the dashboard (Desk 2a, #413).
+ *
+ * Activated by useDesignMode() === 'terminal' in app/dashboard/page.tsx.
+ * Mirrors Dashboard's data logic and component structure exactly; the only
+ * differences are visual: no GlobalSpotlight, no mb-glow-card, border-radius
+ * 0 on any inline style that sets one. CSS token overrides in globals.css
+ * handle the class-level radii (--radius-card → 0, --radius-data → 0, plus
+ * targeted rules for hardcoded px values like .edge-card and .scc-card). */
+
 import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
-import { useDesignMode } from '@/components/DesignModeProvider';
-import DashboardTerminal from '@/components/DashboardTerminal';
 import { useOnboarding } from '@/components/OnboardingProvider';
-import { useMarket, COINS, COIN_DEC, fmtPrice, computeCoinHealth, classifyFunding, computeSqueezeScore, FUNDING_TIP_KEY } from '@/lib/marketStore';
+import {
+  useMarket, COINS, COIN_DEC, fmtPrice,
+  computeCoinHealth, classifyFunding, computeSqueezeScore, FUNDING_TIP_KEY,
+} from '@/lib/marketStore';
 import type { CoinId } from '@/lib/marketStore';
 import { useOI1h, oi1hSignal } from '@/lib/useOI1h';
 import { useSettings } from '@/lib/settings';
@@ -19,18 +29,13 @@ import Tip from '@/components/Tip';
 import { coinBadgeColor } from '@/lib/coinBadge';
 import { withAlpha } from '@/lib/color';
 import Sparkline24h from '@/components/Sparkline24h';
-
-/* The sparkline's width, shared with .csb2-bottom's middle grid column via the
-   --csb2-spark-w custom property below. The CSS used to hardcode nothing at all
-   and the prop said 36 - the column and the chart had no way to disagree
-   loudly, so they disagreed quietly (#401). One number, two consumers. */
-const SPARK_W = 36;
 import CoinIcon from '@/components/CoinIcon';
-import { GlobalSpotlight, useMobile } from '@/components/MagicBento';
 import { SkeletonBar } from '@/components/Skeleton';
 import { useLabels } from '@/lib/labels';
 import type { LabelKey } from '@/lib/labelKeys';
 import PerpSpotCard from '@/components/PerpSpotCard';
+
+const SPARK_W = 36;
 
 const OI_TREND_META: Record<string, { txtKey: LabelKey; subKey: LabelKey; col: string }> = {
   strong_up:   { txtKey: 'OI_TREND_STRONG_UP_TXT',   subKey: 'OI_TREND_STRONG_UP_SUB',   col: 'var(--green)' },
@@ -39,9 +44,9 @@ const OI_TREND_META: Record<string, { txtKey: LabelKey; subKey: LabelKey; col: s
   weak_down:   { txtKey: 'OI_TREND_WEAK_DOWN_TXT',   subKey: 'OI_TREND_WEAK_DOWN_SUB',   col: 'var(--txt3)' },
 };
 
+const SIDEBAR_DEFAULT = 7;
 
-/* ── Market Pulse Strip - compact stat chips replacing 3 sidebar indicator cards ── */
-function MarketPulseStrip() {
+function TMarketPulseStrip() {
   const { store } = useMarket();
   const { t } = useLabels();
   const [volLabel, setVolLabel] = useState<string | null>(null);
@@ -58,8 +63,6 @@ function MarketPulseStrip() {
     } catch {}
   }, []);
 
-  // Fear & Greed intentionally lives in the Market Read hero now (deduped) - the
-  // strip carries the dominance/altseason/volatility context that isn't there.
   const dom = store.btcDom;
   const alt = store.altSeasonScore;
 
@@ -85,9 +88,9 @@ function MarketPulseStrip() {
 
   return (
     <div style={{
-      background: 'var(--bg2)',
-      border: '0.5px solid var(--bdr)',
-      borderRadius: 'var(--radius-card)',
+      background: 'var(--bg1)',
+      border: '1px solid var(--bdr)',
+      borderRadius: 0,
       padding: '10px 12px',
       display: 'grid',
       gridTemplateColumns: `repeat(${chips.length}, 1fr)`,
@@ -110,11 +113,7 @@ function MarketPulseStrip() {
   );
 }
 
-
-/* ── Coin Sidebar v2 - signal cards ── */
-const SIDEBAR_DEFAULT = 7;
-
-function CoinSidebar() {
+function TCoinSidebar() {
   const { store, selectCoin } = useMarket();
   const { t } = useLabels();
   const { settings } = useSettings();
@@ -126,16 +125,15 @@ function CoinSidebar() {
   return (
     <div className="csb2-container">
       {visibleCoins.map(id => {
-        const d   = store.coins[id];
-        const dec = COIN_DEC[id];
-        const chg = d?.change ?? 0;
-        const up  = chg >= 0;
-        const sel = store.selectedCoin === id;
+        const d      = store.coins[id];
+        const dec    = COIN_DEC[id];
+        const chg    = d?.change ?? 0;
+        const up     = chg >= 0;
+        const sel    = store.selectedCoin === id;
         const tbp    = d?.takerBuyRatio != null ? Math.round(d.takerBuyRatio * 100) : 50;
         const health = computeCoinHealth(d);
         const badgeCol = coinBadgeColor(id);
 
-        // ── Single priority signal ──
         let sig: { text: string; col: string } | null = null;
         if (d?.fundingRate != null) {
           const fr = d.fundingRate * 100;
@@ -155,24 +153,19 @@ function CoinSidebar() {
           else if (label)   sig = { text: label, col: 'var(--txt3)' };
         }
         if (!sig && d?.oiTrend === 'weak_up')   sig = { text: t('DASH_SIDEBAR_SIG_SHORTS_CLOSING'),   col: 'var(--amber)' };
-        if (!sig && d?.oiTrend === 'weak_down')  sig = { text: t('DASH_SIDEBAR_SIG_BUYERS_PROFIT'),       col: 'var(--txt3)' };
+        if (!sig && d?.oiTrend === 'weak_down')  sig = { text: t('DASH_SIDEBAR_SIG_BUYERS_PROFIT'),   col: 'var(--txt3)' };
         if (!sig && d?.fundingRate != null && d.fundingRate !== 0) {
           const fr = d.fundingRate * 100;
-          if      (fr >= 0.05)   sig = { text: t('DASH_SIDEBAR_SIG_FUNDING_VERY_HIGH'),      col: 'var(--red)' };
-          else if (fr >= 0.01)   sig = { text: t('DASH_SIDEBAR_SIG_FUNDING_SLIGHTLY_HIGH'),  col: 'var(--red-soft)' };
-          else if (fr <= -0.03)  sig = { text: t('DASH_SIDEBAR_SIG_FUNDING_VERY_LOW'),       col: 'var(--green)' };
-          else if (fr <= -0.005) sig = { text: t('DASH_SIDEBAR_SIG_FUNDING_SLIGHTLY_LOW'),   col: 'var(--green-soft)' };
-          else                   sig = { text: t('DASH_SIDEBAR_SIG_FUNDING_NEUTRAL'),         col: 'var(--txt3)' };
+          if      (fr >= 0.05)   sig = { text: t('DASH_SIDEBAR_SIG_FUNDING_VERY_HIGH'),     col: 'var(--red)' };
+          else if (fr >= 0.01)   sig = { text: t('DASH_SIDEBAR_SIG_FUNDING_SLIGHTLY_HIGH'), col: 'var(--red-soft)' };
+          else if (fr <= -0.03)  sig = { text: t('DASH_SIDEBAR_SIG_FUNDING_VERY_LOW'),      col: 'var(--green)' };
+          else if (fr <= -0.005) sig = { text: t('DASH_SIDEBAR_SIG_FUNDING_SLIGHTLY_LOW'),  col: 'var(--green-soft)' };
+          else                   sig = { text: t('DASH_SIDEBAR_SIG_FUNDING_NEUTRAL'),        col: 'var(--txt3)' };
         }
 
         const barCol = tbp >= 60 ? 'var(--green)' : tbp <= 40 ? 'var(--red)' : '#404040';
 
         return (
-          // Plain flat card - was ParticleCard/mb-glow-card, which drew a
-          // cursor-following blue border glow (GLOW_COLOR = accent blue)
-          // across this whole dense scrolling list. Fine for a single hero
-          // feature card, awful on 7 stacked rows - violates the flat-card
-          // rule (color on data values only, never the card frame/border).
           <div
             key={id}
             className={`csb2-card${sel ? ' csb2-sel' : ''}`}
@@ -184,10 +177,10 @@ function CoinSidebar() {
               {d?.price && (
                 <span style={{
                   fontSize: 'var(--fs-caption)', fontWeight: 800, lineHeight: 1,
-                  padding: '2px 4px', borderRadius: 4,
+                  padding: '2px 4px', borderRadius: 0,
                   color: health.color,
                   background: withAlpha(health.color, '22'),
-                  border: `0.5px solid ${withAlpha(health.color, '55')}`,
+                  border: `1px solid var(--bdr)`,
                   letterSpacing: '.04em', flexShrink: 0,
                 }}>
                   {health.grade}
@@ -211,10 +204,7 @@ function CoinSidebar() {
             </div>
 
             <div className="csb2-bar-track">
-              <div
-                className="csb2-bar-fill"
-                style={{ width: tbp + '%', background: barCol }}
-              />
+              <div className="csb2-bar-fill" style={{ width: tbp + '%', background: barCol }} />
             </div>
           </div>
         );
@@ -224,7 +214,7 @@ function CoinSidebar() {
         href="/markets"
         style={{
           display: 'block', width: '100%', background: 'none', border: 'none',
-          borderTop: '1px solid #1a1a1a', padding: '7px 0',
+          borderTop: '1px solid var(--bdr)', padding: '7px 0',
           fontSize: 'var(--fs-caption)', color: 'var(--txt3)', cursor: 'pointer',
           letterSpacing: '0.04em', textAlign: 'center', textDecoration: 'none',
         }}
@@ -235,16 +225,15 @@ function CoinSidebar() {
   );
 }
 
-/* ── Liquidation Cascade Alert Banner ── */
-function CascadeAlertBanner() {
+function TCascadeAlertBanner() {
   const { store, setStore } = useMarket();
   const { t } = useLabels();
   const alert = store.cascadeAlert;
 
   useEffect(() => {
     if (!alert) return;
-    const t = setTimeout(() => setStore(s => ({ ...s, cascadeAlert: null })), 3 * 60_000);
-    return () => clearTimeout(t);
+    const timer = setTimeout(() => setStore(s => ({ ...s, cascadeAlert: null })), 3 * 60_000);
+    return () => clearTimeout(timer);
   }, [alert?.ts]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (!alert) return null;
@@ -255,11 +244,9 @@ function CascadeAlertBanner() {
   const label = alert.side === 'LONG' ? t('DASH_CASCADE_LABEL_LONG')
               : alert.side === 'SHORT' ? t('DASH_CASCADE_LABEL_SHORT')
               : t('DASH_CASCADE_LABEL_NEUTRAL');
-  const hint = alert.side === 'LONG'
-    ? t('DASH_CASCADE_HINT_LONG')
-    : alert.side === 'SHORT'
-    ? t('DASH_CASCADE_HINT_SHORT')
-    : t('DASH_CASCADE_HINT_NEUTRAL');
+  const hint = alert.side === 'LONG'  ? t('DASH_CASCADE_HINT_LONG')
+             : alert.side === 'SHORT' ? t('DASH_CASCADE_HINT_SHORT')
+             : t('DASH_CASCADE_HINT_NEUTRAL');
   const col = alert.side === 'LONG' ? 'var(--red)'
             : alert.side === 'SHORT' ? 'var(--green)'
             : 'var(--amber)';
@@ -284,14 +271,13 @@ function CascadeAlertBanner() {
   );
 }
 
-function EdgeSignals() {
+function TEdgeSignals() {
   const { store } = useMarket();
   const { t } = useLabels();
   const coin = store.selectedCoin;
   const d    = store.coins[coin];
   const oi1h = useOI1h(coin);
 
-  // ── CB Premium ──
   const cbPct = store.cbPremiumPct;
   const cbCol = cbPct == null ? 'var(--txt3)'
     : cbPct >= 0.05  ? 'var(--green)'
@@ -304,154 +290,126 @@ function EdgeSignals() {
     : cbPct <= -0.05 ? t('DASH_EDGE_CB_MILD_SELL')
     : t('DASH_EDGE_CB_NEUTRAL');
 
-  // ── VWAP ──
-  const price    = d?.price;
-  const vwap     = d?.vwap;
+  const price     = d?.price;
+  const vwap      = d?.vwap;
   const vwapAbove = vwap != null && price != null ? price > vwap : null;
   const vwapPct   = vwap && price ? ((price - vwap) / vwap) * 100 : null;
   const vwapCol   = vwapAbove === null ? 'var(--txt3)' : vwapAbove ? 'var(--green)' : 'var(--red)';
 
-  // ── OI Trend ──
   const oiMeta = d?.oiTrend ? OI_TREND_META[d.oiTrend] : null;
 
-  // ── Funding Rate ──
   const fr     = d?.fundingRate;
   const frPct  = fr != null ? fr * 100 : null;
   const frInfo = fr != null ? classifyFunding(fr) : null;
   const frCol  = frPct == null ? 'var(--txt3)'
-    : frPct >= 0.05  ? 'var(--red)'
-    : frPct >= 0.01  ? 'var(--red-soft)'
-    : frPct <= -0.03 ? 'var(--green)'
-    : frPct <= -0.005? 'var(--green-soft)'
+    : frPct >= 0.05   ? 'var(--red)'
+    : frPct >= 0.01   ? 'var(--red-soft)'
+    : frPct <= -0.03  ? 'var(--green)'
+    : frPct <= -0.005 ? 'var(--green-soft)'
     : 'var(--txt2)';
 
-  // ── OI 1h ──
   const { txt: oi1hTxt, col: oi1hCol } = oi1hSignal(oi1h.pct, d?.oiTrend);
   const oi1hPctStr = oi1h.pct != null ? (oi1h.pct >= 0 ? '+' : '') + oi1h.pct.toFixed(2) + '%' : '-';
 
-  // ── Squeeze score ──
-  const sq = computeSqueezeScore(d);
+  const sq    = computeSqueezeScore(d);
   const sqCol = sq.dir === 'SHORT_SQ' ? 'var(--green)' : sq.dir === 'LONG_LIQ' ? 'var(--red)' : 'var(--txt-dim)';
 
-  const vwapCard = (
-    <div className="edge-card">
-      <div className="edge-card-label">
-        <Tip text={t('DASH_EDGE_VWAP_TIP')}>{t('DASH_EDGE_VWAP_LABEL', { coin: coin.toUpperCase() })}</Tip>
-      </div>
-      <div className="edge-card-value" style={{ color: vwapCol, fontSize: 'var(--fs-data)' }}>
-        {price != null ? '$' + fmtPrice(price, COIN_DEC[coin]) : '-'}
-      </div>
-      {vwap != null && (
-        <div className="edge-card-sub">
-          <span style={{ color: 'var(--txt3)' }}>{t('DASH_EDGE_VWAP_SUB_PREFIX')} </span>
-          <span style={{ color: 'var(--txt2)', fontWeight: 600 }}>${vwap.toLocaleString(undefined, { maximumFractionDigits: 2 })}</span>
-          {vwapPct != null && <span style={{ color: vwapCol }}> ({vwapPct >= 0 ? '+' : ''}{vwapPct.toFixed(2)}%)</span>}
-        </div>
-      )}
-      <div className="edge-card-signal" style={{ color: vwapCol }}>
-        {vwapAbove === null ? <SkeletonBar width={100} height={11} radius={4} /> : vwapAbove ? t('DASH_EDGE_VWAP_SIG_ABOVE') : t('DASH_EDGE_VWAP_SIG_BELOW')}
-      </div>
-    </div>
-  );
-
-  const oiCard = (
-    <div className="edge-card">
-      <div className="edge-card-label">
-        <Tip width={260} text={t('DASH_EDGE_OI_TIP')}>{t('DASH_EDGE_OI_LABEL', { coin: coin.toUpperCase() })}</Tip>
-      </div>
-      {oiMeta ? (
-        <>
-          <div className="edge-card-value" style={{ color: oiMeta.col, fontSize: 'var(--fs-data)' }}>{t(oiMeta.txtKey)}</div>
-          <div className="edge-card-signal" style={{ color: oiMeta.col }}>{t(oiMeta.subKey)}</div>
-        </>
-      ) : (
-        <div className="edge-card-signal" style={{ color: 'var(--txt3)', marginTop: 4 }}>
-          {d?.oi != null ? t('DASH_EDGE_OI_FLAT') : <SkeletonBar width={90} height={11} radius={4} />}
-        </div>
-      )}
-    </div>
-  );
-
-  const fundingCard = (
-    <div className="edge-card">
-      <div className="edge-card-label">
-        {/* Tooltip follows the SIGN (#244). The old key described the
-            strongly-positive case unconditionally, so a negative rate was
-            explained as its own inverse - wrong-direction trading guidance
-            delivered with the same confidence as right-direction guidance.
-            frInfo is classifyFunding, already computed above. */}
-        <Tip text={t(frInfo ? FUNDING_TIP_KEY[frInfo.band] : 'DASH_EDGE_FUNDING_TIP')}>{t('DASH_EDGE_FUNDING_LABEL', { coin: coin.toUpperCase() })}</Tip>
-      </div>
-      <div className="edge-card-value" style={{ color: frCol }}>
-        {frPct != null ? (frPct >= 0 ? '+' : '') + frPct.toFixed(4) + '%' : '-'}
-      </div>
-      <div className="edge-card-signal" style={{ color: frCol }}>
-        {frInfo ? frInfo.label : <SkeletonBar width={70} height={11} radius={4} />}
-      </div>
-    </div>
-  );
-
-  const setupCard = (
-    <div className="edge-card">
-      <div className="edge-card-label">
-        <Tip width={260} text={t('DASH_EDGE_SETUP_TIP')}>{t('DASH_EDGE_SETUP_LABEL', { coin: coin.toUpperCase() })}</Tip>
-      </div>
-      <div className="edge-card-value" style={{ color: sqCol, fontSize: 'var(--fs-data)' }}>
-        {sq.score}
-        <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 600, marginLeft: 6 }}>{sq.label}</span>
-      </div>
-      <div className="edge-card-signal" style={{ color: sqCol }}>
-        {sq.dir === 'SHORT_SQ' ? t('DASH_EDGE_SETUP_SHORT_SQ')
-         : sq.dir === 'LONG_LIQ' ? t('DASH_EDGE_SETUP_LONG_LIQ')
-         : t('DASH_EDGE_SETUP_BALANCED')}
-      </div>
-    </div>
-  );
-
-  const cbCard = (
-    <div className="edge-card">
-      <div className="edge-card-label">
-        <Tip text={t('DASH_EDGE_CB_TIP')}>{t('DASH_EDGE_CB_LABEL')}</Tip>
-      </div>
-      <div className="edge-card-value" style={{ color: cbCol, fontSize: 'var(--fs-data)' }}>
-        {cbPct != null ? (cbPct >= 0 ? '+' : '') + cbPct.toFixed(3) + '%' : '-'}
-      </div>
-      <div className="edge-card-signal" style={{ color: cbCol }}>
-        {cbPct == null ? <SkeletonBar width={90} height={11} radius={4} /> : cbSig}
-      </div>
-    </div>
-  );
-
-  const oi1hCard = (
-    <div className="edge-card">
-      <div className="edge-card-label">
-        <Tip text={t('DASH_EDGE_OI1H_TIP')}>{t('DASH_EDGE_OI1H_LABEL', { coin: coin.toUpperCase() })}</Tip>
-      </div>
-      <div className="edge-card-value" style={{ color: oi1hCol }}>
-        {oi1h.loading ? '-' : oi1hPctStr}
-      </div>
-      <div className="edge-card-signal" style={{ color: oi1hCol }}>
-        {oi1h.loading ? <SkeletonBar width={70} height={11} radius={4} /> : oi1hTxt}
-      </div>
-    </div>
-  );
-
-  // Same two-row layout as before; the "2 more" collapse toggle is gone so
-  // CB Premium / OI 1h are always visible instead of gated behind a click.
   return (
     <>
       <div className="edge-grid">
-        {vwapCard}{oiCard}{fundingCard}{setupCard}
+        <div className="edge-card">
+          <div className="edge-card-label">
+            <Tip text={t('DASH_EDGE_VWAP_TIP')}>{t('DASH_EDGE_VWAP_LABEL', { coin: coin.toUpperCase() })}</Tip>
+          </div>
+          <div className="edge-card-value" style={{ color: vwapCol, fontSize: 'var(--fs-data)' }}>
+            {price != null ? '$' + fmtPrice(price, COIN_DEC[coin]) : '-'}
+          </div>
+          {vwap != null && (
+            <div className="edge-card-sub">
+              <span style={{ color: 'var(--txt3)' }}>{t('DASH_EDGE_VWAP_SUB_PREFIX')} </span>
+              <span style={{ color: 'var(--txt2)', fontWeight: 600 }}>${vwap.toLocaleString(undefined, { maximumFractionDigits: 2 })}</span>
+              {vwapPct != null && <span style={{ color: vwapCol }}> ({vwapPct >= 0 ? '+' : ''}{vwapPct.toFixed(2)}%)</span>}
+            </div>
+          )}
+          <div className="edge-card-signal" style={{ color: vwapCol }}>
+            {vwapAbove === null ? <SkeletonBar width={100} height={11} radius={4} /> : vwapAbove ? t('DASH_EDGE_VWAP_SIG_ABOVE') : t('DASH_EDGE_VWAP_SIG_BELOW')}
+          </div>
+        </div>
+
+        <div className="edge-card">
+          <div className="edge-card-label">
+            <Tip width={260} text={t('DASH_EDGE_OI_TIP')}>{t('DASH_EDGE_OI_LABEL', { coin: coin.toUpperCase() })}</Tip>
+          </div>
+          {oiMeta ? (
+            <>
+              <div className="edge-card-value" style={{ color: oiMeta.col, fontSize: 'var(--fs-data)' }}>{t(oiMeta.txtKey)}</div>
+              <div className="edge-card-signal" style={{ color: oiMeta.col }}>{t(oiMeta.subKey)}</div>
+            </>
+          ) : (
+            <div className="edge-card-signal" style={{ color: 'var(--txt3)', marginTop: 4 }}>
+              {d?.oi != null ? t('DASH_EDGE_OI_FLAT') : <SkeletonBar width={90} height={11} radius={4} />}
+            </div>
+          )}
+        </div>
+
+        <div className="edge-card">
+          <div className="edge-card-label">
+            <Tip text={t(frInfo ? FUNDING_TIP_KEY[frInfo.band] : 'DASH_EDGE_FUNDING_TIP')}>{t('DASH_EDGE_FUNDING_LABEL', { coin: coin.toUpperCase() })}</Tip>
+          </div>
+          <div className="edge-card-value" style={{ color: frCol }}>
+            {frPct != null ? (frPct >= 0 ? '+' : '') + frPct.toFixed(4) + '%' : '-'}
+          </div>
+          <div className="edge-card-signal" style={{ color: frCol }}>
+            {frInfo ? frInfo.label : <SkeletonBar width={70} height={11} radius={4} />}
+          </div>
+        </div>
+
+        <div className="edge-card">
+          <div className="edge-card-label">
+            <Tip width={260} text={t('DASH_EDGE_SETUP_TIP')}>{t('DASH_EDGE_SETUP_LABEL', { coin: coin.toUpperCase() })}</Tip>
+          </div>
+          <div className="edge-card-value" style={{ color: sqCol, fontSize: 'var(--fs-data)' }}>
+            {sq.score}
+            <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 600, marginLeft: 6 }}>{sq.label}</span>
+          </div>
+          <div className="edge-card-signal" style={{ color: sqCol }}>
+            {sq.dir === 'SHORT_SQ' ? t('DASH_EDGE_SETUP_SHORT_SQ')
+             : sq.dir === 'LONG_LIQ' ? t('DASH_EDGE_SETUP_LONG_LIQ')
+             : t('DASH_EDGE_SETUP_BALANCED')}
+          </div>
+        </div>
       </div>
+
       <div className="edge-grid" style={{ marginTop: 8 }}>
-        {cbCard}{oi1hCard}
+        <div className="edge-card">
+          <div className="edge-card-label">
+            <Tip text={t('DASH_EDGE_CB_TIP')}>{t('DASH_EDGE_CB_LABEL')}</Tip>
+          </div>
+          <div className="edge-card-value" style={{ color: cbCol, fontSize: 'var(--fs-data)' }}>
+            {cbPct != null ? (cbPct >= 0 ? '+' : '') + cbPct.toFixed(3) + '%' : '-'}
+          </div>
+          <div className="edge-card-signal" style={{ color: cbCol }}>
+            {cbPct == null ? <SkeletonBar width={90} height={11} radius={4} /> : cbSig}
+          </div>
+        </div>
+
+        <div className="edge-card">
+          <div className="edge-card-label">
+            <Tip text={t('DASH_EDGE_OI1H_TIP')}>{t('DASH_EDGE_OI1H_LABEL', { coin: coin.toUpperCase() })}</Tip>
+          </div>
+          <div className="edge-card-value" style={{ color: oi1hCol }}>
+            {oi1h.loading ? '-' : oi1hPctStr}
+          </div>
+          <div className="edge-card-signal" style={{ color: oi1hCol }}>
+            {oi1h.loading ? <SkeletonBar width={70} height={11} radius={4} /> : oi1hTxt}
+          </div>
+        </div>
       </div>
     </>
   );
 }
 
-
-function CoinSignalsHeader() {
+function TCoinSignalsHeader() {
   const { store } = useMarket();
   const { t } = useLabels();
   return (
@@ -461,9 +419,7 @@ function CoinSignalsHeader() {
   );
 }
 
-/* ── Selected-coin glance card - price + change + one signal (no triplicated
-   funding/vol/vwap; those live in Coin Signals below) ── */
-function SelectedCoinCard() {
+function TSelectedCoinCard() {
   const { store } = useMarket();
   const { t } = useLabels();
   const id  = store.selectedCoin;
@@ -497,18 +453,29 @@ function SelectedCoinCard() {
   );
 }
 
-export default function Dashboard() {
-  const mode     = useDesignMode();
-  const { t }    = useLabels();
+/* Flat terminal panel replacing mb-glow-card. No shadow, no glow, no radius. */
+function TPanel({ children, id }: { children: React.ReactNode; id?: string }) {
+  return (
+    <div
+      id={id}
+      style={{
+        background: 'var(--bg1)',
+        border: '1px solid var(--bdr)',
+        borderRadius: 0,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export default function DashboardTerminal() {
+  const { t } = useLabels();
   const [showTour, setShowTour] = useState(false);
   const rightRef = useRef<HTMLElement>(null);
-  const mainRef  = useRef<HTMLDivElement>(null);
-  const isMobile = useMobile();
+
   const { tourPending, clearTourPending } = useOnboarding();
 
-  // OnboardingGate flips tourPending right after a user finishes onboarding
-  // (from whatever page they were on) and routes here, since the spotlight
-  // tour targets dashboard-only DOM (data-spotlight-section, .mb-glow-card).
   useEffect(() => {
     if (tourPending) {
       setShowTour(true);
@@ -516,60 +483,42 @@ export default function Dashboard() {
     }
   }, [tourPending, clearTourPending]);
 
-  if (mode === 'terminal') return <DashboardTerminal />;
-
   return (
     <div className="dashboard-grid" data-spotlight-section>
       {showTour && <SpotlightTour onDone={() => setShowTour(false)} />}
       <SetupChecklist />
-      {/* Floating cascade toast - fixed-positioned, render once */}
-      <CascadeAlertBanner />
+      <TCascadeAlertBanner />
 
-      <GlobalSpotlight gridRef={rightRef} cardSelector=".mb-glow-card" radius={260} disableAnimations={isMobile} />
-      <GlobalSpotlight gridRef={mainRef} cardSelector=".mb-glow-card" radius={320} disableAnimations={isMobile} />
+      {/* No GlobalSpotlight in terminal mode — cursor glow effects don't fit
+          the flat monochrome aesthetic. */}
 
-      {/* ── LEFT · the answers (answer-first order) ── */}
-      <div className="dash-main" ref={mainRef}>
-        {/* 1. Market Read - the verdict */}
+      <div className="dash-main">
         <MarketRead />
 
-        {/* 2. Best Setup Today */}
-        <div id="tour-best-setup" className="mb-glow-card" style={{ borderRadius: 10 }}>
+        <TPanel id="tour-best-setup">
           <div className="dash-section dash-section-hot" style={{ marginTop: 0 }}>{t('DASH_BEST_SETUP_TODAY_HEADER')}</div>
           <SOTD />
-        </div>
+        </TPanel>
 
-        {/* 3. Your coin - glance */}
-        <SelectedCoinCard />
+        <TSelectedCoinCard />
 
-        {/* 4. Coin signals - selected coin detail */}
-        <div id="tour-coin-signals" className="mb-glow-card" style={{ borderRadius: 10 }}>
-          <CoinSignalsHeader />
-          <EdgeSignals />
-        </div>
+        <TPanel id="tour-coin-signals">
+          <TCoinSignalsHeader />
+          <TEdgeSignals />
+        </TPanel>
 
-        {/* 5. Economic calendar preview + Market conditions gauge - full width
-            here instead of the narrow rail, side by side on desktop. */}
         <div className="dash-conditions-row">
           <EconCalendarWidget />
           <MarketConditionsWidget />
         </div>
       </div>
 
-      {/* ── RIGHT · context (sticky rail on desktop, stacks below on mobile) ── */}
       <aside className="dash-right" ref={rightRef}>
-        <CoinSidebar />
-        <MarketPulseStrip />
-        {/* Perps vs spot (#328) - "is this a real buyer or just futures traders".
-            Above the macro card because it is per-coin and follows the coin
-            selection, where the macro backdrop is the same whatever is picked. */}
+        <TCoinSidebar />
+        <TMarketPulseStrip />
         <div className="macro-rail-card">
           <PerpSpotCard />
         </div>
-
-        {/* Macro backdrop - answers "what's the broad market doing", which nothing
-            else on the dashboard covers. Last in the rail so it never pushes the
-            per-coin essentials down on mobile. */}
         <div className="macro-rail-card">
           <GlobalMacroContext />
         </div>


### PR DESCRIPTION
## Summary

- Add `DashboardTerminal` component activated by `?design=terminal` URL flag
- Mirror all data/logic from `Dashboard`; omit `GlobalSpotlight`; replace `mb-glow-card` wrappers with flat `bg1` panels
- CSS token block gains `--radius-card/data/chip/pill/sharp: 0`; targeted class overrides handle hardcoded px radii

## What changed

**`components/DashboardTerminal.tsx`** (new)  
Terminal rendering of the full dashboard. Self-contained: same hooks (`useMarket`, `useOI1h`, `useSettings`, `useLabels`, `useOnboarding`), same child imports (`MarketRead`, `SOTD`, `GlobalMacroContext`, `EconCalendarWidget`, `MarketConditionsWidget`, `PerpSpotCard`, `SpotlightTour`, `SetupChecklist`). Inner components (`TCoinSidebar`, `TEdgeSignals`, etc.) re-implement the logic with terminal styling: `borderRadius: 0` on inline styles, `1px solid var(--bdr)` hairlines, no cursor glow.

**`app/dashboard/page.tsx`**  
`Dashboard()` calls `useDesignMode()`; after all hooks, gates to `<DashboardTerminal />` when `mode === 'terminal'`. Hook ordering preserved (no early-return-before-hooks violation).

**`app/globals.css`**  
`[data-design="terminal"]` token block gains five radius tokens set to 0. Appended targeted class overrides for `.edge-card`, `.scc-card`, `.macro-rail-card`, `.mr`, `.cascade-dismiss`, `.csb2-sig`, `.csb2-bar-track`, `.csb2-bar-fill`.

## Why

Issue #413 Desk 2a — flat monochrome dashboard, one screen at a time. Current design is unchanged for all users who haven't opted in via `?design=terminal`.

## How to test (QA)

**Environment:** `/dashboard?design=terminal` on qa (after deploy) or localhost on this branch.

1. Navigate to `/dashboard?design=terminal` — `data-design="terminal"` should be on `<html>`
2. **No rounded corners anywhere** — coin sidebar cards, edge signal cards, selected-coin card, macro rail cards, cascade banner, pulse strip all flat
3. **IBM Plex Sans** body font (not Figtree) — visible in browser font inspector
4. **Amber accent** (`#d9a626`) on active nav item
5. **No cursor glow** — moving mouse over cards produces no blue border effect
6. **CoinSidebar** — clicking a coin row selects it; data updates in EdgeSignals
7. **EdgeSignals** — six signal cells show live values (VWAP, OI trend, Funding, Squeeze, CB Premium, OI 1h)
8. **SelectedCoinCard** — tapping navigates to `/arena?coin=<id>`
9. **Cascade banner** — fires when a cascade alert is in store; `✕` dismisses it
10. **SpotlightTour** — completes onboarding flow, tour still launches on dashboard
11. Navigate to `/dashboard` (no param) — **current design unchanged**, Figtree font, rounded cards, glow effects present

Risk level: **Low** — additive only; no existing component modified beyond adding a two-line gate. Token overrides are scoped to `[data-design="terminal"]` and do not affect the current design.

## Screenshots

| Current | Terminal |
|---|---|
| Existing rounded cards, glow effects | Flat panels, `borderRadius: 0`, IBM Plex Sans |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y

— Dev Team