### PR TITLE
test(qa): rescue two orphaned pins — consent in contrast, USD/JPY in econ-staleness

### DIFF
--- a/qa/e2e/_shared.ts
+++ b/qa/e2e/_shared.ts
@@ -319,6 +319,23 @@ export const BASELINE = {
       // text on mid-tone green and amber fills; in light it is the /funding
       // chips. Same defect shape, and the exact hex varies with the data.
       'near-white',
+
+      /* ADDED 2026-08-14 WHEN contrast.spec.ts STARTED PINNING CONSENT.
+       *
+       * Both are marginal — 4.47 and 4.37 against the 4.5 bar — and both are
+       * REAL, not artefacts. The pin did not create them; it made the sweep
+       * measure a page the cookie banner had been altering, and these render
+       * there. Two runs on the same commit had been reporting the same COUNT
+       * with a token set that differed by two, which is how they hid.
+       *
+       * `#7a7e94` IS `--txt2`, the app's secondary text token. Fixing it means
+       * moving secondary text everywhere, so it is recorded rather than chased.
+       *
+       * NOT a blessing. If `--txt2` is ever adjusted, delete this line and let
+       * the sweep re-measure rather than assuming it still applies. */
+      '#7a7e94',   // --txt2, worst 4.47:1 on /about
+      '#8a8a8a',   // worst 4.37:1 on /funding
+
       '#1a7aff', '#414551', '#434754', '#4c4e5d',
       '#4c515f', '#4e5361', '#585d6d', '#63656a',
       '#a54e4f', '#c0595a', 

--- a/qa/e2e/contrast.spec.ts
+++ b/qa/e2e/contrast.spec.ts
@@ -29,6 +29,33 @@ async function themedPage(browser: Browser, theme: 'dark' | 'light'): Promise<{ 
   // hydration and stamps data-theme, so seeding the key is enough — no click on
   // a theme toggle, and no race with hydration.
   await ctx.addInitScript((t) => { try { localStorage.setItem('theme', t); } catch { /* private mode */ } }, theme);
+
+  /* PIN CONSENT — the last visual sweep that was not doing this, and it has been
+   * measuring against an uncontrolled input since it was written.
+   *
+   * `a11y.spec.ts` records that a run starting with consent stored scores ~32
+   * LOWER than one that does not, with zero code change: `a.consent-link` is
+   * 73x14 and the banner renders on EVERY route until dismissed. Its buttons
+   * carry their own colours, and its presence changes which elements render at
+   * all.
+   *
+   * The symptom that exposed it, 2026-08-14: two runs on the same commit both
+   * reported `11 violations across 9 tokens` — the same COUNT — while the token
+   * SET differed by two. `#7a7e94` and `#8a8a8a` appeared as "not in baseline"
+   * and two others silently dropped out. **A stable count hid an unstable
+   * measurement**, and the ratchet asserts on the set.
+   *
+   * `denied` matches layout.spec.ts, a11y.spec.ts and design-tokens.spec.ts, so
+   * all four sweeps now measure the same page. The banner is not left untested —
+   * layout.spec.ts has a dedicated first-visit sweep for it.
+   *
+   * NOTE FOR WHOEVER RE-BASELINES: the existing token lists were captured
+   * WITHOUT this pin, so some entries may be banner-dependent and some real
+   * failures may be missing. The baseline should be re-derived once, deliberately,
+   * rather than trusted. */
+  await ctx.addInitScript(() => {
+    try { localStorage.setItem('lhq_analytics_consent_v1', 'denied'); } catch { /* private mode */ }
+  });
   const page = await ctx.newPage();
   page.on('dialog', d => d.dismiss());
 

--- a/qa/e2e/econ-staleness.spec.ts
+++ b/qa/e2e/econ-staleness.spec.ts
@@ -54,6 +54,25 @@ const event = (hoursAhead: number) => ({
  * as stale", so null is a distinct case worth being able to produce.
  */
 async function installSnapshot(page: Page, opts: { ageHours: number | null; events: unknown[] }) {
+  /* PIN USD/JPY QUIET, and this is not optional.
+   *
+   * `computeMacroRisk` returns `unknown` only when the calendar is stale AND
+   * NOTHING was found - and USD/JPY is a finding. `lib/confluence.ts:126` fires
+   * a caution at >= 158, and qa was serving 159.3 live, so every stale case
+   * legitimately reported the carry-trade line instead of the staleness notice.
+   *
+   * That cost a wrong conclusion: the spec was red on the fixed build and the
+   * obvious reading was "dev's fix does not work". It works. My scenario was
+   * never the one I thought I was testing, because a live input I had not
+   * controlled was supplying a finding.
+   *
+   * Dev's unit test passes `jpyUsd` directly; the browser reads /api/forex/jpy
+   * (arena/page.tsx:403), so this pins it there. 150 is well below the 158
+   * threshold - quiet, no reason emitted, nothing to mask the calendar state. */
+  await page.route('**/api/forex/jpy**', route => route.fulfill({
+    status: 200, contentType: 'application/json', body: JSON.stringify({ jpy: 150 }),
+  }));
+
   await page.route(SNAPSHOT_ROUTE, route => route.fulfill({
     status: 200,
     contentType: 'application/json',


### PR DESCRIPTION
## Summary

Recovers two QA specs that were written, never merged, and were about to be
deleted in the branch cleanup. Both encode findings that already cost a wrong
conclusion once.

QA-authored, `qa/e2e/` only. Opening into `dev` per CONTRIBUTING.md's reverse
handoff — dev reviews and merges.

## What changed

**1. Pin analytics consent in the contrast sweep** (`_shared.ts`, `contrast.spec.ts`)

The cookie banner was altering the page the contrast sweep measured. Two runs on
the same commit reported the same failure *count* with token sets that differed
by two — which is exactly how the discrepancy stayed invisible.

Pinning consent also surfaced two real, marginal failures — `4.47:1` and
`4.37:1` against the 4.5 bar. They are recorded in the baseline rather than
chased, because `#7a7e94` is `--txt2`, the app's secondary text token, and
fixing it means moving secondary text everywhere. The comment in `_shared.ts`
says so explicitly so the next person does not re-litigate it.

**2. Pin USD/JPY quiet in econ-staleness** (`econ-staleness.spec.ts`)

`computeMacroRisk` returns `unknown` only when the calendar is stale **and**
nothing was found — and USD/JPY is a finding. `lib/confluence.ts:126` fires a
caution at >= 158, and qa was serving 159.3 live, so every stale case
legitimately reported the carry-trade line instead of the staleness notice.

That cost a wrong conclusion: the spec read red on a build where the fix
**worked**, and the obvious reading was "dev's fix does not work". The scenario
under test was never the one it appeared to be, because of a live input.

## Why this is worth a PR rather than a delete

Both are negative results. CONTRIBUTING.md is explicit that these count — "what
was measured and showed nothing, and what could not be verified, are worth as
much as the successes, otherwise the other session re-derives them." One of
these already produced a false "the fix does not work" once.

This is the third orphaned branch found in one cleanup: dev found #397's fix
never merged despite the issue being closed (PR #523). Pattern worth watching.

## How to test (QA)

Not runnable without an E2E run, which needs the owner's go — so this is
**unverified beyond static checks**, and I am saying so rather than implying
otherwise. `npx tsc --noEmit` exit 0 and `npx eslint qa/` exit 0 on this branch.

When an E2E run is next authorised: `contrast.spec.ts` should report a stable
token set across two runs on the same commit, and `econ-staleness.spec.ts`
should exercise the staleness notice rather than the carry-trade line.

## Risk level

Low. Test-only, no application code. Nothing here runs in CI — CI is off, which
is the owner's cost decision.

— QA Team
