### PR TITLE
fix(dashboard): zero border-radius on shared shell chrome in terminal mode

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6321,3 +6321,23 @@ main.app-content[data-chrome="none"] {
 [data-design="terminal"] .st-input,
 [data-design="terminal"] .st-affix,
 [data-design="terminal"] .tj-lev-num { border-color: var(--border-input); }
+
+/* ── Shared shell chrome: terminal radius (#526 C6) ────────────────────────
+   NavDrawer and GrokChat render once in AppShell, as siblings outside every
+   page's own -term-wrap div (app/globals.css's nuclear-wrap pattern only
+   reaches descendants of a wrap div it never gets, so it can't zero these).
+   Handoff: "Radius 0 everywhere. No shadows." (README:141) - unconditional,
+   not screen-scoped, so shell chrome owes it too once terminal is active.
+   Same wildcard-subtree shape as the per-screen wraps, just anchored on the
+   chrome's own root classes instead of a wrap div nobody put around them. */
+[data-design="terminal"] .app-bar,
+[data-design="terminal"] .app-bar *,
+[data-design="terminal"] .nav-menu,
+[data-design="terminal"] .nav-menu *,
+[data-design="terminal"] .nav-more-dropdown,
+[data-design="terminal"] .nav-more-dropdown *,
+[data-design="terminal"] .mobile-tab-bar,
+[data-design="terminal"] .mobile-tab-bar *,
+[data-design="terminal"] .gchat-fab,
+[data-design="terminal"] .gchat-panel,
+[data-design="terminal"] .gchat-panel * { border-radius: 0 !important; }


### PR DESCRIPTION
## Summary
Progresses #526 C6 — zeroes `border-radius` on shared shell chrome (nav bar/drawer, global chat) in terminal mode. This is the highest-leverage slice: ~92 of every route's radius violations are identical shared chrome, so this one CSS change clears them on all 29 routes at once.

## What changed
`[data-design="terminal"] .app-bar / .nav-menu / .nav-more-dropdown / .mobile-tab-bar / .gchat-fab / .gchat-panel` and all their descendants get `border-radius: 0 !important`.

## Why these weren't already covered
`NavDrawer` and `GrokChat` render once in `AppShell`, as siblings *outside* every page's own `-term-wrap` div. The existing nuclear-wrap pattern only reaches descendants of a wrap div — these components never got one, since they're shared chrome, not page content. Handoff (`README:141`): "Radius 0 everywhere. No shadows." — unconditional, so shell chrome owes it too.

## A note on how this was verified
The local Next.js **dev server** (Turbopack) showed the fix working for most elements but gave a false negative for `.desktop-nav-item` specifically — `getComputedStyle` and even a fresh screenshot after a full page reload kept reporting the old rounded value, while directly `curl`-ing the served CSS chunk showed my rule present and correct with `!important`, matched the element (confirmed via `element.matches()`), and no other rule competed for the property. Setting an inline `!important` style via JS didn't change `getComputedStyle`'s report either, which shouldn't be possible under normal cascade rules — strong evidence of a dev-server/HMR-specific rendering-vs-CSSOM desync, not a real cascade bug.

Rather than trust that, I ran `npm run build && npm start` (a real production build) and re-tested there. Every element — the active nav pill, chat panel corners, Fast/Live toggle, coin chips — renders correctly square. Screenshots in this PR description's testing were taken against that production build, not dev.

**Ask for QA**: please verify on the `qa` deploy (a real build, like production) rather than a local `next dev` session, if you ever re-check this locally — dev-mode Turbopack gave me unreliable readings for this specific change.

## How to test (QA)
On `qa`, any page with `?design=terminal`: the active nav tab, the chat FAB and panel (corners, coin-selector chips, Fast/Live toggle) should all be sharp-cornered, not rounded.

## Risk level
Low — additive CSS only, scoped to `[data-design="terminal"]`, verified against a production build. All 4 gates pass (lint 0 errors, tsc clean, 414/414 tests, build clean).
