### PR TITLE
feat(dashboard): terminal mode for UpgradeGateModal components (#413)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6264,3 +6264,10 @@ main.app-content[data-chrome="none"] {
 /* login / forgot-password / reset-password terminal (#413) */
 [data-design="terminal"] .login-term-wrap,
 [data-design="terminal"] .login-term-wrap * { border-radius: 0 !important; }
+/* upgrade-gate / locked-feature-card / full-page-upgrade-gate terminal (#413) */
+[data-design="terminal"] .locked-card-term-wrap,
+[data-design="terminal"] .locked-card-term-wrap * { border-radius: 0 !important; }
+[data-design="terminal"] .upgrade-gate-term-wrap,
+[data-design="terminal"] .upgrade-gate-term-wrap * { border-radius: 0 !important; }
+[data-design="terminal"] .upgrade-modal-term-wrap,
+[data-design="terminal"] .upgrade-modal-term-wrap * { border-radius: 0 !important; }

--- a/components/UpgradeGateModal.tsx
+++ b/components/UpgradeGateModal.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useAuth } from '@/components/AuthProvider';
 import { getCheckoutUrl, isCheckoutConfigured } from '@/lib/checkout';
 import { useLabels } from '@/lib/labels';
+import { useDesignMode } from '@/components/DesignModeProvider';
 
 interface Props {
   open: boolean;
@@ -21,6 +22,7 @@ export function LockedFeatureCard({ title, description, onUnlock }: {
   description: string;
   onUnlock: () => void;
 }) {
+  const mode = useDesignMode();
   const { t } = useLabels();
   return (
     /* data-testid so the paywall can be COUNTED per screen (#441).
@@ -37,7 +39,7 @@ export function LockedFeatureCard({ title, description, onUnlock }: {
      * gradient binds it to styling the redesign is actively changing - so the
      * check would break on the very commit it exists to catch. An explicit
      * hook survives both. */
-    <div data-testid="locked-feature" style={{
+    <div data-testid="locked-feature" className={mode === 'terminal' ? 'locked-card-term-wrap' : undefined} style={{
       background: 'linear-gradient(180deg, var(--bg2), var(--bg1))',
       border: '0.5px solid var(--bdr)',
       borderRadius: 'var(--radius-card, 12px)',
@@ -87,10 +89,11 @@ function useCheckoutHref() {
 // (UpgradeGateModal). Same copy conventions as both - one "Pro Feature"
 // eyebrow + CTA pattern instead of three hand-rolled versions drifting apart.
 export function FullPageUpgradeGate({ title, description }: { title: string; description: string }) {
+  const mode = useDesignMode();
   const ctaHref = useCheckoutHref();
   const { t } = useLabels();
   return (
-    <div style={{ minHeight: '70vh', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24 }}>
+    <div className={mode === 'terminal' ? 'upgrade-gate-term-wrap' : undefined} style={{ minHeight: '70vh', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24 }}>
       <div style={{
         width: '100%', maxWidth: 480,
         background: 'linear-gradient(180deg, var(--bg2), var(--bg1))',
@@ -138,6 +141,7 @@ export function FullPageUpgradeGate({ title, description }: { title: string; des
 // user's email + id (or falls back to /login?signup=1 while checkout is not
 // configured yet).
 export default function UpgradeGateModal({ open, onClose, feature }: Props) {
+  const mode = useDesignMode();
   const ctaHref = useCheckoutHref();
   const { t } = useLabels();
 
@@ -162,6 +166,7 @@ export default function UpgradeGateModal({ open, onClose, feature }: Props) {
       role="dialog"
       aria-modal="true"
       aria-label={t('UPGRADE_GATE_CTA')}
+      className={mode === 'terminal' ? 'upgrade-modal-term-wrap' : undefined}
       style={{
         position: 'fixed', inset: 0, zIndex: 10000,
         background: 'rgba(4, 6, 12, 0.72)',


### PR DESCRIPTION
## Summary

Applies terminal mode (sharp corners) to the three components in `UpgradeGateModal.tsx`:
- `LockedFeatureCard` — in-place paywall card
- `FullPageUpgradeGate` — full-page Pro gate
- `UpgradeGateModal` — interrupting paywall modal

## What changed

- `components/UpgradeGateModal.tsx`: Added `useDesignMode` import + hook call in each of the three components; added wrapper className (`locked-card-term-wrap`, `upgrade-gate-term-wrap`, `upgrade-modal-term-wrap`) to each root div.
- `app/globals.css`: Nuclear CSS selectors zero all `border-radius` under `[data-design="terminal"]` for all three wrapper classes.

## Why

Continues issue #413 — Monochrome Terminal redesign for all screens. These components had 6 hardcoded `borderRadius` values that survived the batch passes covering pages.

## How to test (QA)

On `qa` branch at liquidity-hq-qa.onrender.com (or localhost on `qa`):

1. Sign in as a free user (or downgrade in Supabase).
2. Visit any Pro-gated page (e.g. one that shows a `LockedFeatureCard`).
3. Append `?design=terminal` — confirm card corners are square.
4. Navigate to a full-page Pro gate (`FullPageUpgradeGate`) with `?design=terminal` — sharp corners on the container card and CTA button.
5. Trigger the `UpgradeGateModal` (click a locked feature) with `?design=terminal` — modal card and CTA button have square corners.
6. Remove `?design=terminal` — all three should revert to rounded corners (unchanged).

## Risk level

Low — additive className only; no style or behaviour change for non-terminal users.
