### PR TITLE
fix(c9): tokenize hardcoded white text to var(--on-accent)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3863,7 +3863,12 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   background: var(--accent-solid);
   border-color: transparent;
   box-shadow: 0 4px 20px rgba(0,82,204,0.22), 0 1px 4px rgba(0,0,0,0.10);
-  color: #fff;
+  /* #559: was #fff. --on-accent already resolves to #ffffff for both
+     current-design light and terminal light at this exact call site, so
+     this is a governance fix with no visual change today - tokenizing it
+     stops it silently going wrong if either theme's --on-accent ever
+     moves, the same reasoning as the "Unlock with Pro" button fix. */
+  color: var(--on-accent);
 }
 [data-theme="light"] .gchat-fab:hover {
   box-shadow: 0 6px 28px rgba(0,82,204,0.30), 0 2px 6px rgba(0,0,0,0.12);

--- a/components/UpgradeGateModal.tsx
+++ b/components/UpgradeGateModal.tsx
@@ -60,7 +60,7 @@ export function LockedFeatureCard({ title, description, onUnlock }: {
       <button
         onClick={onUnlock}
         style={{
-          background: 'var(--accent-solid)', color: '#fff', border: 'none', cursor: 'pointer',
+          background: 'var(--accent-solid)', color: 'var(--on-accent)', border: 'none', cursor: 'pointer',
           fontSize: 'var(--fs-label)', fontWeight: 700, padding: '9px 16px', borderRadius: 8,
           flexShrink: 0,
         }}
@@ -118,7 +118,7 @@ export function FullPageUpgradeGate({ title, description }: { title: string; des
           href={ctaHref}
           style={{
             display: 'block', textAlign: 'center',
-            background: 'var(--accent-solid)', color: '#fff',
+            background: 'var(--accent-solid)', color: 'var(--on-accent)',
             fontSize: 'var(--fs-body)', fontWeight: 700,
             padding: '12px 16px', borderRadius: 8,
             textDecoration: 'none',
@@ -226,7 +226,7 @@ export default function UpgradeGateModal({ open, onClose, feature }: Props) {
           href={ctaHref}
           style={{
             display: 'block', textAlign: 'center',
-            background: 'var(--accent-solid)', color: '#fff',
+            background: 'var(--accent-solid)', color: 'var(--on-accent)',
             fontSize: 'var(--fs-body)', fontWeight: 700,
             padding: '12px 16px', borderRadius: 8,
             textDecoration: 'none',


### PR DESCRIPTION
## Summary
- Fixes #559 C9's remaining traceable `#ffffff` instances on `/dashboard`: `UpgradeGateModal`'s three CTAs and `.gchat-fab`'s light-theme text, all pairing a tokenized `--accent-solid` background with hardcoded white text.

## What changed
- `components/UpgradeGateModal.tsx`: 3 sites (`background: var(--accent-solid), color: '#fff'`) → `color: var(--on-accent)`.
- `app/globals.css:3862`, `[data-theme="light"] .gchat-fab`: same pairing → `color: var(--on-accent)`.

## Why
`--on-accent` exists specifically for this pairing - `#ffffff` in terminal light/both current-design themes, `var(--bg0)` (near-black) in terminal dark, documented with an 8.95:1 figure. Hardcoding white skips the token's actual point: terminal dark's `--accent-solid` is bright gold and needs dark text.

**Verified before shipping, not assumed:** `--on-accent` resolves to identical `#ffffff` in every context these four sites currently render in - none of them reach a terminal-dark `--accent-solid` surface today. So this ships with **zero visible change** - a governance fix closing the gap before some future combination renders wrong the way `gchat-fab`'s dark case only avoided by accident (it never matched the light-scoped selector at all, not because it was correctly handled).

Also traced why `#572`'s widened rule didn't already catch these: `color: '#fff'` is a bare hex text literal, which the *original* pre-#572 rule already flags - part of the pre-existing ~56-site backlog #110 exists to burn down, not a #572-specific gap.

## Not in this PR
QA's larger finding (75 `[data-theme]`-scoped, non-design-scoped rules leaking current-design colors into terminal, `.gchat-fab`'s own background/shadow rule included) is explicitly **not** being acted on - that's a scoping-architecture question QA flagged as needing a design decision first, not a fix to start converting.

## How to test (QA)
Nothing should look different - confirmable only via computed style (now resolves through `var(--on-accent)`) not visually.

## Risk level
Low. Zero visual change today, all 4 gates green.
