### PR TITLE
fix(chart): #559 platform conformance batch — tokens, contrast, radius, targets

### DIFF
--- a/__tests__/terminalTokens.test.mts
+++ b/__tests__/terminalTokens.test.mts
@@ -87,4 +87,50 @@ test('terminal design tokens', async (t) => {
       'hex-valued custom properties in the terminal block not listed in TERMINAL_COLORS - ' +
       'add them there (or to the radius/other exception if they are not a colour)');
   });
+
+  await t.test('every custom property USED under [data-design="terminal"] is DECLARED in the terminal block', () => {
+    // #559: the asymmetry that let --accent-bg/--accent-solid/--blue/--bg3/
+    // --bg4 etc fall through ungoverned for months. The test above only ever
+    // checked "does the block declare anything undocumented" - never the
+    // opposite direction, "does everything a terminal-scoped rule USES
+    // actually get declared here". A token can be perfectly correct by
+    // inheritance (--purple: var(--accent) resolves via cascade even though
+    // --purple itself is never redeclared in this block) so this check is
+    // scoped to what terminal-scoped SELECTORS reference directly, not every
+    // var() in the stylesheet - the same query QA specified.
+    const declaredNames = new Set(
+      [...block.matchAll(/(--[a-z][a-z0-9-]*)\s*:/g)].map(m => m[1])
+    );
+
+    // Tokens that are legitimately universal - not part of the colour
+    // palette, so never redeclared per design mode (typography scale,
+    // spacing scale, neumorphic shadows, structural sizing).
+    const EXEMPT = new Set([
+      '--font-mono', '--font-sans-terminal',
+      '--fs-body', '--fs-caption', '--fs-card-title', '--fs-data',
+      '--fs-display', '--fs-label', '--fs-micro', '--fs-page', '--fs-section',
+      '--space-1', '--space-2', '--space-3', '--space-4', '--space-5',
+      '--space-6', '--space-7', '--space-8',
+      '--nm-btn', '--nm-inset', '--nm-raise', '--nm-raise-sm',
+      '--banner-h',
+    ]);
+
+    const rulePattern = /\[data-design="terminal"\][^{]*\{([^}]*)\}/g;
+    const missing = new Map<string, Set<string>>();
+    for (const ruleMatch of CSS.matchAll(rulePattern)) {
+      const selector = ruleMatch[0].slice(0, ruleMatch[0].indexOf('{')).trim();
+      if (selector === BLOCK_SELECTOR.slice(0, -2)) continue; // the token block itself
+      for (const varMatch of ruleMatch[1].matchAll(/var\((--[a-z][a-z0-9-]*)/g)) {
+        const name = varMatch[1];
+        if (declaredNames.has(name) || EXEMPT.has(name)) continue;
+        if (!missing.has(name)) missing.set(name, new Set());
+        missing.get(name)!.add(selector);
+      }
+    }
+
+    assert.deepEqual([...missing.keys()], [],
+      [...missing.entries()]
+        .map(([name, selectors]) => `${name} used in [${[...selectors].join(', ')}] but not declared in the terminal token block`)
+        .join('\n'));
+  });
 });

--- a/app/correlation/page.tsx
+++ b/app/correlation/page.tsx
@@ -85,7 +85,7 @@ function pearson(a: number[], b: number[]): number | null {
    identical green. Rescale 0.35→1.0 onto the full range with a power curve so
    0.6 reads faint and 0.95+ pops. */
 function cellBg(r: number | null, diag: boolean): string {
-  if (diag)    return 'rgba(26,122,255,0.22)';
+  if (diag)    return 'var(--accent-bdr)';
   if (r == null) return 'rgba(255,255,255,0.03)';
   if (r > 0) {
     const t = Math.max(0, (r - 0.35) / 0.65);
@@ -118,7 +118,7 @@ function altSignal(avg: number | null): AltSig {
   };
   if (avg < 0.75)  return {
     labelKey: 'CORRELATION_ALT_SIG_BTC_LEADING_LABEL',
-    color: '#d4b483', bg: 'rgba(212,180,131,0.06)',
+    color: 'var(--fr-slight-long)', bg: 'rgba(212,180,131,0.06)',
     descKey: 'CORRELATION_ALT_SIG_BTC_LEADING_DESC', avg,
   };
   return {
@@ -297,7 +297,7 @@ export default function CorrelationHeatmap() {
                             background: cellBg(r, diag),
                             color: cellColor(r, diag),
                             opacity: hovered && !inCross ? 0.25 : 1,
-                            outline: isExact ? '1.5px solid rgba(255,255,255,0.55)' : undefined,
+                            outline: isExact ? '1.5px solid var(--accent)' : undefined,
                             outlineOffset: isExact ? '-1px' : undefined,
                             transition: 'opacity 0.1s',
                             cursor: diag ? 'default' : 'crosshair',

--- a/app/funding/page.tsx
+++ b/app/funding/page.tsx
@@ -11,6 +11,7 @@ import { useLabels } from '@/lib/labels';
 import type { LabelKey } from '@/lib/labelKeys';
 import { useDesignMode } from '@/components/DesignModeProvider';
 import FundingTerminal from '@/components/FundingTerminal';
+import { useTheme } from '@/lib/theme';
 
 /* ── types ── */
 interface FRPoint { rate: number; ts: number; }
@@ -114,7 +115,7 @@ function frSignal(r: number): FRSignal {
     id: 'slight_long',
     crowdKey: 'FUNDING_SIG_SLIGHT_LONG_CROWD', hintKey: 'FUNDING_SIG_SLIGHT_LONG_HINT',
     labelKey: 'FUNDING_SIG_SLIGHT_LONG_LABEL',
-    color: '#d4b483', bg: 'rgba(212,180,131,0.06)',
+    color: 'var(--fr-slight-long)', bg: 'rgba(212,180,131,0.06)',
     actionKey: 'FUNDING_SIG_SLIGHT_LONG_ACTION',
     descKey: 'FUNDING_SIG_SLIGHT_LONG_DESC',
   };
@@ -153,7 +154,7 @@ function frSignal(r: number): FRSignal {
 }
 
 /* ── canvas: sparkline ── */
-function drawSparkline(canvas: HTMLCanvasElement, pts: FRPoint[]) {
+function drawSparkline(canvas: HTMLCanvasElement, pts: FRPoint[], isLight: boolean) {
   const W   = canvas.offsetWidth > 10 ? canvas.offsetWidth : 130;
   const H   = 36;
   const dpr = window.devicePixelRatio || 1;
@@ -200,14 +201,14 @@ function drawSparkline(canvas: HTMLCanvasElement, pts: FRPoint[]) {
   /* zero line */
   ctx.beginPath();
   ctx.moveTo(0, yMid); ctx.lineTo(W, yMid);
-  ctx.strokeStyle = 'rgba(255,255,255,0.09)';
+  ctx.strokeStyle = isLight ? 'rgba(0,0,0,0.09)' : 'rgba(255,255,255,0.09)';
   ctx.lineWidth = 0.5;
   ctx.stroke();
 
   /* line */
   ctx.beginPath();
   rates.forEach((r, i) => i === 0 ? ctx.moveTo(xs(i), ys(r)) : ctx.lineTo(xs(i), ys(r)));
-  ctx.strokeStyle = 'rgba(255,255,255,0.6)';
+  ctx.strokeStyle = isLight ? 'rgba(0,0,0,0.55)' : 'rgba(255,255,255,0.6)';
   ctx.lineWidth   = 1.5;
   ctx.lineJoin    = 'round';
   ctx.stroke();
@@ -221,7 +222,7 @@ function drawSparkline(canvas: HTMLCanvasElement, pts: FRPoint[]) {
 }
 
 /* ── canvas: full chart ── */
-function drawFullChart(canvas: HTMLCanvasElement, pts: FRPoint[]) {
+function drawFullChart(canvas: HTMLCanvasElement, pts: FRPoint[], isLight: boolean) {
   const PL = 52, PR = 14, PT = 14, PB = 28;
   const W   = canvas.offsetWidth > 50 ? canvas.offsetWidth : 320;
   const H   = 190;
@@ -251,10 +252,14 @@ function drawFullChart(canvas: HTMLCanvasElement, pts: FRPoint[]) {
     if (y < PT - 4 || y > PT + CH + 4) return;
     ctx.beginPath();
     ctx.moveTo(PL, y); ctx.lineTo(W - PR, y);
-    ctx.strokeStyle = g === 0 ? 'rgba(255,255,255,0.22)' : 'rgba(255,255,255,0.05)';
+    ctx.strokeStyle = g === 0
+      ? (isLight ? 'rgba(0,0,0,0.22)' : 'rgba(255,255,255,0.22)')
+      : (isLight ? 'rgba(0,0,0,0.08)' : 'rgba(255,255,255,0.05)');
     ctx.lineWidth   = g === 0 ? 1 : 0.5;
     ctx.stroke();
-    ctx.fillStyle = g === 0 ? 'rgba(255,255,255,0.5)' : 'rgba(255,255,255,0.22)';
+    ctx.fillStyle = g === 0
+      ? (isLight ? 'rgba(0,0,0,0.6)' : 'rgba(255,255,255,0.5)')
+      : (isLight ? 'rgba(0,0,0,0.35)' : 'rgba(255,255,255,0.22)');
     ctx.fillText((g * 100).toFixed(3) + '%', PL - 5, y);
   });
 
@@ -287,7 +292,7 @@ function drawFullChart(canvas: HTMLCanvasElement, pts: FRPoint[]) {
   /* line */
   ctx.beginPath();
   rates.forEach((r, i) => i === 0 ? ctx.moveTo(xs(i), ys(r)) : ctx.lineTo(xs(i), ys(r)));
-  ctx.strokeStyle = 'rgba(255,255,255,0.75)';
+  ctx.strokeStyle = isLight ? 'rgba(0,0,0,0.65)' : 'rgba(255,255,255,0.75)';
   ctx.lineWidth   = 1.5;
   ctx.lineJoin    = 'round';
   ctx.stroke();
@@ -308,7 +313,7 @@ function drawFullChart(canvas: HTMLCanvasElement, pts: FRPoint[]) {
   /* X-axis time labels */
   ctx.textAlign    = 'center';
   ctx.textBaseline = 'top';
-  ctx.fillStyle    = 'rgba(255,255,255,0.25)';
+  ctx.fillStyle    = isLight ? 'rgba(0,0,0,0.4)' : 'rgba(255,255,255,0.25)';
   const skip = Math.max(1, Math.ceil(pts.length / 7));
   pts.forEach((p, i) => {
     if (i % skip !== 0 && i !== pts.length - 1) return;
@@ -325,6 +330,8 @@ export default function FundingHistory() {
   const mode = useDesignMode();
   const { t }                 = useLabels();
   const { store }             = useMarket();
+  const { theme }             = useTheme();
+  const isLight = theme === 'light';
   const [history, setHistory] = useState<FRHistory>({});
   const [selected, setSelected] = useState<CoinId>('btc');
   const [rangeKey, setRangeKey] = useState<RangeKey>('7d');
@@ -366,10 +373,10 @@ export default function FundingHistory() {
       COINS.forEach(id => {
         const canvas = sparkRefs.current[id];
         if (!canvas) return;
-        drawSparkline(canvas, (history[id] ?? []).slice(-rangeCount));
+        drawSparkline(canvas, (history[id] ?? []).slice(-rangeCount), isLight);
       });
     });
-  }, [history, rangeCount]);
+  }, [history, rangeCount, isLight]);
 
   /* redraw full chart when selection, range, or data changes */
   useEffect(() => {
@@ -377,8 +384,8 @@ export default function FundingHistory() {
     if (!canvas) return;
     const pts = (history[selected] ?? []).slice(-rangeCount);
     if (pts.length < 2) return;
-    requestAnimationFrame(() => drawFullChart(canvas, pts));
-  }, [history, selected, rangeCount]);
+    requestAnimationFrame(() => drawFullChart(canvas, pts, isLight));
+  }, [history, selected, rangeCount, isLight]);
 
   function getStats(id: CoinId) {
     const pts = (history[id] ?? []).slice(-rangeCount);
@@ -442,8 +449,8 @@ export default function FundingHistory() {
                   {t('FUNDING_CONTRARIAN_LONG_COUNT', { count: longSignals.length, plural: longSignals.length !== 1 ? 's' : '' })}
                 </Tip>
               </span>
-              <span style={{ fontSize: 'var(--fs-caption)', padding: '2px 7px', borderRadius: 10, background: 'rgba(26,122,255,0.10)', color: 'var(--accent)', border: '0.5px solid rgba(26,122,255,0.25)', fontWeight: 700 }}>
-                <Tip iconColor="#1a7aff" text={t('FUNDING_CARRY_ARB_TIP')}>
+              <span style={{ fontSize: 'var(--fs-caption)', padding: '2px 7px', borderRadius: 10, background: 'var(--accent-bg)', color: 'var(--accent)', border: '0.5px solid var(--accent-bdr)', fontWeight: 700 }}>
+                <Tip iconColor="var(--accent)" text={t('FUNDING_CARRY_ARB_TIP')}>
                   {t('FUNDING_CARRY_ARB_COUNT', { count: arbs.length })}
                 </Tip>
               </span>
@@ -474,7 +481,7 @@ export default function FundingHistory() {
                     </span>
                   )}
                   {carryArb && (
-                    <span style={{ fontSize: 'var(--fs-caption)', padding: '1px 5px', borderRadius: 3, background: 'rgba(26,122,255,0.10)', color: 'var(--accent)', fontWeight: 600, flexShrink: 0 }}>
+                    <span style={{ fontSize: 'var(--fs-caption)', padding: '1px 5px', borderRadius: 3, background: 'var(--accent-bg)', color: 'var(--accent)', fontWeight: 600, flexShrink: 0 }}>
                       {t('FUNDING_BADGE_ARB_LABEL')}
                     </span>
                   )}

--- a/app/globals.css
+++ b/app/globals.css
@@ -103,6 +103,14 @@
   --amber-bg:  rgba(251,191,36,0.08);
   --amber-bdr: rgba(251,191,36,0.22);
 
+  /* #559: /funding's "slight long" signal state (FundingTerminal.tsx
+     frSignal) was the one state of eight using a bare literal instead of a
+     token - every sibling state already used var(--red)/--orange/--amber/
+     etc, which pick up the light-theme overrides two blocks down. This one
+     didn't, so it rendered the same washed-out tan in both themes: fine on
+     a near-black canvas, ~2:1 on white. */
+  --fr-slight-long: #d4b483;
+
   --orange:     #fb923c;
   --orange-bg:  rgba(251,146,60,0.08);
   --orange-bdr: rgba(251,146,60,0.22);
@@ -2394,6 +2402,9 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   --amber-dim: rgba(180,83,9,0.12);
   --amber-bg:  rgba(180,83,9,0.07);
   --amber-bdr: rgba(180,83,9,0.20);
+  /* #559: same darkened-hue treatment as --amber/--orange above - #d4b483
+     (the dark value) measures ~2:1 on white. */
+  --fr-slight-long: #7C5E2E;
   /* #519: was #C2410C - 3.09:1 for the grade-D badge on a selected watchlist
      row, 3.85:1 normally, both below WCAG AA's 4.5:1 for 12px text. */
   --orange:     #7C2D12;
@@ -3217,6 +3228,7 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .frh-sig-chip    { display: inline-flex; flex-direction: column; gap: 1px; padding: 4px 9px; border-radius: 7px; border: 0.5px solid; white-space: nowrap; }
 .frh-sig-crowd   { font-size: var(--fs-caption); font-weight: 700; line-height: 1.3; }
 .frh-sig-hint    { font-size: var(--fs-caption); font-weight: 500; color: rgba(255,255,255,0.6); line-height: 1.3; }
+[data-theme="light"] .frh-sig-hint { color: var(--txt2); }
 
 .frh-signal      { display: flex; align-items: flex-start; gap: 10px; padding: 10px 12px; border-radius: var(--radius-card); border: 0.5px solid; margin-bottom: 12px; }
 .frh-signal-top   { display: flex; align-items: center; flex-wrap: wrap; gap: 6px; margin-bottom: 4px; }
@@ -4803,7 +4815,10 @@ body.landing {
 .lp-footer-brand p { font-size: var(--fs-caption); color: var(--txt3); line-height: 1.6; margin: 12px 0 0; max-width: 260px; }
 .lp-footer-col      { display: flex; flex-direction: column; gap: 11px; }
 .lp-footer-col-title { font-size: var(--fs-micro); font-weight: 700; letter-spacing: .08em; text-transform: uppercase; color: var(--txt3); margin-bottom: 3px; }
-.lp-footer-col a    { font-size: var(--fs-caption); color: var(--txt2); text-decoration: none; transition: color .15s; }
+/* #559: was mobile-only (the media-query rule below) - desktop viewports
+   never got the same fix, so every link in every landing footer column
+   still measured under WCAG 2.5.8's 24px minimum there. */
+.lp-footer-col a    { font-size: var(--fs-caption); color: var(--txt2); text-decoration: none; transition: color .15s; padding: 4px 0; min-height: 24px; display: inline-flex; align-items: center; }
 .lp-footer-col a:hover { color: var(--accent-2); }
 .lp-footer-bottom   { max-width: 1100px; margin: 36px auto 0; padding-top: 20px; border-top: 0.5px solid var(--bdr); display: flex; flex-direction: column; gap: 10px; }
 .lp-footer-copy     { font-size: var(--fs-caption); color: var(--txt3); }
@@ -5313,6 +5328,50 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
                          4.5:1 against the new --bg1 */
   --txt4: #3a3f45;   /* disabled, axis labels */
   --accent: #d9a626; /* active nav, primary CTA - ALWAYS with #08090a text */
+  /* #559 sweep, forward-check test: --on-accent was never declared ANYWHERE
+     in the file (only named in a comment at .auth-gate-btn, which itself uses
+     a hardcoded #fff instead) - .sshell-cta was the one real consumer, and an
+     undeclared custom property computes to nothing, not to --txt or any other
+     fallback. Declared as --bg0 to match the convention every other on-accent
+     surface in this block already follows (.tnav-item.on, .lt-plan-cta-pro):
+     near-black text on the gold fill. */
+  --on-accent: var(--bg0);
+  /* #559 platform audit: likely THE dominant off-palette source. --accent
+     itself was already governed above, but --accent-bg/--accent-bdr (the
+     Tailwind-blue #1a7aff tint pair used for nearly every "selected/hover"
+     treatment app-wide: .klc-tool-btn.on, .st-preset.on, .obw-row.is-
+     selected, .desktop-nav-item.on, dozens more) and --accent-2 (#5aa3ff,
+     app-logo/links/hover text) were never declared here at all. --purple/
+     --purple-bg/--purple-bdr alias to these three, so the leak was invisible
+     at the --accent level (correctly gold) while every -bg/-bdr/-2 consumer
+     still rendered blue. This is very likely the root cause behind "#1a7aff
+     leaking into terminal scope", named three times now (Arena C21, Markets,
+     Dashboard's initial C9 read) as if each were a separate finding. */
+  --accent-2:   var(--accent);
+  --accent-bg:  rgba(217,166,38,0.07);
+  --accent-bdr: rgba(217,166,38,0.22);
+  /* #559 sweep round 2: --accent-solid (29 uses - desktop-nav-item.on,
+     onboarding wizard, .ncard-ask-btn hover, several CTAs) and --accent-dim
+     were also undeclared, same shape as --accent-bg/-bdr above: root's
+     #1668e3 blue leaking through. --blue/--blue-bg/--blue-bdr are a distinct
+     literal (not an --accent alias) used for "crypto" category tags
+     (.nc-crypto, .wp-london, .gchat-bubble links) - collapsing them into
+     --accent here too, matching the precedent already set for --purple
+     (a categorical hue folded into the single terminal accent, not a
+     bull/bear/caution state like --green/--red/--amber which stay distinct). */
+  --accent-solid: var(--accent);
+  --accent-dim:   rgba(217,166,38,0.12);
+  --blue:      var(--accent);
+  --blue-bg:   var(--accent-bg);
+  --blue-bdr:  var(--accent-bdr);
+  /* --bg3/--bg4 (53 uses combined - .csb2-card, .av-rail-panel, .badge-flat,
+     .gchat-hist-item-active, .login-pw-tab.on, dozens more) are root's own
+     near-black layering scale, undeclared here. Aliased to terminal's own
+     --bg2/--bg1 rather than given new literals, preserving the raised-surface
+     ordering (bg3 sits above card level like bg2; bg4 sits above that like
+     bg1) instead of introducing a fourth near-identical near-black. */
+  --bg3: var(--bg2);
+  --bg4: var(--bg1);
   --green:  #3fb950; /* bullish / FIRING positive */
   --red:    #f0524d; /* bearish / FIRING negative */
   /* #546 C9: --green-2 was undeclared here, so it fell through to the
@@ -5322,6 +5381,19 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
      terminal shade, matching light theme's own precedent at this exact
      token (app/globals.css:2381, "--green-2: var(--green)"). */
   --green-2: var(--green);
+  /* #559 platform audit: --green-soft/--red-soft/--txt-dim were undeclared
+     here too, same governance gap as --green-2/--amber, but hit PER-CALL-SITE
+     fixes on Dashboard (#546) rather than being governed at the token level -
+     which only fixed the specific components touched, not the other ~29
+     routes using the same three tokens. The audit's near-universal off-
+     palette count (1242 instances, every route) is exactly what that partial
+     fix predicted: same shared-source shape, just not closed at the source.
+     Collapsing all three here, matching light theme's own precedent for the
+     first two (line ~2381) and Dashboard's own precedent for --txt-dim
+     (component-level swaps to --txt2 throughout #546). */
+  --green-soft: var(--green);
+  --red-soft:   var(--red);
+  --txt-dim:    var(--txt2);
   /* #546 C9: derived tints for --green/--red, same pattern as the already-
      existing --accent-bg/--accent-bdr. Undeclared here, .chg-up/.chg-dn's
      background/border (app/globals.css:786-787) fell through to the current
@@ -5855,7 +5927,10 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
   font-family: var(--font-mono); font-size: 10px; letter-spacing: .16em;
   text-transform: uppercase; color: var(--txt3); margin-bottom: 4px;
 }
-[data-design="terminal"] .lt-footer-col a { font-size: 13px; color: var(--txt2); text-decoration: none; }
+/* #559: never had the #526 C35 sizing fix applied, unlike the current
+   design's .lp-footer-col a - same footer, same links, undersized in both
+   themes at every viewport. */
+[data-design="terminal"] .lt-footer-col a { font-size: 13px; color: var(--txt2); text-decoration: none; padding: 4px 0; min-height: 24px; display: inline-flex; align-items: center; }
 [data-design="terminal"] .lt-footer-col a:hover { color: var(--txt); }
 [data-design="terminal"] .lt-risk-divider {
   display: flex; align-items: center; gap: 14px; margin-top: 44px;
@@ -6354,6 +6429,55 @@ main.app-content[data-chrome="none"] {
 [data-design="terminal"] .briefing-term-wrap * { border-radius: 0 !important; }
 [data-design="terminal"] .liq-term-wrap,
 [data-design="terminal"] .liq-term-wrap * { border-radius: 0 !important; }
+
+/* ── #559 platform radius sweep: circular-glyph carve-out ──────────────────
+   specs/radius-ruling.md: "border-radius: 0 applies to rectangular surfaces
+   ... It does not apply to elements that are inherently circular in the
+   source - status dots, avatar/coin-marker circles, toggle-switch thumbs."
+   Every *-term-wrap block above (and its 19 live routes: scanner, journal,
+   alerts, news, calc, playbook, hours, research, econ, locked-card, upgrade-
+   gate/modal, faq, terms, refund, upgrade, arena, briefing, liq - confirmed
+   by grep, not dashboard/login/settings which never got the wrap className
+   wired to begin with) zeroes EVERY descendant via `* { border-radius: 0
+   !important }`, which is unconditional: it flattens these dot/marker
+   classes into squares wherever they render inside any of those wraps, not
+   only inside Dashboard where #548 first caught this same shape. Restoring
+   50% here, after the wildcard rules, so source order (both sides carry
+   !important) resolves in this block's favour.
+   Scope note: this list is every element that unambiguously matches one of
+   the ruling's four named categories (status dot / avatar-coin marker /
+   toggle-slider thumb / step circle). It does NOT include round icon
+   buttons that aren't glyphs (.tj-del-btn, .tj-edit-btn, .smod-close,
+   .gchat-login-close), loading spinners, or .num (26px, over the ruling's
+   24px step-circle line) - those are a judgment call for QA, not something
+   this pass assumed either way. */
+[data-design="terminal"] .status-dot,
+[data-design="terminal"] .ticker-dot,
+[data-design="terminal"] .nf-type-dot,
+[data-design="terminal"] .klc-ws-dot,
+[data-design="terminal"] .gchat-dot,
+[data-design="terminal"] .liq-current-dot,
+[data-design="terminal"] .liq-howto-dot,
+[data-design="terminal"] .scan-legend-dot,
+[data-design="terminal"] .ps-live-dot,
+[data-design="terminal"] .wf-dot,
+[data-design="terminal"] .mb-brief-dot,
+[data-design="terminal"] .st-tg-dot,
+[data-design="terminal"] .tg-cond-dot,
+[data-design="terminal"] .cascade-dot,
+[data-design="terminal"] .dash-section-hot::before,
+[data-design="terminal"] .session-pill-dot,
+[data-design="terminal"] .liqfeed-dot,
+[data-design="terminal"] .fng-marker,
+[data-design="terminal"] .cf-signal-icon,
+[data-design="terminal"] .ps-coin-trigger-dot,
+[data-design="terminal"] .ps-coin-opt-dot,
+[data-design="terminal"] .auth-avatar-btn,
+[data-design="terminal"] .coin-icon,
+[data-design="terminal"] .tj-lev-slider::-webkit-slider-thumb,
+[data-design="terminal"] .tj-lev-slider::-moz-range-thumb {
+  border-radius: 50% !important;
+}
 
 /* ── Terminal form input visibility (#512 bug 3) ───────────────────────────
    These wrap/style real <input>/<textarea> elements with background: --bg2

--- a/app/globals.css
+++ b/app/globals.css
@@ -814,7 +814,7 @@ body::after {
     border-radius: var(--radius-card); padding: 14px 18px; position: relative;
     min-width: 96px; transition: border-color 0.2s, box-shadow 0.2s, background 0.2s;
   }
-  .ticker-see-all:active { background: rgba(26,122,255,0.18); box-shadow: 0 0 28px rgba(26,122,255,0.22); }
+  .ticker-see-all:active { background: color-mix(in srgb, var(--purple) 18%, transparent); box-shadow: 0 0 28px color-mix(in srgb, var(--purple) 22%, transparent); }
   .ticker-see-all-count { display: block; font-size: 2rem; font-weight: 700; color: var(--txt); letter-spacing: -1.5px; line-height: 1; text-align: center; }
   .ticker-see-all-label { display: block; font-size: var(--fs-micro); font-weight: 800; color: var(--txt3); letter-spacing: .14em; text-transform: uppercase; text-align: center; margin-top: 3px; }
   .ticker-see-all-arrow { display: block; font-size: 0.6875rem; font-weight: 700; color: var(--purple); margin-top: 10px; letter-spacing: .01em; text-align: center; }
@@ -2118,17 +2118,17 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .gchat-followup-chip {
   font-size: var(--fs-caption); font-weight: 500;
   padding: 5px 11px; border-radius: 20px;
-  border: 0.5px solid rgba(26,122,255,0.22);
-  background: rgba(26,122,255,0.06);
+  border: 0.5px solid var(--accent-bdr);
+  background: var(--accent-bg);
   color: var(--accent-2); cursor: pointer;
   white-space: normal; text-align: left; line-height: 1.35;
   transition: background 0.14s, border-color 0.14s, color 0.14s;
   animation: fadeInUp 0.15s ease;
 }
 .gchat-followup-chip:hover {
-  background: rgba(26,122,255,0.14);
-  border-color: rgba(26,122,255,0.45);
-  color: #d4caff;
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 45%, transparent);
+  color: var(--accent-2);
 }
 @keyframes fadeInUp { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
 

--- a/components/CoinIcon.tsx
+++ b/components/CoinIcon.tsx
@@ -11,7 +11,7 @@ export default function CoinIcon({ coin, size = 22, color, bg }: { coin: CoinId;
   // ever missing, fall back to a plain neutral circle - never a letter/text abbreviation.
   if (failed) {
     return (
-      <span style={{
+      <span className="coin-icon" style={{
         width: size, height: size, borderRadius: '50%', flexShrink: 0,
         background: bg ?? 'rgba(255,255,255,0.07)',
         border: `0.5px solid ${color ? withAlpha(color, '44') : 'rgba(255,255,255,0.1)'}`,
@@ -27,6 +27,7 @@ export default function CoinIcon({ coin, size = 22, color, bg }: { coin: CoinId;
     // arguing about a cost this particular image does not have.
     // eslint-disable-next-line @next/next/no-img-element
     <img
+      className="coin-icon"
       src={src}
       alt={coin}
       width={size}

--- a/components/CorrelationTerminal.tsx
+++ b/components/CorrelationTerminal.tsx
@@ -64,7 +64,7 @@ function pearson(a: number[], b: number[]): number | null {
 }
 
 function cellBg(r: number | null, diag: boolean): string {
-  if (diag)     return 'rgba(26,122,255,0.22)';
+  if (diag)     return 'var(--accent-bdr)';
   if (r == null) return 'rgba(255,255,255,0.03)';
   if (r > 0) {
     const t = Math.max(0, (r - 0.35) / 0.65);
@@ -86,7 +86,7 @@ function altSignal(avg: number | null): AltSig {
   if (avg == null) return { labelKey: 'CORRELATION_ALT_SIG_LOADING_LABEL', descKey: null, avg, color: 'var(--txt-dim)', bg: 'transparent' };
   if (avg < 0.30)  return { labelKey: 'CORRELATION_ALT_SIG_ALT_SEASON_LABEL', color: 'var(--green-2)', bg: 'rgba(52,211,153,0.08)', descKey: 'CORRELATION_ALT_SIG_ALT_SEASON_DESC', avg };
   if (avg < 0.55)  return { labelKey: 'CORRELATION_ALT_SIG_MIXED_LABEL', color: 'var(--amber)', bg: 'rgba(251,191,36,0.07)', descKey: 'CORRELATION_ALT_SIG_MIXED_DESC', avg };
-  if (avg < 0.75)  return { labelKey: 'CORRELATION_ALT_SIG_BTC_LEADING_LABEL', color: '#d4b483', bg: 'rgba(212,180,131,0.06)', descKey: 'CORRELATION_ALT_SIG_BTC_LEADING_DESC', avg };
+  if (avg < 0.75)  return { labelKey: 'CORRELATION_ALT_SIG_BTC_LEADING_LABEL', color: 'var(--fr-slight-long)', bg: 'rgba(212,180,131,0.06)', descKey: 'CORRELATION_ALT_SIG_BTC_LEADING_DESC', avg };
   return { labelKey: 'CORRELATION_ALT_SIG_LOCKSTEP_LABEL', color: 'var(--red)', bg: 'rgba(248,113,113,0.07)', descKey: 'CORRELATION_ALT_SIG_LOCKSTEP_DESC', avg };
 }
 
@@ -252,7 +252,7 @@ export default function CorrelationTerminal() {
                             color: cellColor(r, diag),
                             borderRadius: 0,
                             opacity: hovered && !inCross ? 0.25 : 1,
-                            outline: isExact ? '1.5px solid rgba(255,255,255,0.55)' : undefined,
+                            outline: isExact ? '1.5px solid var(--accent)' : undefined,
                             outlineOffset: isExact ? '-1px' : undefined,
                             transition: 'opacity 0.1s',
                             cursor: diag ? 'default' : 'crosshair',

--- a/components/FundingTerminal.tsx
+++ b/components/FundingTerminal.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useState, useEffect, useRef } from 'react';
 import { COINS, BINANCE_SYMS, BYBIT_SYMS, COIN_LABELS, type CoinId, useMarket } from '@/lib/marketStore';
+import { useTheme } from '@/lib/theme';
 import { coinBadgeColor } from '@/lib/coinBadge';
 import { withAlpha } from '@/lib/color';
 import { Warn } from '@/components/icons';
@@ -107,7 +108,7 @@ function frSignal(r: number): FRSignal {
     id: 'slight_long',
     crowdKey: 'FUNDING_SIG_SLIGHT_LONG_CROWD', hintKey: 'FUNDING_SIG_SLIGHT_LONG_HINT',
     labelKey: 'FUNDING_SIG_SLIGHT_LONG_LABEL',
-    color: '#d4b483', bg: 'rgba(212,180,131,0.06)',
+    color: 'var(--fr-slight-long)', bg: 'rgba(212,180,131,0.06)',
     actionKey: 'FUNDING_SIG_SLIGHT_LONG_ACTION',
     descKey: 'FUNDING_SIG_SLIGHT_LONG_DESC',
   };
@@ -146,7 +147,7 @@ function frSignal(r: number): FRSignal {
 }
 
 /* ── canvas: sparkline ── */
-function drawSparkline(canvas: HTMLCanvasElement, pts: FRPoint[]) {
+function drawSparkline(canvas: HTMLCanvasElement, pts: FRPoint[], isLight: boolean) {
   const W   = canvas.offsetWidth > 10 ? canvas.offsetWidth : 130;
   const H   = 36;
   const dpr = window.devicePixelRatio || 1;
@@ -190,13 +191,13 @@ function drawSparkline(canvas: HTMLCanvasElement, pts: FRPoint[]) {
 
   ctx.beginPath();
   ctx.moveTo(0, yMid); ctx.lineTo(W, yMid);
-  ctx.strokeStyle = 'rgba(255,255,255,0.09)';
+  ctx.strokeStyle = isLight ? 'rgba(0,0,0,0.09)' : 'rgba(255,255,255,0.09)';
   ctx.lineWidth = 0.5;
   ctx.stroke();
 
   ctx.beginPath();
   rates.forEach((r, i) => i === 0 ? ctx.moveTo(xs(i), ys(r)) : ctx.lineTo(xs(i), ys(r)));
-  ctx.strokeStyle = 'rgba(255,255,255,0.6)';
+  ctx.strokeStyle = isLight ? 'rgba(0,0,0,0.55)' : 'rgba(255,255,255,0.6)';
   ctx.lineWidth   = 1.5;
   ctx.lineJoin    = 'round';
   ctx.stroke();
@@ -209,7 +210,7 @@ function drawSparkline(canvas: HTMLCanvasElement, pts: FRPoint[]) {
 }
 
 /* ── canvas: full chart ── */
-function drawFullChart(canvas: HTMLCanvasElement, pts: FRPoint[]) {
+function drawFullChart(canvas: HTMLCanvasElement, pts: FRPoint[], isLight: boolean) {
   const PL = 52, PR = 14, PT = 14, PB = 28;
   const W   = canvas.offsetWidth > 50 ? canvas.offsetWidth : 320;
   const H   = 190;
@@ -238,10 +239,14 @@ function drawFullChart(canvas: HTMLCanvasElement, pts: FRPoint[]) {
     if (y < PT - 4 || y > PT + CH + 4) return;
     ctx.beginPath();
     ctx.moveTo(PL, y); ctx.lineTo(W - PR, y);
-    ctx.strokeStyle = g === 0 ? 'rgba(255,255,255,0.22)' : 'rgba(255,255,255,0.05)';
+    ctx.strokeStyle = g === 0
+      ? (isLight ? 'rgba(0,0,0,0.22)' : 'rgba(255,255,255,0.22)')
+      : (isLight ? 'rgba(0,0,0,0.08)' : 'rgba(255,255,255,0.05)');
     ctx.lineWidth   = g === 0 ? 1 : 0.5;
     ctx.stroke();
-    ctx.fillStyle = g === 0 ? 'rgba(255,255,255,0.5)' : 'rgba(255,255,255,0.22)';
+    ctx.fillStyle = g === 0
+      ? (isLight ? 'rgba(0,0,0,0.6)' : 'rgba(255,255,255,0.5)')
+      : (isLight ? 'rgba(0,0,0,0.35)' : 'rgba(255,255,255,0.22)');
     ctx.fillText((g * 100).toFixed(3) + '%', PL - 5, y);
   });
 
@@ -271,7 +276,7 @@ function drawFullChart(canvas: HTMLCanvasElement, pts: FRPoint[]) {
 
   ctx.beginPath();
   rates.forEach((r, i) => i === 0 ? ctx.moveTo(xs(i), ys(r)) : ctx.lineTo(xs(i), ys(r)));
-  ctx.strokeStyle = 'rgba(255,255,255,0.75)';
+  ctx.strokeStyle = isLight ? 'rgba(0,0,0,0.65)' : 'rgba(255,255,255,0.75)';
   ctx.lineWidth   = 1.5;
   ctx.lineJoin    = 'round';
   ctx.stroke();
@@ -290,7 +295,7 @@ function drawFullChart(canvas: HTMLCanvasElement, pts: FRPoint[]) {
 
   ctx.textAlign    = 'center';
   ctx.textBaseline = 'top';
-  ctx.fillStyle    = 'rgba(255,255,255,0.25)';
+  ctx.fillStyle    = isLight ? 'rgba(0,0,0,0.4)' : 'rgba(255,255,255,0.25)';
   const skip = Math.max(1, Math.ceil(pts.length / 7));
   pts.forEach((p, i) => {
     if (i % skip !== 0 && i !== pts.length - 1) return;
@@ -321,6 +326,8 @@ function TPanel({ children, style }: { children: React.ReactNode; style?: React.
 export default function FundingTerminal() {
   const { t }                 = useLabels();
   const { store }             = useMarket();
+  const { theme }             = useTheme();
+  const isLight = theme === 'light';
   const [history, setHistory] = useState<FRHistory>({});
   const [selected, setSelected] = useState<CoinId>('btc');
   const [rangeKey, setRangeKey] = useState<RangeKey>('7d');
@@ -356,18 +363,18 @@ export default function FundingTerminal() {
       COINS.forEach(id => {
         const canvas = sparkRefs.current[id];
         if (!canvas) return;
-        drawSparkline(canvas, (history[id] ?? []).slice(-rangeCount));
+        drawSparkline(canvas, (history[id] ?? []).slice(-rangeCount), isLight);
       });
     });
-  }, [history, rangeCount]);
+  }, [history, rangeCount, isLight]);
 
   useEffect(() => {
     const canvas = fullChartRef.current;
     if (!canvas) return;
     const pts = (history[selected] ?? []).slice(-rangeCount);
     if (pts.length < 2) return;
-    requestAnimationFrame(() => drawFullChart(canvas, pts));
-  }, [history, selected, rangeCount]);
+    requestAnimationFrame(() => drawFullChart(canvas, pts, isLight));
+  }, [history, selected, rangeCount, isLight]);
 
   function getStats(id: CoinId) {
     const pts = (history[id] ?? []).slice(-rangeCount);

--- a/components/FundingTerminal.tsx
+++ b/components/FundingTerminal.tsx
@@ -436,8 +436,8 @@ export default function FundingTerminal() {
                   {t('FUNDING_CONTRARIAN_LONG_COUNT', { count: longSignals.length, plural: longSignals.length !== 1 ? 's' : '' })}
                 </Tip>
               </span>
-              <span style={{ fontSize: 'var(--fs-caption)', padding: '2px 7px', borderRadius: 0, background: 'rgba(26,122,255,0.10)', color: 'var(--accent)', border: '0.5px solid rgba(26,122,255,0.25)', fontWeight: 700 }}>
-                <Tip iconColor="#1a7aff" text={t('FUNDING_CARRY_ARB_TIP')}>
+              <span style={{ fontSize: 'var(--fs-caption)', padding: '2px 7px', borderRadius: 0, background: 'var(--accent-bg)', color: 'var(--accent)', border: '0.5px solid var(--accent-bdr)', fontWeight: 700 }}>
+                <Tip iconColor="var(--accent)" text={t('FUNDING_CARRY_ARB_TIP')}>
                   {t('FUNDING_CARRY_ARB_COUNT', { count: arbs.length })}
                 </Tip>
               </span>
@@ -468,7 +468,7 @@ export default function FundingTerminal() {
                     </span>
                   )}
                   {carryArb && (
-                    <span style={{ fontSize: 'var(--fs-caption)', padding: '1px 5px', borderRadius: 0, background: 'rgba(26,122,255,0.10)', color: 'var(--accent)', fontWeight: 600, flexShrink: 0 }}>
+                    <span style={{ fontSize: 'var(--fs-caption)', padding: '1px 5px', borderRadius: 0, background: 'var(--accent-bg)', color: 'var(--accent)', fontWeight: 600, flexShrink: 0 }}>
                       {t('FUNDING_BADGE_ARB_LABEL')}
                     </span>
                   )}

--- a/components/PageHint.tsx
+++ b/components/PageHint.tsx
@@ -51,13 +51,13 @@ export default function PageHint({ pageKey, title, body }: Props) {
       display: 'flex',
       alignItems: 'flex-start',
       gap: 10,
-      background: 'rgba(26,122,255,0.07)',
-      border: '0.5px solid rgba(26,122,255,0.22)',
+      background: 'var(--accent-bg)',
+      border: '0.5px solid var(--accent-bdr)',
       borderRadius: 10,
       padding: '10px 12px',
       marginBottom: 14,
     }}>
-      <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 800, color: 'var(--accent)', background: 'rgba(26,122,255,0.18)', borderRadius: '50%', width: 18, height: 18, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, letterSpacing: 0 }}>i</span>
+      <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 800, color: 'var(--accent)', background: 'var(--accent-bg)', borderRadius: '50%', width: 18, height: 18, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, letterSpacing: 0 }}>i</span>
       <div style={{ flex: 1, minWidth: 0 }}>
         <div style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: 'var(--accent)', marginBottom: 3 }}>{title}</div>
         <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', lineHeight: 1.55 }}>{body}</div>


### PR DESCRIPTION
## Summary
Batched fix for QA's #559 consolidated platform-conformance audit (replaces #513/#518/#526/#537/#546/#548). One PR, one deploy, per the owner's explicit batching directive — not the prior fix→deploy→verify→repeat loop.

## What changed
- **Terminal token governance**: declared `--accent-solid`, `--accent-dim`, `--blue`/`-bg`/`-bdr` (collapsed into the single accent, same precedent as `--purple`), `--bg3`/`--bg4` (aliased to `--bg2`/`--bg1`), and `--on-accent` (was never declared anywhere at all — only named in a stale comment) in the `[data-design="terminal"]` block. Closes the bug class where a shared component's token falls through to the current design's colour because terminal never redeclared it.
- **New conformance test direction**: every `var(--x)` referenced by a literal `[data-design="terminal"] ...` selector must now be declared in the terminal token block — not just the reverse (block declares nothing undocumented). Caught `--on-accent` immediately on the first run.
- **`/funding` and `/correlation` light-theme contrast**: `.frh-sig-hint` had no `[data-theme="light"]` override (~1.4:1 on white). Both pages' `<canvas>` funding-rate charts drew every gridline/axis-label/stroke as fixed white rgba with zero theme awareness — fixed with an `isLight` branch wired to `useTheme()`. The "slight long"/"BTC leading" signal state used a bare `#d4b483` literal instead of a token, **duplicated across four files** (`FundingTerminal.tsx`, `app/funding/page.tsx`, `app/correlation/page.tsx`, `CorrelationTerminal.tsx`) — all four now use one new `--fr-slight-long` token. Same pattern closed a hardcoded `#1a7aff` diagonal-cell background and "exact match" outline in both correlation files, and three carry-arb badge call sites in the funding pair.
- **Platform radius sweep**: 19 of 21 `*-term-wrap` routes have the C6-style `* { border-radius: 0 !important }` wildcard live (dashboard/login/settings never got the className wired). Per `specs/radius-ruling.md`'s carve-out, this was flattening every status dot / avatar-marker / toggle-thumb into a square platform-wide, not just on Dashboard where #548 first caught the same shape. Added a carve-out block restoring 50% for every element matching the ruling's four named categories, plus a `coin-icon` className so `CoinIcon.tsx` (used everywhere) has something for the selector to hook onto.
- **PageHint** (renders on most terminal routes via scanner/etc.) had two hardcoded `#1a7aff`-family blues — swapped for `var(--accent-bg)`/`var(--accent-bdr)`.
- **`.gchat-followup-chip`** and **`.ticker-see-all:active`** (shared shell chrome) — same hardcoded-blue governance gap, fixed with `color-mix()` against the governed accent/purple tokens.
- **Footer link touch targets**: `.lp-footer-col a` only had the #526 C35 sizing fix inside a mobile media query — desktop never cleared 24px. The terminal design's `.lt-footer-col a` never got the fix at all. Both now match `PlatformFooter`'s `.pf-footer-link` precedent.
- **Empty-field question** (`/scanner` 392, `/econ-calendar` 74, `/correlation` 50): investigated, no fix needed — all three are correct empty states (threshold gates, insufficient lookback data, unreleased events), not dead feeds.

## Why
QA's #559 consolidated conformance audit. Batched per the owner's explicit instruction: group related findings under one PR/deploy instead of shipping and verifying one small fix at a time.

## How to test (QA)
On the `qa` build with `?design=terminal` set, sweep every route below and confirm no `#1a7aff`/`#5aa3ff` blue remains anywhere (nav, chips, badges, diagonal cells): all 19 `*-term-wrap` routes (scanner, journal, alerts, news, calc, playbook, hours, research, econ, locked-card, upgrade-gate/modal, faq, terms, refund, upgrade, arena, briefing, liq) plus dashboard.

On `/funding` and `/correlation` in **light theme** (toggle both themes, both design modes): confirm the line charts render visible grey/black strokes and axis labels instead of near-invisible pale lines, and every coin's signal chip/diagonal-cell/exact-match highlight uses the active accent colour, not blue.

On scanner (or any of the 19 routes): confirm small circular markers — status dots, coin avatars — render as circles, not squares.

On any authenticated page's footer: confirm every link has a comfortable click area. On the landing page footer (logged out, `/`), same check at **desktop** width, not just mobile.

## Risk level
**Medium.** CSS/token/component changes across many shared files, covered by all 4 gates (lint 0 errors — down from 160 to 156 warnings, tsc clean, 434/434 tests, build clean) but the radius carve-out and canvas theme fix could not be visually verified locally.

**Deliberately out of scope**, flagged rather than silently dropped:
- Round icon buttons that aren't glyphs (`.tj-del-btn`, `.tj-edit-btn`, `.smod-close`, `.gchat-login-close`), loading spinners, and `.num` (26px, over the ruling's 24px step-circle line) — a judgment call for QA on the radius carve-out's exact boundary.
- A broader sweep found 17 files still referencing `1a7aff`/`5aa3ff` literals platform-wide beyond what's fixed here (alerts, arena, backtest, news, settings, several components). Worth a dedicated follow-up pass rather than expanding this batch further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
