### PR TITLE
fix(dashboard): two more off-palette colours found in QA's re-check (#546 C9)

### DIFF
--- a/components/DashboardTerminal.tsx
+++ b/components/DashboardTerminal.tsx
@@ -301,11 +301,17 @@ function TEdgeSignals() {
   const fr     = d?.fundingRate;
   const frPct  = fr != null ? fr * 100 : null;
   const frInfo = fr != null ? classifyFunding(fr) : null;
+  // --green/--red, not the -soft variants (#546 C9): --green-soft/--red-soft
+  // are undeclared in terminal's 16-token palette (same gap #542 found for
+  // --amber), and unlike --amber design hasn't confirmed a terminal value for
+  // them. Collapsing to the base tone here - narrower than adding two more
+  // governed tokens on a guess, and light theme already sets this precedent
+  // ("no separate soft tier... collapse to the same audited colour").
   const frCol  = frPct == null ? 'var(--txt3)'
     : frPct >= 0.05   ? 'var(--red)'
-    : frPct >= 0.01   ? 'var(--red-soft)'
+    : frPct >= 0.01   ? 'var(--red)'
     : frPct <= -0.03  ? 'var(--green)'
-    : frPct <= -0.005 ? 'var(--green-soft)'
+    : frPct <= -0.005 ? 'var(--green)'
     : 'var(--txt2)';
 
   const { txt: oi1hTxt, col: oi1hCol } = oi1hSignal(oi1h.pct, d?.oiTrend);

--- a/components/MarketConditionsWidget.tsx
+++ b/components/MarketConditionsWidget.tsx
@@ -182,8 +182,11 @@ export default function MarketConditionsWidget() {
           return (
             <>
               <div style={{ display: 'flex', height: 5, borderRadius: 3, overflow: 'hidden', marginBottom: 5 }}>
-                <div style={{ width: `${longPct}%`, background: '#34d399' }} />
-                <div style={{ width: `${shortPct}%`, background: '#f87171' }} />
+                {/* Was hardcoded Tailwind emerald-400/red-400 (#546 C9) - off
+                    the terminal palette, and mismatched the labels below,
+                    which already used the real tokens. */}
+                <div style={{ width: `${longPct}%`, background: 'var(--green-2)' }} />
+                <div style={{ width: `${shortPct}%`, background: 'var(--red)' }} />
               </div>
               <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 'var(--fs-caption)' }}>
                 <span style={{ color: 'var(--green-2)', fontWeight: 600 }}>{t('MARKET_CONDITIONS_WIDGET_LONG_PCT', { pct: longPct.toFixed(1) })}</span>


### PR DESCRIPTION
Fixes the two real remaining C9 sources QA's re-check found: funding-rate ladder's soft branches collapsed to base --green/--red (avoids adding 2 new ungoverned terminal tokens on a guess), and MarketConditionsWidget's long/short bar hardcodes swapped for the same tokens its own labels already use. #4ade80 (4/7 sidebar rows) not resolved — same unexplained partial-application as C6, flagged on #546 rather than guessed at again. All 4 gates pass.