### PR TITLE
fix(dashboard): market read banner — wrong background token, no loading state, no mobile geometry

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6683,17 +6683,21 @@ main.app-content[data-chrome="none"] {
 [data-design="terminal"] .edge-card     { border-radius: 0; }
 [data-design="terminal"] .scc-card      { border-radius: 0; }
 [data-design="terminal"] .macro-rail-card { border-radius: 0; border: 1px solid var(--bdr); }
-[data-design="terminal"] .mr            { border-radius: 0; }
+/* .mr / .mr-track / .mr-fill / .mr-factor rules removed (#587): MarketRead is
+   emitted only by app/dashboard/page.tsx's non-terminal branch now that the
+   terminal dashboard renders TMarketReadBanner in that slot, so nothing on a
+   terminal route can carry those classes. Same reasoning as deleting the
+   component's own terminal branch - dead design-specific code, just in CSS. */
 [data-design="terminal"] .cascade-dismiss { border-radius: 0; }
 [data-design="terminal"] .csb2-sig      { border-radius: 0; }
 [data-design="terminal"] .csb2-bar-track,
 [data-design="terminal"] .csb2-bar-fill { border-radius: 0; }
 /* #559 C8: the rest of dashboard's rectangular pixel-radii, found by QA's
-   full-page sweep rather than by route inspection - MarketRead and SOTD sit
-   in the dashboard rail but aren't dashboard-specific components, so they'd
-   been missed by every audit scoped to "dashboard's own classes". */
-[data-design="terminal"] .mr-track,
-[data-design="terminal"] .mr-fill          { border-radius: 0; }
+   full-page sweep rather than by route inspection - SOTD sits in the
+   dashboard rail but isn't a dashboard-specific component, so it had been
+   missed by every audit scoped to "dashboard's own classes". (MarketRead's
+   .mr-track/.mr-fill were here too until #587 moved terminal off that
+   component - see the note above.) */
 [data-design="terminal"] .sotd-static-badge,
 [data-design="terminal"] .sotd-refresh     { border-radius: 0; }
 [data-design="terminal"] .consent-btn      { border-radius: 0; }
@@ -6751,31 +6755,6 @@ main.app-content[data-chrome="none"] {
    classes) are untouched.
    Geometry from qa/reports/dashboard-2a-canvas-geometry.md: cell padding
    12px 16px, label/value/sig 10.5/15/10.5, hairline #16191b (--bdr3). */
-/* Market read banner - the canvas's first main-column panel (#587). Geometry
-   read straight off Dashboard 2a.dc.html: background #141517 (--bg2),
-   padding 15px 20px, bottom hairline #1f2225 (--bdr); eyebrow 10px mono
-   .16em uppercase #7c828a (--txt3); verdict 24px mono 700 line-height 1 at
-   8px above; sub 12.5px/1.5 #8b8f94 (--txt2) at 8px above, capped 680px so
-   the sentence wraps at a readable measure instead of the full column. */
-[data-design="terminal"] .dash-market-read-banner {
-  background: var(--bg2);
-  border-bottom: 1px solid var(--bdr);
-  padding: 15px 20px;
-}
-[data-design="terminal"] .dmrb-eyebrow {
-  font-family: var(--font-mono), monospace;
-  font-size: 10px; letter-spacing: .16em; text-transform: uppercase;
-  color: var(--txt3);
-}
-[data-design="terminal"] .dmrb-verdict {
-  font-family: var(--font-mono), monospace;
-  font-size: 24px; font-weight: 700; line-height: 1; margin-top: 8px;
-}
-[data-design="terminal"] .dmrb-sub {
-  font-size: 12.5px; line-height: 1.5; color: var(--txt2);
-  margin-top: 8px; max-width: 680px;
-}
-
 [data-design="terminal"] .dash-main .edge-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -6795,6 +6774,49 @@ main.app-content[data-chrome="none"] {
 [data-design="terminal"] .dash-main .edge-card-label  { font-size: 10.5px; }
 [data-design="terminal"] .dash-main .edge-card-value  { font-size: 15px; }
 [data-design="terminal"] .dash-main .edge-card-signal { font-size: 10.5px; }
+
+/* Market read banner - the canvas's first main-column panel (#587).
+   Desktop geometry, Dashboard 2a.dc.html:79-83: background #141517, padding
+   15px 20px, bottom hairline #1f2225 (--bdr); eyebrow 10px mono .16em
+   uppercase --txt3; verdict 24px mono 700 line-height 1 at 8px above; sub
+   12.5px/1.5 --txt2 at 8px above, capped 680px so the sentence wraps at a
+   readable measure rather than the full column width.
+
+   #141517 is --bg1, NOT --bg2. This shipped as --bg2 (#111416) with a
+   comment claiming it was #141517, so the wrong value read as verified:
+   the banner painted DARKER than the TPanel siblings below it, inverting
+   the canvas relationship where the band is a lifted surface on the
+   column ground. Light theme had the same inversion (canvas #ebe9e6 is
+   terminal-light --bg1; --bg2 there is #e3e1dd). */
+[data-design="terminal"] .dash-market-read-banner {
+  background: var(--bg1);
+  border-bottom: 1px solid var(--bdr);
+  padding: 15px 20px;
+}
+[data-design="terminal"] .dmrb-eyebrow {
+  font-family: var(--font-mono), monospace;
+  font-size: 10px; letter-spacing: .16em; text-transform: uppercase;
+  color: var(--txt3);
+}
+[data-design="terminal"] .dmrb-verdict {
+  font-family: var(--font-mono), monospace;
+  font-size: 24px; font-weight: 700; line-height: 1; margin-top: 8px;
+}
+[data-design="terminal"] .dmrb-sub {
+  font-size: 12.5px; line-height: 1.5; color: var(--txt2);
+  margin-top: 8px; max-width: 680px;
+}
+/* Mobile band, Dashboard 2a.dc.html:236-239 - a distinct geometry, not the
+   desktop one reflowed: padding 14, verdict 21px at line-height 1.1, sub
+   12px. The canvas hand-breaks its verdict string ("RISK-ON,<br>CAUTIOUS")
+   precisely because 24px at line-height 1 does not survive a narrow column -
+   production strings are longer still ("Decent conditions - be selective" is
+   32 characters), so without this they wrap and the lines touch. */
+@media (max-width: 640px) {
+  [data-design="terminal"] .dash-market-read-banner { padding: 14px; }
+  [data-design="terminal"] .dmrb-verdict { font-size: 21px; line-height: 1.1; }
+  [data-design="terminal"] .dmrb-sub { font-size: 12px; }
+}
 
 /* briefing */
 [data-design="terminal"] .mb-macro-item { border-radius: 0; }
@@ -7016,12 +7038,11 @@ main.app-content[data-chrome="none"] {
    chips, inputs, cells). Circular markers <=24px (coin/avatar icons, status
    dots, toggle thumbs, step-number circles) are a different glyph and stay
    round - that's why the CoinIcon <img> markers this section's own audit
-   flagged are correct as-is and NOT touched here. These four are genuinely
-   rectangular: a progress track, a factor chip, a rail panel, and the
-   shared skeleton-loading bar (SkeletonBar sets its radius via inline
-   style, per-instance, across ~26 pages - !important is required to beat
-   that, and is scoped to terminal only). */
-[data-design="terminal"] .mr-track { --_c8-tag: mr-track; border-radius: 0 !important; }
-[data-design="terminal"] .mr-factor { --_c8-tag: mr-factor; border-radius: 0 !important; }
+   flagged are correct as-is and NOT touched here. These are genuinely
+   rectangular: a rail panel and the shared skeleton-loading bar
+   (SkeletonBar sets its radius via inline style, per-instance, across ~26
+   pages - !important is required to beat that, and is scoped to terminal
+   only). The .mr-track/.mr-factor entries that were here are gone with
+   #587: MarketRead no longer renders on any terminal route. */
 [data-design="terminal"] .av-rail-panel { --_c8-tag: av-rail-panel; border-radius: 0 !important; }
 [data-design="terminal"] .skel-bar { --_c8-tag: skel-bar; border-radius: 0 !important; }

--- a/components/DashboardTerminal.tsx
+++ b/components/DashboardTerminal.tsx
@@ -8,7 +8,7 @@
  * handle the class-level radii (--radius-card → 0, --radius-data → 0, plus
  * targeted rules for hardcoded px values like .edge-card and .scc-card). */
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import Link from 'next/link';
 import { useOnboarding } from '@/components/OnboardingProvider';
 import {
@@ -39,9 +39,12 @@ const SPARK_W = 36;
  * other time-derived value on this route (session windows, day-of-week
  * scoring in computeMarketRead) is anchored to UTC, and a local stamp beside
  * a UTC-derived read would disagree either side of the viewer's midnight. */
-function formatUtcStamp(d: Date): string {
+function formatUtcStamp(d: Date, locale?: string): string {
   const day   = d.getUTCDate();
-  const month = d.toLocaleString(undefined, { month: 'short', timeZone: 'UTC' });
+  // The app's own selected locale, not the browser's: the label beside this
+  // stamp resolves through t(), so passing undefined here spliced a
+  // navigator.language month into an otherwise app-locale line.
+  const month = d.toLocaleString(locale, { month: 'short', timeZone: 'UTC' });
   const hh    = String(d.getUTCHours()).padStart(2, '0');
   const mm    = String(d.getUTCMinutes()).padStart(2, '0');
   return `${day} ${month} ${hh}:${mm} UTC`;
@@ -74,9 +77,9 @@ function formatUtcStamp(d: Date): string {
  * #587 - either this mapping is confirmed, or a market-wide directional
  * read is a data question to answer before the colour can mean direction. */
 function TMarketReadBanner() {
-  const { t } = useLabels();
+  const { t, locale } = useLabels();
   const { store } = useMarket();
-  const [, setTick] = useState(0);
+  const [tick, setTick] = useState(0);
 
   // Re-derive every 60s so the stamp and the time-of-day factor inside
   // computeMarketRead stay current without a reload - same cadence the
@@ -86,17 +89,50 @@ function TMarketReadBanner() {
     return () => clearInterval(id);
   }, []);
 
-  const read = computeMarketRead(store);
+  const coin = store.coins[store.selectedCoin];
+
+  /* Memoised on the same inputs computeMarketRead actually reads. useMarket()
+     is a context, so without this the whole read - wallProximity's reduce over
+     the wall arrays, computeSmartMoney, computeContrarian - re-ran on every
+     websocket price tick, tens of times a second, for a string that changes
+     once a minute. `tick` is a dependency on purpose: it is what makes the
+     time-of-day and day-of-week factors re-derive on the 60s interval. */
+  const read = useMemo(
+    () => computeMarketRead(store),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [store.fng, store.selectedCoin, store.cbPremiumPct, store.btcExchangeNetFlow, coin, tick],
+  );
+
   const verdictCol = read.band === 'good' ? 'var(--green)' : 'var(--txt2)';
 
+  /* No market data yet - render the band's shape without its conclusion.
+     computeMarketRead has no "unknown" state: with an empty store it still
+     scores time-of-day and day-of-week, lands around 40, and returns "Weak
+     setup - better to wait" - a confident market call derived from no market
+     data, in the largest text on the route. The gauge this replaced at least
+     showed a 0/100 track and five blank factor cells beside that string;
+     the banner shows only the conclusion, so it needs the guard the gauge
+     did not. Same SkeletonBar every other card in this file falls back to. */
+  const hasData = coin?.price != null;
+
   return (
-    <div className="dash-market-read-banner">
-      <div className="dmrb-eyebrow" suppressHydrationWarning>
-        {t('MARKET_READ_TITLE')} · {formatUtcStamp(new Date())}
+    <section className="dash-market-read-banner" aria-label={t('MARKET_READ_TITLE')}>
+      <div className="dmrb-eyebrow">
+        <Tip width={280} text={t('MARKET_READ_TIP')}>{t('MARKET_READ_TITLE')}</Tip>
+        {hasData && <span suppressHydrationWarning> · {formatUtcStamp(new Date(), locale)}</span>}
       </div>
-      <div className="dmrb-verdict" style={{ color: verdictCol }}>{read.verdict}</div>
-      <div className="dmrb-sub">{read.sub}</div>
-    </div>
+      {hasData ? (
+        <>
+          <h2 className="dmrb-verdict" style={{ color: verdictCol }}>{read.verdict}</h2>
+          <div className="dmrb-sub">{read.sub}</div>
+        </>
+      ) : (
+        <>
+          <div className="dmrb-verdict"><SkeletonBar width={260} height={24} radius={0} /></div>
+          <div className="dmrb-sub"><SkeletonBar width={420} height={12} radius={0} /></div>
+        </>
+      )}
+    </section>
   );
 }
 


### PR DESCRIPTION
## Summary
Nine fixes to the market read banner shipped in `e92ef73` (#603), found by a code review run **after** that PR had already merged and deployed. One of them was live and wrong on `qa`.

## The one that was live

The banner set `background: var(--bg2)` under a comment asserting it was `"#141517 (--bg2)"`. **`#141517` is `--bg1`.** `--bg2` is `#111416` dark / `#e3e1dd` light (`lib/terminalTokens.ts:26-27`).

So the band painted **darker** than the `TPanel` siblings below it, inverting the canvas relationship where it's a lifted surface on the column ground — in both themes. QA confirmed independently, by source and by eye: the deployed banner renders as the darkest of the three stacked bands where the canvas draws it as the lightest.

The false comment is the worse half — it made the wrong value read as verified, which is how it got past both a self-check and a review.

## The rest

| # | Fix |
|---|---|
| 2 | **No loading state.** `computeMarketRead` has no "unknown" band — against an empty store it still scores time-of-day and day-of-week, lands ~40, and returns *"Weak setup - better to wait"*. A confident market call from **zero market data**, in the largest text on the route. The gauge this replaced at least showed a 0/100 track and blank factor cells beside that string. Now falls back to `SkeletonBar` like every sibling card. |
| 3 | **No mobile geometry.** `Dashboard 2a.dc.html:236` draws a distinct mobile band — padding 14, verdict 21px at `line-height: 1.1`, sub 12px — and hand-breaks its own verdict string because 24px/1.0 doesn't survive a narrow column. Production strings are longer still, so they wrapped and the lines touched. |
| 4 | **Dropped `useMemo`.** `useMarket` is a context, so the whole read — `wallProximity`'s reduce, `computeSmartMoney`, `computeContrarian` — re-ran on every websocket tick for a string that changes once a minute. Memoised on real inputs, with the 60s tick as an explicit dependency so time-of-day still re-derives. |
| 5 | Month formatted with the **browser** locale while the label beside it used the app locale. |
| 6 | Eyebrow lost `MARKET_READ_TIP` — the only explanation of what the read measures. `Tip` restored. |
| 7 | `<div>` soup → `<section>` + `<h2>`, so the route's answer-first summary is reachable by landmark and heading. |
| 8 | The CSS block was spliced between the edge-grid comment and the rules it documents. Moved below them. |
| 9 | Removed now-dead `.mr` / `.mr-track` / `.mr-fill` / `.mr-factor` terminal rules — `MarketRead` renders only on the non-terminal branch, so nothing on a terminal route can carry those classes. |

## How to test (QA)
- `/dashboard?design=terminal`, **dark and light** — the banner reads as **lifted** off the column: lighter than the panels below it, not darker.
- **Hard-reload with a cold store** — verdict area shows skeleton bars, not a "Weak setup" verdict, until prices arrive.
- **360 / 320** — verdict is 21px and does not collide with its own second line.
- Hover the eyebrow — the tip is back.
- `/dashboard` without the flag — current design unchanged throughout.

## Risk level: Low-Medium
Touches only the terminal banner and CSS that can no longer match on a terminal route.

**Two findings from the same review are deliberately not here** — both need decisions above this fix, and both are filed:
- the dropped `computeContrarian` risk warning → **#606**
- `.dash-main`'s 14px gap vs the canvas's hairline-only dividers → **#607**

Also for QA, in your own tooling: `qa/e2e/_design-tokens.ts:84` still lists `'.mr'` as a terminal selector that can no longer appear. Not touching `qa/`.

All 4 gates pass: lint 0 errors, `tsc --noEmit` clean, `npm test` green, `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
