### PR TITLE
fix(dashboard): guard terminal color tokens from overriding light theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5262,8 +5262,15 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
 
    Radius is 0 EVERYWHERE in this direction. Not a token - an absence. The
    current app uses border-radius extensively, so opting a screen in means
-   removing radii, not overriding them. */
-[data-design="terminal"] {
+   removing radii, not overriding them.
+
+   :not([data-theme="light"]) guard (#511): terminal has no light palette -
+   every rule below reads these vars via var(), never a literal hex, so
+   withholding this override when light theme is active makes the whole
+   terminal scope fall back to light's own tokens instead of colliding on
+   source order (this block sits after [data-theme="light"] in the file,
+   so without the guard terminal's black --bg1 always won). */
+[data-design="terminal"]:not([data-theme="light"]) {
   --bg0:  #08090a;   /* canvas */
   --bg1:  #0c0d0f;   /* raised region */
   --bg2:  #111416;   /* bar/track background */


### PR DESCRIPTION
## Summary
Fixes the CSS source-order collision from #511: terminal color tokens (`--bg1` etc.) were overriding light theme's when both `data-design="terminal"` and `data-theme="light"` were on `<html>`, making cards render black on a light-grey page.

## What changed
`[data-design="terminal"]` root token block in `app/globals.css` now reads `[data-design="terminal"]:not([data-theme="light"])`. Terminal has no light palette of its own, and every downstream terminal-scoped rule reads these tokens through `var()` — none use literal hex — so withholding the override when light theme is active makes the whole scope fall back to light's own tokens instead of colliding on source order.

## Why
Terminal's token block sits after `[data-theme="light"]` in `globals.css` (line ~5266 vs ~2313), so on source order alone terminal's `--bg1: #0c0d0f` always won, even though the page `--bg` correctly showed light grey. QA confirmed reproducible on qa @ 6acb3e9.

## Scope note — Problem 2 not included
#511 also described `DesignModeProvider` persisting `lhq-design-mode` and treating it as "sticky" across navigation as a bug ("spread vector"). That persistence is intentional, documented behavior from #413/#417 (see `lib/designMode.ts` comment: *"the query param WINS and is sticky... QA measured it on #417"* — the earlier bug was the flag un-stuck itself too easily). Reverting that now would reintroduce #417. Left a comment on #511 asking QA to confirm intent before any change there — did not touch `DesignModeProvider.tsx` in this PR.

## How to test (QA)
1. On qa (liquidity-hq-qa.onrender.com or localhost on `qa`), set theme to light (moon/sun toggle).
2. Visit `/dashboard?design=terminal` (or any `?design=terminal` URL).
3. Cards should render white/light, matching the rest of light theme — not black.
4. Confirm no regression in terminal dark mode (`data-theme` unset or `dark` + `?design=terminal`) — cards should still be `--bg1: #0c0d0f` as before.

## Risk level
Low — single CSS selector guard, all 4 gates pass (lint 0 errors, tsc clean, 414/414 tests, build clean).
