### PR TITLE
feat(arena): drop the second sentence from the futures-led explanation

### DIFF
--- a/__tests__/grokPerpSpot.test.mts
+++ b/__tests__/grokPerpSpot.test.mts
@@ -57,7 +57,7 @@ test('the prompt carries reading.explanation VERBATIM - not a paraphrase', () =>
 
   assert.ok(prompt.includes(r.explanation),
     'the prompt must contain the card sentence character-for-character');
-  assert.match(r.explanation, /leveraged traders/, 'sanity: this fixture is the perp-led wording');
+  assert.match(r.explanation, /usual share against spot/, 'sanity: this fixture is the perp-led wording');
 });
 
 test('every prompt builder carries it, not just the long one', () => {

--- a/__tests__/perpSpot.test.mts
+++ b/__tests__/perpSpot.test.mts
@@ -55,7 +55,10 @@ test('a genuine spike above the coin\'s own normal reads as futures-driven', () 
   const r = computePerpSpot(spot, perp, HOUR, nowMs);
   assert.equal(r.lean, 'perp');
   assert.ok(r.relative! > PERP_LED_AT);
-  assert.match(r.explanation, /leveraged traders/);
+  assert.match(r.explanation, /usual share against spot/);
+  // The owner removed the second sentence on #397. Asserted as an absence so
+  // it cannot drift back in via a copy edit nobody reviews.
+  assert.doesNotMatch(r.explanation, /leveraged traders|unwinds faster/);
 });
 
 test('unusually quiet futures reads as spot-led', () => {

--- a/lib/perpSpot.ts
+++ b/lib/perpSpot.ts
@@ -167,7 +167,7 @@ export function computePerpSpot(
      the explanation explicitly, which means it is the part they will read. */
   const explanation =
     lean === 'perp'
-      ? `Futures trading is ${times} its usual share against spot. The move is being driven by leveraged traders more than by people buying the coin itself, which unwinds faster if it turns.`
+      ? `Futures trading is ${times} its usual share against spot.`
       : lean === 'spot'
         ? `Futures trading is unusually quiet at ${times} its usual share. More of this move is people actually buying the coin, which tends to hold better.`
         : `Futures and spot are trading in their usual proportions for this coin. Nothing unusual about who is driving the move.`;


### PR DESCRIPTION
## Summary
Recovers lost, owner-approved work: #397 was closed 2026-08-13 but its fix commit lived only on an orphaned branch (`feature/shorten-perp-explanation`), never merged. Found it while triaging QA's branch-cleanup list — `lib/perpSpot.ts` still has the full two-sentence copy in production today.

## What changed
The perp-led reading now reads "Futures trading is {times}x its usual share against spot." and stops — the "leveraged traders... unwinds faster" sentence is gone. Only the `perp` branch of `lib/perpSpot.ts:167` changed; `spot`, `normal`, `unknown` untouched. Feeds both `/arena`'s Confluence card and `/dashboard`'s PerpSpotCard (same source, deliberately).

## Why
Owner's request on #397: *"remove this text in arena page we dont need it anymore"*. `lib/grok.ts:401/428` deliberately keep the same reasoning for the AI's own instructions — that's not user-facing copy, out of scope.

## How to test (QA)
`/arena` for a coin reading FUTURES LEADING — the Confluence card's amber row should be one sentence ending at "against spot." Same on `/dashboard`'s Perps vs Spot card. A SPOT LEADING coin still gets its full two-sentence wording (unchanged).

Note: this will likely still break `qa/e2e/score-perps-coupling.spec.ts` if it anchors on the removed phrase — same as originally flagged in #397. QA may need to re-anchor that spec.

## Risk level
Low — copy-only change to one template string, plus test re-anchoring. All 4 gates pass (lint 0 errors, tsc clean, 414/414 tests, build clean).
