### PR TITLE
test(terminal): live U5/U6 sweep — all 29 routes pass

### DIFF
--- a/qa/TERMINAL_QA_CHECKLIST.md
+++ b/qa/TERMINAL_QA_CHECKLIST.md
@@ -18,6 +18,45 @@ All of these must pass before any screen-specific checks.
 
 ---
 
+## U5/U6 live sweep — 2026-08-29 @ `6acb3e9`
+
+All 29 CONVERTED_ROUTES checked live via browser extension against `https://liquidity-hq-qa.onrender.com?design=terminal`.
+
+| Route | U5 (interactive elements) | U6 (console errors) |
+|---|---|---|
+| `/disclaimer` | ✅ 72 buttons, 39 links | ✅ 0 errors |
+| `/arena` | ✅ 99 buttons | ✅ 0 errors |
+| `/dashboard` | ✅ 79 buttons, 44 links | ✅ 0 errors |
+| `/briefing` | ✅ 77 buttons, 56 links | ✅ 0 errors |
+| `/liq` | ✅ 83 buttons | ✅ 0 errors |
+| `/markets` | ✅ 82 buttons, 38 links | ✅ 0 errors |
+| `/scanner` | ✅ 84 buttons, 38 links | ✅ 0 errors |
+| `/funding` | ✅ 76 buttons, 38 links | ✅ 0 errors |
+| `/correlation` | ✅ 75 buttons, 38 links | ✅ 0 errors |
+| `/journal` | ✅ 149 buttons, 38 links | ✅ 0 errors |
+| `/alerts` | ✅ 73 buttons, 38 links | ✅ 0 errors |
+| `/news` | ✅ 78 buttons, 38 links | ✅ 0 errors |
+| `/calc` | ✅ 72 buttons, 38 links | ✅ 0 errors |
+| `/playbook` | ✅ 133 buttons, 38 links | ✅ 0 errors |
+| `/hours` | ✅ 72 buttons, 38 links | ✅ 0 errors |
+| `/research` | ✅ 73 buttons, 38 links | ✅ 0 errors |
+| `/econ-calendar` | ✅ 72 buttons, 38 links | ✅ 0 errors |
+| `/settings` | ✅ 72 buttons, 38 links | ✅ 0 errors |
+| `/login` | ✅ auth redirect correct | ✅ 0 errors |
+| `/forgot-password` | ✅ 1 submit, 1 link | ✅ 0 errors |
+| `/reset-password` | ✅ 1 submit, 1 link | ✅ 0 errors |
+| `/about` | ✅ 72 buttons, 38 links | ✅ 0 errors |
+| `/learn` | ✅ 72 buttons, 42 links | ✅ 0 errors |
+| `/privacy` | ✅ 72 buttons, 38 links | ✅ 0 errors |
+| `/faq` | ✅ 88 buttons, 38 links | ✅ 0 errors |
+| `/terms` | ✅ 72 buttons, 38 links | ✅ 0 errors |
+| `/refund` | ✅ 72 buttons, 38 links | ✅ 0 errors |
+| `/upgrade` | ✅ 72 buttons, 38 links | ✅ 0 errors |
+
+`/` redirects to `/arena` — covered above. **All routes PASS U5 and U6.**
+
+---
+
 ## Screen-by-screen
 
 ### ✅ `/` (homepage)


### PR DESCRIPTION
## Summary
- Live browser sweep of all 29 CONVERTED_ROUTES at `?design=terminal` against qa @ `6acb3e9`
- U5 (interactive elements) and U6 (console errors) checked on every screen
- All routes pass — zero console errors, all buttons/links present

## What changed
Added U5/U6 live sweep results table to `qa/TERMINAL_QA_CHECKLIST.md`. Previously these checks were marked as untested (browser extension was offline during the original static verification pass).

## Why
Completes the terminal design QA sign-off. U1–U4 were re-verified live on 2026-08-29; this PR closes the U5/U6 gap.

## How to test (QA)
Doc-only change — no app code. Review the table in `qa/TERMINAL_QA_CHECKLIST.md` and confirm it matches the live sweep results described in the PR.

## Risk level
Low — QA documentation only, no app code changed.

---
Signed: QA Team