### PR TITLE
fix(correlation): cap heatmap tint alpha and use --txt so cell numbers stay readable

### DIFF
--- a/components/CorrelationTerminal.tsx
+++ b/components/CorrelationTerminal.tsx
@@ -63,22 +63,39 @@ function pearson(a: number[], b: number[]): number | null {
   return Math.max(-1, Math.min(1, num / denom));
 }
 
+/* #570: was a hardcoded rgba(52,211,153/248,113,113) ramp, uncapped up to
+   92-96% alpha, with --txt3 as the default text colour and --txt reserved
+   for |r| >= 0.8. Three bugs compounding: the hardcoded colour isn't
+   theme-aware, so the same ramp ran over a near-black card and a
+   near-white one; the text-colour switch sat far past where the tint
+   started mattering, so 2292 of 2368 dark failures were mid-band cells
+   still on --txt3; and at high alpha the tint itself gets bright/saturated
+   enough (worst measured 1.66:1) that not even --txt could save it - the
+   ramp had to stop short, not just change which token painted it.
+   var(--green)/var(--red) fixes theme-awareness for free (each already has
+   its own dark/light value). The 50%/65% caps are hand-verified against
+   the WCAG contrast formula: dark theme's --green crosses 4.5:1 against
+   --txt at ~60% alpha, light's at ~74% - 50% clears both with margin.
+   Red's two thresholds sit close together (~72-73% either theme) so 65%
+   covers both. Text is always --txt now; at the low end that's compositing
+   against a nearly-untinted card (4% alpha), which --txt already passes
+   everywhere else in the app. */
 function cellBg(r: number | null, diag: boolean): string {
   if (diag)     return 'var(--accent-bdr)';
   if (r == null) return 'rgba(255,255,255,0.03)';
   if (r > 0) {
     const t = Math.max(0, (r - 0.35) / 0.65);
-    const a = 0.04 + Math.pow(t, 2.2) * 0.92;
-    return `rgba(52,211,153,${a.toFixed(2)})`;
+    const pct = 4 + Math.pow(t, 2.2) * 46;
+    return `color-mix(in srgb, var(--green) ${pct.toFixed(1)}%, transparent)`;
   }
-  const a = 0.06 + Math.pow(Math.abs(r), 1.5) * 0.86;
-  return `rgba(248,113,113,${a.toFixed(2)})`;
+  const pct = 6 + Math.pow(Math.abs(r), 1.5) * 59;
+  return `color-mix(in srgb, var(--red) ${pct.toFixed(1)}%, transparent)`;
 }
 
 function cellColor(r: number | null, diag: boolean): string {
   if (diag) return 'var(--accent)';
   if (r == null) return 'var(--txt3)';
-  return Math.abs(r) >= 0.8 ? 'var(--txt)' : 'var(--txt3)';
+  return 'var(--txt)';
 }
 
 interface AltSig { labelKey: LabelKey; descKey: LabelKey | null; avg: number | null; color: string; bg: string; }


### PR DESCRIPTION
## Summary
- Fixes #570: `/correlation` heatmap cell numbers were unreadable against their own tint - dark theme worst case 1.66:1, 2368 of 2450 numeric cells below 4.5:1.

## What changed
`components/CorrelationTerminal.tsx`'s `cellBg`/`cellColor`: replaced the hardcoded `rgba(52,211,153,...)`/`rgba(248,113,113,...)` alpha ramp (uncapped, running to 92-96% alpha) with `color-mix(in srgb, var(--green)/var(--red) N%, transparent)`, so the tint is theme-aware for free. Capped the ramp at 50% (green) / 65% (red) instead of near-full saturation. Cell text is now always `var(--txt)` - dropped the `|r| >= 0.8` switch to `--txt3`, which was on the wrong side of the curve (2292 of 2368 dark failures were mid-band `--txt3` cells, not the rare high-|r| ones).

Caps are hand-verified against the WCAG contrast formula: dark `--green` crosses 4.5:1 against `--txt` at ~60% alpha, light's threshold is ~74% - 50% clears both with margin. Red's two theme thresholds sit close together (~72-73%) so 65% covers both.

## Why
QA's `token-surfaces.mjs` audit measured this composited surface directly (real cell background against real cell text) and found it as one defect repeated across a 50x49 matrix - not 2368 separate ones, per their own sizing note on #570.

## Scope
`components/CorrelationTerminal.tsx` only - the terminal-design component (`mode === 'terminal'` branch of `/correlation`). `app/correlation/page.tsx` has its own near-duplicate `cellBg`/`cellColor` for the non-terminal branch, out of scope - QA's audit ran under terminal design mode.

## How to test (QA)
On `liquidity-hq-qa.onrender.com` (once deployed), open `/correlation?design=terminal` in dark theme. Cells in the 0.6-0.9 correlation band should read clearly instead of nearly vanishing into the green tint. Repeat in light theme - should clear 4.5:1 outright now. The heatmap will look visibly less saturated at the extremes than before (old ramp hit ~96% alpha, near-solid color) - that's the fix working, not a regression.

## Risk level
Low-Med. Single-file, contained to the heatmap's cell styling function. Visual character change at the high-correlation end (less saturated) is expected and intentional, not a bug. All 4 gates green (lint 0 errors, tsc clean, 437/437 tests, build clean). Route has no design frame yet per #570 - QA/design may revise the ramp later; this fixes readability now per QA's explicit call to proceed ahead of that.
