### PR TITLE
fix(dashboard,arena): band the main column (#607), two arena overflows (#609)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6411,7 +6411,14 @@ main.app-content[data-chrome="none"] {
   border-right: 1px solid var(--bdr3);
 }
 [data-design="terminal"] .at-vlabel {
-  font-family: var(--font-mono); font-size: 34px; font-weight: 700; line-height: 1;
+  font-family: var(--font-mono); font-size: 34px; font-weight: 700;
+  /* #609: was line-height: 1, which makes the line BOX exactly 34px while the
+     font's ascenders and descenders paint past it - measured 4-5px of spill.
+     The canvas specifies the 34px size, not the leading, so raising the line
+     box to contain the glyphs keeps the specified figure and stops the
+     overflow. Same shape as the 24px/line-height-1 wrap on the dashboard
+     banner (#608). */
+  line-height: 1.15;
 }
 [data-design="terminal"] .at-vconf { display: flex; align-items: center; gap: 8px; }
 [data-design="terminal"] .at-vtrack {
@@ -6611,8 +6618,16 @@ main.app-content[data-chrome="none"] {
 }
 [data-design="terminal"] .at-snapcells .edge-card {
   background: transparent; border: 0; border-right: 1px solid var(--bdr3);
-  padding: 0 18px; display: flex; flex-direction: column; justify-content: center; gap: 6px;
-  min-height: 0;
+  padding: 0 18px; display: flex; flex-direction: column; justify-content: center;
+  /* #609: label + value + note plus two 6px gaps measured 87px of content in
+     the band's 88px slot - no headroom, and any rounding or a taller glyph
+     tips it over. 4px buys 4px back without changing the three type sizes,
+     which are the parts the canvas actually specifies. overflow guards the
+     remainder: this is a fixed-height band, so content that still does not
+     fit should crop rather than spill into the verdict band below it - the
+     same rule already applied to .at-chart and the panel headers. */
+  gap: 4px;
+  min-height: 0; overflow: hidden;
 }
 [data-design="terminal"] .at-snapcells .edge-card:last-child { border-right: 0; }
 [data-design="terminal"] .at-snapcells .edge-card-label {
@@ -6688,6 +6703,28 @@ main.app-content[data-chrome="none"] {
    reach because they are literal px values in the shared class definitions.
    Each rule is one class, one property: no cascade, no specificity surprise. */
 [data-design="terminal"] .edge-card     { border-radius: 0; }
+/* #607: the main column is banded, not carded - see TPanel's comment. Same
+   treatment for the three .dash-main children that still drew their own box:
+   no gap between bands, bottom hairline only, column ground rather than a
+   per-band fill. Terminal only - the current design's dashboard keeps its
+   spaced cards, and .scc-card/.dash-conditions-row both render there too. */
+[data-design="terminal"] .dash-main { gap: 0; }
+[data-design="terminal"] .dash-main > .scc-card {
+  border: 0; border-bottom: 1px solid var(--bdr);
+  background: transparent; border-radius: 0;
+}
+[data-design="terminal"] .dash-main > .dash-conditions-row {
+  gap: 0; border-bottom: 1px solid var(--bdr);
+}
+/* The split's own internal divider, which the 14px grid gap used to imply. */
+[data-design="terminal"] .dash-main > .dash-conditions-row > * + * {
+  border-left: 1px solid var(--bdr);
+}
+[data-design="terminal"] .dash-conditions-row .av-rail-panel { background: transparent; }
+/* Kept as the radius floor for .scc-card. Under terminal the only .scc-card
+   that renders is the one inside .dash-main above (app/dashboard/page.tsx's
+   copy is on the branch terminal early-returns past), so this is belt to
+   that rule's braces rather than a second live case. */
 [data-design="terminal"] .scc-card      { border-radius: 0; }
 [data-design="terminal"] .macro-rail-card { border-radius: 0; border: 1px solid var(--bdr); }
 /* .mr / .mr-track / .mr-fill / .mr-factor rules removed (#587): MarketRead is

--- a/app/globals.css
+++ b/app/globals.css
@@ -6417,8 +6417,12 @@ main.app-content[data-chrome="none"] {
      The canvas specifies the 34px size, not the leading, so raising the line
      box to contain the glyphs keeps the specified figure and stops the
      overflow. Same shape as the 24px/line-height-1 wrap on the dashboard
-     banner (#608). */
-  line-height: 1.15;
+     banner (#608).
+     1.25, not the 1.15 this first shipped as: QA measured the 1.15 box at
+     39px against 41px needed on "NO READ" - still 2px short, because 34 x
+     1.15 = 39.1 only just exceeds the nominal size and leaves nothing for
+     the glyphs' actual overshoot. 34 x 1.25 = 42.5 clears it with margin. */
+  line-height: 1.25;
 }
 [data-design="terminal"] .at-vconf { display: flex; align-items: center; gap: 8px; }
 [data-design="terminal"] .at-vtrack {

--- a/components/DashboardTerminal.tsx
+++ b/components/DashboardTerminal.tsx
@@ -729,13 +729,21 @@ function TBestSetupToday() {
 }
 
 /* Flat terminal panel replacing mb-glow-card. No shadow, no glow, no radius. */
+/* A main-column BAND, not a card (#607). The canvas's main column is a flex
+   column with no gap, where each band carries only a bottom hairline and sits
+   on the column's own ground - Dashboard 2a.dc.html:77-86. This used to be a
+   free-standing bordered card on --bg1, which with .dash-main's 14px gap read
+   as a stack of floating boxes rather than the canvas's continuous banded
+   column: every band drew four borders, and the 14px of page ground between
+   them turned each hairline into a stray underline instead of a divider.
+   Background left to the column so the market-read banner stays the one
+   lifted surface, which is how the canvas distinguishes it. */
 function TPanel({ children, id }: { children: React.ReactNode; id?: string }) {
   return (
     <div
       id={id}
       style={{
-        background: 'var(--bg1)',
-        border: '1px solid var(--bdr)',
+        borderBottom: '1px solid var(--bdr)',
         borderRadius: 0,
       }}
     >


### PR DESCRIPTION
## Summary
Closes #607 and #609. Two commits, split so they can be reviewed apart — the component change carries #607's blast radius, the CSS commit carries the rest.

## #607 — the main column is banded, not carded

The canvas's main column (`Dashboard 2a.dc.html:77-86`) is a flex column with **no gap**, where each band carries a **bottom hairline only** and sits on the column's own ground. Production had `TPanel` drawing a full 1px border on a `--bg1` fill, with `.dash-main` separating children by `gap: 14px` — so every band drew four borders, and the 14px of page ground turned each hairline into a stray underline instead of a divider.

**Panels touched** (QA asked for this list so the rest of the route can be swept):

| Element | Change |
|---|---|
| `TPanel` (component, terminal-only) | full border + `--bg1` → `border-bottom` only, no fill |
| `.dash-main` | `gap: 14px` → `0` |
| `.dash-main > .scc-card` | border → `border-bottom`, fill removed |
| `.dash-main > .dash-conditions-row` | gap → 0, bottom hairline, `border-left` between its halves |
| `.dash-conditions-row .av-rail-panel` | fill removed |

Background deliberately dropped from the bands so the market-read banner stays the one lifted surface — that's how the canvas distinguishes it.

Every CSS rule is scoped to `[data-design="terminal"]` **and** to `.dash-main`'s direct children: `.scc-card` and `.dash-conditions-row` both render in the current design, which keeps its spaced cards. The rail is untouched.

## #609 — two arena overflows, same cause

Both are a box sized to its content with no headroom.

- **`.at-vlabel`** had `line-height: 1`, which makes the line *box* exactly 34px while the font's ascenders and descenders paint past it — the measured 4-5px. The canvas specifies the 34px **size**, not the leading, so the line box goes to 1.15 and the specified figure is unchanged. Same shape as the 24px/`line-height: 1` wrap fixed in #608.
- **`.at-snapcells .edge-card`** stacked label + value + note with two 6px gaps: 87px of content in the 88px band. One pixel of headroom, so any rounding or a taller glyph tips it. Gap 6→4 buys 4px back without touching the three type sizes the canvas specifies, and `overflow: hidden` guards the rest — a fixed-height band should crop rather than spill into the verdict band, the rule already applied to `.at-chart` and the panel headers.

## How to test (QA)
- `/dashboard?design=terminal` — main column reads as one continuous banded surface, single hairlines, no gaps, no boxed panels. The market read banner is still visibly **lifted** off the bands below it.
- `/dashboard` **without** the flag — untouched, spaced cards.
- `/arena?design=terminal` — verdict text no longer clips its descenders; the five snapshot stat cells sit inside the 88px band.
- Both themes.

## Risk level: Medium
#607 changes the visual model of every panel in the terminal dashboard's main column — that's the intent, but it's a wide blast radius for one route, which is why the panel list is above and why the component change is its own commit. #609 is Low: two properties and a clip guard.

All 4 gates pass: lint 0 errors, `tsc --noEmit` clean, `npm test` green, `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
