### PR TITLE
fix(chart): empty-cell legibility, /liq radius wiring, terminal-light body bg

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2428,8 +2428,20 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 }
 
 [data-theme="light"] html { background: #E8EAED; }
-[data-theme="light"] body {
+/* #557 investigation (QA, terminal-light audit): unscoped, so terminal+light
+   pages rendered the current design's #E8EAED canvas instead of terminal's
+   own --bg0 (#f7f6f3) - close enough in hue that it went unnoticed visually,
+   caught only by exact-hex contrast measurement on /scanner. Split into two
+   rules rather than switching this one to var(--bg0), since --bg0 isn't
+   declared in the current design's own light block (only :root/dark and the
+   two terminal blocks are) - reading it there would fall through to root's
+   dark value and blacken the current design's light body. */
+[data-theme="light"]:not([data-design="terminal"]) body {
   background: #E8EAED;
+  background-attachment: fixed;
+}
+[data-design="terminal"][data-theme="light"] body {
+  background: var(--bg0);
   background-attachment: fixed;
 }
 [data-theme="light"] body::after { opacity: 0; }

--- a/app/liq/page.tsx
+++ b/app/liq/page.tsx
@@ -350,7 +350,7 @@ export default function LiqPage() {
   if (mode === 'terminal') return <LiqTerminal />;
 
   return (
-    <div className="liq-term-wrap">
+    <div>
       {/* Header */}
       <div style={{ padding: '1rem 0 0.75rem' }}>
         <h1 style={{ fontSize: 'var(--fs-section)', fontWeight: 700, color: 'var(--txt)', marginBottom: 2 }}>

--- a/components/CoinHeatmap.tsx
+++ b/components/CoinHeatmap.tsx
@@ -192,7 +192,7 @@ export default function CoinHeatmap() {
             border: '0.5px solid rgba(255,255,255,0.04)',
           }}>
             <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 800, color: 'var(--txt-dim)' }}>-</span>
-            <span style={{ fontSize: 'var(--fs-caption)', color: '#2a2a2a' }}>-</span>
+            <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)' }}>-</span>
             <span style={{ fontSize: 'var(--fs-label)', fontWeight: 700, color: 'var(--txt-dim)', lineHeight: 1 }}>-</span>
           </div>
         ))}

--- a/components/LiqTerminal.tsx
+++ b/components/LiqTerminal.tsx
@@ -336,7 +336,7 @@ export default function LiqTerminal() {
     : null;
 
   return (
-    <div>
+    <div className="liq-term-wrap">
       <div style={{ padding: '1rem 0 0.75rem' }}>
         <h1 style={{ fontSize: 'var(--fs-section)', fontWeight: 700, color: 'var(--txt)', marginBottom: 2 }}>
           {t('LIQ_TITLE')}


### PR DESCRIPTION
## Summary
Three items from QA's post-deploy audit on `7f0178d` (terminal light theme batch): the designer's ruling on the placeholder-dash colour, `/liq`'s remaining radius violations, and the `#e8eaed` background QA flagged on `/scanner` (checked before changing, per their request).

## What changed
- **Empty-cell dash legibility.** `CoinHeatmap.tsx`'s empty-cell dash was `#2a2a2a` (1.16:1, effectively invisible) instead of a token. Designer's ruling: use `--txt3` (4.9:1), not `--txt4` — an empty cell needs to read as "no data," not disappear, and `--txt4`'s job elsewhere (disabled labels, route strings) doesn't fit a value the user should notice is absent. Keeping the `-` character, not blanking it.
- **`/liq`'s 20 radius violations.** `.liq-term-wrap` (the class the existing C6 wildcard already targets) was wired to the **current design's** div in `app/liq/page.tsx`, not to `LiqTerminal.tsx`'s actual root — which had no wrap class at all. Same shape as the funding/correlation duplicate-file bug from #560: the CSS rule was correct, the terminal component just never carried the class that activates it. Moved the className to `LiqTerminal.tsx`'s root; removed the now-pointless one from the current-design branch (that div never renders under `[data-design="terminal"]`, so the rule could never have matched there).
- **Terminal+light's body background.** `[data-theme="light"] body` was an unconditional literal `#E8EAED` (the current design's canvas), never checking design mode — so terminal+light pages rendered the wrong background colour under any element without its own card background. QA found it via `/scanner`'s `scan-stat-lbl` sitting on `#e8eaed`, a colour outside the light terminal palette. Split into two rules: current design keeps the literal (`--bg0` isn't declared in its own light block, so switching to `var(--bg0)` there would've fallen through to `:root`'s dark value and blackened it), terminal+light gets `var(--bg0)` (`#f7f6f3`, already governed).

## Why
QA's audit on the terminal-light deploy, plus a designer ruling relayed through the same thread.

## How to test (QA)
On `qa` with `?design=terminal`, confirm a coin missing OI data on `/scanner` shows a legible grey `-` instead of a near-invisible one, in both themes. On `/liq` in terminal mode, confirm every panel/button/badge is square-cornered (radius 0), not rounded, in both themes. On `/scanner` in terminal light theme specifically, confirm the page background reads as the terminal's warm off-white (`#f7f6f3`), not the current design's cooler grey (`#e8eaed`) — easiest to spot side-by-side with `/dashboard` in the same mode.

## Risk level
**Low.** Four small, independently-verifiable changes. All 4 gates pass (22/22 conformance test, tsc clean, tests pass, build clean). Not visually verified locally — needs a `qa` deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
