### PR TITLE
fix(dashboard): nuclear term-wrap on /arena /dashboard /briefing /liq (#505)

### DIFF
--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -1249,7 +1249,7 @@ function ArenaContent() {
     : scannerRows;
 
   return (
-    <div>
+    <div className="arena-term-wrap">
 
       {/* ── PAGE HEADER ── */}
       <div style={{ padding: '1rem 0 0.75rem' }}>

--- a/app/briefing/page.tsx
+++ b/app/briefing/page.tsx
@@ -412,7 +412,7 @@ export default function MorningBriefing() {
   if (mode === 'terminal') return <BriefingTerminal />;
 
   return (
-    <div>
+    <div className="briefing-term-wrap">
 
       {/* ── Header ── */}
       <div className="mb-header">

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -519,7 +519,7 @@ export default function Dashboard() {
   if (mode === 'terminal') return <DashboardTerminal />;
 
   return (
-    <div className="dashboard-grid" data-spotlight-section>
+    <div className="dashboard-grid dashboard-term-wrap" data-spotlight-section>
       {showTour && <SpotlightTour onDone={() => setShowTour(false)} />}
       <SetupChecklist />
       {/* Floating cascade toast - fixed-positioned, render once */}

--- a/app/globals.css
+++ b/app/globals.css
@@ -6280,3 +6280,13 @@ main.app-content[data-chrome="none"] {
 [data-design="terminal"] .refund-term-wrap * { border-radius: 0 !important; }
 [data-design="terminal"] .upgrade-term-wrap,
 [data-design="terminal"] .upgrade-term-wrap * { border-radius: 0 !important; }
+
+/* arena / dashboard / briefing / liq nuclear term-wrap (#505) */
+[data-design="terminal"] .arena-term-wrap,
+[data-design="terminal"] .arena-term-wrap * { border-radius: 0 !important; }
+[data-design="terminal"] .dashboard-term-wrap,
+[data-design="terminal"] .dashboard-term-wrap * { border-radius: 0 !important; }
+[data-design="terminal"] .briefing-term-wrap,
+[data-design="terminal"] .briefing-term-wrap * { border-radius: 0 !important; }
+[data-design="terminal"] .liq-term-wrap,
+[data-design="terminal"] .liq-term-wrap * { border-radius: 0 !important; }

--- a/app/liq/page.tsx
+++ b/app/liq/page.tsx
@@ -350,7 +350,7 @@ export default function LiqPage() {
   if (mode === 'terminal') return <LiqTerminal />;
 
   return (
-    <div>
+    <div className="liq-term-wrap">
       {/* Header */}
       <div style={{ padding: '1rem 0 0.75rem' }}>
         <h1 style={{ fontSize: 'var(--fs-section)', fontWeight: 700, color: 'var(--txt)', marginBottom: 2 }}>


### PR DESCRIPTION
## Summary

Nuclear `term-wrap` className + CSS fix for bug #505 — rounded corners persisting on four early pages in terminal mode.

## What changed

- Added `arena-term-wrap` className to `ArenaContent` root div (`app/arena/page.tsx`)
- Added `dashboard-term-wrap` to `dashboard-grid` root div (`app/dashboard/page.tsx`)
- Added `briefing-term-wrap` className to `BriefingPage` root div (`app/briefing/page.tsx`)
- Added `liq-term-wrap` className to `LiqPage` root div (`app/liq/page.tsx`)
- Appended 4 nuclear CSS rules in `app/globals.css`:
  ```css
  [data-design="terminal"] .X-term-wrap,
  [data-design="terminal"] .X-term-wrap * { border-radius: 0 !important; }
  ```

Classes are always present; the CSS selector gates activation on `[data-design="terminal"]`, so the current design layout is unaffected.

## Why

Early pages used individual element-level CSS class overrides. New elements added since original verification (badges, chips, fire buttons, glow cards, etc.) were not covered, leaving rounded corners in terminal mode.

## How to test (QA)

On qa @ `?design=terminal` (set `lhq-design-mode=terminal` in localStorage or append `?design=terminal`):

1. `/arena` — no rounded corners on any card, badge, button, chip, or scanner row
2. `/dashboard` — no rounded corners on any card, widget, or badge
3. `/briefing` — no rounded corners on any card, badge, or container
4. `/liq` — no rounded corners on any card, level badge, or container

In all four pages, switch back to current design and confirm layout is unchanged.

## Risk level

Low — CSS-only change scoped to terminal mode. No logic change. All 4 gates pass (lint 0 errors, tsc clean, 414/414 tests pass, build clean).

— Dev Team