### PR TITLE
fix(dashboard): terminal dark-mode contrast fixes for cards, inputs, labels

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5265,14 +5265,18 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
    removing radii, not overriding them. */
 [data-design="terminal"] {
   --bg0:  #08090a;   /* canvas */
-  --bg1:  #0c0d0f;   /* raised region */
+  --bg1:  #141517;   /* raised region - lifted from #0c0d0f (#512 bug 2): that
+                         was only 13 hex units off --bg (#000), imperceptible
+                         as a card boundary */
   --bg2:  #111416;   /* bar/track background */
   --bdr:  #1f2225;   /* structural hairline */
   --bdr2: #131618;   /* row hairline */
   --bdr3: #16191b;   /* cell hairline */
   --txt:  #e8e9ea;   /* primary text and data */
   --txt2: #8b8f94;   /* secondary text, prose */
-  --txt3: #5a5f66;   /* micro-labels, meta */
+  --txt3: #7c828a;   /* micro-labels, meta - raised from #5a5f66 (#512 bug 4):
+                         that failed WCAG AA (~3:1) against --bg1; this clears
+                         4.5:1 against the new --bg1 */
   --txt4: #3a3f45;   /* disabled, axis labels */
   --accent: #d9a626; /* active nav, primary CTA - ALWAYS with #08090a text */
   --green:  #3fb950; /* bullish / FIRING positive */
@@ -6290,3 +6294,19 @@ main.app-content[data-chrome="none"] {
 [data-design="terminal"] .briefing-term-wrap * { border-radius: 0 !important; }
 [data-design="terminal"] .liq-term-wrap,
 [data-design="terminal"] .liq-term-wrap * { border-radius: 0 !important; }
+
+/* ── Terminal form input visibility (#512 bug 3) ───────────────────────────
+   These wrap/style real <input>/<textarea> elements with background: --bg2
+   and border-color: --bdr / --bdr2. In terminal's palette --bg2 (#111416)
+   and --bdr2 (#131618) are only 2-3 RGB units apart per channel - the same
+   class of near-invisible gap as #512 bug 2, just on inputs instead of
+   cards. --border-input (#2a2e32) already exists in the terminal token
+   block for exactly this ("input and secondary-button border") but was
+   only wired to 2-3 button classes, never to actual form fields. */
+[data-design="terminal"] .tj-irow,
+[data-design="terminal"] .tj-notes,
+[data-design="terminal"] .ps-irow,
+[data-design="terminal"] .login-email-input,
+[data-design="terminal"] .st-input,
+[data-design="terminal"] .st-affix,
+[data-design="terminal"] .tj-lev-num { border-color: var(--border-input); }


### PR DESCRIPTION
## Summary
Fixes bugs 2-4 from QA's terminal dark-mode contrast audit (#512): flat card backgrounds, invisible form inputs, low-contrast section labels.

## What changed
- `--bg1` raised `#0c0d0f` → `#141517` (bug 2 — card lift)
- `--txt3` raised `#5a5f66` → `#7c828a` (bug 4 — WCAG AA contrast)
- `.tj-irow`, `.tj-notes`, `.ps-irow`, `.login-email-input`, `.st-input`, `.st-affix`, `.tj-lev-num` now use the existing `--border-input` token for `border-color` (bug 3 — input visibility)

## Why
- **Bug 2**: `--bg1` sat 13 hex units off the page `--bg` (#000) — imperceptible as a card boundary.
- **Bug 4**: `--txt3` measured ~3:1 contrast against `--bg1`, below WCAG AA's 4.5:1 for normal text. Recomputed against the new `--bg1`: `#7c828a` clears ~4.7:1.
- **Bug 3**: input-wrapping classes use `--bg2` + `--bdr2`, two tokens only 2-3 RGB units apart per channel — the border was effectively invisible. `--border-input` (`#2a2e32`) already exists in the terminal token block for exactly this ("input and secondary-button border") but was only wired to 2-3 button classes, never to actual `<input>` elements. Now wired.

## Not included
**Bug 1** (Arena chart invisible, originally Critical): QA re-verified 2026-09-01 that it no longer reproduces on qa and downgraded it pending a second look. Nothing to fix until it recurs — will pick it up if QA re-flags.

**Note on `lib/terminalTokens.ts`**: that file documents itself as "verbatim from the design handoff README," with a comment claiming a `__tests__/terminalTokens.test.mts` enforces it stays in sync with `globals.css`. That test file doesn't exist in the repo (`grep -rl terminalTokens` finds only the one file, unreferenced elsewhere) — nothing currently enforces or consumes it. Left it un-updated rather than unilaterally editing what claims to be an external design spec I don't have visibility into; flagging for design/QA to reconcile.

## How to test (QA)
1. On qa, visit `/dashboard?design=terminal` in dark mode (no `data-theme=light`).
2. Cards should read as visibly lifted off the page background.
3. Section labels (CONDITIONS, ACCOUNT, TRADING PROFILE, etc.) should be legible, not near-black-on-near-black.
4. `/journal?design=terminal` — PRICE LEVELS inputs and leverage number field should show a visible border.
5. `/settings?design=terminal` — form inputs should show a visible border, not blend into the card.

## Risk level
Low — CSS token values + one new selector block. All 4 gates pass (lint 0 errors, tsc clean, 414/414 tests, build clean).
