### PR TITLE
chore(qa): restore 12 routes lost in #497 merge + add 3 static pages to CONVERTED_ROUTES

### DIFF
--- a/qa/TERMINAL_QA_CHECKLIST.md
+++ b/qa/TERMINAL_QA_CHECKLIST.md
@@ -76,97 +76,82 @@ Verified: 2026-08-29 · #496 @ `8496ea7` (static — browser extension offline)
 
 ---
 
-### `/calc`
-**Test URL:** `/calc?design=terminal`
-Extra checks:
-- Calculator panels flat
-- Input fields use `--border-input`
-- Result display uses `--txt` on `--bg1`
-
----
-
-### `/playbook`
-**Test URL:** `/playbook?design=terminal`
-Extra checks:
-- Playbook cards flat
-- Tag chips flat
-- Pagination controls flat
-
----
-
-### `/hours`
-**Test URL:** `/hours?design=terminal`
-Extra checks:
-- Session blocks flat rectangles
-- Active session uses `--accent` (#d9a626) indicator
-- Table rows flat
-
----
-
-### `/research`
-**Test URL:** `/research?design=terminal`
-Extra checks:
-- Article/note cards flat
-- Tag chips flat
-
----
-
 ### ✅ `/news`
 Verified: 2026-08-29 · #496 @ `8496ea7` (static — browser extension offline)
 
 ---
 
-### `/econ-calendar`
-**Test URL:** `/econ-calendar?design=terminal`
-Extra checks:
-- Event rows flat
-- Impact badges flat (no pill)
-- Day header uses `--bdr` separator
+### ✅ `/calc`
+Verified: 2026-08-29 · #498 @ `35986d3` (static — browser extension offline)
 
 ---
 
-### `/settings`
-**Test URL:** `/settings?design=terminal`
-Extra checks:
-- Settings sections flat panels
-- Toggle inputs styled flat
-- Form inputs use `--border-input`
-- Destructive actions use `--red`
+### ✅ `/playbook`
+Verified: 2026-08-29 · #498 @ `35986d3` (static — browser extension offline)
 
 ---
 
-### `/login`
-**Test URL:** `/login?design=terminal`
-Extra checks:
-- Auth card flat (no rounded card shadow)
-- Input fields use `--border-input`
-- Submit button uses `--accent`
+### ✅ `/hours`
+Verified: 2026-08-29 · #498 @ `35986d3` (static — browser extension offline)
 
 ---
 
-### `/forgot-password` / `/reset-password`
-**Test URL:** `?design=terminal`
-Extra checks:
-- Same as login: flat card, `--border-input` inputs, `--accent` CTA
+### ✅ `/research`
+Verified: 2026-08-29 · #498 @ `35986d3` (static — browser extension offline)
 
 ---
 
-### Onboarding / SetupChecklist
-**How to trigger:** new account or clear onboarding state, visit `/dashboard?design=terminal`
-Extra checks:
-- Onboarding modal/wizard flat (0px radius)
-- Step indicators use `--accent`
-- Checklist items flat rows
+### ✅ `/econ-calendar`
+Verified: 2026-08-29 · #498 @ `35986d3` (static — browser extension offline)
 
 ---
 
-### Popup dialogs / modals
-**Where they appear:** confirm dialogs, alert modals, settings modals across all screens
-Extra checks:
-- Modal overlay uses `--bg0` / `--bg1` tokens
-- Modal panel flat (0px radius)
-- Close button / actions styled with terminal palette
-- No rounded card shadow
+### ✅ `/settings`
+Verified: 2026-08-29 · #498 @ `35986d3` (static — browser extension offline)
+
+---
+
+### ✅ `/login`
+Verified: 2026-08-29 · #499 @ `6ffe068` (static — browser extension offline)
+
+---
+
+### ✅ `/forgot-password` / `/reset-password`
+Verified: 2026-08-29 · #499 @ `6ffe068` (static — browser extension offline)
+Both share `.login-term-wrap` nuclear rule.
+
+---
+
+### ✅ `/about`
+Verified: 2026-08-29 (static — no treatment needed, 0 hardcoded radii)
+
+---
+
+### ✅ `/learn`
+Verified: 2026-08-29 (static — no treatment needed, 0 hardcoded radii)
+
+---
+
+### ✅ `/privacy`
+Verified: 2026-08-29 (static — no treatment needed, 0 hardcoded radii)
+
+---
+
+### ✅ Onboarding / SetupChecklist
+No treatment needed — `SetupChecklist.tsx` has 0 hardcoded `borderRadius` values (confirmed by dev audit).
+
+---
+
+### ✅ Popup dialogs / modals
+Verified: 2026-08-29 · #500 @ `aafd6a5` (static — browser extension offline)
+- `SetupChecklist` — no treatment needed (0 hardcoded radii)
+- `UsageModal` — no treatment needed (0 hardcoded radii)
+- `UpgradeGateModal` (`LockedFeatureCard`, `FullPageUpgradeGate`, `UpgradeGateModal`) — `.locked-card-term-wrap *`, `.upgrade-gate-term-wrap *`, `.upgrade-modal-term-wrap *` nuclear rules all confirmed
+
+---
+
+### ⏳ `/faq` · `/terms` · `/refund` · `/upgrade`
+Pending: #501 — inline `borderRadius` values need nuclear wrapper. Assigned to dev.
 
 ---
 

--- a/qa/e2e/_design-tokens.ts
+++ b/qa/e2e/_design-tokens.ts
@@ -7,19 +7,31 @@
  * terminal palette — zero impact on users until they opt in.
  *
  * Verified (with commit + date):
- *   /            — #448, verified 2026-08-26
- *   /disclaimer  — #420, verified 2026-08-26
- *   /arena       — #460, verified 2026-08-26
- *   /dashboard   — #491 @ d3d7e15, verified 2026-08-28
- *   /briefing    — #492 @ 27e495a, verified 2026-08-28
- *   /liq         — #494 @ 8496ea7, verified 2026-08-29 (static)
- *   /funding     — #494 @ 8496ea7, verified 2026-08-29 (static)
- *   /correlation — #494 @ 8496ea7, verified 2026-08-29 (static)
- *   /markets     — #495 @ 8496ea7, verified 2026-08-29 (static)
- *   /scanner     — #495 @ 8496ea7, verified 2026-08-29 (static)
- *   /journal     — #496 @ 8496ea7, verified 2026-08-29 (static)
- *   /alerts      — #496 @ 8496ea7, verified 2026-08-29 (static)
- *   /news        — #496 @ 8496ea7, verified 2026-08-29 (static)
+ *   /               — #448, verified 2026-08-26
+ *   /disclaimer     — #420, verified 2026-08-26
+ *   /arena          — #460, verified 2026-08-26
+ *   /dashboard      — #491 @ d3d7e15, verified 2026-08-28
+ *   /briefing       — #492 @ 27e495a, verified 2026-08-28
+ *   /liq            — #494 @ 8496ea7, verified 2026-08-29 (static)
+ *   /funding        — #494 @ 8496ea7, verified 2026-08-29 (static)
+ *   /correlation    — #494 @ 8496ea7, verified 2026-08-29 (static)
+ *   /markets        — #495 @ 8496ea7, verified 2026-08-29 (static)
+ *   /scanner        — #495 @ 8496ea7, verified 2026-08-29 (static)
+ *   /journal        — #496 @ 8496ea7, verified 2026-08-29 (static)
+ *   /alerts         — #496 @ 8496ea7, verified 2026-08-29 (static)
+ *   /news           — #496 @ 8496ea7, verified 2026-08-29 (static)
+ *   /calc           — #498 @ 35986d3, verified 2026-08-29 (static)
+ *   /playbook       — #498 @ 35986d3, verified 2026-08-29 (static)
+ *   /hours          — #498 @ 35986d3, verified 2026-08-29 (static)
+ *   /research       — #498 @ 35986d3, verified 2026-08-29 (static)
+ *   /econ-calendar  — #498 @ 35986d3, verified 2026-08-29 (static)
+ *   /settings       — #498 @ 35986d3, verified 2026-08-29 (static)
+ *   /login          — #499 @ 6ffe068, verified 2026-08-29 (static)
+ *   /forgot-password — #499 @ 6ffe068, verified 2026-08-29 (static)
+ *   /reset-password  — #499 @ 6ffe068, verified 2026-08-29 (static)
+ *   /about          — no treatment needed (0 hardcoded radii), verified 2026-08-29 (static)
+ *   /learn          — no treatment needed (0 hardcoded radii), verified 2026-08-29 (static)
+ *   /privacy        — no treatment needed (0 hardcoded radii), verified 2026-08-29 (static)
  */
 export const CONVERTED_ROUTES: string[] = [
   '/',
@@ -35,6 +47,18 @@ export const CONVERTED_ROUTES: string[] = [
   '/journal',
   '/alerts',
   '/news',
+  '/calc',
+  '/playbook',
+  '/hours',
+  '/research',
+  '/econ-calendar',
+  '/settings',
+  '/login',
+  '/forgot-password',
+  '/reset-password',
+  '/about',
+  '/learn',
+  '/privacy',
 ];
 
 /**


### PR DESCRIPTION
## Summary
- CONVERTED_ROUTES on dev had only 13 routes after #497 merged — conflict resolution kept dev's version, dropping 9 verified routes
- Restored /calc /playbook /hours /research /econ-calendar /settings /login /forgot-password /reset-password
- Added /about /learn /privacy (no treatment needed — 0 hardcoded border-radii)
- Checklist updated to mark all 25 routes ✅

## What changed
`qa/e2e/_design-tokens.ts`: 13 → 25 routes in `CONVERTED_ROUTES`
`qa/TERMINAL_QA_CHECKLIST.md`: all restored screens marked ✅, 3 new static pages added, `/faq /terms /refund /upgrade` flagged as pending #501

## Why
`git show origin/dev:qa/e2e/_design-tokens.ts` showed only 13 routes. The 9 that #497 added were present on the branch but the merge picked dev's version during conflict. Specs looping CONVERTED_ROUTES were testing 13 screens instead of 22+.

## How to test (QA)
QA-only docs change — no app code. Verify `CONVERTED_ROUTES` has 25 entries and every route in the list appears in `TERMINAL_QA_CHECKLIST.md` as ✅.

## Risk level
Low — QA docs only, no app code.