### PR TITLE
feat(auth): Monochrome Terminal — Auth batch (#413)

### DIFF
--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -5,10 +5,12 @@ import { Turnstile, type TurnstileInstance } from '@marsidev/react-turnstile';
 import { getSupabase } from '@/lib/supabase';
 import { friendlyAuthError } from '@/lib/authErrors';
 import { useLabels } from '@/lib/labels';
+import { useDesignMode } from '@/components/DesignModeProvider';
 
 const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? '';
 
 export default function ForgotPasswordPage() {
+  const mode = useDesignMode();
   const { t } = useLabels();
   const [email, setEmail]         = useState('');
   const [loading, setLoading]     = useState(false);
@@ -43,7 +45,7 @@ export default function ForgotPasswordPage() {
   };
 
   return (
-    <div className="login-wrap">
+    <div className={`login-wrap${mode === 'terminal' ? ' login-term-wrap' : ''}`}>
       <div className="login-card">
         <div className="login-logo">Liquidity<span>HQ</span></div>
         <p className="login-sub">{t('FORGOT_PASSWORD_SUBTITLE')}</p>

--- a/app/globals.css
+++ b/app/globals.css
@@ -6261,3 +6261,6 @@ main.app-content[data-chrome="none"] {
 [data-design="terminal"] .econ-term-wrap * { border-radius: 0 !important; }
 [data-design="terminal"] .settings-term-wrap,
 [data-design="terminal"] .settings-term-wrap * { border-radius: 0 !important; }
+/* login / forgot-password / reset-password terminal (#413) */
+[data-design="terminal"] .login-term-wrap,
+[data-design="terminal"] .login-term-wrap * { border-radius: 0 !important; }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -12,6 +12,7 @@ import LoadingState from '@/components/LoadingState';
 import PasswordField from '@/components/PasswordField';
 import { passwordMeetsPolicy } from '@/lib/passwordPolicy';
 import { useLabels } from '@/lib/labels';
+import { useDesignMode } from '@/components/DesignModeProvider';
 
 // Only rendered once NEXT_PUBLIC_TURNSTILE_SITE_KEY is set - until then the
 // magic-link form works exactly as before (no widget, no token required).
@@ -21,6 +22,7 @@ import { useLabels } from '@/lib/labels';
 const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? '';
 
 function LoginInner() {
+  const mode = useDesignMode();
   const searchParams = useSearchParams();
   const router       = useRouter();
   const { user, loading: authLoading } = useAuth();
@@ -208,7 +210,7 @@ function LoginInner() {
   if (authLoading || user) return <LoginFallback />;
 
   return (
-    <div className="login-wrap">
+    <div className={`login-wrap${mode === 'terminal' ? ' login-term-wrap' : ''}`}>
       <div className="login-card">
 
         {/* Logo */}

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -8,6 +8,7 @@ import LoadingState from '@/components/LoadingState';
 import PasswordField from '@/components/PasswordField';
 import { passwordMeetsPolicy } from '@/lib/passwordPolicy';
 import { useLabels } from '@/lib/labels';
+import { useDesignMode } from '@/components/DesignModeProvider';
 
 // Landed on directly from the password-reset email link
 // (resetPasswordForEmail's redirectTo), not routed through /auth/callback -
@@ -17,6 +18,7 @@ import { useLabels } from '@/lib/labels';
 // same as everywhere else in this app) and fires a PASSWORD_RECOVERY auth
 // event once it's parsed - that's the signal this form is safe to show.
 export default function ResetPasswordPage() {
+  const mode = useDesignMode();
   const router = useRouter();
   const { t } = useLabels();
   const [ready, setReady]     = useState(false);
@@ -79,7 +81,7 @@ export default function ResetPasswordPage() {
 
   if (invalid) {
     return (
-      <div className="login-wrap">
+      <div className={`login-wrap${mode === 'terminal' ? ' login-term-wrap' : ''}`}>
         <div className="login-card">
           <div className="login-logo">Liquidity<span>HQ</span></div>
           <div className="login-error" data-testid="login-error" style={{ marginTop: 16 }}>{t('RESET_PASSWORD_INVALID_LINK')}</div>
@@ -94,7 +96,7 @@ export default function ResetPasswordPage() {
   if (!ready) return <LoadingState message={t('LOGIN_LOADING')} fullPage />;
 
   return (
-    <div className="login-wrap">
+    <div className={`login-wrap${mode === 'terminal' ? ' login-term-wrap' : ''}`}>
       <div className="login-card">
         <div className="login-logo">Liquidity<span>HQ</span></div>
         <p className="login-sub">{t('RESET_PASSWORD_SUBTITLE')}</p>


### PR DESCRIPTION
## Summary

- Applied `useDesignMode` hook + `login-term-wrap` wrapper class + nuclear CSS `border-radius: 0 !important` to all three auth screens.
- All return paths covered in `/reset-password` (invalid-link state + main form).

## What changed

| Screen | Notes |
|---|---|
| `/login` | Applied to `LoginInner` — covers magic-link, password, and OAuth flows |
| `/forgot-password` | Single return path |
| `/reset-password` | Two `login-wrap` return paths (invalid-link + main form); loading spinner left as-is |

One shared CSS selector covers all three since they share `.login-wrap`:
```css
[data-design="terminal"] .login-term-wrap,
[data-design="terminal"] .login-term-wrap * { border-radius: 0 !important; }
```

## Why

Issue #413 — all screens must render zero border-radius in Monochrome Terminal design mode.

## How to test (QA)

Environment: qa branch on https://liquidity-hq-qa.onrender.com (after promotion + deploy)

1. `/login?design=terminal` — login card, email input, Google button, divider, magic-link button → all sharp corners. Switch to password tab — same.
2. `/forgot-password?design=terminal` — card, input, submit button → sharp corners.
3. `/reset-password?design=terminal` — navigate to page without a valid reset token → invalid-link card renders with sharp corners. (Full form requires a live reset email link.)

Verify: same pages without `?design=terminal` show current rounded design unchanged.

## Risk level

Low — CSS-only nuclear override scoped to `login-term-wrap`. No auth logic or data path changes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y

— Dev Team