### PR TITLE
feat(dashboard): build the market read banner the canvas specifies

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6751,6 +6751,31 @@ main.app-content[data-chrome="none"] {
    classes) are untouched.
    Geometry from qa/reports/dashboard-2a-canvas-geometry.md: cell padding
    12px 16px, label/value/sig 10.5/15/10.5, hairline #16191b (--bdr3). */
+/* Market read banner - the canvas's first main-column panel (#587). Geometry
+   read straight off Dashboard 2a.dc.html: background #141517 (--bg2),
+   padding 15px 20px, bottom hairline #1f2225 (--bdr); eyebrow 10px mono
+   .16em uppercase #7c828a (--txt3); verdict 24px mono 700 line-height 1 at
+   8px above; sub 12.5px/1.5 #8b8f94 (--txt2) at 8px above, capped 680px so
+   the sentence wraps at a readable measure instead of the full column. */
+[data-design="terminal"] .dash-market-read-banner {
+  background: var(--bg2);
+  border-bottom: 1px solid var(--bdr);
+  padding: 15px 20px;
+}
+[data-design="terminal"] .dmrb-eyebrow {
+  font-family: var(--font-mono), monospace;
+  font-size: 10px; letter-spacing: .16em; text-transform: uppercase;
+  color: var(--txt3);
+}
+[data-design="terminal"] .dmrb-verdict {
+  font-family: var(--font-mono), monospace;
+  font-size: 24px; font-weight: 700; line-height: 1; margin-top: 8px;
+}
+[data-design="terminal"] .dmrb-sub {
+  font-size: 12.5px; line-height: 1.5; color: var(--txt2);
+  margin-top: 8px; max-width: 680px;
+}
+
 [data-design="terminal"] .dash-main .edge-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);

--- a/components/DashboardTerminal.tsx
+++ b/components/DashboardTerminal.tsx
@@ -18,7 +18,7 @@ import {
 import type { CoinId, CoinData } from '@/lib/marketStore';
 import { useOI1h, oi1hSignal } from '@/lib/useOI1h';
 import { useSettings } from '@/lib/settings';
-import MarketRead from '@/components/MarketRead';
+import { computeMarketRead } from '@/lib/marketRead';
 import GlobalMacroContext from '@/components/GlobalMacroContext';
 import EconCalendarWidget from '@/components/EconCalendarWidget';
 import SpotlightTour from '@/components/SpotlightTour';
@@ -34,6 +34,71 @@ import type { LabelKey } from '@/lib/labelKeys';
 import PerpSpotCard from '@/components/PerpSpotCard';
 
 const SPARK_W = 36;
+
+/* "14 Aug 11:42 UTC" - the canvas eyebrow's stamp. UTC, not local: every
+ * other time-derived value on this route (session windows, day-of-week
+ * scoring in computeMarketRead) is anchored to UTC, and a local stamp beside
+ * a UTC-derived read would disagree either side of the viewer's midnight. */
+function formatUtcStamp(d: Date): string {
+  const day   = d.getUTCDate();
+  const month = d.toLocaleString(undefined, { month: 'short', timeZone: 'UTC' });
+  const hh    = String(d.getUTCHours()).padStart(2, '0');
+  const mm    = String(d.getUTCMinutes()).padStart(2, '0');
+  return `${day} ${month} ${hh}:${mm} UTC`;
+}
+
+/* Market read banner - Dashboard 2a.dc.html's first main-column panel (#587).
+ *
+ * This slot used to render <MarketRead />, the production conditions gauge
+ * (58/100 bar + Order Wall / Fear & Greed / Day / Funding / Smart Money
+ * boxes + a funding override control). None of that is in the canvas or in
+ * specs/dashboard-2a.md: the frame draws one eyebrow line, one 24px verdict
+ * string, one sentence. The gauge stayed because this branch restyled the
+ * existing component rather than checking what the canvas wanted in the
+ * position - the owner caught it by comparing the live page to the frame.
+ *
+ * Same computeMarketRead() the gauge used, so the words are the production
+ * read, not a second opinion - only the presentation changes here.
+ *
+ * COLOUR, and the one place this deliberately departs from criterion 5:
+ * the spec asks the verdict to take the READ'S DIRECTION (bullish --green /
+ * bearish --red / neutral --txt2), and the canvas fixture shows a
+ * directional string ("RISK-ON, CAUTIOUS"). computeMarketRead does not
+ * produce a direction - its band is trade-CONDITIONS QUALITY (good / mid /
+ * weak, "Good time to trade" ... "Weak setup - better to wait"), and no
+ * market-wide directional read exists anywhere in the codebase (confluence
+ * and Grok are both per-coin). Painting "weak conditions" --red would tell
+ * the reader the market is falling when it means the setup is poor - the
+ * exact substitution §"Colour is data" forbids. So the band maps on its own
+ * axis: favourable --green, everything else quiet. Flagged for design on
+ * #587 - either this mapping is confirmed, or a market-wide directional
+ * read is a data question to answer before the colour can mean direction. */
+function TMarketReadBanner() {
+  const { t } = useLabels();
+  const { store } = useMarket();
+  const [, setTick] = useState(0);
+
+  // Re-derive every 60s so the stamp and the time-of-day factor inside
+  // computeMarketRead stay current without a reload - same cadence the
+  // gauge used.
+  useEffect(() => {
+    const id = setInterval(() => setTick(n => n + 1), 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const read = computeMarketRead(store);
+  const verdictCol = read.band === 'good' ? 'var(--green)' : 'var(--txt2)';
+
+  return (
+    <div className="dash-market-read-banner">
+      <div className="dmrb-eyebrow" suppressHydrationWarning>
+        {t('MARKET_READ_TITLE')} · {formatUtcStamp(new Date())}
+      </div>
+      <div className="dmrb-verdict" style={{ color: verdictCol }}>{read.verdict}</div>
+      <div className="dmrb-sub">{read.sub}</div>
+    </div>
+  );
+}
 
 const OI_TREND_META: Record<string, { txtKey: LabelKey; subKey: LabelKey; col: string }> = {
   strong_up:   { txtKey: 'OI_TREND_STRONG_UP_TXT',   subKey: 'OI_TREND_STRONG_UP_SUB',   col: 'var(--green)' },
@@ -667,7 +732,7 @@ export default function DashboardTerminal() {
           the flat monochrome aesthetic. */}
 
       <div className="dash-main">
-        <MarketRead />
+        <TMarketReadBanner />
 
         <TPanel id="tour-best-setup">
           <div className="dash-section dash-section-hot" style={{ marginTop: 0 }}>{t('DASH_BEST_SETUP_TODAY_HEADER')}</div>

--- a/components/MarketRead.tsx
+++ b/components/MarketRead.tsx
@@ -4,19 +4,14 @@ import { useMarket } from '@/lib/marketStore';
 import { computeMarketRead, type FundingSide } from '@/lib/marketRead';
 import Tip from '@/components/Tip';
 import { useLabels } from '@/lib/labels';
-import { useDesignMode } from '@/components/DesignModeProvider';
 
-/* "14 Aug 11:42 UTC" - Dashboard 2a.dc.html's canvas eyebrow (#413 canvas
- * mirror, #587). Terminal-only: current design keeps its Tip+question
- * eyebrow, since MarketRead is shared with both dashboard designs and this
- * branch does not restyle current design. */
-function formatUtcStamp(d: Date): string {
-  const day   = d.getUTCDate();
-  const month = d.toLocaleString(undefined, { month: 'short', timeZone: 'UTC' });
-  const hh    = String(d.getUTCHours()).padStart(2, '0');
-  const mm    = String(d.getUTCMinutes()).padStart(2, '0');
-  return `${day} ${month} ${hh}:${mm} UTC`;
-}
+/* Current-design only as of #587. This used to carry a `mode === 'terminal'`
+ * eyebrow branch and a formatUtcStamp helper for it, from when the terminal
+ * dashboard rendered this component in its first main-column slot. The
+ * canvas wants a three-line verdict banner there, not this conditions gauge,
+ * so terminal now renders DashboardTerminal's own TMarketReadBanner and the
+ * terminal branch here became unreachable - removed rather than left as dead
+ * design-specific code in a shared component. */
 
 // The dashboard's answer-first hero. Replaces the RaidMeter + Smart Money Score
 // + Sentiment Extremes stack with one plain-language verdict (see lib/marketRead
@@ -24,7 +19,6 @@ function formatUtcStamp(d: Date): string {
 export default function MarketRead() {
   const { t } = useLabels();
   const { store } = useMarket();
-  const mode = useDesignMode();
   const [manualFund, setManualFund] = useState<FundingSide | null>(null);
   const [showOverride, setShowOverride] = useState(false);
   const [, setTick] = useState(0);
@@ -60,16 +54,10 @@ export default function MarketRead() {
   return (
     <section className="mr" data-band={read.band}>
       <div className="mr-eyebrow">
-        {mode === 'terminal' ? (
-          <span suppressHydrationWarning>{t('MARKET_READ_TITLE')} · {formatUtcStamp(new Date())}</span>
-        ) : (
-          <>
-            <Tip width={280} text={t('MARKET_READ_TIP')}>
-              {t('MARKET_READ_TITLE')}
-            </Tip>
-            <span className="mr-eyebrow-q">{t('MARKET_READ_EYEBROW_Q')}</span>
-          </>
-        )}
+        <Tip width={280} text={t('MARKET_READ_TIP')}>
+          {t('MARKET_READ_TITLE')}
+        </Tip>
+        <span className="mr-eyebrow-q">{t('MARKET_READ_EYEBROW_Q')}</span>
       </div>
 
       <div className="mr-top">


### PR DESCRIPTION
## Summary
Fixes the reopened half of #587 — the terminal dashboard's first main-column panel rendered the wrong component.

## What changed
The slot rendered `<MarketRead />`, the production conditions gauge: a 58/100 score bar, five metric boxes (Order Wall / Fear & Greed / Day / Funding / Smart Money) and a funding override control. **None of that is in `Dashboard 2a.dc.html` or `specs/dashboard-2a.md`** — the canvas draws one eyebrow line, one 24px verdict string, one sentence.

Replaced with `TMarketReadBanner`, geometry read straight off the frame: `--bg2` ground, `padding: 15px 20px`, bottom hairline; eyebrow 10px mono `.16em` uppercase `--txt3`; verdict 24px mono 700 `line-height: 1`; sub 12.5px/1.5 `--txt2` capped at 680px.

It calls **the same `computeMarketRead()`** the gauge called — the verdict and sentence are the production read, not a second opinion. Only presentation changed.

`MarketRead.tsx`'s terminal eyebrow branch (added back when this slot still rendered it) is now unreachable; removed along with its `formatUtcStamp` helper rather than left as dead design-specific code in a component the current design still shares.

## Why
The owner compared the live dashboard against the canvas band by band and found it; QA confirmed against frame + spec and retracted dashboard's "done". Everything after this panel already matched canvas order — a one-panel gap, but the first thing on the route.

It survived because this branch **restyled the component already in the slot instead of checking what the canvas wanted to occupy it** — and because `spec-conformance`'s C1 counts sections *in position*, not *which component fills each position*.

## How to test (QA)
On this branch (not on `qa` yet):
- `/dashboard?design=terminal` — top of main column is three lines: `Market read · <DD Mon HH:MM UTC>`, a large verdict string, one sentence. No score bar, no metric boxes, no funding override. Everything below (Best Setup Today, selected-coin card, 6 signal cards, Next Events / Market Conditions) unchanged.
- `/dashboard` **without** the flag — current design still shows the full gauge with its `Tip` eyebrow, unchanged.

## Risk level: Medium
Touches `MarketRead.tsx`, which the current design also renders — but only to delete a branch terminal no longer reaches; current-design output is byte-identical.

**One deliberate departure from criterion 5, flagged rather than resolved unilaterally.** The spec asks the verdict to take the read's **direction** (bullish `--green` / bearish `--red`), and the canvas fixture shows a directional string (`RISK-ON, CAUTIOUS`). But `computeMarketRead` doesn't produce a direction — its band is trade-**conditions quality** (good/mid/weak: "Good time to trade" … "Weak setup - better to wait"), and no market-wide directional read exists anywhere in the codebase (confluence and Grok are both per-coin).

Colouring "Weak setup - better to wait" `--red` would tell a trader the market is falling when it means the setup is poor — the exact substitution the spec's own §"Colour is data" forbids. So the band maps on its own axis: favourable `--green`, everything else `--txt2`. **Design's call:** confirm that mapping, or specify a market-wide directional read as its own data question.

All 4 gates pass: lint 0 errors, `tsc --noEmit` clean, `npm test` green, `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
