### PR TITLE
fix(dashboard): perp/spot pill text off the self-tint, onto --txt

### DIFF
--- a/components/PerpSpotCard.tsx
+++ b/components/PerpSpotCard.tsx
@@ -72,7 +72,12 @@ export default function PerpSpotCard() {
         background: `color-mix(in srgb, ${tone} 12%, transparent)`,
         border: `0.5px solid color-mix(in srgb, ${tone} 40%, transparent)`,
       }}>
-        <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 800, color: tone, letterSpacing: '0.05em' }}>
+        {/* Text is --txt, not `tone` (#590 review, design ruling) - a self-tint
+         * where text colour equals the tint's source colour is structurally
+         * marginal in light theme by construction (the surface drags toward
+         * the text), independent of alpha. State is carried by the tint and
+         * border alone now. Same shape as CorrelationTerminal's diagonal fix. */}
+        <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 800, color: 'var(--txt)', letterSpacing: '0.05em' }}>
           {verdict}
         </span>
       </div>


### PR DESCRIPTION
## Summary
Fixes a WCAG AA contrast failure in `PerpSpotCard`'s verdict pill, found during #590's review and ruled on by design tonight.

## What changed
Pill text now uses `var(--txt)` instead of the same `tone` token used for its own background tint (`color-mix(in srgb, tone 12%, transparent)`). State is still communicated — the tint and border still carry the tone colour — text just no longer self-tints.

## Why
QA measured all four `lean` states (perp/spot/normal/unknown) computed directly from tokens rather than waiting for live market state to cycle through them: 4 of 8 state×theme combinations fail AA in light theme. Structural cause — a self-tint where the text colour equals the tint's own source colour drags the effective surface toward the text colour as alpha rises, so it's marginal by construction, not a tunable-alpha problem. Design ruled: fix the text colour once (this PR) rather than tune alpha per site — the same shape exists at 6 more call sites across `/arena`, `/briefing`, `/liq`, deliberately not touched here since those routes haven't been rebuilt to their design canvases yet and a contrast-only fix would likely be discarded by that rebuild.

Flagged, not fixed here: with text no longer carrying state colour, the pill's tint alone may not distinguish `normal` (--txt2) from `unknown` (--txt3) at 12% alpha — two similar greys. That's a design call on whether the two states need to be visually distinguishable there at all, not something this fix should guess at.

## How to test (QA)
Not on `qa` yet — test the branch directly, or wait for promotion.
1. `/dashboard`, terminal mode, light theme, rail's "Perps vs Spot" panel.
2. Pill text (FUTURES LEADING / SPOT LEADING / NORMAL / CANNOT MEASURE, depending on live state) should render in the page's standard text colour, not tinted to match its own background.
3. Tint/border on the pill still visibly change per state.
4. Dark theme and current design (non-terminal `/dashboard`, if this component is visible there) unaffected — PerpSpotCard's dark-theme states already passed.

## Risk level: Low
One-line, one-file, text-colour-only change on an already-isolated component. Other 6 self-tint sites intentionally out of scope, tracked via QA's log rather than a separate ticket per design's explicit sequencing (fix lands with each screen's own canvas rebuild).

## Screenshots
None — text-colour-only change, verify colour numerically per the contrast measurement above rather than visually.
