### PR TITLE
fix(dashboard): grade-C badge and PerpSpotCard's --txt-dim (#546 C9)

### DIFF
--- a/components/PerpSpotCard.tsx
+++ b/components/PerpSpotCard.tsx
@@ -44,10 +44,12 @@ export default function PerpSpotCard() {
   if (!reading) return null;
 
   const unknown = reading.lean === 'unknown';
+  // --txt2, not --txt-dim (#546 C9): --txt-dim isn't in terminal's
+  // 16-token palette.
   const tone =
     reading.lean === 'perp' ? 'var(--amber)' :
     reading.lean === 'spot' ? 'var(--green-2)' :
-    unknown ? 'var(--txt3)' : 'var(--txt-dim)';
+    unknown ? 'var(--txt3)' : 'var(--txt2)';
 
   const verdict =
     reading.lean === 'perp' ? 'FUTURES LEADING' :

--- a/lib/marketStore.ts
+++ b/lib/marketStore.ts
@@ -339,10 +339,13 @@ export function computeCoinHealth(coin: CoinData | undefined): {
     score >= 42 ? 'C' :
     score >= 25 ? 'D' : 'F';
 
+  // --txt2, not --txt-dim (#546 C9): --txt-dim isn't in terminal's 16-token
+  // palette, and this is the actual source of the grade-C badge colour
+  // rendered app-wide.
   const color =
     grade === 'A' ? 'var(--amber)' :   // gold
     grade === 'B' ? 'var(--green-2)' :   // green
-    grade === 'C' ? 'var(--txt-dim)' :   // gray
+    grade === 'C' ? 'var(--txt2)' :   // gray
     grade === 'D' ? 'var(--orange)' :   // orange
                     'var(--txt3)';  // muted (F)
 


### PR DESCRIPTION
Two more --txt-dim call sites: computeCoinHealth's grade-C badge colour (the actual source of the C badges shown throughout the coin sidebar) and PerpSpotCard's NORMAL tone. All 4 gates pass.