### PR TITLE
fix(terminal): move --accent light to design's contrast-verified value

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5578,7 +5578,18 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
      just --bg0. */
   --txt3: #5e6267;
   --txt4: #aeaaa4;
-  --accent: #8a5c00; /* 5.38:1 on --bg0 - darkened from dark theme's #d9a626, which measures 2.23:1 here */
+  /* #559: was #8a5c00 (5.38:1 on --bg0 only - the canvas figure, not the
+     binding one; same --bg0-only gap that dropped --txt3/--green/--red/
+     --amber here before design required a per-token surface figure).
+     Failed 8 of 17 observed surfaces. QA verified #754e00 against all 17:
+     worst 4.55:1 on #d6cab3 (the /correlation diagonal), 4.77 /liq LIVE
+     tag, 4.99 /briefing, 5.20+ on the rest, --bg0 6.83, --bg1 6.09.
+     Design accepted the trade explicitly - fixing the 8 failing surfaces
+     individually was real scope for a marginal gain over one token move,
+     and a brand colour that fails 8 of 17 places it's used isn't holding
+     its job. Visible effect: darker accent chrome (buttons, links) across
+     every light-theme route - intended, not a regression. */
+  --accent: #754e00;
   --green:  #14702c; /* 4.752:1 on --bg2, the binding figure - see --txt3 comment above */
   /* #559: was #cf222e (4.97:1 on --bg0 only - the canvas figure, not the
      binding one, same gap that dropped --txt3 and --green here before


### PR DESCRIPTION
## Summary
- Fixes #559, the last of four light-token moves: `--accent` failed 8 of 17 observed surfaces, worst 4.55:1.

## What changed
`app/globals.css`, terminal-light block, pure value change: `--accent: #8a5c00` → `#754e00`. Contrast comment now states binding figure + surface, matching the other three moves.

## Why
Old value's only recorded figure was `--bg0`-only (5.38:1) - the same class of gap that dropped every other light token before design required a per-surface number. QA verified `#754e00` against all 17 observed surfaces: worst 4.55:1 on `#d6cab3` (the `/correlation` diagonal), 4.77 `/liq`'s LIVE tag, 4.99 `/briefing`, 5.20+ on the rest.

Design considered fixing the 8 failing surfaces individually instead and rejected it - real scope for a marginal 3.5% gain over one token move, and a brand color failing 8/17 places it's used isn't holding its job.

`--accent-2`/`--accent-solid`/`--accent-bg`/`--accent-bdr`/`--accent-dim` all alias or derive from `--accent` already (`app/globals.css:5563-5570`) - they inherit the new value automatically, no separate edit needed.

## How to test (QA)
On `qa` (once deployed), any light-theme route with accent chrome - buttons, links, active nav, the LIVE tags on `/arena`/`/liq`, the `/correlation` diagonal. Expect visibly darker gold/brown everywhere - intended, the widest-reaching of the four token moves (30+ surfaces).

## Risk level
Med. Highest-visibility of the four token changes - touches brand color across every light-theme route. Value change only, all 4 gates green, verified by design + QA before merging.
