### PR TITLE
fix(dashboard): two off-palette colours in terminal mode (#546 C9)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6407,3 +6407,15 @@ main.app-content[data-chrome="none"] {
 [data-design="terminal"] .gchat-coin { --_c6-tag: gchat-coin; border-radius: 0 !important; }
 [data-design="terminal"] .gchat-quick { --_c6-tag: gchat-quick; border-radius: 0 !important; }
 [data-design="terminal"] .gchat-send { --_c6-tag: gchat-send; border-radius: 0 !important; }
+
+/* ── Dashboard rail change colour (#546 C9) ────────────────────────────────
+   .chg-up/.chg-dn already read color: var(--green)/var(--red) (app/globals.
+   css:786-787), which should resolve to the terminal palette (--green
+   #3fb950) purely through custom-property inheritance from the
+   [data-design="terminal"] root block - no descendant selector needed. QA
+   measured #4ade80 (the ROOT, non-terminal --green) on .csb2-chg instead,
+   the same "correct rule, wrong resolved value" shape as #526's C6 chrome
+   findings, which never got a cascade explanation either. Forcing it
+   explicitly here rather than re-opening that investigation. */
+[data-design="terminal"] .chg-up { color: var(--green) !important; }
+[data-design="terminal"] .chg-dn { color: var(--red) !important; }

--- a/components/DashboardTerminal.tsx
+++ b/components/DashboardTerminal.tsx
@@ -312,7 +312,10 @@ function TEdgeSignals() {
   const oi1hPctStr = oi1h.pct != null ? (oi1h.pct >= 0 ? '+' : '') + oi1h.pct.toFixed(2) + '%' : '-';
 
   const sq    = computeSqueezeScore(d);
-  const sqCol = sq.dir === 'SHORT_SQ' ? 'var(--green)' : sq.dir === 'LONG_LIQ' ? 'var(--red)' : 'var(--txt-dim)';
+  // --txt2, not --txt-dim (#546 C9): --txt-dim isn't in terminal's 16-token
+  // palette, and every sibling ladder in this file (cbCol, frCol) already
+  // uses --txt2 for its own "quiet" state - this brings squeeze in line.
+  const sqCol = sq.dir === 'SHORT_SQ' ? 'var(--green)' : sq.dir === 'LONG_LIQ' ? 'var(--red)' : 'var(--txt2)';
 
   return (
     <>


### PR DESCRIPTION
Fixes #546's two Dashboard-scoped C9 swaps: squeeze card's neutral state (--txt-dim → --txt2, matching its sibling ladders) and .chg-up/.chg-dn forced to terminal --green/--red explicitly (QA measured the non-terminal root value resolving instead — same unexplained shape as the C6 chrome findings). C8's radius work is intentionally NOT included — QA found the 'radius 0 everywhere' premise contradicted by the design canvases themselves, holding until design rules on #548. All 4 gates pass.