### PR TITLE
feat(arena): give the four AI-read rows a home in the terminal restyle

### DIFF
--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -1383,6 +1383,77 @@ function ArenaContent() {
     // whichever tree is actually rendered, so there is exactly one
     // <KLineProChart> and one candle subscription regardless of viewport -
     // arena.md's own requirement (§Absent vs hidden, criterion 25).
+    /* The four AI-read rows the restyle had no home for (#594). arena.md
+       promises "nothing dropped" in its panel inventory but never names the
+       override notice, wait-for line, liquidity-raid block or catalysts -
+       production's AI-read card carries all four and the verdict band
+       visually replaces that card. QA's ruling: append them below the verdict
+       band in the current design's own order, restyled to terminal tokens.
+       Not folded into a named panel (that puts AI-read output in a slot with
+       a different job - the mistake #606 was raised against) and not dropped.
+
+       Same conditionals and same fields as the current-design blocks, so
+       nothing renders here that would not render there. Terminal treatment
+       is hairline + no radius + token colours instead of the rounded/tinted
+       card; the raid block keeps its red/green semantic because that IS the
+       setup's direction, which §"Colour is data" allows. */
+    const prevQuickSignal = quickSignals[selectedCoin];
+    const showOverride = !!(
+      cacheEntry?.mode === 'deep' && prevQuickSignal && prevQuickSignal !== result?.signal
+    );
+    const raidGreen = result?.raidSetup === 'SHORT SQUEEZE';
+
+    const aiReadRows = result && (
+      <>
+        {showOverride && (
+          <div className="at-airow at-airow-override">
+            {t('ARENA_OVERRIDE_NOTICE_PRE')}{' '}
+            <strong>{prevQuickSignal}</strong> {t('ARENA_OVERRIDE_NOTICE_TO')}{' '}
+            <strong>{result.signal}</strong>{t('ARENA_OVERRIDE_NOTICE_POST')}
+          </div>
+        )}
+
+        {result.waitFor && (
+          <div className="at-airow at-airow-waitfor">
+            <span className="at-airow-label">
+              {result.signal === 'LEAN BEARISH' ? t('ARENA_CONFIRMS_TO_SHORT')
+                : result.signal === 'LEAN BULLISH' ? t('ARENA_CONFIRMS_TO_LONG')
+                : t('ARENA_WAIT_FOR')}
+            </span>
+            <span className="at-airow-body">{result.waitFor}</span>
+          </div>
+        )}
+
+        {result.raidSetup && (
+          <div className="at-airow at-airow-raid">
+            <div className="at-airow-label" style={{ color: raidGreen ? 'var(--green)' : 'var(--red)' }}>
+              {t('ARENA_RAID_HEADER', { setup: result.raidSetup })}
+            </div>
+            {result.raidTarget && (
+              <div className="at-airow-kv">
+                <span className="at-micro">{t('ARENA_RAID_TARGET_LABEL')}</span>
+                <span className="at-airow-val">{result.raidTarget}</span>
+              </div>
+            )}
+            {result.raidTrigger && (
+              <div className="at-airow-kv">
+                <span className="at-micro">{t('ARENA_RAID_TRIGGER_LABEL')}</span>
+                <span className="at-airow-body">{result.raidTrigger}</span>
+              </div>
+            )}
+          </div>
+        )}
+
+        {result.catalysts && result.catalysts.length > 0 && (
+          <div className="at-airow at-airow-catalysts">
+            <ul>
+              {result.catalysts.slice(0, 3).map((c, i) => <li key={i}>{c}</li>)}
+            </ul>
+          </div>
+        )}
+      </>
+    );
+
     const timeframeRow = (
       <div className="at-tfrow">
         {TIMEFRAMES.map(tf => {
@@ -1532,6 +1603,8 @@ function ArenaContent() {
             </div>
           </div>
 
+          {aiReadRows}
+
           {timeframeRow}
 
           <div className="at-main">
@@ -1644,6 +1717,8 @@ function ArenaContent() {
             </button>
           </div>
         </div>
+
+        {aiReadRows}
 
         {timeframeRow}
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -6443,6 +6443,42 @@ main.app-content[data-chrome="none"] {
 }
 
 /* ── region 6: timeframe row, 42 ── */
+/* AI-read rows (#594) - the override notice, wait-for line, liquidity-raid
+   block and catalysts, which arena.md's inventory never named despite its own
+   "nothing dropped" promise. They sit between the verdict band and the
+   timeframe row, in the current design's order, as bands rather than the
+   rounded/tinted cards production draws: hairline bottom, no radius, token
+   colours. Same geometry language as every other band on this route. */
+[data-design="terminal"] .at-airow {
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--bdr);
+  font-size: 12.5px; line-height: 1.5; color: var(--txt2);
+}
+[data-design="terminal"] .at-airow-label {
+  font-family: var(--font-mono); font-size: 10px; font-weight: 700;
+  letter-spacing: .14em; text-transform: uppercase; color: var(--txt3);
+  margin-right: 8px;
+}
+[data-design="terminal"] .at-airow-waitfor .at-airow-label { color: var(--accent); }
+[data-design="terminal"] .at-airow-val {
+  font-family: var(--font-mono); font-weight: 600; color: var(--txt);
+  font-variant-numeric: tabular-nums;
+}
+[data-design="terminal"] .at-airow-kv {
+  display: flex; gap: 8px; align-items: baseline; margin-top: 5px;
+}
+/* The raid header keeps a directional colour because that IS the setup's
+   direction (short squeeze vs long flush) - §"Colour is data" permits it,
+   and it is set per-instance in the JSX rather than here. */
+[data-design="terminal"] .at-airow-raid .at-airow-label { margin-right: 0; display: block; }
+[data-design="terminal"] .at-airow-catalysts ul {
+  margin: 0; padding-left: 16px; list-style: disc;
+}
+[data-design="terminal"] .at-airow-catalysts li { margin-top: 3px; }
+@media (max-width: 767px) {
+  [data-design="terminal"] .at-airow { padding: 10px 14px; }
+}
+
 [data-design="terminal"] .at-tfrow {
   display: flex; align-items: center; gap: 2px; height: 42px; padding: 0 16px;
   border-bottom: 1px solid var(--bdr); overflow: hidden;


### PR DESCRIPTION
## Summary
Closes #594. The override notice, wait-for line, liquidity-raid block and top-3 catalysts now render in terminal mode, appended below the verdict band in the current design's own order, ahead of the timeframe row — both desktop and mobile trees.

## Why
`specs/arena.md` opens its panel inventory with *"Production order preserved. **Nothing dropped.**"* but never names any of these four — while the verdict band it *does* name visually replaces the production AI-read card that carries them. Both statements couldn't hold: either the card's contents moved somewhere, or something was being dropped silently. That's the failure this redesign has already been called on twice.

QA's ruling on #594: **append**, don't fold into a named panel (that puts AI-read output in a slot with a different job — the mistake #606 was raised against), don't drop.

## What it renders
Same conditionals, same fields as the current-design blocks, so nothing appears here that wouldn't appear there:

| Row | Condition | Content |
|---|---|---|
| Override notice | `showOverride` (deep read disagreeing with the prior quick) | one line, prev → current signal |
| Wait-for | `result.waitFor` | label + body, label varies by LEAN direction |
| Liquidity raid | `result.raidSetup` | header + target/trigger pair |
| Catalysts | `result.catalysts.length > 0` | up to 3 bullets |

Terminal treatment is band-shaped — hairline bottom, no radius, token colours — rather than production's rounded/tinted cards, matching every other band on the route.

The raid header keeps a red/green directional colour because that **is** the setup's direction (short squeeze vs long flush), not a quality or sentiment reading — the case §"Colour is data" permits.

## How to test (QA)
`/arena?design=terminal` with a cached read carrying these fields:
- Run a **Quick** read, then a **Deep** read that disagrees — the override notice appears under the verdict band.
- A read with `waitFor` / `raidSetup` / `catalysts` shows the corresponding row; the raid block shows target and trigger.
- All four sit **above** the timeframe row, and each is absent from the DOM when its own condition is false.
- Current design's arena card untouched.

## Risk level: Medium
Adds four conditional rows to both terminal trees, and the JSX around the verdict band was edited in both.

**One near-miss worth recording.** An earlier attempt used a `perl` regex to insert the new fragment before each `{timeframeRow}`. It deleted **both** `{timeframeRow}` usages and inserted nothing — which would have shipped the terminal arena with no timeframe row at all. Caught by grepping the result rather than trusting the command's exit code; both placements restored with explicit edits and all four verified present. Same "command succeeded, state isn't what I think it is" shape as the stale-ref near-miss earlier today, so it's in the commit message too rather than only here.

All 4 gates pass: lint 0 errors, `tsc --noEmit` clean, `npm test` green, `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
