### PR TITLE
fix(terminal): give --txt-dash light its own value instead of aliasing --txt3

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5620,7 +5620,16 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
   --green-soft: var(--green);
   --red-soft:   var(--red);
   --txt-dim:    var(--txt2);
-  --txt-dash:   var(--txt3); /* #559: light not flagged as failing, see :root's own comment */
+  /* #559: was var(--txt3) - "light not flagged as failing" at the time this
+     alias shipped. It was flagged next round: 3 of 9 observed surfaces
+     failed, worst 3.52:1, because aliasing meant --txt-dash could never be
+     darker than --txt3 lets it be for THAT token's own uses. Same shape as
+     dark theme's --txt-dash (line ~50): a dedicated value for this one use,
+     not a change to the shared token. #4f5257 clears all nine observed
+     surfaces - worst 4.50:1 on #c6c4c0, 5.40/5.49 on the two that were
+     failing, 5.94+ on the rest. --txt3 itself is unchanged - #5e6267,
+     still governs every other muted-text use in light. */
+  --txt-dash:   #4f5257;
   /* rgb(20,112,44) = #14702c, kept in sync with --green above - these tints
      went stale once already when --green moved from #1a7f37 without them. */
   --green-bg:  rgba(20,112,44,0.08);


### PR DESCRIPTION
## Summary
- Fixes #559: `--txt-dash` light aliased `--txt3`, failing 3 of 9 observed surfaces at worst 3.52:1.

## What changed
`app/globals.css`, terminal-light block: `--txt-dash: var(--txt3)` → `--txt-dash: #4f5257`, a dedicated value. `--txt3` itself unchanged (`#5e6267`).

## Why
Aliasing shipped on the assumption light "wasn't flagged as failing" - it was, next round. An alias means `--txt-dash` can never be darker than whatever `--txt3`'s own uses need it to be. Design ruled `#4f5257`, QA-verified against all nine observed surfaces: worst 4.50:1 (was 3.52), 5.94+ on the rest.

Also worth noting for future sweeps: while both tokens shared a hex, QA's per-token audit couldn't distinguish a `--txt-dash` failure from a `--txt3` failure on the same value - two of the three originally-reported `--txt-dash` failures were actually `--txt3` uses. Splitting the values restores real attribution.

## Scope
Terminal-light block only. Current-design's own `--txt-dash` alias (`app/globals.css:2413`) untouched - separate, older token history, outside #559's scope.

## Not touched
`--accent` light (8/17 failing) - still with design.

## How to test (QA)
On `qa` (once deployed), `/dashboard` or `/liq` in light theme - the empty-cell dash placeholder should read clearly. Subtle visual change, not dramatic like amber/red.

## Risk level
Low. Single value change to one dedicated token, all 4 gates green.
