### PR TITLE
fix(chart): #557 mobile overflow root cause, light --txt3 darkening

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4821,6 +4821,15 @@ body.landing {
 @media (max-width: 900px) { .pf-footer-grid { grid-template-columns: repeat(2, 1fr); } }
 @media (max-width: 640px) {
   .pf-footer-top { flex-direction: column; }
+  /* #557: this row's 7 links (min-width defaults to auto on a flex item,
+     and flex-shrink:0 above blocks shrinking too) refused to wrap even after
+     .pf-footer-top stacked it below the brand, so it alone forced the
+     document's layout width to 466px on a 390px viewport - the root cause
+     behind .app-bar/.nav-drawer also measuring 466 (position:fixed;left:0;
+     right:0 resolves against that inflated layout width, not the visual
+     viewport). Confirmed by bisection: hiding only this element restores
+     app-bar to exactly 390px, with .nav-drawer untouched. */
+  .pf-footer-nav { flex-wrap: wrap; row-gap: 8px; }
   .pf-footer-grid { grid-template-columns: 1fr; gap: 16px; }
   .pf-footer-bottom { flex-direction: column; align-items: flex-start; }
 }
@@ -5493,10 +5502,20 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
   --bdr3: #e2dfda;
   --txt:  #15181b;
   --txt2: #585c61;
-  --txt3: #6a6e73;
+  /* #559 second round: was #6a6e73 (5.14:1 on --bg0), the light-theme-
+     tokens.md figure - measured against the canvas, not the darkest
+     composited surface actually used (--bg2, tinted badge backgrounds).
+     Design's fix, QA-verified across all four observed surfaces (5.69 /
+     5.08 / 4.71 / 4.87) - clean, shipped. --green below is NOT: design's
+     #16752f (4.60:1 against #dee7e1) measures only 4.44:1 against --bg2,
+     which QA found is a surface this token demonstrably lands on
+     (liq-row-lev, scanner badges) - holding at the prior value pending
+     design's ruling on QA's #14702c candidate (5.75/4.72/4.92 across the
+     three surfaces checked). */
+  --txt3: #5e6266;
   --txt4: #aeaaa4;
   --accent: #8a5c00; /* 5.38:1 on --bg0 - darkened from dark theme's #d9a626, which measures 2.23:1 here */
-  --green:  #1a7f37; /* 4.70:1 on --bg0 */
+  --green:  #1a7f37; /* 4.70:1 on --bg0 - held per QA, see --txt3 comment above */
   --red:    #cf222e; /* 4.97:1 on --bg0 */
   --amber:  #9a6a00;
   --mark-idle:    #d1cec9;


### PR DESCRIPTION
## Summary
Fixes issue #557 (mobile shell overflow, present on every route in both design modes since before the terminal redesign) plus one of the light-theme token corrections from QA's follow-up audit.

## What changed
- **#557's root cause, empirically bisected against the live `qa` deploy** (not reasoned from source): `.pf-footer-nav` (the platform footer's 7-link nav row) had `flex-shrink:0` and no `flex-wrap`, so it never wrapped even after `.pf-footer-top` stacks vertically at the existing 640px breakpoint. Its own unwrapped width inflated the document's layout width — and because `.app-bar`/`.nav-drawer` are `position:fixed;left:0;right:0`, they resolve their own width against that inflated layout width instead of the true 390px visual viewport, making the whole shell nav read ~76-79px too wide on every route. Confirmed by hiding elements one at a time on the live page and re-measuring: hiding only `.pf-footer-nav` (with `.nav-drawer` untouched) drops `.app-bar` from 466px to exactly 390px. Added `flex-wrap` + `row-gap` at the existing breakpoint — turned out to need no navigation-architecture decision (hamburger/wrap/scroll) at all, just this one row wrapping.
- **Terminal light theme's `--txt3`**: was `#6a6e73` (5.14:1 on `--bg0`, the spec's original figure — the token's *best* case), which measured only 3.93-4.26:1 on the raised/composited surfaces it actually renders on. Design's fix, QA-verified against all four observed surfaces (5.69/5.08/4.71/4.87): `#5e6266`.

**Held, not shipped, both per QA's follow-up re-measurement against every surface each token lands on:**
- `--green` light's candidate `#16752f` clears design's own reference surface (4.60:1) but only 4.44:1 on `--bg2`, a surface this token demonstrably renders on (`liq-row-lev`, scanner badges). Staying at the prior `#1a7f37` pending a ruling on QA's `#14702c` candidate.
- The empty-cell dash's `--txt3` (dark, already shipped in #566) measures 4.30:1 on `/scanner`'s actual composited surface `#1d1e20` — below the same bar. Not touching `--txt3` dark platform-wide to fix one surface; flagged for design's call on a dedicated token.

## Why
#557 has been open since before this session's terminal work and predates the redesign entirely (current design overflows too) — worth fixing now that the actual cause is found and small. The `--txt3` fix is QA's verified value from their surface-by-surface audit.

## How to test (QA)
On `qa`, resize to 390px width on any route in either design mode and confirm no horizontal scroll — `.app-bar` should measure exactly the viewport width, not ~76px wider. On terminal light theme, confirm `--txt3` (secondary/meta text) reads clearly on raised card surfaces, not just the page canvas.

## Risk level
**Low.** One flex property, one hex value, both narrow and independently verifiable. The overflow fix was verified empirically against the live deploy before shipping. All 4 gates pass (22/22 conformance test, tsc clean, tests pass, build clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
