### PR TITLE
fix(landing,dashboard,chart): three design rulings — ticker alpha, contrarian warning, perp-spot copy

### DIFF
--- a/components/DashboardTerminal.tsx
+++ b/components/DashboardTerminal.tsx
@@ -18,7 +18,7 @@ import {
 import type { CoinId, CoinData } from '@/lib/marketStore';
 import { useOI1h, oi1hSignal } from '@/lib/useOI1h';
 import { useSettings } from '@/lib/settings';
-import { computeMarketRead } from '@/lib/marketRead';
+import { computeMarketRead, computeContrarian } from '@/lib/marketRead';
 import GlobalMacroContext from '@/components/GlobalMacroContext';
 import EconCalendarWidget from '@/components/EconCalendarWidget';
 import SpotlightTour from '@/components/SpotlightTour';
@@ -428,6 +428,57 @@ function TCascadeAlertBanner() {
   );
 }
 
+/* Contrarian crowd warning (#606). computeContrarian fires at 2-of-3 crowd
+ * extremes and the old <MarketRead /> surfaced it as .mr-flag; when the
+ * terminal dashboard moved to TMarketReadBanner (#587) the value was still
+ * computed and then discarded, so a real risk-facing string disappeared from
+ * the route with nothing else showing it.
+ *
+ * Reuses TCascadeAlertBanner's .cascade-alert pattern rather than inventing
+ * geometry the canvas doesn't draw: same conditional/dismissible/colour-coded
+ * shape, same slot above the main column, and the two never both fire on the
+ * same input (one reads liquidation cascades, the other crowd positioning).
+ *
+ * Colour follows the cascade banner's own semantics - the direction that is
+ * BAD for the reader is red. Longs overcrowded is flush risk (--red); shorts
+ * overcrowded is squeeze risk against shorts, which favours a long (--green).
+ *
+ * label/desc are English literals from lib/marketRead.ts, not label keys -
+ * they predate this component and are shared with the current design's
+ * MarketRead. Rendering them as-is rather than forking the strings; the i18n
+ * gap is marketRead.ts's and is the same one TMarketReadBanner's verdict has. */
+function TContrarianBanner() {
+  const { store } = useMarket();
+  const { t } = useLabels();
+  const c = computeContrarian(store);
+  const [dismissed, setDismissed] = useState<string | null>(null);
+
+  // Identity, not a boolean: dismissing "Longs overcrowded 2/3" should not
+  // also suppress a later escalation to 3/3, or a flip to the other side.
+  const id = c ? `${c.dir}-${c.count}` : null;
+  if (!c || dismissed === id) return null;
+
+  const col = c.dir === 'bear' ? 'var(--red)' : 'var(--green)';
+  const bdr = c.dir === 'bear' ? 'rgba(248,113,113,0.35)' : 'rgba(52,211,153,0.35)';
+
+  return (
+    <div className="cascade-alert" style={{ borderColor: bdr }}>
+      <div className="cascade-dot" style={{ background: col }} />
+      <div className="cascade-body">
+        <div className="cascade-title" style={{ color: col }}>
+          {c.label} · {c.count}/3
+        </div>
+        <div className="cascade-sub">{c.desc}</div>
+      </div>
+      <button
+        className="cascade-dismiss"
+        style={{ textTransform: 'uppercase', letterSpacing: '.1em', fontSize: 10 }}
+        onClick={() => setDismissed(id)}
+      >{t('DASH_CASCADE_DISMISS')} ✕</button>
+    </div>
+  );
+}
+
 function TEdgeSignals() {
   const { store } = useMarket();
   const { t } = useLabels();
@@ -771,6 +822,7 @@ export default function DashboardTerminal() {
       {showTour && <SpotlightTour onDone={() => setShowTour(false)} />}
       <SetupChecklist />
       <TCascadeAlertBanner />
+      <TContrarianBanner />
 
       {/* No GlobalSpotlight in terminal mode — cursor glow effects don't fit
           the flat monochrome aesthetic. */}

--- a/components/LandingTerminal.tsx
+++ b/components/LandingTerminal.tsx
@@ -367,6 +367,15 @@ export default function LandingTerminal({ dict, locale, dir }: Props) {
                   <span style={{ fontSize: 10.5, fontFamily: 'var(--font-mono), monospace', letterSpacing: '.12em', color: 'var(--accent)', textTransform: 'uppercase' }}>
                     {dict.features.openLabel} {stepArrow}
                   </span>
+                  {/* --txt4 is correct here and measured 1.88:1 on purpose:
+                      the design's accessibility section exempts it by name -
+                      "--txt4 is used only for the excluded-feature ✕ and the
+                      route string in card footers. Both are non-essential
+                      decoration paired with a text label, so they are exempt
+                      from 4.5:1 - but if either ever becomes the only carrier
+                      of meaning, it must be re-tokened." Checked on #593
+                      against the design project itself, not the repo's copy.
+                      Do not "fix" this without re-reading that clause. */}
                   <span style={{ fontSize: 10, fontFamily: 'var(--font-mono), monospace', color: 'var(--txt4)' }}>{FEATURE_ROUTES[i]}</span>
                 </div>
               )}

--- a/components/LandingTicker.tsx
+++ b/components/LandingTicker.tsx
@@ -10,7 +10,6 @@
  * question (flagged to QA, not resolved here) - this file only answers it
  * for landing, where the spec is explicit. */
 import { useMarket, COINS, COIN_DEC, fmtPrice } from '@/lib/marketStore';
-import { withAlpha } from '@/lib/color';
 
 export default function LandingTicker({ mobile, dir }: { mobile: boolean; dir: 'ltr' | 'rtl' }) {
   const { store } = useMarket();
@@ -50,7 +49,19 @@ export default function LandingTicker({ mobile, dir }: { mobile: boolean; dir: '
             )}
             <span style={{
               fontSize: mobile ? 10 : 11, fontVariantNumeric: 'tabular-nums',
-              color: chg == null ? 'var(--txt2)' : withAlpha(up ? 'var(--green)' : 'var(--red)', 'cc'),
+              /* No alpha, both signs (#593). The Ticker panel spec mandated
+                 80% on the change value, which put --red at 3.96:1 - but the
+                 same document's accessibility section forbids exactly this:
+                 "Do not apply alpha to a token to de-emphasise it. This
+                 pattern has already produced sub-AA text five times. Size and
+                 weight carry de-emphasis; the token is already tuned to the
+                 line." The ticker rule was the current instance of the banned
+                 pattern, so the fix is removing the alpha rather than tuning
+                 it - raising it to 90% would have kept the pattern and just
+                 moved the number. Verified against the design project itself,
+                 not the repo's static copy. If this needs de-emphasising, use
+                 size or weight. */
+              color: chg == null ? 'var(--txt2)' : (up ? 'var(--green)' : 'var(--red)'),
             }}>
               {chg == null ? '—' : `${up ? '+' : '−'}${Math.abs(chg).toFixed(2)}%`}
             </span>

--- a/design-handoff-dir/design_files/Dashboard 2a-light-theme.dc.html
+++ b/design-handoff-dir/design_files/Dashboard 2a-light-theme.dc.html
@@ -201,8 +201,9 @@
             <div style="flex-shrink:0; border-top:1px solid #d5d2cd; padding:12px 14px;">
               <div style="font-family:'IBM Plex Mono',monospace; font-size:9.5px; font-weight:700; letter-spacing:.14em; text-transform:uppercase; color:#585c61;">Perp vs spot · BTC</div>
               <div style="display:flex; align-items:center; gap:10px; margin-top:8px;">
-                <div style="font-size:11.5px; color:#585c61;">Spot leading perp by</div>
-                <div style="font-family:'IBM Plex Mono',monospace; font-size:13px; font-weight:600; color:#1a7f37;">+0.18%</div>
+                <!-- Amended per #588 - see the dark variant's note. -->
+                <div style="font-size:11.5px; color:#585c61;">Spot volume vs perp, against its 7d median</div>
+                <div style="font-family:'IBM Plex Mono',monospace; font-size:13px; font-weight:600; color:#1a7f37;">1.4x</div>
               </div>
             </div>
 

--- a/design-handoff-dir/design_files/Dashboard 2a.dc.html
+++ b/design-handoff-dir/design_files/Dashboard 2a.dc.html
@@ -203,8 +203,15 @@
             <div style="flex-shrink:0; border-top:1px solid #1f2225; padding:12px 14px;">
               <div style="font-family:'IBM Plex Mono',monospace; font-size:9.5px; font-weight:700; letter-spacing:.14em; text-transform:uppercase; color:#8b8f94;">Perp vs spot · BTC</div>
               <div style="display:flex; align-items:center; gap:10px; margin-top:8px;">
-                <div style="font-size:11.5px; color:#8b8f94;">Spot leading perp by</div>
-                <div style="font-family:'IBM Plex Mono',monospace; font-size:13px; font-weight:600; color:#3fb950;">+0.18%</div>
+                <!-- Amended per #588: was "Spot leading perp by +0.18%", which
+                     reads as a PRICE lead. Nothing in the codebase computes
+                     one. lib/perpSpot.ts measures spot vs perp QUOTE VOLUME as
+                     a ratio against that coin's own 7d median, and
+                     PerpSpotCard renders that as a verdict (SPOT LEADING /
+                     FUTURES LEADING / NORMAL). Copy now describes the volume
+                     relationship the metric actually is. -->
+                <div style="font-size:11.5px; color:#8b8f94;">Spot volume vs perp, against its 7d median</div>
+                <div style="font-family:'IBM Plex Mono',monospace; font-size:13px; font-weight:600; color:#3fb950;">1.4x</div>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
Implements QA's rulings on **#593**, **#606** and **#588**, made against the design project itself after the owner gave them access to it.

## #593 — ticker alpha removed, route string reverted

**Ticker change value: drop the alpha entirely, both signs.** The Ticker panel spec mandated 80%, putting `--red` at 3.96:1 over `--bg0`. But the same document's accessibility section forbids exactly that:

> Do not apply alpha to a token to de-emphasise it. This pattern has already produced sub-AA text five times. Size and weight carry de-emphasis; the token is already tuned to the line.

So the ticker rule *was* the banned pattern. The fix is removing the alpha, not tuning it — raising it to 90% (QA's first ruling, since retracted) would have kept the pattern and just moved the number past threshold. `withAlpha`'s import goes with it, now unused in that file.

**Feature-card route string: stays `--txt4`, stays at 1.88:1.** Briefly changed to `--txt3` under the first ruling and reverted here — the design's accessibility section exempts it by name:

> `--txt4` is used only for the excluded-feature ✕ and the route string in card footers. Both are non-essential decoration paired with a text label, so they are exempt from 4.5:1 — but if either ever becomes the only carrier of meaning, it must be re-tokened.

That clause is quoted at the call site so the next contrast sweep doesn't re-"fix" it and loop.

## #606 — contrarian warning restored
`TContrarianBanner` brings back the crowd warning that disappeared when the terminal dashboard stopped rendering `<MarketRead />` (#587). `computeContrarian` was still being called and its result discarded, so a real risk string ("Longs overcrowded — high flush risk") left the route with nothing else surfacing it.

Reuses `TCascadeAlertBanner`'s `.cascade-alert` pattern and slot rather than inventing geometry the canvas doesn't draw. The two can't both fire on the same input — one reads liquidation cascades, the other crowd positioning. Dismissal is keyed on `dir+count`, not a boolean, so dismissing "2/3" doesn't suppress a later escalation to 3/3 or a flip to the other side.

## #588 — perp-vs-spot canvas copy
Both dark and light variants, amended from *"Spot leading perp by +0.18%"* to describe the volume relationship. Nothing computes a price lead: `lib/perpSpot.ts` measures spot vs perp **quote volume** as a ratio against that coin's own 7d median, and `PerpSpotCard` renders it as a verdict. The old copy described a metric that doesn't exist.

## Not changed, deliberately
The contrarian `label`/`desc` stay English literals from `lib/marketRead.ts` rather than label keys. They predate this component and are shared with the current design's `MarketRead` — forking them here would duplicate the strings, and the i18n gap is `marketRead.ts`'s to close.

## How to test (QA)
- `/?design=terminal` — ticker change values are full-opacity green/red; feature-card route strings unchanged (dim, by design).
- `/dashboard?design=terminal` with FNG ≥ 75, funding ≥ 0.04%, longs ≥ 60% on the selected coin — a red crowd-warning banner appears above the main column, dismissible, styled like the cascade alert. Dismiss it and it stays gone until the count or direction changes.
- Canvas files are docs — no runtime effect.

## Risk level: Low
One colour property, one reverted property, one new conditional component reusing an existing pattern, and a docs copy change.

All 4 gates pass: lint 0 errors, `tsc --noEmit` clean, `npm test` green, `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
