### PR TITLE
feat(dashboard): Monochrome Terminal — /journal, /alerts, /news (#413)

### DIFF
--- a/app/alerts/page.tsx
+++ b/app/alerts/page.tsx
@@ -1,4 +1,5 @@
 ﻿'use client';
+import { useDesignMode } from '@/components/DesignModeProvider';
 import { useState, useEffect, useCallback, useRef } from 'react';
 import AuthGate from '@/components/AuthGate';
 import UpgradeGateModal, { LockedFeatureCard } from '@/components/UpgradeGateModal';
@@ -63,6 +64,7 @@ const LINK_POLL_MAX     = 40;
 const LINK_CODE_TTL_SEC = 600;
 
 export default function AlertsPage() {
+  const mode = useDesignMode();
   const { t } = useLabels();
   const { user, entitled, loading: authLoading } = useAuth();
   const { settings, loading: settingsLoading, refresh: refreshSettings } = useSettings();
@@ -522,7 +524,7 @@ export default function AlertsPage() {
   };
 
   return (
-    <div>
+    <div className={mode === 'terminal' ? 'alerts-term-wrap' : undefined}>
       {/* Header */}
       <div className="mb-header">
         <h1 className="mb-title">{t('ALERTS_PAGE_TITLE')}</h1>

--- a/app/globals.css
+++ b/app/globals.css
@@ -6215,3 +6215,11 @@ main.app-content[data-chrome="none"] {
 [data-design="terminal"] .mb-event-tag  { border-radius: 0; }
 [data-design="terminal"] .mb-brief-btn  { border-radius: 0; }
 [data-design="terminal"] .mb-cvd-chip   { border-radius: 0; }
+
+/* journal / alerts / news terminal — nuke hardcoded pixel radii (#413) */
+[data-design="terminal"] .journal-term-wrap,
+[data-design="terminal"] .journal-term-wrap * { border-radius: 0 !important; }
+[data-design="terminal"] .alerts-term-wrap,
+[data-design="terminal"] .alerts-term-wrap * { border-radius: 0 !important; }
+[data-design="terminal"] .news-term-wrap,
+[data-design="terminal"] .news-term-wrap * { border-radius: 0 !important; }

--- a/app/journal/page.tsx
+++ b/app/journal/page.tsx
@@ -1,18 +1,20 @@
 'use client';
+import { useDesignMode } from '@/components/DesignModeProvider';
 import TradeJournal from '@/components/TradeJournal';
 import PageHint from '@/components/PageHint';
 import { useLabels } from '@/lib/labels';
 
 export default function JournalPage() {
+  const mode = useDesignMode();
   const { t } = useLabels();
   return (
-    <>
+    <div className={mode === 'terminal' ? 'journal-term-wrap' : undefined}>
       <PageHint
         pageKey="journal"
         title={t('JOURNAL_HINT_TITLE')}
         body={t('JOURNAL_HINT_BODY')}
       />
       <TradeJournal />
-    </>
+    </div>
   );
 }

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { useDesignMode } from '@/components/DesignModeProvider';
 import { useState } from 'react';
 import { useNews } from '@/components/NewsProvider';
 import { GEO_KEYWORDS, ECON_NOTES, getCoinsInHeadline } from '@/lib/classify';
@@ -343,6 +344,7 @@ function NewsCard({ a, hero = false }: { a: AlertItem & { geo?: { tag: string; n
    PAGE
 ──────────────────────────────────────────────── */
 export default function NewsPage() {
+  const mode = useDesignMode();
   const { t } = useLabels();
   const { alerts, geoEvents, econEvents, whaleAlerts, alertsLoaded } = useNews();
   const [tab, setTab] = useState<Tab>('foryou');
@@ -417,7 +419,7 @@ export default function NewsPage() {
   }
 
   return (
-    <div>
+    <div className={mode === 'terminal' ? 'news-term-wrap' : undefined}>
       {/* ── Header ── */}
       <div style={{ padding: '1rem 0 0.5rem' }}>
         <h1 style={{ fontSize: 'var(--fs-section)', fontWeight: 700, color: 'var(--txt)', marginBottom: 2, letterSpacing: '-0.3px' }}>


### PR DESCRIPTION
## Summary
- `/journal`, `/alerts`, `/news` now render Monochrome Terminal layout when `?design=terminal` is active
- Nuclear CSS (`border-radius: 0 !important`) zeroes all hardcoded pixel radii in page JSX and every sub-component underneath

## What changed
- `app/journal/page.tsx` — added `useDesignMode`, root wrapped in `journal-term-wrap` class when terminal mode active
- `app/alerts/page.tsx` — added `useDesignMode` as first hook, root div receives `alerts-term-wrap` class in terminal mode
- `app/news/page.tsx` — added `useDesignMode` as first hook, root div receives `news-term-wrap` class in terminal mode
- `app/globals.css` — appended nuclear `* { border-radius: 0 !important }` overrides scoped to each wrapper class

## Why
Book batch of issue #413 — Monochrome Terminal redesign for all screens.

## How to test (QA)
On `qa` environment after promote + deploy:

1. Go to `/journal?design=terminal` — TradeJournal cards render with 0 border-radius, no rounded corners anywhere
2. Go to `/alerts?design=terminal` — Telegram connect wizard, toggle chips, status badges, price alert rows all sharp-edged
3. Go to `/news?design=terminal` — news cards, tab bar, sentiment badges, source pills all sharp-edged
4. On each page: remove `?design=terminal` (or set design=current) — original rounded design restored unchanged
5. Toggle between modes mid-session — no layout shift, no hook errors in console

## Risk level
Low — additive CSS class + scoped `!important` override. Default (current) design path unchanged; terminal wrapper class is only applied when `lhq-design-mode=terminal` is set.

**Dev Team**
