### PR TITLE
fix(dashboard): remaining --green-soft/--red-soft/--txt-dim usages (#546 C9)

### DIFF
--- a/components/DashboardTerminal.tsx
+++ b/components/DashboardTerminal.tsx
@@ -66,10 +66,11 @@ function TMarketPulseStrip() {
   const dom = store.btcDom;
   const alt = store.altSeasonScore;
 
+  // --green/--red, not -soft (#546 C9 - see the fuller note at sqCol below).
   const altColor = alt == null ? 'var(--txt3)'
     : alt >= 75 ? 'var(--green)'
-    : alt >= 50 ? 'var(--green-soft)'
-    : alt >= 25 ? 'var(--red-soft)'
+    : alt >= 50 ? 'var(--green)'
+    : alt >= 25 ? 'var(--red)'
     : 'var(--red)';
 
   const volColor = volLabel === 'Low Vol' ? 'var(--green)'
@@ -157,9 +158,9 @@ function TCoinSidebar() {
         if (!sig && d?.fundingRate != null && d.fundingRate !== 0) {
           const fr = d.fundingRate * 100;
           if      (fr >= 0.05)   sig = { text: t('DASH_SIDEBAR_SIG_FUNDING_VERY_HIGH'),     col: 'var(--red)' };
-          else if (fr >= 0.01)   sig = { text: t('DASH_SIDEBAR_SIG_FUNDING_SLIGHTLY_HIGH'), col: 'var(--red-soft)' };
+          else if (fr >= 0.01)   sig = { text: t('DASH_SIDEBAR_SIG_FUNDING_SLIGHTLY_HIGH'), col: 'var(--red)' };
           else if (fr <= -0.03)  sig = { text: t('DASH_SIDEBAR_SIG_FUNDING_VERY_LOW'),      col: 'var(--green)' };
-          else if (fr <= -0.005) sig = { text: t('DASH_SIDEBAR_SIG_FUNDING_SLIGHTLY_LOW'),  col: 'var(--green-soft)' };
+          else if (fr <= -0.005) sig = { text: t('DASH_SIDEBAR_SIG_FUNDING_SLIGHTLY_LOW'),  col: 'var(--green)' };
           else                   sig = { text: t('DASH_SIDEBAR_SIG_FUNDING_NEUTRAL'),        col: 'var(--txt3)' };
         }
 

--- a/components/EconCalendarWidget.tsx
+++ b/components/EconCalendarWidget.tsx
@@ -18,8 +18,11 @@ type TFn = (key: LabelKey, vars?: Record<string, string | number>) => string;
 
 /* LOW was #6b7280 = 3.77:1 on the rail card - and since econImpactKey did not
    exist, EVERY row used it regardless of real impact. See lib/classify.ts. */
+// --txt2, not --txt-dim (#546 C9): --txt-dim isn't in terminal's 16-token
+// palette; --txt2 is the correctly-governed "quiet" text token used for the
+// same role elsewhere in the terminal design.
 const IMPACT_COLOR: Record<EconImpact, string> = {
-  HIGH: 'var(--red)', MEDIUM: 'var(--amber)', LOW: 'var(--txt-dim)',
+  HIGH: 'var(--red)', MEDIUM: 'var(--amber)', LOW: 'var(--txt2)',
 };
 
 const MAX_ROWS = 5;


### PR DESCRIPTION
Third pass on #546 C9's remaining hexes: TMarketPulseStrip's alt-season chip and the sidebar signal ladder's slightly-high/low funding states (both missed --green-soft/--red-soft call sites), plus EconCalendarWidget's LOW-impact badge (--txt-dim, same governance gap as sqCol). Also traced but not fixed: SpotlightTour's hardcoded #fff-on-accent button has zero terminal-mode awareness, real ~2.23:1 contrast issue in terminal but a bigger scope than this PR — flagged on #546. All 4 gates pass.