### PR TITLE
fix(dashboard): grade-F badge contrast in dark, mobile price-row overflow

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -496,8 +496,14 @@ body::after {
 [data-design="terminal"][data-theme="light"] .csb2-health-badge.grade-c {
   background: color-mix(in srgb, var(--txt2) 4%, transparent) !important;
 }
+/* Base rule, not theme-scoped: dark had the identical self-tint problem
+   (--txt3 text on a 13% tint of --txt3, 4.11:1) and was simply never fixed
+   when light was. DashboardTerminal.tsx no longer sets an inline `color`
+   for grade F, so this needs no !important to win. */
+[data-design="terminal"] .csb2-health-badge.grade-f {
+  color: var(--txt);
+}
 [data-design="terminal"][data-theme="light"] .csb2-health-badge.grade-f {
-  color: var(--txt) !important;
   background: color-mix(in srgb, var(--txt3) 4%, transparent) !important;
 }
 
@@ -800,7 +806,14 @@ body::after {
   text-decoration: none; color: inherit; cursor: pointer;
   transition: border-color 0.15s, background 0.15s; }
 .scc-card:hover { border-color: var(--bdr2); background: var(--bg2); }
-.scc-id { display: flex; flex-direction: column; min-width: 0; }
+/* flex-shrink: 0 - #587: at 390/360/320 this shrank below .scc-price's own
+   content width (an unbreakable string like "$77,585.08" has no space to
+   wrap on, so a squeezed container doesn't wrap it, it overflows past the
+   box and paints across .scc-meta's text to its right - measured 76px in a
+   116px-needed box at 390, worse narrower). .scc-meta's .scc-sig already
+   truncates safely with an ellipsis for exactly this squeeze - it should
+   be the one absorbing narrow viewports, not the price. */
+.scc-id { display: flex; flex-direction: column; min-width: 0; flex-shrink: 0; }
 .scc-ticker { font-family: var(--font-mono), monospace; font-size: var(--fs-micro);
   font-weight: 700; letter-spacing: .08em; color: var(--txt3); }
 .scc-price { font-family: var(--font-mono), monospace; font-size: 1.25rem; font-weight: 700;

--- a/components/DashboardTerminal.tsx
+++ b/components/DashboardTerminal.tsx
@@ -225,7 +225,13 @@ function TCoinSidebar() {
                 <span className={`csb2-health-badge grade-${health.grade.toLowerCase()}`} style={{
                   fontSize: 'var(--fs-caption)', fontWeight: 800, lineHeight: 1,
                   padding: '2px 4px', borderRadius: 0,
-                  color: health.color,
+                  // Grade F's own colour is --txt3 - text painted in the same
+                  // token as its own tint reads 4.11:1 in dark by construction
+                  // (the self-tint pattern design ruled on for PerpSpotCard).
+                  // Left unset here so the .grade-f CSS rule below can set it
+                  // to --txt without needing !important to beat this inline
+                  // style, the way the light-only fix at globals.css had to.
+                  ...(health.grade !== 'F' && { color: health.color }),
                   background: withAlpha(health.color, '22'),
                   border: `1px solid var(--bdr)`,
                   letterSpacing: '.04em', flexShrink: 0,


### PR DESCRIPTION
## Summary
Closes both open items on #587 — the two defects QA's mobile visual pass found on the dashboard route.

## What changed
1. **Grade-F health badge, 4.11:1 in dark.** It painted `--txt3` text on a 13% tint of `--txt3` — the self-tint pattern design already ruled on for `PerpSpotCard`. Light theme was fixed previously; dark never was. `DashboardTerminal.tsx` no longer sets an inline `color` for grade F specifically, so a **base rule** (`.csb2-health-badge.grade-f { color: var(--txt) }`) now covers both themes without needing `!important` to beat an inline style — and the light-only override simplifies down to just its background tint.
2. **Mobile price-row overflow at 390/360/320.** `TSelectedCoinCard`'s price had no `flex-shrink` protection: its container shrank below the price string's own width, and since a price has no spaces to wrap on, it overflowed its box and painted across the signal text to its right. `.scc-id` (ticker + price) now has `flex-shrink: 0`. `.scc-meta`'s `.scc-sig` already truncates with an ellipsis for exactly this squeeze, so it absorbs narrow viewports instead of the price.

## Why
QA's four-way pass (dark + light × desktop + mobile, images read then measured) found these as the only two real defects on the route — grade F measured 4.11:1 in dark, and the price/label pair were the only two elements on the whole route whose text exceeded its own box.

## How to test (QA)
On this branch (not on `qa` yet):
- `/dashboard?design=terminal`, **dark theme**, with a coin graded F (no clear setup) in the sidebar — badge text should read clearly against its tint rather than blending into it.
- Narrow to **390 / 360 / 320** — the selected-coin card's price stays on one line, fully inside its box, never overlapping the "New sellers opening"-style text to its right. That text should ellipsis-truncate instead if space runs out.
- **Light theme unchanged** from before this PR on both checks.

## Risk level: Low
Two independent, narrowly-scoped changes on one component. Neither touches layout structure or data.

One thing **not** addressed: QA's passing mention that `0.00% away · tight` joins the overflow set below 390. No box/needed measurements were given for it and I couldn't identify it confidently from the description alone — flagging rather than guessing at the wrong element. Happy to take it as a follow-up with a locator.

All 4 gates pass: lint 0 errors, `tsc --noEmit` clean, `npm test` green, `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
