### PR TITLE
fix(dashboard): scope health-grade badge tint alpha to theme on terminal light

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -461,6 +461,23 @@ body::after {
 .csb2-sig       { font-size: var(--fs-caption); font-weight: 700; padding: 1px 5px; border-radius: 4px; max-width: 130px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; background: rgba(255,255,255,0.02); }
 .csb2-bar-track { height: 3px; background: rgba(255,255,255,0.06); border-radius: 0 0 var(--radius-data) var(--radius-data); margin: 0 -10px; }
 .csb2-bar-fill  { height: 100%; border-radius: 0 0 var(--radius-data) var(--radius-data); transition: width 0.8s ease, background 0.3s; }
+/* #559 Bug 2, "the tint recipe": the health-grade badge backgrounds
+   color-mix the grade's own token toward transparent at 13.3%, composited
+   over --bg2. On dark that pulls the surface toward black while the text
+   stays light, so text and background diverge and contrast holds - same
+   shape as .csb2-sig above. Grades C and F use the two muted-grey tokens
+   (--txt2, --txt3), which are themselves mid-dark on light theme, so the
+   same mix pulls the surface toward the TEXT colour instead of away from
+   it and the gap the badge needs shrinks under it. Measured: 3.99:1 (C)
+   and 3.99:1 (F) on --bg2 at 13.3%, both clear 4.5:1 at 4%. Grades A/B/D
+   (amber/green/orange) aren't touched here - they clear the floor already,
+   and this is the alpha, not a token value, so it isn't design's Bug 1. */
+[data-design="terminal"][data-theme="light"] .csb2-health-badge.grade-c {
+  background: color-mix(in srgb, var(--txt2) 4%, transparent) !important;
+}
+[data-design="terminal"][data-theme="light"] .csb2-health-badge.grade-f {
+  background: color-mix(in srgb, var(--txt3) 4%, transparent) !important;
+}
 
 /* ── MARKET EVENTS STRIP ── */
 

--- a/components/DashboardTerminal.tsx
+++ b/components/DashboardTerminal.tsx
@@ -176,7 +176,7 @@ function TCoinSidebar() {
               <CoinIcon coin={id} size={18} color={badgeCol} bg={withAlpha(badgeCol, '24')} />
               <span className="csb2-name">{id.toUpperCase()}</span>
               {d?.price && (
-                <span style={{
+                <span className={`csb2-health-badge grade-${health.grade.toLowerCase()}`} style={{
                   fontSize: 'var(--fs-caption)', fontWeight: 800, lineHeight: 1,
                   padding: '2px 4px', borderRadius: 0,
                   color: health.color,


### PR DESCRIPTION
## Summary
- Fixes #559 Bug 2 ("the tint recipe") for the two composited surfaces QA verified failing: grade-C and grade-F health badges on `/dashboard` in terminal light theme.

## What changed
Both badges color-mix their own muted-grey token (`--txt2` for C, `--txt3` for F) into their background at 13.3% alpha - same recipe as every grade. On dark theme that pulls the surface toward black while badge text stays light, so contrast holds. On light theme those two tokens are themselves mid-dark, so the identical mix pulls the surface *toward* the text colour instead of away from it, and the badge fails contrast (measured 3.99:1 on `--bg2`, floor is 4.5:1).

Added `className="csb2-health-badge grade-${health.grade.toLowerCase()}"` to the badge span in `DashboardTerminal.tsx`, plus a theme-scoped CSS override in `app/globals.css` that drops the alpha to 4% for just grade-C and grade-F under `[data-design="terminal"][data-theme="light"]`. Verified 4.90:1 (C) and 4.51:1 (F) by hand against the WCAG contrast formula used all session for this token work.

Grades A/B/D (amber/green/orange) are untouched - they already clear the floor at 13.3%, and this is an alpha fix, not a token-value change. Amber/red base-hex corrections are QA's #559 Bug 1, design's call, tracked separately.

**Not in scope, flagged separately below:** `--orange` (grade D's token) is ungoverned in both terminal blocks - same bug class as the earlier `--amber` fix this session, but a value/governance decision, not mine to invent. Left the existing inline behavior alone for grade D.

`app/dashboard/page.tsx`'s own duplicate badge (the non-terminal branch, `mode !== 'terminal'`) is untouched - out of scope, that route only renders it when NOT in terminal mode, so it was never part of this audit.

## Why
QA's `token-surfaces.mjs` audit (desktop + mobile, both `c289017`) found this composited surface - `color(srgb 94 98 103 / 0.13)`, a span inside `.csb2-card` - as one of the light-theme "inherited the dark tint recipe" failures. Same severity on both viewports.

## How to test (QA)
On `liquidity-hq-qa.onrender.com` (once deployed), open `/dashboard?design=terminal`, switch to light theme via the theme toggle. Each coin row has a small boxed letter (A-F) health-grade badge next to the price. Grade C and F badges should read clearly against their background - no longer a barely-visible grey smear. Compare against pre-fix `qa` side by side if the difference isn't obvious at a glance. `qa/token-surfaces.mjs` should no longer flag this `.csb2-card` span.

## Risk level
Low. Two-file, CSS-alpha-only change scoped to `[data-design="terminal"][data-theme="light"]` plus one added className with no behavioral effect outside that selector. All 4 gates green (lint 0 errors, tsc clean, 437/437 tests, build clean).
