### PR TITLE
chore(qa): mark /faq /terms /refund /upgrade verified in CONVERTED_ROUTES (#501)

### DIFF
--- a/qa/TERMINAL_QA_CHECKLIST.md
+++ b/qa/TERMINAL_QA_CHECKLIST.md
@@ -150,8 +150,27 @@ Verified: 2026-08-29 · #500 @ `aafd6a5` (static — browser extension offline)
 
 ---
 
-### ⏳ `/faq` · `/terms` · `/refund` · `/upgrade`
-Pending: #501 — inline `borderRadius` values need nuclear wrapper. Assigned to dev.
+### ✅ `/faq`
+Verified: 2026-08-29 · #503 @ `701d368` (static — browser extension offline)
+Nuclear wrapper `.faq-term-wrap *` covers accordion item cards.
+
+---
+
+### ✅ `/terms`
+Verified: 2026-08-29 · #503 @ `701d368` (static — browser extension offline)
+Nuclear wrapper `.terms-term-wrap *` covers callout box.
+
+---
+
+### ✅ `/refund`
+Verified: 2026-08-29 · #503 @ `701d368` (static — browser extension offline)
+Nuclear wrapper `.refund-term-wrap *` covers callout box.
+
+---
+
+### ✅ `/upgrade`
+Verified: 2026-08-29 · #503 @ `701d368` (static — browser extension offline)
+Nuclear wrapper `.upgrade-term-wrap *` covers badge pill, plan cards, "Best value" label, CTA button.
 
 ---
 

--- a/qa/e2e/_design-tokens.ts
+++ b/qa/e2e/_design-tokens.ts
@@ -32,6 +32,10 @@
  *   /about          — no treatment needed (0 hardcoded radii), verified 2026-08-29 (static)
  *   /learn          — no treatment needed (0 hardcoded radii), verified 2026-08-29 (static)
  *   /privacy        — no treatment needed (0 hardcoded radii), verified 2026-08-29 (static)
+ *   /faq            — #503 @ 701d368, verified 2026-08-29 (static)
+ *   /terms          — #503 @ 701d368, verified 2026-08-29 (static)
+ *   /refund         — #503 @ 701d368, verified 2026-08-29 (static)
+ *   /upgrade        — #503 @ 701d368, verified 2026-08-29 (static)
  */
 export const CONVERTED_ROUTES: string[] = [
   '/',
@@ -59,6 +63,10 @@ export const CONVERTED_ROUTES: string[] = [
   '/about',
   '/learn',
   '/privacy',
+  '/faq',
+  '/terms',
+  '/refund',
+  '/upgrade',
 ];
 
 /**


### PR DESCRIPTION
## Summary
Final terminal design sign-off. All user-facing screens now in CONVERTED_ROUTES (29 total).

## What changed
`qa/e2e/_design-tokens.ts`: 25 → 29 routes — added /faq /terms /refund /upgrade
`qa/TERMINAL_QA_CHECKLIST.md`: 4 screens marked ✅, pending section removed

## Why
#503 shipped the nuclear wrappers for these 4 pages. HTTP 200 confirmed on qa @ 701d368. CSS rules confirmed in git at same commit. Static verification (browser extension offline).

## How to test (QA)
QA docs only — no app code. Verify CONVERTED_ROUTES has 29 entries and all routes are marked ✅ in the checklist.

## Risk level
Low — QA docs only.