### PR TITLE
feat(dashboard): Monochrome Terminal — Book batch 2 (#413)

### DIFF
--- a/app/calc/page.tsx
+++ b/app/calc/page.tsx
@@ -10,6 +10,7 @@ import RiskRewardCalc   from '@/components/RiskRewardCalc';
 import FundingCostCalc  from '@/components/FundingCostCalc';
 import DcaCalc          from '@/components/DcaCalc';
 import { useLabels } from '@/lib/labels';
+import { useDesignMode } from '@/components/DesignModeProvider';
 
 const TABS = [
   { id: 'sizer',       key: 'CALC_TAB_SIZER'       },
@@ -21,6 +22,7 @@ const TABS = [
 ] as const;
 
 function CalcPageContent() {
+  const mode = useDesignMode();
   const searchParams = useSearchParams();
   const [tab, setTab] = useState('sizer');
   const { t } = useLabels();
@@ -56,7 +58,7 @@ function CalcPageContent() {
   }, [coinMenuOpen]);
 
   return (
-    <div>
+    <div className={mode === 'terminal' ? 'calc-term-wrap' : undefined}>
       <div style={{ padding: '1rem 0 0.75rem' }}>
         <h1 style={{ fontSize: 'var(--fs-section)', fontWeight: 700, color: 'var(--txt)', marginBottom: 2 }}>{t('CALC_PAGE_TITLE')}</h1>
         <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)' }}>{t('CALC_PAGE_SUBTITLE')}</div>

--- a/app/econ-calendar/page.tsx
+++ b/app/econ-calendar/page.tsx
@@ -5,6 +5,7 @@ import LoadingState from '@/components/LoadingState';
 import { useLabels } from '@/lib/labels';
 import type { LabelKey } from '@/lib/labelKeys';
 import { econImpactKey, type EconImpact } from '@/lib/classify';
+import { useDesignMode } from '@/components/DesignModeProvider';
 
 type CalEvent = {
   name: string; type: string; isoDate: string; impact: string;
@@ -80,6 +81,7 @@ const COL_LABEL_KEYS: LabelKey[] = [
 ];
 
 export default function EconCalendarPage() {
+  const mode = useDesignMode();
   const { t } = useLabels();
   const [events, setEvents]   = useState<CalEvent[]>([]);
   const [source, setSource]   = useState('');
@@ -112,7 +114,7 @@ export default function EconCalendarPage() {
   }
 
   return (
-    <div style={{ maxWidth: 960, margin: '0 auto', padding: '0 16px 48px' }}>
+    <div className={mode === 'terminal' ? 'econ-term-wrap' : undefined} style={{ maxWidth: 960, margin: '0 auto', padding: '0 16px 48px' }}>
 
       {/* Page header */}
       <div style={{ padding: '20px 0 16px' }}>

--- a/app/globals.css
+++ b/app/globals.css
@@ -6248,3 +6248,16 @@ main.app-content[data-chrome="none"] {
 [data-design="terminal"] .alerts-term-wrap * { border-radius: 0 !important; }
 [data-design="terminal"] .news-term-wrap,
 [data-design="terminal"] .news-term-wrap * { border-radius: 0 !important; }
+/* calc / playbook / hours / research / econ-calendar / settings terminal (#413) */
+[data-design="terminal"] .calc-term-wrap,
+[data-design="terminal"] .calc-term-wrap * { border-radius: 0 !important; }
+[data-design="terminal"] .playbook-term-wrap,
+[data-design="terminal"] .playbook-term-wrap * { border-radius: 0 !important; }
+[data-design="terminal"] .hours-term-wrap,
+[data-design="terminal"] .hours-term-wrap * { border-radius: 0 !important; }
+[data-design="terminal"] .research-term-wrap,
+[data-design="terminal"] .research-term-wrap * { border-radius: 0 !important; }
+[data-design="terminal"] .econ-term-wrap,
+[data-design="terminal"] .econ-term-wrap * { border-radius: 0 !important; }
+[data-design="terminal"] .settings-term-wrap,
+[data-design="terminal"] .settings-term-wrap * { border-radius: 0 !important; }

--- a/app/hours/page.tsx
+++ b/app/hours/page.tsx
@@ -6,6 +6,7 @@ import SessionCountdown from '@/components/SessionCountdown';
 import Tip from '@/components/Tip';
 import { useLabels } from '@/lib/labels';
 import type { LabelKey } from '@/lib/labelKeys';
+import { useDesignMode } from '@/components/DesignModeProvider';
 
 /* Typical-weekday session blocks, as UTC hour ranges - the same windows
    lib/session.ts enforces. These used to be PHT hours on a fixed PHT axis
@@ -61,6 +62,7 @@ const WINDOWS: { cls: string; badgeKey: LabelKey; descKey: LabelKey; utc: [numbe
 function pad(n: number) { return n < 10 ? '0' + n : '' + n; }
 
 export default function BestHours() {
+  const mode = useDesignMode();
   // This page is statically prerendered, so which session window is "active"
   // in the server HTML reflects whenever the last build ran, not real time.
   // Gate the win/dead-driven blocks below on `mounted` so the server render
@@ -89,7 +91,7 @@ export default function BestHours() {
   const upcoming = (!win && !dead) ? getUpcomingWindows(now, 3) : [];
 
   return (
-    <div>
+    <div className={mode === 'terminal' ? 'hours-term-wrap' : undefined}>
       <div style={{ padding: '1rem 0 0.5rem' }}>
         <h1 style={{ fontSize: 'var(--fs-section)', fontWeight: 700, color: 'var(--txt)', marginBottom: 2 }}>{t('HOURS_TITLE')}</h1>
         <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', marginBottom: 14 }}>{t('HOURS_SUBTITLE')}</div>

--- a/app/playbook/page.tsx
+++ b/app/playbook/page.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react';
 import { SECRETS, Secret } from '@/lib/secrets';
 import { useLabels } from '@/lib/labels';
 import type { LabelKey } from '@/lib/labelKeys';
+import { useDesignMode } from '@/components/DesignModeProvider';
 
 type Cat = 'all' | 'hunt' | 'time' | 'trap' | 'psych' | 'fav';
 
@@ -12,6 +13,7 @@ const CAT_LABEL_KEYS: Record<string, LabelKey> = {
 const CAT_CLS: Record<string, string>    = { hunt: 'cat-hunt', time: 'cat-time', trap: 'cat-trap', psych: 'cat-psych' };
 
 export default function LiquidityPlaybook() {
+  const mode = useDesignMode();
   const { t }                = useLabels();
   const [query, setQuery]   = useState('');
   const [cat, setCat]       = useState<Cat>('all');
@@ -36,7 +38,7 @@ export default function LiquidityPlaybook() {
   });
 
   return (
-    <div>
+    <div className={mode === 'terminal' ? 'playbook-term-wrap' : undefined}>
       <div style={{ padding: '1rem 0 0.5rem' }}>
         <div style={{ fontSize: 'var(--fs-section)', fontWeight: 700, color: 'var(--txt)', marginBottom: 2 }}>{t('PLAYBOOK_PAGE_TITLE')}</div>
         <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', marginBottom: 14 }}>{t('PLAYBOOK_SUBTITLE', { count: SECRETS.length })}</div>

--- a/app/research/page.tsx
+++ b/app/research/page.tsx
@@ -9,11 +9,13 @@ import DryPowder from '@/components/DryPowder';
 import GlobalMacroContext from '@/components/GlobalMacroContext';
 import OnChainScore from '@/components/OnChainScore';
 import { useLabels } from '@/lib/labels';
+import { useDesignMode } from '@/components/DesignModeProvider';
 
 export default function ResearchPage() {
+  const mode = useDesignMode();
   const { t } = useLabels();
   return (
-    <>
+    <div className={mode === 'terminal' ? 'research-term-wrap' : undefined}>
       <PageHint
         pageKey="research"
         title={t('RESEARCH_HINT_TITLE')}
@@ -36,6 +38,6 @@ export default function ResearchPage() {
         </div>
         <HypothesisTracker />
       </div>
-    </>
+    </div>
   );
 }

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -17,6 +17,7 @@ import { friendlyAuthError } from '@/lib/authErrors';
 import PasswordField from '@/components/PasswordField';
 import { passwordMeetsPolicy } from '@/lib/passwordPolicy';
 import { readConsent, writeConsent, onConsentChange, type ConsentState } from '@/lib/consent';
+import { useDesignMode } from '@/components/DesignModeProvider';
 
 
 
@@ -105,6 +106,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 
 
 export default function SettingsPage() {
+  const mode = useDesignMode();
   const { t } = useLabels();
   const { user, loading: authLoading, signOut, entitled } = useAuth();
   const { settings, saveStatus, update } = useSettings();
@@ -229,7 +231,7 @@ export default function SettingsPage() {
       t('SETTINGS_SECTION_TELEGRAM'),
     ];
     return (
-      <div className="st-page" data-testid="settings-page">
+      <div className={`st-page${mode === 'terminal' ? ' settings-term-wrap' : ''}`} data-testid="settings-page">
         <div className="st-header"><h1 className="st-header-title">{t('SETTINGS_PAGE_TITLE')}</h1></div>
 
         <Section title={t('SETTINGS_SECTION_APPEARANCE')}>


### PR DESCRIPTION
## Summary

- Applied `useDesignMode` hook + conditional wrapper class + nuclear CSS `border-radius: 0 !important` override to all 6 Book batch 2 screens.
- Pattern identical to Book batch 1 (journal / alerts / news) and previous batches.

## What changed

| Screen | Wrapper class | CSS selector |
|---|---|---|
| `/calc` | `calc-term-wrap` | `[data-design="terminal"] .calc-term-wrap, .calc-term-wrap *` |
| `/playbook` | `playbook-term-wrap` | `[data-design="terminal"] .playbook-term-wrap, .playbook-term-wrap *` |
| `/hours` | `hours-term-wrap` | `[data-design="terminal"] .hours-term-wrap, .hours-term-wrap *` |
| `/research` | `research-term-wrap` | `[data-design="terminal"] .research-term-wrap, .research-term-wrap *` |
| `/econ-calendar` | `econ-term-wrap` | `[data-design="terminal"] .econ-term-wrap, .econ-term-wrap *` |
| `/settings` | `settings-term-wrap` (both auth states) | `[data-design="terminal"] .settings-term-wrap, .settings-term-wrap *` |

## Why

Issue #413 — all screens must render zero border-radius in Monochrome Terminal design mode.

## How to test (QA)

Environment: qa branch on https://liquidity-hq-qa.onrender.com (after promotion + deploy)

For each page below, append `?design=terminal` to the URL on first visit (sets `localStorage` flag):

1. `/calc?design=terminal` — coin picker dropdown, tab buttons, calculator cards → all sharp corners
2. `/playbook?design=terminal` — category filter chips, play cards, star button → all sharp corners
3. `/hours?design=terminal` — session timeline bar, window pills, countdown cards → all sharp corners
4. `/research?design=terminal` — cycle/risk/volatility/macro cards → all sharp corners
5. `/econ-calendar?design=terminal` — next-event banner, date group containers, impact badges → all sharp corners
6. `/settings?design=terminal` — section cards, toggle buttons, input fields, chips (signed in AND signed out states) → all sharp corners

Verify: navigating back without the flag shows current design unchanged (rounded corners intact).

## Risk level

Low — CSS-only nuclear override scoped to `[data-design="terminal"]` wrapper class; zero impact on current design. No logic or data path changes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y

— Dev Team