### PR TITLE
fix(dashboard): --green-2 token and oi1hSignal's soft colours (#546 C9)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5315,6 +5315,13 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
   --accent: #d9a626; /* active nav, primary CTA - ALWAYS with #08090a text */
   --green:  #3fb950; /* bullish / FIRING positive */
   --red:    #f0524d; /* bearish / FIRING negative */
+  /* #546 C9: --green-2 was undeclared here, so it fell through to the
+     current design's root value (#34d399, Tailwind emerald-400) - used by
+     computeCoinHealth's grade-B badge and MarketConditionsWidget's LONG %
+     label, among others. Aliased to --green rather than given its own
+     terminal shade, matching light theme's own precedent at this exact
+     token (app/globals.css:2381, "--green-2: var(--green)"). */
+  --green-2: var(--green);
   /* #546 C9: derived tints for --green/--red, same pattern as the already-
      existing --accent-bg/--accent-bdr. Undeclared here, .chg-up/.chg-dn's
      background/border (app/globals.css:786-787) fell through to the current

--- a/lib/useOI1h.ts
+++ b/lib/useOI1h.ts
@@ -107,10 +107,13 @@ export function oi1hSignal(pct: number | null, oiTrend?: string | null): { txt: 
     ? (trendTxt ?? (isPos ? 'OI spike - rising' : 'OI spike - unwinding'))
     : trendTxt ?? (Math.abs(pct) < 2 ? 'Stable' : isPos ? 'Rising' : 'Unwinding');
 
+  // --green/--red, not the -soft variants (#546 C9): --green-soft/--red-soft
+  // are undeclared in terminal's 16-token palette and fall through to the
+  // current design's Tailwind-derived root values there.
   const col = isSpike && isPos ? 'var(--green)'
     : isSpike && !isPos        ? 'var(--red)'
-    : isPos                    ? 'var(--green-soft)'
-    : pct < 0                  ? 'var(--red-soft)'
+    : isPos                    ? 'var(--green)'
+    : pct < 0                  ? 'var(--red)'
     : 'var(--txt3)';
 
   return { txt, col };


### PR DESCRIPTION
Fixes two more of QA's remaining C9 hexes: --green-2 governed in terminal (aliased to --green, matching light theme's own precedent), and oi1hSignal's green-soft/red-soft collapse (shared lib function, also fixes Arena and CoinMarketSnapshot for free). All 4 gates pass.