### PR TITLE
fix(dashboard): zero the 8 remaining C8 radii, tokenize barCol, fix impact chip alpha

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -165,7 +165,7 @@ function CoinSidebar() {
           else                   sig = { text: t('DASH_SIDEBAR_SIG_FUNDING_NEUTRAL'),         col: 'var(--txt3)' };
         }
 
-        const barCol = tbp >= 60 ? 'var(--green)' : tbp <= 40 ? 'var(--red)' : '#404040';
+        const barCol = tbp >= 60 ? 'var(--green)' : tbp <= 40 ? 'var(--red)' : 'var(--txt3)';
 
         return (
           // Plain flat card - was ParticleCard/mb-glow-card, which drew a

--- a/app/globals.css
+++ b/app/globals.css
@@ -6601,6 +6601,19 @@ main.app-content[data-chrome="none"] {
 [data-design="terminal"] .csb2-sig      { border-radius: 0; }
 [data-design="terminal"] .csb2-bar-track,
 [data-design="terminal"] .csb2-bar-fill { border-radius: 0; }
+/* #559 C8: the rest of dashboard's rectangular pixel-radii, found by QA's
+   full-page sweep rather than by route inspection - MarketRead and SOTD sit
+   in the dashboard rail but aren't dashboard-specific components, so they'd
+   been missed by every audit scoped to "dashboard's own classes". */
+[data-design="terminal"] .mr-track,
+[data-design="terminal"] .mr-fill          { border-radius: 0; }
+[data-design="terminal"] .sotd-static-badge,
+[data-design="terminal"] .sotd-refresh     { border-radius: 0; }
+[data-design="terminal"] .consent-btn      { border-radius: 0; }
+[data-design="terminal"] .psc-verdict-pill { border-radius: 0; }
+[data-design="terminal"] .vr-hv-track,
+[data-design="terminal"] .vr-hv-track > *  { border-radius: 0; }
+[data-design="terminal"] .ecw-impact-chip  { border-radius: 0; }
 /* briefing */
 [data-design="terminal"] .mb-macro-item { border-radius: 0; }
 [data-design="terminal"] .mb-event-tag  { border-radius: 0; }

--- a/components/DashboardTerminal.tsx
+++ b/components/DashboardTerminal.tsx
@@ -164,7 +164,7 @@ function TCoinSidebar() {
           else                   sig = { text: t('DASH_SIDEBAR_SIG_FUNDING_NEUTRAL'),        col: 'var(--txt3)' };
         }
 
-        const barCol = tbp >= 60 ? 'var(--green)' : tbp <= 40 ? 'var(--red)' : '#404040';
+        const barCol = tbp >= 60 ? 'var(--green)' : tbp <= 40 ? 'var(--red)' : 'var(--txt3)';
 
         return (
           <div

--- a/components/EconCalendarWidget.tsx
+++ b/components/EconCalendarWidget.tsx
@@ -6,6 +6,7 @@ import { useLabels } from '@/lib/labels';
 import type { LabelKey } from '@/lib/labelKeys';
 import { getAuthToken } from '@/lib/supabase';
 import { econImpactKey, type EconImpact } from '@/lib/classify';
+import { withAlpha } from '@/lib/color';
 
 type CalEvent = {
   name: string; type: string; isoDate: string; impact: string;
@@ -140,9 +141,9 @@ export default function EconCalendarWidget() {
               <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt)', fontWeight: 500, flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                 {e.name}
               </span>
-              <span style={{
+              <span className="ecw-impact-chip" style={{
                 fontSize: 'var(--fs-micro)', fontWeight: 700, letterSpacing: '.03em', padding: '2px 6px', borderRadius: 4,
-                color: col, background: `${col}22`, flexShrink: 0,
+                color: col, background: withAlpha(col, '22'), flexShrink: 0,
               }}>
                 {e.impact}
               </span>

--- a/components/PerpSpotCard.tsx
+++ b/components/PerpSpotCard.tsx
@@ -66,7 +66,7 @@ export default function PerpSpotCard() {
         Perps vs Spot · {coin.toUpperCase()}
       </div>
 
-      <div style={{
+      <div className="psc-verdict-pill" style={{
         display: 'inline-flex', alignItems: 'center', gap: 5, padding: '3px 10px',
         borderRadius: 20, marginBottom: 8,
         background: `color-mix(in srgb, ${tone} 12%, transparent)`,

--- a/components/VolatilityRegime.tsx
+++ b/components/VolatilityRegime.tsx
@@ -112,7 +112,7 @@ function HVRow({ label, data }: { label: string; data: LoadState }) {
            this puts every marker at a position meaning a different value -
            rendering perfectly and lying. Explicit rather than inherited, so
            it stays true when the document direction changes. */}
-      <div dir="ltr" style={{ position: 'relative', height: 5, borderRadius: 3, background: 'rgba(255,255,255,0.06)', overflow: 'visible' }}>
+      <div dir="ltr" className="vr-hv-track" style={{ position: 'relative', height: 5, borderRadius: 3, background: 'rgba(255,255,255,0.06)', overflow: 'visible' }}>
         {/* Low zone (0–20%) */}
         <div style={{ position: 'absolute', left: 0, width: '20%', height: '100%', background: 'rgba(52,211,153,0.2)', borderRadius: '3px 0 0 3px' }} />
         {/* High zone (80–100%) */}


### PR DESCRIPTION
## Summary
- Fixes #559's dashboard C8 (8 rectangular radius shapes) and C9 (`#404040` neutral) findings from QA's full-page sweep. Also fixes a real rendering bug found while in the file: the econ calendar impact chip's background has never rendered on any build.

## What changed

**C8 - radius, all get `border-radius:0` under terminal:**
`.mr-fill`/`.mr-track` (MarketRead), `.sotd-static-badge`/`.sotd-refresh` (SOTD), `.consent-btn` (CookieConsent), `.psc-verdict-pill` (PerpSpotCard - new className, was inline-styled with no hook), `.vr-hv-track` (VolatilityRegime - same), `.ecw-impact-chip` (EconCalendarWidget - same). None of these are "dashboard" named components - they're rail widgets shared across routes, which is why a route-scoped read missed them.

**C9 - neutral color:** `barCol`'s mid-range case was bare `#404040` in both `app/dashboard/page.tsx:168` and `components/DashboardTerminal.tsx:167` (duplicate code, same literal). Tokenized to `var(--txt3)`.

**Real bug found in the same file:** `EconCalendarWidget`'s impact chip built its background as `` `${col}22` `` where `col` is `var(--red)`/`var(--amber)`/`var(--txt2)` - producing the invalid CSS string `"var(--red)22"`. A var() reference can't have characters appended outside a function; the browser silently drops the whole declaration. The chip's tinted background has been transparent on every build regardless of impact level - not a design choice, a parse failure. Replaced with `withAlpha(col, '22')`, the existing helper already used 129 other places for this exact purpose. Fixes all three impact levels (HIGH/MEDIUM/LOW share the code path).

## Why
QA's dashboard C8/C9 sweep against `29668a4`→`536510e`, cross-referenced against the rendered page (not just source), with exact classes/sizes/counts per finding.

## How to test (QA)
On `qa` (once deployed), `/dashboard`, both themes: the 7 named UI elements should have square corners. The econ calendar preview's impact chips should show a faint color-tinted background behind the HIGH/MEDIUM/LOW text - new correct behavior, not a regression, since it never rendered before.

## Risk level
Low. All 4 gates green. Batches with #582 (already on `dev`) for one qa deploy per QA's request.
