### PR TITLE
fix(dashboard): wrap the market-read factor sub-label instead of truncating it

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -777,6 +777,13 @@ body::after {
   .mr-factors { grid-template-columns: repeat(2, 1fr); }
   .mr-score { font-size: 2.7rem; }
   .mr-verdict { font-size: 1.05rem; }
+  /* #587: the sub-label ("0.00% away · tight") needs 126px and the cell is
+     121 at 360, 101 at 320, so nowrap+ellipsis was cutting real values off
+     the end. Two columns leave enough height for a second line, and the
+     grid's auto rows absorb it - wrap rather than truncate, so the number
+     survives at every width. .mr-factor-v keeps its ellipsis: it is a short
+     single token ("Tight", "Neutral") that does not benefit from wrapping. */
+  .mr-factor-s { white-space: normal; }
 }
 
 /* ── Dashboard columns: answers (left) + context rail (right) ──


### PR DESCRIPTION
## Summary
Clears the last measured text-overflow on the dashboard route — the `.mr-factor-s` sub-label QA located on #587.

## What changed
`.mr-factor-s` (the factor cards' sub-label — `0.00% away · tight`, the Fear & Greed number, Smart Money's `±n/max`) carried `white-space: nowrap` with an ellipsis. Below 640px the grid drops to two columns and the cell is narrower than the string, so the tail was cut off. It now wraps at that breakpoint; the grid's auto rows absorb the second line.

`.mr-factor-v` keeps `nowrap` + ellipsis deliberately — it holds a single short token (`Tight`, `Neutral`, `Long-heavy`) that gains nothing from wrapping.

## Why
QA measured 121px box / 126px needed at 360, and 101/126 at 320 — the only element left on the route whose text exceeded its own box after the price-row fix landed. Truncating loses a real value here: for Fear & Greed and Smart Money the sub-label *is* the number. Wrapping is the correct degradation, not a narrower ellipsis.

## How to test (QA)
On this branch:
- `/dashboard` at **360** and **320** wide, both designs — each of the five factor cards shows its full sub-label, wrapping to a second line where needed, nothing clipped at the right edge.
- At **641px and above** the layout is unchanged: five columns, one line each.

## Risk level: Low
One property, inside an existing `max-width: 640` block. Shared by both designs — the factor grid renders in current design too and had the same truncation, so both are fixed.

All 4 gates pass: lint 0 errors, `tsc --noEmit` clean, `npm test` green, `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
