### PR TITLE
fix(landing): scope terminal landing off current-design dark pin, stop Sign In wrap on mobile

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4497,6 +4497,15 @@ body.landing .app-content {
 }
 body.landing {
   overflow-x: hidden;
+}
+
+/* Scoped to the CURRENT design only - LandingTerminal (data-design="terminal")
+   also sets body.landing (it needs the shell-hiding rules further down this
+   file) but has its own light/dark tokens and must fall through to them
+   instead of inheriting this design's forced-dark pin. Without the :not()
+   guard, terminal landing rendered this design's black ground + blue accent
+   in light theme (#595). */
+:root:not([data-design="terminal"]) body.landing {
   background: #050505 !important;
 }
 
@@ -4505,8 +4514,9 @@ body.landing {
    --txt/--accent tokens, which the light theme overrides globally - so a
    visitor with light mode set elsewhere in the app got a black page with
    light-mode card/text colors bleeding through. Re-pin the dark values
-   here, scoped to the landing subtree only, so nothing outside it changes. */
-[data-theme="light"] body.landing {
+   here, scoped to the landing subtree only, so nothing outside it changes.
+   Also scoped off terminal landing for the same reason as above (#595). */
+:root[data-theme="light"]:not([data-design="terminal"]) body.landing {
   --bg0: #030405;
   --bg:  #000000;
   --bg1: #06070a;

--- a/components/LandingTerminal.tsx
+++ b/components/LandingTerminal.tsx
@@ -200,28 +200,34 @@ export default function LandingTerminal({ dict, locale, dir }: Props) {
       {/* ── NAV ── */}
       <nav style={{
         height: isDesktop ? 56 : 52, display: 'flex', alignItems: 'center',
-        padding: isDesktop ? '0 40px' : '0 16px', gap: isDesktop ? 12 : 9,
+        padding: isDesktop ? '0 40px' : '0 16px', gap: isDesktop ? 12 : 6,
         borderBottom: '1px solid var(--bdr)',
       }}>
-        <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
           <BrandMark size={isDesktop ? 26 : 22} tone="dark" radiusPct={0} />
-          <span style={{ fontFamily: 'var(--font-mono), monospace', fontWeight: 700, letterSpacing: '.16em', fontSize: isDesktop ? 14 : 11.5, color: 'var(--txt)' }}>
+          <span style={{
+            fontFamily: 'var(--font-mono), monospace', fontWeight: 700, letterSpacing: '.16em',
+            fontSize: isDesktop ? 14 : 11.5, color: 'var(--txt)', whiteSpace: 'nowrap',
+            overflow: 'hidden', textOverflow: 'ellipsis',
+          }}>
             LIQUIDITYHQ
           </span>
         </span>
-        <span style={{ flex: 1 }} />
+        <span style={{ flex: 1, minWidth: isDesktop ? undefined : 4 }} />
         <LanguageSwitcher locale={locale} />
         <Link href="/login" style={{
           fontFamily: 'var(--font-mono), monospace', fontSize: 11.5, letterSpacing: '.12em',
-          color: 'var(--txt2)', border: '1px solid var(--border-input)', padding: '9px 16px',
-          textDecoration: 'none', textTransform: 'uppercase',
+          color: 'var(--txt2)', border: '1px solid var(--border-input)',
+          padding: isDesktop ? '9px 16px' : '9px 10px',
+          textDecoration: 'none', textTransform: 'uppercase', whiteSpace: 'nowrap', flexShrink: 0,
         }}>
           {isDesktop ? dict.nav.signIn : dict.nav.signIn}
         </Link>
         <Link href="/login?signup=1" style={{
           fontFamily: 'var(--font-mono), monospace', fontSize: 11.5, fontWeight: 700, letterSpacing: '.12em',
-          color: 'var(--bg0)', background: 'var(--accent)', padding: '10px 18px',
-          textDecoration: 'none', textTransform: 'uppercase',
+          color: 'var(--bg0)', background: 'var(--accent)',
+          padding: isDesktop ? '10px 18px' : '10px 12px',
+          textDecoration: 'none', textTransform: 'uppercase', whiteSpace: 'nowrap', flexShrink: 0,
         }}>
           {isDesktop ? dict.nav.getStarted : 'START'}
         </Link>


### PR DESCRIPTION
## Summary
Two independent, QA-found defects on `/?design=terminal`, batched into one PR since they're the same screen and the same root visual pass (#595).

## What changed
1. **Light theme paints the current design's colours, not terminal's.** `body.landing`'s forced dark background and its light-theme token re-pin (`app/globals.css` ~4492-4524) had no `[data-design]` guard. Both scoped to `:root:not([data-design="terminal"])` — terminal landing now falls through to its own `--bg0`/`--accent` instead of inheriting the other design's black ground + `#1a7aff` blue.
2. **Mobile nav: "Sign In" wraps to 3 lines, overflows the 52px nav.** `Sign In` and `Start` now get `white-space:nowrap` + `flexShrink:0` so they physically cannot wrap. The brand text (`LIQUIDITYHQ`) takes `minWidth:0` + `text-overflow:ellipsis` as the shrink-absorber instead — least critical thing to truncate first if the row is ever genuinely too tight. Nav gap trimmed 9px→6px at mobile.

## Why
Found by QA rendering the page at each theme/viewport and measuring what the image showed — the conformance suite scored this page 20/21 with the wrong design's colours painted (no criterion asserts a colour), and C18 passed on the nav's own height while its child rendered 3px taller. See #595 for full measurement detail.

## How to test (QA)
On this branch (not on `qa` yet):
- `/?design=terminal` in light theme: ground should be the light terminal token family (`#f7f6f3`-ish), CTA should be the terminal accent (`#754e00`-ish) — not black / `#1a7aff`.
- `/?design=terminal` at 390/360/320px width: "Sign In" renders on one line, fully inside the nav's top/bottom rules.
- Current (non-terminal) landing should be pixel-identical to before on both checks — only terminal-scoped rules and one terminal-only component touched.

## Risk level: Low
Both fixes scoped narrowly (one design, one component). Reproduced and confirmed the light-theme fix directly via `data-theme` attribute + `getComputedStyle` — matched QA's exact measured values (`rgb(5,5,5)`/`rgb(26,122,255)`) before, correct tokens after. Could not personally re-render the nav fix at mobile widths — this session's `resize_window` tool reports success but doesn't actually change `window.innerWidth` (confirmed again: requested 390×844, got 2087 wide). Implemented per QA's exact diagnosis; their Playwright-based pass is what confirms it, same as landing's first round.

All 4 gates pass: lint 0 errors, `tsc --noEmit` clean, `npm test` green, `npm run build` clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
