### PR TITLE
fix(terminal): move --amber and --red light to design's contrast-verified values

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5580,8 +5580,21 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
   --txt4: #aeaaa4;
   --accent: #8a5c00; /* 5.38:1 on --bg0 - darkened from dark theme's #d9a626, which measures 2.23:1 here */
   --green:  #14702c; /* 4.752:1 on --bg2, the binding figure - see --txt3 comment above */
-  --red:    #cf222e; /* 4.97:1 on --bg0 */
-  --amber:  #9a6a00;
+  /* #559: was #cf222e (4.97:1 on --bg0 only - the canvas figure, not the
+     binding one, same gap that dropped --txt3 and --green here before
+     design started requiring a per-token surface figure). QA verified
+     #9d1a23 against every surface --red is observed on: worst 4.52:1 on
+     #c6c1be, every other surface higher. Design accepted the trade
+     explicitly - a duller alert red that passes everywhere over a vivid
+     one that failed 23 of 28 places it's actually used. */
+  --red:    #9d1a23;
+  /* #559: was #9a6a00, shipped with no contrast figure at all - the actual
+     cause it went unmeasured on every surface this long. #755100 verified
+     by QA against every surface --amber is observed on: worst 4.51:1 on
+     #cfcdca, every other surface higher. Design's ruling, no more waiting
+     on the tint fix - it never touched these surfaces, and --amber had
+     zero passing surfaces before this. */
+  --amber:  #755100;
   --mark-idle:    #d1cec9;
   --border-input: #75797e;
 


### PR DESCRIPTION
## Summary
- Fixes #559: `--amber` light had zero passing observed surfaces, `--red` light failed 23 of 28. Design ruled new values after QA verified each against every surface the token is actually observed on.

## What changed
`app/globals.css`, terminal-light token block, pure value changes:
- `--amber: #9a6a00` → `#755100`
- `--red: #cf222e` → `#9d1a23`

Both now carry a contrast comment stating binding figure + surface, matching `--txt3`/`--green`'s existing comments. `--amber` never had one before - a contributing cause it shipped unmeasured this long.

## Why
Both were originally measured against `--bg0` (canvas) only, never the darker composited surfaces they actually render on - same gap #526 already closed for `--txt3`/`--green`. QA verified the new values against every observed surface: `--amber` worst 4.51:1 on `#cfcdca`, `--red` worst 4.52:1 on `#c6c1be`, every other surface higher for both. Design accepted the red trade explicitly - duller but passes everywhere, vs. vivid but failing in 23 of 28 places it's used.

## Not touched
`--accent` light (8/17 failing) and `--txt-dash` light - both still with design, separate rulings in progress.

## How to test (QA)
On `qa` (once deployed), any route with amber/red status text in light theme, both design modes. Colors will read visibly less saturated - duller gold, duller red - that's the fix, not a regression. Dark theme unaffected (light block only).

## Risk level
Low-Med. Value-only change to two widely-used tokens; visual character shift is intentional per design's ruling. All 4 gates green.
