### PR TITLE
fix(dashboard): terminal target sizes (C35) + split the C6 chrome-radius rule

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -534,9 +534,14 @@ body::after {
   border-radius: 9px;
 }
 .nav-search-icon { color: var(--txt3); flex-shrink: 0; }
+/* #526 C35: measured 20px tall - under WCAG 2.5.8's 24px minimum. The
+   surrounding .nav-search-wrap has its own padding, but this input is the
+   actual focusable target a screen reader or switch-access user acts on,
+   so its own box needs to clear 24, not just the pill around it. */
 .nav-search {
   flex: 1; min-width: 0; background: none; border: none; outline: none;
   color: var(--txt); font-size: var(--fs-label); font-family: inherit; padding: 0;
+  min-height: 24px;
 }
 .nav-search::placeholder { color: var(--txt3); }
 .nav-search-clear {
@@ -4721,7 +4726,11 @@ body.landing {
 .pf-footer-logo { font-size: var(--fs-caption); font-weight: 700; color: var(--txt); letter-spacing: -0.02em; }
 .pf-footer-tagline { font-size: var(--fs-caption); color: var(--txt3); line-height: 1.4; }
 .pf-footer-nav { display: flex; gap: 20px; align-items: center; flex-shrink: 0; }
-.pf-footer-link { font-size: var(--fs-caption); color: var(--txt3); text-decoration: none; transition: color 0.15s; letter-spacing: 0.01em; padding: 12px 0; display: inline-flex; align-items: center; }
+/* #526 C35: "FAQ" measured 23px wide with only vertical padding - the
+   shortest link in the row, and the only one under the 24px WCAG 2.5.8
+   minimum. Horizontal padding added so every link in .pf-footer-nav clears
+   24 on both axes, not just this one. */
+.pf-footer-link { font-size: var(--fs-caption); color: var(--txt3); text-decoration: none; transition: color 0.15s; letter-spacing: 0.01em; padding: 12px 4px; display: inline-flex; align-items: center; }
 .pf-footer-link:hover { color: var(--txt); }
 .pf-footer-divider { display: flex; align-items: center; gap: 12px; margin-bottom: 20px; }
 .pf-footer-divider-label {
@@ -5150,10 +5159,15 @@ html[lang="ar"] .lp-h1-accent {
   height: 100%; background: var(--purple); border-radius: 2px;
   transition: width 0.3s;
 }
+/* #526 C35: measured 10x16 - a bare glyph with no hit-area padding, well
+   under WCAG 2.5.8's 24x24. min-width/height plus flex-centering keeps the
+   glyph the same visual size while growing the actual tap target. */
 .ob-cl-mini-close {
   background: none; border: none; color: var(--txt3);
   font-size: 1rem; cursor: pointer; line-height: 1; padding: 0; flex-shrink: 0;
   opacity: 0.7;
+  min-width: 24px; min-height: 24px;
+  display: inline-flex; align-items: center; justify-content: center;
 }
 .ob-cl-mini-close:hover { opacity: 1; color: var(--txt); }
 
@@ -6340,17 +6354,33 @@ main.app-content[data-chrome="none"] {
    chrome's own root classes instead of a wrap div nobody put around them.
    .ob-checklist (SetupChecklist) added after QA's multi-route sweep found
    its mini-mode track/fill on every route - same AppShell-sibling shape as
-   NavDrawer and GrokChat, just missed in the first pass. */
-[data-design="terminal"] .app-bar,
-[data-design="terminal"] .app-bar *,
-[data-design="terminal"] .nav-menu,
-[data-design="terminal"] .nav-menu *,
-[data-design="terminal"] .nav-more-dropdown,
-[data-design="terminal"] .nav-more-dropdown *,
-[data-design="terminal"] .mobile-tab-bar,
-[data-design="terminal"] .mobile-tab-bar *,
-[data-design="terminal"] .gchat-fab,
-[data-design="terminal"] .gchat-panel,
-[data-design="terminal"] .gchat-panel *,
-[data-design="terminal"] .ob-checklist,
+   NavDrawer and GrokChat, just missed in the first pass.
+
+   ONE RULE PER COMPONENT, not one big comma list (#526 follow-up). QA found
+   the single combined rule applied to .nav-menu's branch on the deployed qa
+   build but NOT to .app-bar's or .gchat-panel's branches, in the same
+   declaration, same !important, same specificity - unreproducible locally
+   (my own prod build had every branch working) and not explainable from the
+   cascade. Splitting each root into its own standalone rule removes any
+   possibility of a long comma-list/minifier interaction being the cause,
+   and is the same defensive shape already proven for every other nuclear
+   wrap in this file (one wrap, one rule, never grouped across components).
+   Also added explicit non-wildcard fallbacks for the specific classes QA's
+   sweep named (desktop-nav-item, theme-btn, gchat-coin) so those clear even
+   if a `*` descendant selector is ever the actual point of failure. */
+[data-design="terminal"] .app-bar { border-radius: 0 !important; }
+[data-design="terminal"] .app-bar * { border-radius: 0 !important; }
+[data-design="terminal"] .nav-menu { border-radius: 0 !important; }
+[data-design="terminal"] .nav-menu * { border-radius: 0 !important; }
+[data-design="terminal"] .nav-more-dropdown { border-radius: 0 !important; }
+[data-design="terminal"] .nav-more-dropdown * { border-radius: 0 !important; }
+[data-design="terminal"] .mobile-tab-bar { border-radius: 0 !important; }
+[data-design="terminal"] .mobile-tab-bar * { border-radius: 0 !important; }
+[data-design="terminal"] .gchat-fab { border-radius: 0 !important; }
+[data-design="terminal"] .gchat-panel { border-radius: 0 !important; }
+[data-design="terminal"] .gchat-panel * { border-radius: 0 !important; }
+[data-design="terminal"] .ob-checklist { border-radius: 0 !important; }
 [data-design="terminal"] .ob-checklist * { border-radius: 0 !important; }
+[data-design="terminal"] .desktop-nav-item { border-radius: 0 !important; }
+[data-design="terminal"] .theme-btn { border-radius: 0 !important; }
+[data-design="terminal"] .gchat-coin { border-radius: 0 !important; }


### PR DESCRIPTION
## Summary
Two related follow-ups on #526: C35 (sub-24px touch targets) and a hardening fix for C6's chrome-radius rule.

## C35 — target sizes
`.nav-search` (20px tall), `.pf-footer-link` "FAQ" (23px wide), `.ob-cl-mini-close` (10×16) now clear WCAG 2.5.8's 24×24 minimum. `.pf-footer-bottom-link` deliberately **not** touched — it's an inline link inside a legal-notice sentence, exempt under 2.5.8's own text-link criterion.

## C6 follow-up
QA found the single combined comma-list rule from #531 applied to `.nav-menu`'s branch on the deployed qa build but **not** to `.app-bar`'s or `.gchat-panel`'s branches — same declaration, same `!important`, same specificity. I confirmed the rule is genuinely present and correctly formed in the served CSS (curl'd the live qa chunks directly), and could not explain the partial application from cascade rules. My own local production build showed every branch working, which doesn't match what's live on qa — a real discrepancy between build environments I can't fully diagnose from here.

Split the rule into one declaration per component (matches the pattern already used for every other nuclear-wrap rule in this file) and added explicit non-wildcard fallbacks for the specific classes QA named (`.desktop-nav-item`, `.theme-btn`, `.gchat-coin`). This is a defensive fix, not a diagnosis — it doesn't require understanding why the combined rule partially failed.

## How to test (QA)
**On qa, not local dev or a local build** — that distinction has mattered for this specific rule twice now. Terminal mode, light and dark: nav search box, footer FAQ link, and the setup checklist's × button should have a comfortably clickable hit area. Active nav pill, coin-selector chips, and the theme toggle should render sharp-cornered.

## Risk level
Low — additive CSS, no layout restructuring. All 4 gates pass (lint 0 errors, tsc clean, 433/433 tests, build clean).
