### PR TITLE
fix(dashboard): grade-D badge fails WCAG AA in light theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2382,9 +2382,11 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   --amber-dim: rgba(180,83,9,0.12);
   --amber-bg:  rgba(180,83,9,0.07);
   --amber-bdr: rgba(180,83,9,0.20);
-  --orange:     #C2410C;
-  --orange-bg:  rgba(194,65,12,0.07);
-  --orange-bdr: rgba(194,65,12,0.20);
+  /* #519: was #C2410C - 3.09:1 for the grade-D badge on a selected watchlist
+     row, 3.85:1 normally, both below WCAG AA's 4.5:1 for 12px text. */
+  --orange:     #7C2D12;
+  --orange-bg:  rgba(124,45,18,0.07);
+  --orange-bdr: rgba(124,45,18,0.20);
   --blue:     #1D4ED8;
   --blue-bg:  rgba(29,78,216,0.07);
   --blue-bdr: rgba(29,78,216,0.20);


### PR DESCRIPTION
## Summary
Fixes #519 — the coin health-grade "D" badge fails WCAG AA in light theme.

## What changed
`--orange` (light theme) raised `#C2410C` → `#7C2D12`. `--orange-bg`/`--orange-bdr` rgba values updated to match.

## Why
Grade D badge uses `var(--orange)` at 12px (`lib/marketStore.ts:346`). Measured against a normal watchlist row (3.85:1) and the selected row (3.09:1) — both below WCAG AA's 4.5:1 for normal text. Grades A/B/C use different tokens and were unaffected. New value: 6.98:1 on the normal backdrop, 5.60:1 selected. Dark theme's `--orange` untouched.

## How to test (QA)
Light theme on qa, `/dashboard?design=terminal`. Find a coin graded D in the watchlist rail (grades move — pick whichever shows D). Letter should be legible both in a normal row and when that row is selected.

## Risk level
Low — single token value. All 4 gates pass (lint 0 errors, tsc clean, 414/414 tests, build clean).
