### PR TITLE
feat(dashboard): terminal mode for faq / terms / refund / upgrade (#501)

### DIFF
--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import { useLabels } from '@/lib/labels';
 import type { LabelKey } from '@/lib/labelKeys';
+import { useDesignMode } from '@/components/DesignModeProvider';
 
 interface FaqItem { id: string; qKey: LabelKey; aKey: LabelKey }
 interface FaqCategory { titleKey: LabelKey; items: FaqItem[] }
@@ -46,11 +47,12 @@ const CATEGORIES: FaqCategory[] = [
 ];
 
 export default function FaqPage() {
+  const mode = useDesignMode();
   const { t } = useLabels();
   const [openId, setOpenId] = useState<string | null>(null);
 
   return (
-    <div style={{ maxWidth: 860, margin: '0 auto', padding: '48px 24px 80px' }}>
+    <div className={mode === 'terminal' ? 'faq-term-wrap' : undefined} style={{ maxWidth: 860, margin: '0 auto', padding: '48px 24px 80px' }}>
 
       <div style={{ marginBottom: 40 }}>
         <div style={{

--- a/app/globals.css
+++ b/app/globals.css
@@ -6271,3 +6271,12 @@ main.app-content[data-chrome="none"] {
 [data-design="terminal"] .upgrade-gate-term-wrap * { border-radius: 0 !important; }
 [data-design="terminal"] .upgrade-modal-term-wrap,
 [data-design="terminal"] .upgrade-modal-term-wrap * { border-radius: 0 !important; }
+/* faq / terms / refund / upgrade terminal (#501) */
+[data-design="terminal"] .faq-term-wrap,
+[data-design="terminal"] .faq-term-wrap * { border-radius: 0 !important; }
+[data-design="terminal"] .terms-term-wrap,
+[data-design="terminal"] .terms-term-wrap * { border-radius: 0 !important; }
+[data-design="terminal"] .refund-term-wrap,
+[data-design="terminal"] .refund-term-wrap * { border-radius: 0 !important; }
+[data-design="terminal"] .upgrade-term-wrap,
+[data-design="terminal"] .upgrade-term-wrap * { border-radius: 0 !important; }

--- a/app/refund/page.tsx
+++ b/app/refund/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useLabels } from '@/lib/labels';
+import { useDesignMode } from '@/components/DesignModeProvider';
 
 const SECTIONS = [
   { titleKey: 'REFUND_SECTION_NO_REFUNDS_TITLE', bodyKey: 'REFUND_SECTION_NO_REFUNDS_BODY' },
@@ -11,10 +12,11 @@ const SECTIONS = [
 ] as const;
 
 export default function RefundPolicy() {
+  const mode = useDesignMode();
   const { t } = useLabels();
 
   return (
-    <div style={{ maxWidth: 1100, margin: '0 auto', padding: '48px 24px 80px' }}>
+    <div className={mode === 'terminal' ? 'refund-term-wrap' : undefined} style={{ maxWidth: 1100, margin: '0 auto', padding: '48px 24px 80px' }}>
 
       <div style={{ marginBottom: 48 }}>
         <div style={{

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useLabels } from '@/lib/labels';
+import { useDesignMode } from '@/components/DesignModeProvider';
 
 const SECTIONS = [
   { titleKey: 'TERMS_SECTION_ACCEPTANCE_TITLE', bodyKey: 'TERMS_SECTION_ACCEPTANCE_BODY' },
@@ -23,10 +24,11 @@ const SECTIONS = [
 ] as const;
 
 export default function TermsOfUse() {
+  const mode = useDesignMode();
   const { t } = useLabels();
 
   return (
-    <div style={{ maxWidth: 1100, margin: '0 auto', padding: '48px 24px 80px' }}>
+    <div className={mode === 'terminal' ? 'terms-term-wrap' : undefined} style={{ maxWidth: 1100, margin: '0 auto', padding: '48px 24px 80px' }}>
 
       <div style={{ marginBottom: 48 }}>
         <div style={{

--- a/app/upgrade/page.tsx
+++ b/app/upgrade/page.tsx
@@ -8,6 +8,7 @@ import LoadingState from '@/components/LoadingState';
 import { AI_LIMITS } from '@/lib/limits';
 import { useLabels } from '@/lib/labels';
 import type { LabelKey } from '@/lib/labelKeys';
+import { useDesignMode } from '@/components/DesignModeProvider';
 
 const CHECKOUT_CONFIGURED = isCheckoutConfigured();
 const CHECKOUT_ANNUAL_CONFIGURED = isCheckoutConfiguredAnnual();
@@ -67,6 +68,7 @@ const PRO_FEATURES: Array<[LabelKey, Record<string, string | number>?]> = [
 ];
 
 export default function UpgradePage() {
+  const mode = useDesignMode();
   const { user, loading, isPro } = useAuth();
   const router = useRouter();
   const [redirecting, setRedirecting] = useState(false);
@@ -105,7 +107,7 @@ export default function UpgradePage() {
   }
 
   return (
-    <div style={{ minHeight: '100vh', background: 'var(--bg)', color: 'var(--txt)', fontFamily: 'inherit' }}>
+    <div className={mode === 'terminal' ? 'upgrade-term-wrap' : undefined} style={{ minHeight: '100vh', background: 'var(--bg)', color: 'var(--txt)', fontFamily: 'inherit' }}>
 
       {/* Nav */}
       <nav style={{ position: 'sticky', top: 0, zIndex: 100, background: 'var(--bg)', borderBottom: '0.5px solid var(--bdr)', padding: '0 24px', height: 52, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>


### PR DESCRIPTION
## Summary

Applies terminal mode (sharp corners) to the 4 remaining screens flagged in #501:
- `/faq` — accordion item cards
- `/terms` — callout box
- `/refund` — callout box  
- `/upgrade` — badge pill, plan cards, "Best value" label, CTA buttons

## What changed

- `app/faq/page.tsx`, `app/terms/page.tsx`, `app/refund/page.tsx`, `app/upgrade/page.tsx`: Added `useDesignMode` import + hook call + wrapper className to each page's root div.
- `app/globals.css`: Nuclear CSS selectors (`.faq-term-wrap`, `.terms-term-wrap`, `.refund-term-wrap`, `.upgrade-term-wrap`) zero all `border-radius` under `[data-design="terminal"]`.

## Why

Closes #501 — final 4 screens not covered by the #413 batch passes.

## How to test (QA)

On `qa` at liquidity-hq-qa.onrender.com (or localhost on `qa`):

1. `/faq?design=terminal` — accordion cards square corners.
2. `/terms?design=terminal` — callout box square corners.
3. `/refund?design=terminal` — callout box square corners.
4. `/upgrade?design=terminal` — badge pill, plan cards, "Best value" label, and all CTA buttons have square corners.
5. Each page without `?design=terminal` — unchanged rounded corners.

## Risk level

Low — additive className only; no style or behaviour change for non-terminal users.
