### PR TITLE
fix(arena): stop Quick Research button using green as an interactive color

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1315,9 +1315,11 @@ body.ticker-on .breaking-alert { top: calc(84px + var(--banner-h)); }
 .arena-fire-btn:disabled { opacity: 0.35; cursor: not-allowed; }
 .arena-fire-btn:not(:disabled):hover { background: rgba(26,122,255,0.12); border-color: var(--accent); }
 .arena-fire-btn:not(:disabled):active { transform: scale(0.98); }
-/* Quick mode button - green tint */
-.arena-quick-btn { background: rgba(52,211,153,0.08) !important; border-color: rgba(52,211,153,0.3) !important; color: var(--green-2) !important; }
-.arena-quick-btn:not(:disabled):hover { box-shadow: 0 4px 20px rgba(52,211,153,0.15) !important; border-color: #34d399 !important; }
+/* Quick mode button (#513): was a green tint, which reads as a bullish signal
+   next to the Deep Research / Unlock-with-Pro row, not an interactive state.
+   Green means up/long/bullish in this product - never "interactive". Quick
+   now inherits .arena-fire-btn's --accent styling, same as every other
+   interactive control. */
 /* Deep button - locked state (not signed in) */
 /* "Locked" styling for the Quick/Deep Research buttons when signed out.
    Was #8a6020 under opacity 0.75, which computed to #694a1b = 2.4:1 - the


### PR DESCRIPTION
## Summary
Fixes the Arena "Quick Research" half of #513 — green was being used as an interactive/active-state color, competing with blue (`--accent`) as if both were the brand primary.

## What changed
`.arena-quick-btn` no longer overrides `.arena-fire-btn` to a green tint (`rgba(52,211,153,...)`). It now inherits the base `--accent` (blue) styling shared by Deep Research and every other interactive control.

## Why
Per QA's decision on #513: green is never a brand/interactive color in this product — it already means up/long/bullish, and using it for "this button is active" too means a user can't tell a market reading from a clickable control at a glance. This was the one genuinely-wrong instance in Arena; everything else in QA's original list was already correct blue.

## Not included in this PR — held for confirmation
**Journal leverage slider filled track**: QA's decision named this as also-wrong (green → blue), but tracing the code shows `levColor` is a **3-way risk gauge**, not a decorative primary: `green` under 10x, `--amber` 10–24x, `--red` 25x+ (`components/TradeJournal.tsx:910`). Changing only the low end to blue would leave a green-less amber/red risk scale with an unrelated blue floor — same category of bug as the thing #513 is fixing, not a fix. Flagged back on the issue for QA to confirm intent before I touch it.

**Dashboard "Good time to trade" heading**: QA asked me to check whether this is derived from the verdict or hardcoded, not to fix it either way. Confirmed derived — `components/MarketRead.tsx` sets `data-band` from the computed score band, and `app/globals.css:639-641` maps `good/mid/weak` → `green/amber/red`. Not hardcoded, not a bug. Reported on the issue.

## How to test (QA)
1. On qa, current (non-terminal) design, light or dark, visit `/arena`.
2. Quick Research and Deep Research buttons should render the same color (accent blue) — not one green, one blue.

## Risk level
Low — one CSS rule removed, button falls back to an already-shipped base style. All 4 gates pass (lint 0 errors, tsc clean, 414/414 tests, build clean).
