### PR TITLE
fix(whale-trades): tokenize buy/sell cyan and orange to --green/--red

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3163,8 +3163,8 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 /* bias bar */
 .wf-bias-wrap   { display: flex; height: 3px; background: var(--bg3); }
 .wf-bias-bar    { height: 100%; transition: width .6s ease; }
-.wf-bias-buy    { background: #22d3ee; }
-.wf-bias-sell   { background: #f97316; }
+.wf-bias-buy    { background: var(--green); }
+.wf-bias-sell   { background: var(--red); }
 .wf-bias-label  { padding: 6px 14px 8px; font-size: var(--fs-label); font-weight: 600; border-bottom: 0.5px solid var(--bdr); }
 
 /* feed list */
@@ -3174,8 +3174,8 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .wf-row-big     { background: rgba(255,255,255,.025); }
 .wf-row-coin    { font-size: var(--fs-caption); font-weight: 800; }
 .wf-row-side    { font-size: var(--fs-caption); font-weight: 700; letter-spacing: .04em; }
-.wf-row-side-buy  { color: #22d3ee; }
-.wf-row-side-sell { color: #f97316; }
+.wf-row-side-buy  { color: var(--green); }
+.wf-row-side-sell { color: var(--red); }
 .wf-row-usd     { font-size: var(--fs-label); font-weight: 700; font-variant-numeric: tabular-nums; }
 .wf-row-price   { font-size: var(--fs-data); color: var(--txt3); font-variant-numeric: tabular-nums; }
 .wf-row-time    { font-size: var(--fs-caption); color: var(--txt3); text-align: right; font-variant-numeric: tabular-nums; }

--- a/components/WhaleTradesFeed.tsx
+++ b/components/WhaleTradesFeed.tsx
@@ -135,12 +135,12 @@ export default function WhaleTradesFeed() {
       <div className="wf-stats">
         <div className="wf-stat">
           <span className="wf-stat-lbl">{t('WHALE_TRADES_FEED_STAT_BUYS')}</span>
-          <span className="wf-stat-val" style={{ color: '#22d3ee' }}>{fmtUSD(stats.buyUsd)}</span>
+          <span className="wf-stat-val" style={{ color: 'var(--green)' }}>{fmtUSD(stats.buyUsd)}</span>
         </div>
         <div className="wf-stat-sep" />
         <div className="wf-stat" style={{ textAlign: 'center' }}>
           <span className="wf-stat-lbl">{t('WHALE_TRADES_FEED_STAT_NET_FLOW')}</span>
-          <span className="wf-stat-val" style={{ color: netFlow >= 0 ? '#22d3ee' : '#f97316' }}>
+          <span className="wf-stat-val" style={{ color: netFlow >= 0 ? 'var(--green)' : 'var(--red)' }}>
             {netFlow >= 0 ? '+' : ''}{fmtUSD(Math.abs(netFlow))}
             <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt-dim)', marginLeft: 3 }}>
               {netFlow >= 0 ? '↑' : '↓'}
@@ -150,7 +150,7 @@ export default function WhaleTradesFeed() {
         <div className="wf-stat-sep" />
         <div className="wf-stat" style={{ textAlign: 'right' }}>
           <span className="wf-stat-lbl">{t('WHALE_TRADES_FEED_STAT_SELLS')}</span>
-          <span className="wf-stat-val" style={{ color: '#f97316' }}>{fmtUSD(stats.sellUsd)}</span>
+          <span className="wf-stat-val" style={{ color: 'var(--red)' }}>{fmtUSD(stats.sellUsd)}</span>
         </div>
       </div>
 
@@ -163,8 +163,8 @@ export default function WhaleTradesFeed() {
       )}
       {totalUsd > 0 && (
         <div className="wf-bias-label">
-          {netBull && <span style={{ color: '#22d3ee' }}>{t('WHALE_TRADES_FEED_BIAS_NET_BUY')}</span>}
-          {netBear && <span style={{ color: '#f97316' }}>{t('WHALE_TRADES_FEED_BIAS_NET_SELL')}</span>}
+          {netBull && <span style={{ color: 'var(--green)' }}>{t('WHALE_TRADES_FEED_BIAS_NET_BUY')}</span>}
+          {netBear && <span style={{ color: 'var(--red)' }}>{t('WHALE_TRADES_FEED_BIAS_NET_SELL')}</span>}
           {!netBull && !netBear && <span style={{ color: 'var(--txt3)' }}>{t('WHALE_TRADES_FEED_BIAS_BALANCED')}</span>}
         </div>
       )}
@@ -197,7 +197,7 @@ export default function WhaleTradesFeed() {
           const isBuy  = trade.side === 'BUY';
           const isMega = trade.usd >= MEGA_USD;
           const isBig  = trade.usd >= BIG_USD;
-          const accent = isBuy ? '#22d3ee' : '#f97316';
+          const accent = isBuy ? 'var(--green)' : 'var(--red)';
           const badge  = isMega ? t('WHALE_TRADES_FEED_BADGE_MEGA') : isBig ? t('WHALE_TRADES_FEED_BADGE_WHALE') : trade.side;
 
           return (


### PR DESCRIPTION
## Summary
- Fixes #559/#572's WhaleTradesFeed finding: `.wf-stat-val` and related buy/sell colors were bare hex (`#22d3ee` cyan, `#f97316` orange) with zero theme adaptation - QA measured 1.73:1 and 2.69:1 against a light-theme surface, both design modes (an inline style beats every stylesheet, so no theme block could reach them).

## What changed
6 inline styles in `components/WhaleTradesFeed.tsx` + 4 CSS declarations in `app/globals.css` (`.wf-bias-buy/sell`, `.wf-row-side-buy/sell`) - all replaced with `var(--green)`/`var(--red)`.

Not a new color pair: this same component already had a governed instance of the identical semantic sitting right next to the ungoverned one - `.wf-dot-live`/`.wf-dot-error` already use `var(--green)`/`var(--red)` for connection status. Tokenizing the rest to match removes an inconsistency within this one file, reuses values already contrast-verified across all four theme/design combos this session, rather than asking design to verify a third color pair.

Component isn't design-mode-scoped (no `[data-design="terminal"]` prefix anywhere in it), so `var(--green)`/`var(--red)` resolve correctly in both design modes without extra scoping.

## How to test (QA)
On `qa` (once deployed), the whale trades feed in light theme, both design modes. Buy-side reads standard green, sell-side standard red - previously cyan/orange, that's the intended visual change. Dark theme: green/red at similar visual weight to the old cyan/orange, not a dramatic shift.

## Risk level
Low. Straightforward tokenization reusing already-verified values, all 4 gates green.
