### PR TITLE
fix(chart): --green re-ruled to #14702c, dedicated --txt-dash token

### DIFF
--- a/__tests__/terminalTokens.test.mts
+++ b/__tests__/terminalTokens.test.mts
@@ -76,7 +76,7 @@ test('terminal design tokens', async (t) => {
     assert.equal(shipped, TERMINAL_FLAT_CELL.toLowerCase());
   });
 
-  await t.test('the block declares nothing outside the 17 documented tokens plus --flat-cell', () => {
+  await t.test('the block declares nothing outside the 18 documented tokens plus --flat-cell', () => {
     // Catches a token added to CSS and forgotten in terminalTokens.ts - the
     // mirror-image of the drift this file exists to prevent.
     const declared = [...block.matchAll(/(--[a-z][a-z0-9-]*):\s*#[0-9a-fA-F]{6}\s*;/g)]

--- a/app/globals.css
+++ b/app/globals.css
@@ -5505,17 +5505,23 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
   /* #559 second round: was #6a6e73 (5.14:1 on --bg0), the light-theme-
      tokens.md figure - measured against the canvas, not the darkest
      composited surface actually used (--bg2, tinted badge backgrounds).
-     Design's fix, QA-verified across all four observed surfaces (5.69 /
-     5.08 / 4.71 / 4.87) - clean, shipped. --green below is NOT: design's
-     #16752f (4.60:1 against #dee7e1) measures only 4.44:1 against --bg2,
-     which QA found is a surface this token demonstrably lands on
-     (liq-row-lev, scanner badges) - holding at the prior value pending
-     design's ruling on QA's #14702c candidate (5.75/4.72/4.92 across the
-     three surfaces checked). */
-  --txt3: #5e6266;
+     Design's ruling, QA-verified against all five observed surfaces:
+     --bg0 5.690, --bg1 5.075, --bg2 4.709, #dee7e1 4.868, #e8eaed 5.102.
+     Matches light-theme-tokens.md's literal exactly (#5e6267, not the
+     visually-identical #5e6266 an earlier round of this file shipped -
+     three decimal places apart in the contrast math, but globals.css and
+     the spec must not disagree on the literal or the next audit reads it
+     as drift). --green below went through two candidates before landing:
+     design's first #16752f cleared their own reference surface but only
+     4.44:1 on --bg2 (a surface it demonstrably lands on - liq-row-lev,
+     scanner badges); ruled #17702f instead, off QA's re-measurement
+     rather than design's own #14702c, verified against all four (5.73 /
+     5.11 / 4.70 / 4.92). light-theme-tokens.md is being restructured so
+     every token states its --bg2 figure, not just --bg0. */
+  --txt3: #5e6267;
   --txt4: #aeaaa4;
   --accent: #8a5c00; /* 5.38:1 on --bg0 - darkened from dark theme's #d9a626, which measures 2.23:1 here */
-  --green:  #1a7f37; /* 4.70:1 on --bg0 - held per QA, see --txt3 comment above */
+  --green:  #17702f; /* 4.70:1 on --bg2, the binding figure - see --txt3 comment above */
   --red:    #cf222e; /* 4.97:1 on --bg0 */
   --amber:  #9a6a00;
   --mark-idle:    #d1cec9;

--- a/app/globals.css
+++ b/app/globals.css
@@ -47,6 +47,15 @@
      semantic that sits beside --green and --red (squeeze direction, funding
      bias, EMA pass state) and should not read as tinted. */
   --txt-dim: #909090;
+  /* #559: the empty-cell "-" placeholder's own colour, not --txt3
+     (#7c828a) - that passes on --bg0/--bg1/--bg2 but only 4.30:1 on
+     /scanner's composited tile background #1d1e20. Design's ruling:
+     moving --txt3 dark to fix one composited edge case would be the same
+     "wrong surface" mistake in reverse, since --txt3 passes on three of
+     four surfaces already. Dedicated value instead - CoinHeatmap.tsx's
+     empty-cell dash only. Verified: 5.724/5.248/5.312/4.791 across
+     --bg0/--bg1/--bg2/#1d1e20. */
+  --txt-dash: #848a92;
 
   /* Borders - neutral white hairline, no indigo tint */
   --bdr:  rgba(255,255,255,0.08);
@@ -2359,6 +2368,10 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
      in issue #53: 190 of 882. AA on white/card/canvas/bg3/bg4:
      6.48/5.84/5.38/5.19/4.63 - clears the floor on every light surface. */
   --txt-dim: #5E5E5E;
+  /* #559: light was never flagged as failing for the empty-cell dash -
+     only dark's composited /scanner tile background was. Alias rather
+     than invent a second light value nobody measured a failure on. */
+  --txt-dash: var(--txt3);
   --bdr:  rgba(0,0,0,0.08);
   --bdr2: rgba(0,0,0,0.14);
 
@@ -5422,6 +5435,10 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
   --green-soft: var(--green);
   --red-soft:   var(--red);
   --txt-dim:    var(--txt2);
+  /* #559: same dedicated-value shape as :root's own --txt-dash (line ~50)
+     - terminal's --txt3 is the identical #7c828a literal, so the same
+     composited-surface failure applies here too. */
+  --txt-dash: #848a92;
   /* #546 C9: derived tints for --green/--red, same pattern as the already-
      existing --accent-bg/--accent-bdr. Undeclared here, .chg-up/.chg-dn's
      background/border (app/globals.css:786-787) fell through to the current
@@ -5511,17 +5528,19 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
      visually-identical #5e6266 an earlier round of this file shipped -
      three decimal places apart in the contrast math, but globals.css and
      the spec must not disagree on the literal or the next audit reads it
-     as drift). --green below went through two candidates before landing:
-     design's first #16752f cleared their own reference surface but only
-     4.44:1 on --bg2 (a surface it demonstrably lands on - liq-row-lev,
-     scanner badges); ruled #17702f instead, off QA's re-measurement
-     rather than design's own #14702c, verified against all four (5.73 /
-     5.11 / 4.70 / 4.92). light-theme-tokens.md is being restructured so
-     every token states its --bg2 figure, not just --bg0. */
+     as drift). --green below went through three candidates before
+     landing: design's first #16752f cleared their own reference surface
+     but only 4.44:1 on --bg2 (a surface it demonstrably lands on -
+     liq-row-lev, scanner badges); design provisionally ruled #17702f,
+     then re-ruled #14702c once QA argued --bg2 is the binding surface
+     rather than design's own reference #dee7e1 - verified against all
+     five (5.742 / 5.122 / 4.752 / 4.913 / 5.149). light-theme-tokens.md
+     is being restructured so every token states its --bg2 figure, not
+     just --bg0. */
   --txt3: #5e6267;
   --txt4: #aeaaa4;
   --accent: #8a5c00; /* 5.38:1 on --bg0 - darkened from dark theme's #d9a626, which measures 2.23:1 here */
-  --green:  #17702f; /* 4.70:1 on --bg2, the binding figure - see --txt3 comment above */
+  --green:  #14702c; /* 4.752:1 on --bg2, the binding figure - see --txt3 comment above */
   --red:    #cf222e; /* 4.97:1 on --bg0 */
   --amber:  #9a6a00;
   --mark-idle:    #d1cec9;
@@ -5549,8 +5568,11 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
   --green-soft: var(--green);
   --red-soft:   var(--red);
   --txt-dim:    var(--txt2);
-  --green-bg:  rgba(26,127,55,0.08);
-  --green-bdr: rgba(26,127,55,0.22);
+  --txt-dash:   var(--txt3); /* #559: light not flagged as failing, see :root's own comment */
+  /* rgb(20,112,44) = #14702c, kept in sync with --green above - these tints
+     went stale once already when --green moved from #1a7f37 without them. */
+  --green-bg:  rgba(20,112,44,0.08);
+  --green-bdr: rgba(20,112,44,0.22);
   --red-bg:    rgba(207,34,46,0.08);
   --red-bdr:   rgba(207,34,46,0.22);
   /* Unlike dark (--on-accent: var(--bg0), near-black on bright gold), light's

--- a/components/CoinHeatmap.tsx
+++ b/components/CoinHeatmap.tsx
@@ -192,7 +192,7 @@ export default function CoinHeatmap() {
             border: '0.5px solid rgba(255,255,255,0.04)',
           }}>
             <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 800, color: 'var(--txt-dim)' }}>-</span>
-            <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)' }}>-</span>
+            <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dash)' }}>-</span>
             <span style={{ fontSize: 'var(--fs-label)', fontWeight: 700, color: 'var(--txt-dim)', lineHeight: 1 }}>-</span>
           </div>
         ))}

--- a/lib/terminalTokens.ts
+++ b/lib/terminalTokens.ts
@@ -15,7 +15,7 @@
  * unchanged. The redesign opts in screen by screen.
  */
 
-/** The 17 documented colour tokens. Values are the README's, EXCEPT --bg1 and
+/** The 18 documented colour tokens. Values are the README's, EXCEPT --bg1 and
  *  --txt3 - see the amendment note below. */
 export const TERMINAL_COLORS = {
   '--bg0':          '#08090a',  // Canvas
@@ -53,6 +53,11 @@ export const TERMINAL_COLORS = {
      eight states using a bare literal instead of a token, undeclared in the
      terminal block, same governance shape as --amber above. */
   '--fr-slight-long': '#d4b483',
+  /* #559: the empty-cell dash's own colour - --txt3 passes on --bg0/-1/-2
+     but only 4.30:1 on the composited tile background CoinHeatmap.tsx's
+     placeholder actually renders on. Design's ruling: a dedicated value
+     for this one use, not a change to --txt3 itself. */
+  '--txt-dash': '#848a92',
 } as const;
 
 /* The seventeenth value: the FLAT cell in the hours expectancy grid.


### PR DESCRIPTION
## Summary
Two corrections QA caught during #567's review, after that PR had already merged — folded into this quick follow-up rather than left dangling.

## What changed
- **`--green` light re-ruled.** #567 shipped `#17702f`, design's provisional pick. Design then re-ruled `#14702c` once QA argued `--bg2` is the token's actual binding surface, not design's reference `#dee7e1`. Verified against all five observed surfaces: 5.742/5.122/4.752/4.913/5.149. Also fixed the terminal-light block's `--green-bg`/`--green-bdr` tints, which still referenced the *old* `--green`'s RGB numerically and would have silently gone stale a second time.
- **Empty-cell dash gets its own token.** Design ruled `--txt3` dark stays `#7c828a` everywhere — moving it to fix one composited surface (the em-dash's `/scanner` tile background) would repeat the exact "wrong surface" mistake the light-theme round just fixed, since `--txt3` already passes on three of four surfaces. New dedicated token, `--txt-dash`: `#848a92` in both dark contexts (root and terminal — same underlying `--txt3` literal, so the same failure applies to both; verified against `--bg0`/`-1`/`-2`/the composited `#1d1e20`: 5.724/5.248/5.312/4.791), aliased to `var(--txt3)` in both light contexts since light was never flagged as failing. `CoinHeatmap.tsx`'s placeholder dash now reads `var(--txt-dash)`. `lib/terminalTokens.ts` and the conformance test updated for the 18th token.

## Why
QA's #567 review found the relayed `--green` value was one message stale by the time it reached this session, and separately flagged that the em-dash fix (shipped in #566, `var(--txt3)`) measures only 4.30:1 on the actual composited surface it renders on.

## How to test (QA)
`/liq` and `/scanner` light-theme badges should read a very slightly different green than the last deploy. The empty-cell dash on `/scanner`'s heatmap should be legible in both dark contexts (terminal and current design) without any other micro-label's colour having moved.

## Risk level
**Low.** One value correction plus one new single-use token, both narrowly scoped. All 4 gates pass (22/22 conformance test — 18 tokens now, tsc clean, tests pass, lint clean, build clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
