### PR TITLE
docs(chart): record the owner-approved token amendment in the handoff

### DIFF
--- a/design-handoff-dir/design_handoff_arena/README.md
+++ b/design-handoff-dir/design_handoff_arena/README.md
@@ -134,6 +134,35 @@ New view state is only: selected coin, selected timeframe, hint dismissal, and t
 
 Reference by name from `lib/terminalTokens.ts`. **Do not restate hex in code.** 15 tokens: `--bg0` `--bg1` `--bg2` `--bdr` `--bdr2` `--bdr3` `--txt` `--txt2` `--txt3` `--txt4` `--accent` `--green` `--red` `--mark-idle` `--border-input`.
 
+> ### Amendment — 2026-09-01, owner-approved
+>
+> **Three token values are superseded.** The originals could not satisfy this
+> handoff's own accessibility requirement. Originals are kept on the record
+> rather than overwritten — a handoff that quietly rewrites its own numbers is
+> how the next drift becomes invisible.
+>
+> | Token | Original | **Amended** | Why |
+> |---|---|---|---|
+> | `--bg1` | `#0c0d0f` | **`#141517`** | sat 13 hex units off `--bg0`; imperceptible as a card boundary (#512) |
+> | `--txt3` | `#5a5f66` | **`#7c828a`** | failed 4.5:1 — see below (#512) |
+> | `--border-input` | `#2a2e32` | **`#5e646b`** | **1.36:1** against `--bg1`; WCAG 1.4.11 requires **3:1** for UI component boundaries. `#5e646b` clears **3.14:1**. Amended on the same accessibility grounds, after the owner's ruling rather than as part of it (#520, #527). |
+>
+> **The conflict.** `specs/arena.md` §Accessibility enumerates `--txt3`/`--bg0`
+> as a pair that **must clear 4.5:1**. Measured with the original values it is
+> **3.10:1**; `--txt3` on the original `--bg1` is **3.03:1**. The specified value
+> could not meet the specified bar, on a pair the spec itself names.
+>
+> The amended value clears both: **5.14:1** on `--bg0`, **4.78:1** on the
+> amended `--bg1`.
+>
+> Measured by QA on qa `c16bb62` (#512, #520). The owner ratified on #526, having
+> been offered the alternative of reverting and accepting a documented AA
+> failure. The remaining 12 tokens are unchanged.
+>
+> **`lib/terminalTokens.ts` is the file of record and must match this table.**
+> At time of writing it still holds the originals — which is exactly how this
+> drift stayed invisible, since nothing imports it. See #518.
+
 One documented exception: the liquidation heatmap's canvas is `#0a0710` with a 7-stop ramp over it. It sits under a continuous gradient rather than beside palette colours. Whether it deserves a 16th token is a design-system call, flagged in the spec.
 
 **Type.** IBM Plex Mono for every number, label, nav item and heading; IBM Plex Sans for prose. Scale in use: 34 / 30 / 28 / 26 / 24 / 20 / 19 / 16 / 15 / 14 / 13 / 12 / 11 / 10 / 9.

--- a/design-handoff-dir/design_handoff_arena/specs/arena.md
+++ b/design-handoff-dir/design_handoff_arena/specs/arena.md
@@ -251,6 +251,23 @@ Labels are DB-driven and can change length at runtime. Nothing on this route may
 
 Pairs requiring 4.5:1: `--txt`/`--bg0`, `--txt`/`--bg1`, `--txt2`/`--bg0`, `--txt2`/`--bg1`, `--txt3`/`--bg0`, `--bg0`/`--accent`, `--green`/`--bg1`, `--red`/`--bg1`, `--green`/`--bg0`, `--red`/`--bg0`.
 
+> **Amendment — 2026-09-01, owner-approved.** This clause and the original
+> `--txt3` value were in direct conflict. `--txt3` `#5a5f66` on `--bg0`
+> `#08090a` measures **3.10:1** — the pair is named in the list above, and it
+> failed the bar the list sets. On the original `--bg1` `#0c0d0f` it is
+> **3.03:1**.
+>
+> `--txt3` is now **`#7c828a`** and `--bg1` is now **`#141517`**: **5.14:1** on
+> `--bg0`, **4.78:1** on `--bg1`. `--border-input` is now **`#5e646b`**, for
+> WCAG 1.4.11's separate 3:1 component-boundary bar (**1.36:1** before,
+> **3.14:1** after). Every pair above now clears 4.5:1.
+>
+> Rationale, originals, and the alternatives considered are in the README's
+> Design tokens amendment.
+>
+> **Acceptance criterion 19** — "every colour on the route is one of the 15
+> tokens in `lib/terminalTokens.ts`" — is scored against the **amended** values.
+
 `--txt4` appears only on snapshot notes and structure timestamps — non-essential, paired with a labelled value. `--mark-idle` is a 2px marker, decorative.
 
 **Never apply alpha to a token to de-emphasise it.**


### PR DESCRIPTION
## Summary

Records the owner-approved token amendment in the handoff itself, on top of the
pristine material dev landed in #528.

Deliberately a separate commit rather than folded into #528: that gives a
history reading **original owner material → amendment**, so it is always clear
which numbers came from the owner and which QA changed and why. Squashing them
would have made the two indistinguishable.

**46 insertions, 0 deletions.** Nothing dev committed in #528 is modified.

## What changed

An amendment block in `README.md` §Design tokens and a matching note in
`specs/arena.md` §Accessibility.

| Token | Original | Amended | Clears |
|---|---|---|---|
| `--bg1` | `#0c0d0f` | `#141517` | — (card boundary, #512) |
| `--txt3` | `#5a5f66` | `#7c828a` | 5.14:1 on `--bg0`, 4.78:1 on `--bg1` |
| `--border-input` | `#2a2e32` | `#5e646b` | 3.14:1 (WCAG 1.4.11) |

The other 12 tokens are unchanged. **Originals are kept beside the amended
values, not overwritten** — a handoff that quietly rewrites its own numbers is
how the next drift becomes invisible.

## Why

The handoff contradicted itself. `specs/arena.md` §Accessibility enumerates
`--txt3`/`--bg0` as a pair that **must clear 4.5:1**. Measured with the
specified values it is **3.10:1** — and `--txt3` on the original `--bg1` is
**3.03:1**. The specified value could not meet the specified bar, on a pair the
spec itself names.

`--border-input` is a separate criterion: WCAG 1.4.11 wants 3:1 for UI component
boundaries and it measured 1.36:1.

The owner ratified on #526, having been offered the alternative of reverting
#515 and accepting a documented AA failure. `--border-input` came after that
ruling rather than as part of it, and is flagged as such in the table rather
than folded in silently.

## What still has to happen

**`lib/terminalTokens.ts` still holds the originals.** The handoff (README:135)
names it as the palette source implementations must read from, so until it is
updated the file of record disagrees with the handoff of record. That is #518,
and it is dev's — `lib/` is not this session's to write.

The conformance test that file's own header claims exists is the thing that
makes this class of drift impossible rather than merely detectable. Three tokens
drifted in a single day without it.

## How to test (QA)

Docs only — no app code, no behaviour change, nothing to exercise in a browser.
Read `design-handoff-dir/design_handoff_arena/README.md` §Design tokens: the
amendment table should list all three tokens with both original and amended
values and the measurement behind each. `specs/arena.md` §Accessibility should
carry the matching note and state that acceptance criterion 19 is scored against
the amended values.

## Risk level

Low. Documentation only. The risk it removes is larger than any it adds: without
this, anyone reading the handoff on `dev` — including whoever writes the
conformance test — would build to `--txt3: #5a5f66`, the value the owner just
ruled against.

— QA Team
