### PR TITLE
fix(dashboard): stop inline radius from beating the terminal class override, fix last 3 C8 shapes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6610,10 +6610,31 @@ main.app-content[data-chrome="none"] {
 [data-design="terminal"] .sotd-static-badge,
 [data-design="terminal"] .sotd-refresh     { border-radius: 0; }
 [data-design="terminal"] .consent-btn      { border-radius: 0; }
+/* #559: these three classes exist ONLY to give a terminal selector a hook -
+   the elements are not design-mode-scoped in JS, so the base (current-
+   design) radius has to live here as an unscoped rule, not stay inline,
+   or the inline declaration keeps winning over the terminal override the
+   same way it did before this comment: a class selector cannot beat an
+   inline style at equal-or-lower specificity, so "add the class" alone
+   does nothing while the inline property is still there to win. Base
+   values match what was previously inline, so current design is
+   pixel-identical to before; only terminal's override actually changes. */
+.psc-verdict-pill  { border-radius: 20px; }
+.ecw-impact-chip   { border-radius: 4px; }
+.vr-hv-zone-low    { border-radius: 3px 0 0 3px; }
+.vr-hv-zone-high   { border-radius: 0 3px 3px 0; }
+.vr-hv-track       { border-radius: 3px; }
+.mcw-rsi-track,
+.mcw-rsi-fill,
+.mcw-ls-bar        { border-radius: 3px; }
 [data-design="terminal"] .psc-verdict-pill { border-radius: 0; }
 [data-design="terminal"] .vr-hv-track,
 [data-design="terminal"] .vr-hv-track > *  { border-radius: 0; }
 [data-design="terminal"] .ecw-impact-chip  { border-radius: 0; }
+[data-design="terminal"] .mcw-rsi-track,
+[data-design="terminal"] .mcw-rsi-fill,
+[data-design="terminal"] .mcw-ls-bar,
+[data-design="terminal"] .mcw-ls-bar > *   { border-radius: 0; }
 /* briefing */
 [data-design="terminal"] .mb-macro-item { border-radius: 0; }
 [data-design="terminal"] .mb-event-tag  { border-radius: 0; }

--- a/components/EconCalendarWidget.tsx
+++ b/components/EconCalendarWidget.tsx
@@ -142,7 +142,7 @@ export default function EconCalendarWidget() {
                 {e.name}
               </span>
               <span className="ecw-impact-chip" style={{
-                fontSize: 'var(--fs-micro)', fontWeight: 700, letterSpacing: '.03em', padding: '2px 6px', borderRadius: 4,
+                fontSize: 'var(--fs-micro)', fontWeight: 700, letterSpacing: '.03em', padding: '2px 6px',
                 color: col, background: withAlpha(col, '22'), flexShrink: 0,
               }}>
                 {e.impact}

--- a/components/MarketConditionsWidget.tsx
+++ b/components/MarketConditionsWidget.tsx
@@ -163,9 +163,9 @@ export default function MarketConditionsWidget() {
             {rsi != null ? rsi.toFixed(1) : '-'} {rsi != null && `· ${rsiLabel}`}
           </span>
         </div>
-        <div style={{ height: 5, borderRadius: 3, background: 'var(--bg3)', position: 'relative', overflow: 'hidden' }}>
+        <div className="mcw-rsi-track" style={{ height: 5, background: 'var(--bg3)', position: 'relative', overflow: 'hidden' }}>
           {rsi != null && (
-            <div style={{ position: 'absolute', inset: 0, width: `${Math.min(100, rsi)}%`, background: rsiCol, borderRadius: 3 }} />
+            <div className="mcw-rsi-fill" style={{ position: 'absolute', inset: 0, width: `${Math.min(100, rsi)}%`, background: rsiCol }} />
           )}
         </div>
       </div>
@@ -181,7 +181,7 @@ export default function MarketConditionsWidget() {
           const shortPct = 100 - longPct;
           return (
             <>
-              <div style={{ display: 'flex', height: 5, borderRadius: 3, overflow: 'hidden', marginBottom: 5 }}>
+              <div className="mcw-ls-bar" style={{ display: 'flex', height: 5, overflow: 'hidden', marginBottom: 5 }}>
                 {/* Was hardcoded Tailwind emerald-400/red-400 (#546 C9) - off
                     the terminal palette, and mismatched the labels below,
                     which already used the real tokens. */}

--- a/components/PerpSpotCard.tsx
+++ b/components/PerpSpotCard.tsx
@@ -68,7 +68,7 @@ export default function PerpSpotCard() {
 
       <div className="psc-verdict-pill" style={{
         display: 'inline-flex', alignItems: 'center', gap: 5, padding: '3px 10px',
-        borderRadius: 20, marginBottom: 8,
+        marginBottom: 8,
         background: `color-mix(in srgb, ${tone} 12%, transparent)`,
         border: `0.5px solid color-mix(in srgb, ${tone} 40%, transparent)`,
       }}>

--- a/components/VolatilityRegime.tsx
+++ b/components/VolatilityRegime.tsx
@@ -112,11 +112,11 @@ function HVRow({ label, data }: { label: string; data: LoadState }) {
            this puts every marker at a position meaning a different value -
            rendering perfectly and lying. Explicit rather than inherited, so
            it stays true when the document direction changes. */}
-      <div dir="ltr" className="vr-hv-track" style={{ position: 'relative', height: 5, borderRadius: 3, background: 'rgba(255,255,255,0.06)', overflow: 'visible' }}>
+      <div dir="ltr" className="vr-hv-track" style={{ position: 'relative', height: 5, background: 'rgba(255,255,255,0.06)', overflow: 'visible' }}>
         {/* Low zone (0–20%) */}
-        <div style={{ position: 'absolute', left: 0, width: '20%', height: '100%', background: 'rgba(52,211,153,0.2)', borderRadius: '3px 0 0 3px' }} />
+        <div className="vr-hv-zone-low" style={{ position: 'absolute', left: 0, width: '20%', height: '100%', background: 'rgba(52,211,153,0.2)' }} />
         {/* High zone (80–100%) */}
-        <div style={{ position: 'absolute', left: '80%', width: '20%', height: '100%', background: 'rgba(248,113,113,0.2)', borderRadius: '0 3px 3px 0' }} />
+        <div className="vr-hv-zone-high" style={{ position: 'absolute', left: '80%', width: '20%', height: '100%', background: 'rgba(248,113,113,0.2)' }} />
         {/* Marker dot */}
         <div style={{
           position: 'absolute', top: '50%', transform: 'translate(-50%, -50%)',


### PR DESCRIPTION
## Summary
- Fixes #559 C8: QA's re-sweep found the className hooks from #583 present and correctly scoped, but the elements still had their original radius - inline `border-radius` beats a class selector, and I'd left it in the inline style object alongside the new hook. Also fixes the 3 remaining C8 shapes QA located (MarketConditionsWidget's RSI track/fill and long/short bar).

## What changed
For each affected element (`.psc-verdict-pill`, `.ecw-impact-chip`, and three new hooks in `MarketConditionsWidget.tsx`): removed `border-radius` from the inline style object, added the pre-existing radius value as an unscoped base CSS rule (so current design - not design-mode-scoped in JS for any of these - stays pixel-identical), kept the `[data-design="terminal"]` override, which can now actually win since nothing outranks it.

Also noted: `VolatilityRegime.tsx`'s `.vr-hv-track` fix from #583 was confirmed **not** the element QA originally meant by "277x5/127x5 bars" - flagged as an unconfirmed inference at the time, now disconfirmed. Left it in - it's a real terminal-radius gap on its own merits, just not the one being chased. The actual elements were `MarketConditionsWidget`'s RSI bar.

## Why
QA's dashboard C8 sweep against `e29132d`.

## How to test (QA)
On `qa` (once deployed), `/dashboard`, terminal mode, both themes - the FUTURES LEADING pill, econ calendar impact chips, and the RSI/long-short bars in Market Conditions should have square corners. `?design=current` should look unchanged - that's what the base rules exist to guarantee.

## Risk level
Low. All 4 gates green.
