### PR TITLE
feat(dashboard): Monochrome Terminal — /briefing (#413)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6210,3 +6210,8 @@ main.app-content[data-chrome="none"] {
 [data-design="terminal"] .csb2-sig      { border-radius: 0; }
 [data-design="terminal"] .csb2-bar-track,
 [data-design="terminal"] .csb2-bar-fill { border-radius: 0; }
+/* briefing */
+[data-design="terminal"] .mb-macro-item { border-radius: 0; }
+[data-design="terminal"] .mb-event-tag  { border-radius: 0; }
+[data-design="terminal"] .mb-brief-btn  { border-radius: 0; }
+[data-design="terminal"] .mb-cvd-chip   { border-radius: 0; }

--- a/components/BriefingTerminal.tsx
+++ b/components/BriefingTerminal.tsx
@@ -18,10 +18,8 @@ import Tip from '@/components/Tip';
 import { SkeletonBar } from '@/components/Skeleton';
 import { useLabels } from '@/lib/labels';
 import type { LabelKey } from '@/lib/labelKeys';
-import { useDesignMode } from '@/components/DesignModeProvider';
-import BriefingTerminal from '@/components/BriefingTerminal';
 
-/* ── helpers ── */
+/* ── helpers (identical to briefing/page.tsx) ── */
 
 const OI_ICONS: Record<string, string> = {
   strong_up: '▲', strong_down: '▼', weak_up: '△', weak_down: '▽',
@@ -31,9 +29,8 @@ const OI_COLORS: Record<string, string> = {
   weak_up: 'var(--amber)', weak_down: 'var(--txt-dim)',
 };
 
-/* Convert decimal hours → "Xh Ym" */
 function hToHM(h: number): string {
-  if (h < 0.017) return 'NOW';          // < 1 min
+  if (h < 0.017) return 'NOW';
   const totalMins = Math.round(h * 60);
   if (totalMins < 60) return `${totalMins}m`;
   const hrs = Math.floor(totalMins / 60);
@@ -41,7 +38,6 @@ function hToHM(h: number): string {
   return mins > 0 ? `${hrs}h ${mins}m` : `${hrs}h`;
 }
 
-/* Convert unix-second timestamp → "Xh Ym ago" */
 function tsAgo(ts: number): string {
   const s = Math.floor(Date.now() / 1000 - ts);
   if (s < 60) return 'just now';
@@ -71,16 +67,8 @@ function volRatioColor(vr: number | null): string {
 
 function pad2(n: number) { return String(n).padStart(2, '0'); }
 
-// Was `new Date(new Date().toLocaleString('en-US', { timeZone: 'Asia/Manila' }))`
-// - the round-trip-through-a-string trick that yields a Date whose LOCAL getters
-// read out Manila's wall clock. Every getHours()/getDay() below then reported
-// Manila regardless of where the viewer actually is. A plain Date gives the
-// viewer their own clock, which is what this page's header is claiming to show.
-function localNow() {
-  return new Date();
-}
+function localNow() { return new Date(); }
 
-/* ── Which signals fired for a given setup direction ── */
 function getSignalTags(
   coin: CoinData,
   dir: 'LONG_LIQ' | 'SHORT_SQ',
@@ -120,30 +108,21 @@ function getSignalTags(
   return tags;
 }
 
-/* ── context builder for Grok ── */
 function buildBriefingContext(
   store: MarketStore,
   coinRows: Array<{ id: CoinId; c: MarketStore['coins'][CoinId] }>,
   urgentEcon: Array<{ type: string; name: string; h: number; impact: string; dt: Date }>,
   recentGeo:  Array<{ tag: string; headline: string }>,
-  // Passed in rather than read from the clock inside, so the "in Nh" / "Nm ago"
-  // lines describe the same instant as the events list the caller just built.
   nowMs: number,
   jpyUsd?: number | null,
 ): string {
-  // UTC, not the viewer's clock: this string is fed to Grok as context, and a
-  // bare local time with no zone made the model reason about session timing
-  // against an unknown offset. (It used to be Manila's clock labelled "PHT",
-  // which was at least unambiguous but wrong for every other user.)
   const nowUtc = new Date().toLocaleString('en-GB', {
     timeZone: 'UTC', hour: '2-digit', minute: '2-digit', hour12: false,
   });
-
   const jpyStatus = jpyUsd == null ? 'N/A'
     : jpyUsd >= 160 ? `${jpyUsd.toFixed(2)} - DANGER ZONE (BOJ intervention risk, carry trade unwind can trigger BTC liquidations)`
     : jpyUsd >= 158 ? `${jpyUsd.toFixed(2)} - WARNING (approaching 160 danger zone, watch BOJ signals)`
     : `${jpyUsd.toFixed(2)} - Safe (below 158, carry trade stable)`;
-
   const lines = [
     `Time: ${nowUtc} UTC`,
     `Fear & Greed: ${store.fng ?? '?'} - ${store.fngLabel ?? '?'}`,
@@ -154,7 +133,6 @@ function buildBriefingContext(
     '',
     'COINS (24h change | FR | RSI 15m | CVD divergence | OI trend):',
   ];
-
   for (const { id, c } of coinRows) {
     if (!c) continue;
     const chg = c.change != null ? (c.change >= 0 ? '+' : '') + c.change.toFixed(2) + '%' : '-';
@@ -164,7 +142,6 @@ function buildBriefingContext(
     const oi  = c.oiTrend ?? '-';
     lines.push(`${id.toUpperCase()}: ${chg} | FR ${fr} | RSI ${rsi} | CVD ${cvd} | OI ${oi}`);
   }
-
   if (urgentEcon.length) {
     lines.push('', 'MACRO EVENTS (recent + upcoming):');
     urgentEcon.forEach(e => {
@@ -177,79 +154,58 @@ function buildBriefingContext(
       }
     });
   }
-
   if (recentGeo.length) {
     lines.push('', 'RECENT MARKET NEWS:');
     recentGeo.slice(0, 3).forEach(e => lines.push(`  ${e.tag}: ${e.headline}`));
   }
-
   return lines.join('\n');
 }
 
-/* ── page ── */
-export default function MorningBriefing() {
-  const mode                                   = useDesignMode();
+/* ── flat panel ── */
+function TPanel({ children, style }: { children: React.ReactNode; style?: React.CSSProperties }) {
+  return (
+    <div style={{
+      background: 'var(--bg1)',
+      border: '1px solid var(--bdr)',
+      borderRadius: 0,
+      marginBottom: 10,
+      padding: 16,
+      ...style,
+    }}>
+      {children}
+    </div>
+  );
+}
+
+/* ── terminal briefing ── */
+export default function BriefingTerminal() {
   const { store }                              = useMarket();
   const { econEvents, geoEvents, whaleAlerts } = useNews();
   const { user }                               = useAuth();
   const { usage, setUsage }                    = useGrokUsage();
-  const { t }                                   = useLabels();
-  /* NULL UNTIL THE BROWSER HAS MOUNTED, and that is the whole fix for #193.
-   *
-   * This was `useState<Date>(localNow)`. `'use client'` does not mean
-   * client-only - Next still renders this component on the server to produce the
-   * initial HTML, so the lazy initialiser ran twice against two different
-   * clocks IN TWO DIFFERENT TIMEZONES. React then found different text and threw
-   * #418, 75 times in production and once per load for every user outside the
-   * server's zone.
-   *
-   * Measured, and the timezone is the part that matters - milliseconds would
-   * only have broken the minute display:
-   *
-   *   server  "Sun, Aug 9"      <div className="mb-subtitle">
-   *   client  "Mon, Aug 10"     (America/New_York)
-   *
-   * A whole day apart, so this was never a near-miss that usually agreed.
-   *
-   * `null` renders identically on the server and on the client's FIRST render,
-   * which is the only render hydration compares. The effect below then sets the
-   * real clock, and everything downstream re-renders with it. */
+  const { t }                                  = useLabels();
+
   const [now, setNow]           = useState<Date | null>(null);
-  // Milliseconds form of the same ticking clock. The event/freshness maths
-  // below used to call Date.now() directly, which both made render impure and
-  // quietly ignored this state - meaning the "next 24h" and "already released"
-  // cutoffs did not actually move with the minute tick that exists right here.
-  /* 0 while the clock is unknown, and that is deliberate rather than a fallback
-   * nobody thought about. Every real event is decades after the epoch, so the
-   * "within the next 24h" filters below evaluate to EMPTY at 0 - the first paint
-   * shows no urgent events rather than the wrong ones, on both server and
-   * client, and the real list appears a frame later. */
   const nowMs = now?.getTime() ?? 0;
   const [generating, setGen]    = useState(false);
   const [briefErr, setBriefErr] = useState('');
   const [jpyUsd, setJpyUsd]     = useState<number | null>(null);
   const [jpyUpdated, setJpyUpdated] = useState<Date | null>(null);
 
-  /* ── AI brief - persist across refreshes via sessionStorage (4h TTL) ── */
   const [brief, setBriefState] = useState('');
   useEffect(() => {
     try {
       const saved = sessionStorage.getItem('lhq_brief');
       const ts    = sessionStorage.getItem('lhq_brief_ts');
-      if (saved && ts && Date.now() - parseInt(ts) < 4 * 3_600_000) {
-        setBriefState(saved);
-      }
-    } catch { /* incognito / storage blocked */ }
+      if (saved && ts && Date.now() - parseInt(ts) < 4 * 3_600_000) setBriefState(saved);
+    } catch { /* incognito */ }
   }, []);
+
   function setBrief(text: string) {
     setBriefState(text);
     try {
       if (text) {
         sessionStorage.setItem('lhq_brief', text);
-        // Stamping when the brief was actually written has to read the real
-        // clock, not the render-scoped `now` below - setBrief runs from the
-        // generate handler, not during render, so this is genuinely a side
-        // effect and the timestamp needs to be accurate rather than stable.
         // eslint-disable-next-line react-hooks/purity
         sessionStorage.setItem('lhq_brief_ts', String(Date.now()));
       } else {
@@ -259,22 +215,13 @@ export default function MorningBriefing() {
     } catch { /* */ }
   }
 
-  /* Set the clock on mount, then tick once per minute so the header stays fresh.
-   * The immediate call is not decoration - without it the header would stay
-   * blank for up to 60 seconds waiting for the first interval. */
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => {
-    /* `set-state-in-effect` is right about the general case and wrong about this
-       one. Reading a browser-only value after mount is precisely what an effect
-       is for, and it is the only place this CAN be read: the whole point of #193
-       is that the server must not produce this value. Same reasoning as the
-       `react-hooks/purity` disable in setBrief above. */
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setNow(localNow());
     const timer = setInterval(() => setNow(localNow()), 60_000);
     return () => clearInterval(timer);
   }, []);
 
-  /* Fetch USD/JPY via server proxy (avoids CORS), refreshes every 5 min */
   useEffect(() => {
     const load = () =>
       fetch('/api/forex/jpy')
@@ -290,30 +237,21 @@ export default function MorningBriefing() {
 
   const days   = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
   const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
-  /* Empty until the clock exists. `localZoneAbbr()` is the SECOND client-only
-   * value on this line and it is not mentioned in #193 - it reads the browser's
-   * zone, so it mismatches for exactly the same reason and would have kept
-   * throwing after the date was fixed. Both are behind the same guard. */
   const h = now?.getHours() ?? 0, m = now?.getMinutes() ?? 0;
   const timeStr = now ? `${pad2(h % 12 || 12)}:${pad2(m)} ${h >= 12 ? 'PM' : 'AM'} ${localZoneAbbr()}` : '';
   const dateStr = now ? `${days[now.getDay()]}, ${months[now.getMonth()]} ${now.getDate()}` : '';
 
-  /* Coin rows */
   const coinRows = COINS.map(id => ({
     id,
     c: store.coins[id],
     sq: computeSqueezeScore(store.coins[id]),
   }));
 
-  /* Loading state - true until at least 8 coins have price data */
   const pricesLoaded = coinRows.filter(r => r.c?.price != null && r.c.price > 0).length >= 8;
-
-  /* Active CVD divergences */
   const cvdAlerts = COINS
     .filter(id => store.coins[id]?.cvdDivergence)
     .map(id => ({ id, div: store.coins[id]!.cvdDivergence! }));
 
-  /* Generate AI briefing */
   async function generateBriefing() {
     if (!user) { setBriefErr(t('BRIEFING_SIGN_IN_REQUIRED')); return; }
     setGen(true); setBrief(''); setBriefErr('');
@@ -321,7 +259,6 @@ export default function MorningBriefing() {
       const sb    = getSupabase();
       const token = sb ? (await sb.auth.getSession()).data.session?.access_token : undefined;
       if (!token) { setBriefErr(t('BRIEFING_SESSION_EXPIRED')); setGen(false); return; }
-
       const ctx = buildBriefingContext(store, coinRows, urgentEcon, recentGeo, nowMs, jpyUsd);
       const res = await fetch('/api/briefing', {
         method:  'POST',
@@ -342,23 +279,18 @@ export default function MorningBriefing() {
         setBrief(data.briefing ?? '');
         if (data._usage && usage) setUsage({ ...usage, ...data._usage });
       }
-    } catch (e) {
-      setBriefErr(String(e));
-    }
+    } catch (e) { setBriefErr(String(e)); }
     setGen(false);
   }
 
-  /* Top 3 Setups - non-neutral direction only, sorted by score */
   const top3Setups = coinRows
     .filter(r => r.sq.dir !== 'NEUTRAL' && r.c?.price != null && r.c.price > 0)
     .sort((a, b) => b.sq.score - a.sq.score)
     .slice(0, 3);
 
-  /* Events - upcoming (next 24h) + recently released (last 6h) */
   const urgentEcon = econEvents.filter(e => { const lh = (e.dt.getTime() - nowMs) / 3600000; return lh > -6 && lh < 24; }).slice(0, 8);
   const recentGeo  = geoEvents.slice(0, 4);
 
-  /* Macro colors */
   const fng      = store.fng;
   const fngColor = fng == null ? 'var(--txt3)'
     : fng >= 75 ? 'var(--red)'
@@ -390,7 +322,6 @@ export default function MorningBriefing() {
   const futureEcon = urgentEcon.filter(e => e.dt.getTime() > nowMs);
   const noEvents = futureEcon.length === 0 && recentGeo.length === 0 && (!whaleAlerts || whaleAlerts.length === 0);
 
-  /* Yen Watch */
   const jpyStatus = jpyUsd == null ? null
     : jpyUsd >= 160
       ? { label: t('BRIEFING_YEN_DANGER'), color: 'var(--red)', bg: 'rgba(248,113,113,0.08)', border: 'rgba(248,113,113,0.25)',
@@ -400,16 +331,10 @@ export default function MorningBriefing() {
           desc: t('BRIEFING_YEN_WARNING_DESC') }
       : { label: t('BRIEFING_YEN_SAFE'), color: 'var(--green-2)', bg: 'rgba(52,211,153,0.06)', border: 'rgba(52,211,153,0.2)',
           desc: t('BRIEFING_YEN_SAFE_DESC') };
-  // progress bar: 140 = left edge, 165 = right edge
   const jpyPct        = jpyUsd != null ? Math.max(0, Math.min(100, ((jpyUsd - 140) / 25) * 100)) : 0;
-  const warn158Pct    = ((158 - 140) / 25) * 100;  // 72%
-  const danger160Pct  = ((160 - 140) / 25) * 100;  // 80%
-  /* `jpyUpdated` is only ever set from the fetch effect, so it cannot be
-     non-null while `now` is still null - but the compiler cannot know that and
-     `nowMs` already carries the same guard. Reusing it rather than asserting. */
+  const warn158Pct    = ((158 - 140) / 25) * 100;
+  const danger160Pct  = ((160 - 140) / 25) * 100;
   const jpyMinutesAgo = jpyUpdated ? Math.round((nowMs - jpyUpdated.getTime()) / 60_000) : null;
-
-  if (mode === 'terminal') return <BriefingTerminal />;
 
   return (
     <div>
@@ -417,10 +342,7 @@ export default function MorningBriefing() {
       {/* ── Header ── */}
       <div className="mb-header">
         <h1 className="mb-title">{t('BRIEFING_PAGE_TITLE')}</h1>
-        {/* The separator lives inside the guard too, or the first paint is a
-            lone "·" floating under the title. Non-breaking space holds the
-            line's height so the header does not jump when the clock arrives. */}
-        <div className="mb-subtitle">{now ? `${dateStr} · ${timeStr}` : ' '}</div>
+        <div className="mb-subtitle">{now ? `${dateStr} · ${timeStr}` : ' '}</div>
       </div>
 
       <PageHint
@@ -429,8 +351,8 @@ export default function MorningBriefing() {
         body={t('BRIEFING_HINT_BODY')}
       />
 
-      {/* ── Top 3 Setups Today ── */}
-      <div className="card" style={{ marginBottom: 10 }}>
+      {/* ── Top 3 Setups ── */}
+      <TPanel>
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
           <div className="lbl" style={{ margin: 0 }}>{t('BRIEFING_TOP3_TITLE')}</div>
           <Link href="/arena" style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', textDecoration: 'none', display: 'inline-flex', alignItems: 'center', minHeight: 24 }}>
@@ -450,11 +372,11 @@ export default function MorningBriefing() {
           </div>
         ) : (
           top3Setups.map(({ id, c, sq }, i) => {
-            const isLong    = sq.dir === 'SHORT_SQ';
-            const dirColor  = isLong ? 'var(--green-2)' : 'var(--red)';
-            const dirLabel  = isLong ? t('BRIEFING_DIR_LONG') : t('BRIEFING_DIR_SHORT');
-            const tags      = c ? getSignalTags(c, sq.dir as 'LONG_LIQ' | 'SHORT_SQ', t) : [];
-            const isLast    = i === top3Setups.length - 1;
+            const isLong   = sq.dir === 'SHORT_SQ';
+            const dirColor = isLong ? 'var(--green-2)' : 'var(--red)';
+            const dirLabel = isLong ? t('BRIEFING_DIR_LONG') : t('BRIEFING_DIR_SHORT');
+            const tags     = c ? getSignalTags(c, sq.dir as 'LONG_LIQ' | 'SHORT_SQ', t) : [];
+            const isLast   = i === top3Setups.length - 1;
             return (
               <Link key={id} href="/arena" style={{ textDecoration: 'none', display: 'block' }}>
                 <div style={{
@@ -462,15 +384,11 @@ export default function MorningBriefing() {
                   padding: '11px 0',
                   borderBottom: isLast ? 'none' : '0.5px solid var(--bdr)',
                 }}>
-                  <div style={{
-                    fontSize: 'var(--fs-label)', fontWeight: 800, color: 'var(--txt)',
-                    minWidth: 46, letterSpacing: '-0.3px',
-                  }}>
+                  <div style={{ fontSize: 'var(--fs-label)', fontWeight: 800, color: 'var(--txt)', minWidth: 46, letterSpacing: '-0.3px' }}>
                     {COIN_LABELS[id]}
                   </div>
-
                   <span style={{
-                    fontSize: 'var(--fs-caption)', fontWeight: 700, padding: '3px 9px', borderRadius: 20,
+                    fontSize: 'var(--fs-caption)', fontWeight: 700, padding: '3px 9px', borderRadius: 0,
                     letterSpacing: '.03em', flexShrink: 0,
                     color: dirColor,
                     background: isLong ? 'rgba(52,211,153,0.12)' : 'rgba(248,113,113,0.12)',
@@ -478,19 +396,17 @@ export default function MorningBriefing() {
                   }}>
                     {dirLabel}
                   </span>
-
                   <div style={{ display: 'flex', gap: 5, flex: 1, flexWrap: 'wrap' }}>
                     {tags.map(tag => (
                       <span key={tag} style={{
                         fontSize: 'var(--fs-caption)', fontWeight: 600, color: 'var(--txt3)',
-                        background: 'var(--bg2)', borderRadius: 4,
+                        background: 'var(--bg2)', borderRadius: 0,
                         padding: '2px 6px', letterSpacing: '.02em',
                       }}>
                         {tag}
                       </span>
                     ))}
                   </div>
-
                   <div style={{ flexShrink: 0, display: 'flex', alignItems: 'baseline', gap: 1 }}>
                     <span style={{ fontSize: 'var(--fs-data)', fontWeight: 800, color: sq.color, letterSpacing: '-0.5px' }}>
                       {sq.score}
@@ -503,10 +419,10 @@ export default function MorningBriefing() {
             );
           })
         )}
-      </div>
+      </TPanel>
 
       {/* ── AI Briefing ── */}
-      <div className="card mb-brief-card">
+      <TPanel>
         <div className="mb-brief-header">
           <span className="lbl" style={{ margin: 0 }}>{t('BRIEFING_AI_TITLE')}</span>
           <button
@@ -519,9 +435,7 @@ export default function MorningBriefing() {
         </div>
 
         {!brief && !generating && !briefErr && (
-          <div className="mb-brief-empty">
-            {t('BRIEFING_EMPTY_STATE')}
-          </div>
+          <div className="mb-brief-empty">{t('BRIEFING_EMPTY_STATE')}</div>
         )}
 
         {generating && (
@@ -533,7 +447,9 @@ export default function MorningBriefing() {
         )}
 
         {briefErr && (
-          <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--red)', marginTop: 8, display: 'flex', alignItems: 'center', gap: 5 }}><Warn /> {briefErr}</div>
+          <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--red)', marginTop: 8, display: 'flex', alignItems: 'center', gap: 5 }}>
+            <Warn /> {briefErr}
+          </div>
         )}
 
         {brief && !generating && (
@@ -552,11 +468,11 @@ export default function MorningBriefing() {
             })()}
           </div>
         )}
-      </div>
+      </TPanel>
 
-      {/* ── CVD Divergence Callout ── */}
+      {/* ── CVD Divergence ── */}
       {cvdAlerts.length > 0 && (
-        <div className="card mb-cvd-card">
+        <TPanel>
           <div className="lbl" style={{ marginBottom: 6, display: 'flex', alignItems: 'center', gap: 6 }}>
             <svg width="13" height="13" viewBox="0 0 20 20" fill="none" aria-hidden="true"><path d="M11 1.5 3.5 11.5H9L8 18.5 16 8H10.5L11 1.5Z" fill="currentColor" /></svg>
             {t('BRIEFING_CVD_TITLE')}
@@ -567,6 +483,7 @@ export default function MorningBriefing() {
                 key={id}
                 className="mb-cvd-chip"
                 style={{
+                  borderRadius: 0,
                   color:       div === 'bullish' ? 'var(--green-2)' : 'var(--red)',
                   borderColor: div === 'bullish' ? 'rgba(52,211,153,0.4)' : 'rgba(248,113,113,0.4)',
                   background:  div === 'bullish' ? 'rgba(52,211,153,0.08)' : 'rgba(248,113,113,0.08)',
@@ -576,56 +493,34 @@ export default function MorningBriefing() {
               </div>
             ))}
           </div>
-        </div>
+        </TPanel>
       )}
 
       {/* ── Session Countdown ── */}
       <SessionCountdown />
 
       {/* ── Macro Pulse ── */}
-      <div className="card" style={{ marginBottom: 10 }}>
+      <TPanel>
         <div className="lbl">{t('BRIEFING_MACRO_PULSE_TITLE')}</div>
         <div className="mb-macro-row">
-
           <div className="mb-macro-item">
-            <div className="mb-macro-label">
-              <Tip text={t('BRIEFING_FNG_TIP')}>{t('BRIEFING_FNG_LABEL')}</Tip>
-            </div>
-            <div className="mb-macro-val" style={{ color: fngColor }}>
-              {fng != null ? fng : '-'}
-            </div>
-            <div className="mb-macro-sub" style={{ color: fngColor }}>
-              {store.fngLabel || '-'}
-            </div>
+            <div className="mb-macro-label"><Tip text={t('BRIEFING_FNG_TIP')}>{t('BRIEFING_FNG_LABEL')}</Tip></div>
+            <div className="mb-macro-val" style={{ color: fngColor }}>{fng != null ? fng : '-'}</div>
+            <div className="mb-macro-sub" style={{ color: fngColor }}>{store.fngLabel || '-'}</div>
           </div>
-
           <div className="mb-macro-item">
-            <div className="mb-macro-label">
-              <Tip text={t('BRIEFING_BTCDOM_TIP')}>{t('BRIEFING_BTCDOM_LABEL')}</Tip>
-            </div>
-            <div className="mb-macro-val">
-              {store.btcDom != null ? store.btcDom.toFixed(1) + '%' : '-'}
-            </div>
-            <div className="mb-macro-sub" style={{ color: domTrend?.col ?? 'var(--txt3)' }}>
-              {domTrend?.txt ?? '-'}
-            </div>
+            <div className="mb-macro-label"><Tip text={t('BRIEFING_BTCDOM_TIP')}>{t('BRIEFING_BTCDOM_LABEL')}</Tip></div>
+            <div className="mb-macro-val">{store.btcDom != null ? store.btcDom.toFixed(1) + '%' : '-'}</div>
+            <div className="mb-macro-sub" style={{ color: domTrend?.col ?? 'var(--txt3)' }}>{domTrend?.txt ?? '-'}</div>
           </div>
-
           <div className="mb-macro-item">
-            <div className="mb-macro-label">
-              <Tip width={260} text={t('BRIEFING_DXY_TIP')}>{t('BRIEFING_DXY_LABEL')}</Tip>
-            </div>
-            <div className="mb-macro-val">
-              {store.dxy != null ? store.dxy.toFixed(2) : '-'}
-            </div>
+            <div className="mb-macro-label"><Tip width={260} text={t('BRIEFING_DXY_TIP')}>{t('BRIEFING_DXY_LABEL')}</Tip></div>
+            <div className="mb-macro-val">{store.dxy != null ? store.dxy.toFixed(2) : '-'}</div>
             <div className="mb-macro-sub" style={{ color: dxyColor }}>{dxySig}</div>
           </div>
-
           {etfFlow != null && (
             <div className="mb-macro-item">
-              <div className="mb-macro-label">
-                <Tip width={260} text={t('BRIEFING_ETF_TIP')}>{t('BRIEFING_ETF_LABEL')}</Tip>
-              </div>
+              <div className="mb-macro-label"><Tip width={260} text={t('BRIEFING_ETF_TIP')}>{t('BRIEFING_ETF_LABEL')}</Tip></div>
               <div className="mb-macro-val" style={{ color: etfColor }}>
                 {(etfFlow >= 0 ? '+' : '') + '$' + Math.abs(etfFlow).toFixed(0) + 'M'}
               </div>
@@ -637,17 +532,16 @@ export default function MorningBriefing() {
               </div>
             </div>
           )}
-
         </div>
-      </div>
+      </TPanel>
 
       {/* ── Yen Watch ── */}
-      <div className="card" style={{ marginBottom: 10 }}>
+      <TPanel>
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
           <div className="lbl" style={{ margin: 0 }}>{t('BRIEFING_YEN_WATCH_TITLE')}</div>
           {jpyStatus && (
             <span style={{
-              fontSize: 'var(--fs-caption)', fontWeight: 700, padding: '2px 9px', borderRadius: 20, letterSpacing: '.06em',
+              fontSize: 'var(--fs-caption)', fontWeight: 700, padding: '2px 9px', borderRadius: 0, letterSpacing: '.06em',
               color: jpyStatus.color, background: jpyStatus.bg, border: `0.5px solid ${jpyStatus.border}`,
             }}>{jpyStatus.label}</span>
           )}
@@ -661,7 +555,6 @@ export default function MorningBriefing() {
           </div>
         ) : (
           <>
-            {/* Rate */}
             <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 12 }}>
               <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', letterSpacing: '.05em' }}>{t('BRIEFING_YEN_PAIR_LABEL')}</span>
               <span style={{ fontSize: '1.75rem', fontWeight: 700, letterSpacing: '-0.5px', color: jpyStatus!.color }}>
@@ -669,30 +562,21 @@ export default function MorningBriefing() {
               </span>
             </div>
 
-            {/* Danger zone bar */}
-            {/* dir="ltr": a QUANTITATIVE AXIS DOES NOT MIRROR (#353).
-                 Arabic text reads right-to-left; a 140-165 USD/JPY scale does not.
-                 Flipping this would put the low end on the right and every
-                 marker at a position meaning a different value - rendering
-                 perfectly and lying. Explicit rather than inherited so it stays
-                 true when the document direction changes. */}
             <div dir="ltr" style={{ position: 'relative', paddingBottom: 18, marginBottom: 6 }}>
               <div style={{
-                height: 6, borderRadius: 3, overflow: 'hidden',
+                height: 6, borderRadius: 0, overflow: 'hidden',
                 background: `linear-gradient(to right,
                   rgba(52,211,153,0.35) 0%, rgba(52,211,153,0.35) ${warn158Pct}%,
                   rgba(251,191,36,0.45) ${warn158Pct}%, rgba(251,191,36,0.45) ${danger160Pct}%,
                   rgba(248,113,113,0.45) ${danger160Pct}%, rgba(248,113,113,0.45) 100%)`,
               }}>
-                {/* Current rate dot */}
                 <div style={{
                   position: 'absolute', top: 0, left: `${jpyPct}%`, transform: 'translate(-50%, 0)',
-                  width: 12, height: 12, borderRadius: '50%', marginTop: -3,
+                  width: 12, height: 12, borderRadius: 0, marginTop: -3,
                   background: jpyStatus!.color, border: '2px solid #111',
                   boxShadow: `0 0 8px ${withAlpha(jpyStatus!.color, '88')}`,
                 }} />
               </div>
-              {/* Threshold labels */}
               <span style={{ position: 'absolute', bottom: 0, left: 0, fontSize: 'var(--fs-caption)', color: 'var(--txt3)' }}>140</span>
               <span style={{
                 position: 'absolute', bottom: 0, left: `${warn158Pct}%`, transform: 'translateX(-50%)',
@@ -705,7 +589,6 @@ export default function MorningBriefing() {
               <span style={{ position: 'absolute', bottom: 0, right: 0, fontSize: 'var(--fs-caption)', color: 'var(--txt3)' }}>165</span>
             </div>
 
-            {/* Interpretation */}
             <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt2)', lineHeight: 1.55, marginTop: 4 }}>
               {jpyStatus!.desc}
             </div>
@@ -716,7 +599,7 @@ export default function MorningBriefing() {
             )}
           </>
         )}
-      </div>
+      </TPanel>
 
       {/* ── Notable Signals ── */}
       {(() => {
@@ -738,7 +621,7 @@ export default function MorningBriefing() {
           if (c.volRatio != null && c.volRatio >= 1.5)
             chips.push({ text: t('BRIEFING_TAG_VOL', { x: c.volRatio.toFixed(1) }), color: 'var(--accent)' });
           if (c.oiTrend === 'strong_up')        chips.push({ text: t('BRIEFING_TAG_OI_STRONG_UP'),    color: 'var(--green-2)' });
-          else if (c.oiTrend === 'strong_down') chips.push({ text: t('BRIEFING_TAG_OI_STRONG_DOWN'),    color: 'var(--red)' });
+          else if (c.oiTrend === 'strong_down') chips.push({ text: t('BRIEFING_TAG_OI_STRONG_DOWN'),   color: 'var(--red)' });
           if (c.cvdDivergence === 'bullish')    chips.push({ text: t('BRIEFING_TAG_CVD_BULL'), color: 'var(--green-2)' });
           else if (c.cvdDivergence === 'bearish') chips.push({ text: t('BRIEFING_TAG_CVD_BEAR'), color: 'var(--red)' });
           if (chips.length > 0) byCoins.push({ id, label: COIN_LABELS[id], chips });
@@ -749,7 +632,7 @@ export default function MorningBriefing() {
         const extra = byCoins.length - shown.length;
 
         return (
-          <div className="card" style={{ marginBottom: 10 }}>
+          <TPanel>
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: shown.length > 0 ? 10 : 0 }}>
               <div className="lbl" style={{ margin: 0 }}>{t('BRIEFING_NOTABLE_SIGNALS_TITLE')}</div>
               <Link href="/scanner" style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', textDecoration: 'none', display: 'inline-flex', alignItems: 'center', minHeight: 24 }}>
@@ -777,7 +660,7 @@ export default function MorningBriefing() {
                       <div style={{ display: 'flex', gap: 5, flex: 1, flexWrap: 'wrap' }}>
                         {chips.map(chip => (
                           <span key={chip.text} style={{
-                            fontSize: 'var(--fs-caption)', fontWeight: 700, padding: '2px 7px', borderRadius: 20, flexShrink: 0,
+                            fontSize: 'var(--fs-caption)', fontWeight: 700, padding: '2px 7px', borderRadius: 0, flexShrink: 0,
                             color: chip.color, background: withAlpha(chip.color, '18'), border: `0.5px solid ${withAlpha(chip.color, '50')}`,
                           }}>{chip.text}</span>
                         ))}
@@ -795,13 +678,12 @@ export default function MorningBriefing() {
                 )}
               </>
             )}
-          </div>
+          </TPanel>
         );
       })()}
 
-
       {/* ── Events & News ── */}
-      <div className="card" style={{ marginBottom: 10 }}>
+      <TPanel>
         <div className="lbl">{t('BRIEFING_EVENTS_NEWS_TITLE')}</div>
 
         {noEvents && (
@@ -814,26 +696,28 @@ export default function MorningBriefing() {
           const lh = (e.dt.getTime() - nowMs) / 3600000;
           const isPast = lh < 0;
           return (
-          <div key={i} className="mb-event-row">
-            <div className="mb-event-tag" style={{
-              background: isPast ? 'rgba(100,100,100,0.15)' : lh < 2 ? 'rgba(248,113,113,0.15)' : 'rgba(251,191,36,0.1)',
-              color: isPast ? 'var(--txt3)' : lh < 2 ? 'var(--red)' : 'var(--amber)',
-            }}>
-              {isPast ? '✓ ' : ''}{e.type}
+            <div key={i} className="mb-event-row">
+              <div className="mb-event-tag" style={{
+                borderRadius: 0,
+                background: isPast ? 'rgba(100,100,100,0.15)' : lh < 2 ? 'rgba(248,113,113,0.15)' : 'rgba(251,191,36,0.1)',
+                color: isPast ? 'var(--txt3)' : lh < 2 ? 'var(--red)' : 'var(--amber)',
+              }}>
+                {isPast ? '✓ ' : ''}{e.type}
+              </div>
+              <div className="mb-event-name">{e.name}</div>
+              <div className="mb-event-time" style={{
+                color: isPast ? 'var(--txt3)' : lh < 1 ? 'var(--red)' : lh < 6 ? 'var(--amber)' : 'var(--txt3)',
+              }}>
+                {isPast ? `${Math.round(-lh * 60)}m ago` : lh < 0.017 ? 'NOW' : `in ${hToHM(lh)}`}
+              </div>
             </div>
-            <div className="mb-event-name">{e.name}</div>
-            <div className="mb-event-time" style={{
-              color: isPast ? 'var(--txt3)' : lh < 1 ? 'var(--red)' : lh < 6 ? 'var(--amber)' : 'var(--txt3)',
-            }}>
-              {isPast ? `${Math.round(-lh * 60)}m ago` : lh < 0.017 ? 'NOW' : `in ${hToHM(lh)}`}
-            </div>
-          </div>
           );
         })}
 
         {recentGeo.map((e, i) => (
           <div key={i} className="mb-event-row">
             <div className="mb-event-tag" style={{
+              borderRadius: 0,
               background: e.style === 'crypto'
                 ? 'rgba(52,211,153,0.1)'
                 : e.style === 'speech'
@@ -851,6 +735,7 @@ export default function MorningBriefing() {
         {whaleAlerts && whaleAlerts.slice(0, 4).map((w, i) => (
           <div key={i} className="mb-event-row">
             <div className="mb-event-tag" style={{
+              borderRadius: 0,
               background: w.side === 'BUY' ? 'rgba(52,211,153,0.12)' : 'rgba(248,113,113,0.12)',
               color: w.side === 'BUY' ? 'var(--green-2)' : 'var(--red)',
             }}>
@@ -862,7 +747,7 @@ export default function MorningBriefing() {
             <div className="mb-event-time" style={{ color: 'var(--txt3)' }}>{tsAgo(w.ts)}</div>
           </div>
         ))}
-      </div>
+      </TPanel>
 
     </div>
   );


### PR DESCRIPTION
## Summary
- Self-contained `BriefingTerminal` component (~430 lines) mirrors `MorningBriefing` layout with `TPanel` flat panels replacing all `className=\"card\"` blocks
- `useDesignMode()` gate added to `app/briefing/page.tsx` (first hook, gate after all hooks)
- `border-radius: 0` CSS overrides for `.mb-macro-item`, `.mb-event-tag`, `.mb-brief-btn`, `.mb-cvd-chip` in the `[data-design="terminal"]` block in `globals.css`

## What changed
- `components/BriefingTerminal.tsx` — new self-contained terminal version
- `app/briefing/page.tsx` — imports `useDesignMode` + `BriefingTerminal`, adds mode gate
- `app/globals.css` — 4 briefing-class border-radius overrides in terminal block

## Why
Issue #413: convert all screens to the monochrome terminal design.

## How to test (QA)
1. Open `/briefing?design=terminal` on the `qa` environment
2. Verify: all panels are flat (`bg1` fill, `1px solid var(--bdr)`, zero border-radius)
3. Check chips/tags (CVD, event tags), macro items, and AI briefing button — all square corners
4. Remove `?design=terminal` — default briefing renders unchanged (no regression)
5. Toggle via localStorage: `localStorage.setItem('lhq-design-mode','terminal')` then hard-refresh

## Risk level
Low — additive component; existing `MorningBriefing` JSX untouched.

## Screenshots
Visit `/briefing?design=terminal` to see terminal mode.

— Dev Team