### PR TITLE
fix(dashboard): terminal grade badge takes the canvas's two-state colour rule

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -461,50 +461,62 @@ body::after {
 .csb2-sig       { font-size: var(--fs-caption); font-weight: 700; padding: 1px 5px; border-radius: 4px; max-width: 130px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; background: rgba(255,255,255,0.02); }
 .csb2-bar-track { height: 3px; background: rgba(255,255,255,0.06); border-radius: 0 0 var(--radius-data) var(--radius-data); margin: 0 -10px; }
 .csb2-bar-fill  { height: 100%; border-radius: 0 0 var(--radius-data) var(--radius-data); transition: width 0.8s ease, background 0.3s; }
-/* #559 Bug 2, "the tint recipe": the health-grade badge backgrounds
-   color-mix the grade's own token toward transparent at 13.3%, composited
-   over the card behind it. On dark that pulls the surface toward black
-   while the text stays light, so text and background diverge and
-   contrast holds - same shape as .csb2-sig above. On light, the same mix
-   pulls the surface toward the TEXT colour instead of away from it,
-   shrinking the gap the badge needs. Originally scoped to grades C/F
-   (--txt2/--txt3) on the assumption A/B/D already cleared the floor.
+/* #614 removed four terminal-scoped .csb2-health-badge overrides that used to
+   sit here: grade-b and grade-c background reductions (light), grade-f's
+   `color: var(--txt)` (both themes) and grade-f's background reduction
+   (light). They are gone rather than adjusted because the thing they were
+   patching is gone FOR THOSE THREE STATES - one comes back below, changed.
 
-   QA's full grade x card-state sweep (matrix, not the single earlier
-   reading) found the confirmed live defect is narrower than that: one
-   badge, grade F, ONLY on the selected card (.csb2-sel) in light -
-   4.316:1. Unselected clears at 4.649. Selected renders --bg3, which in
-   terminal light aliases to --bg2 - one step darker than unselected's
-   --bg1 - and that single step is what puts it under. (The earlier "grade
-   B measured 3.98" reading was a mismeasurement of a grade-F badge, not
-   evidence for grade B - see the PR/issue thread. --green-2's own ceiling
-   math below is independently derived, not resting on that number.)
+   They existed to rescue a self-tint: the badge painted its text in a token
+   and its background in a 13.3% mix of THAT SAME token, so on light the
+   surface moved toward the text instead of away, and grade F on a selected
+   card measured 4.316:1. Under the canvas's rule C, D and F escape that
+   entirely - Dashboard 2a.dc.html:377 paints their text --txt but tints with
+   --txt2, two different tokens - and they now measure 11.2:1 to 12.5:1 across
+   both themes and both card states. Nothing left to patch there.
 
-   --txt3 on --bg2 caps at 4.703:1 with NO tint at all - same shape as
-   --green-2's 4.752 ceiling - so alpha alone can't reliably clear 4.5 on
-   the selected card with real margin. Grade F's text is already the
-   muted, no-strong-signal colour (--txt3, not a "bad" red or a "good"
-   green), so there's little semantic loss in the same move already used
-   on the correlation diagonal: text -> --txt, which has no ceiling
-   problem on any card state. Background tint stays reduced too, belt and
-   suspenders. Grades A/D (amber/orange) still untouched - amber's base
-   VALUE is design's #559 Bug 1, not this alpha issue, and orange isn't
-   governed in terminal at all yet (a separate, older gap). */
+   A and B do NOT escape it. The canvas tints green with green, so the self-
+   tint is still exactly what it was, only in a different token: --green
+   rather than --green-2. Measured at the canvas's own 15%:
+
+     dark  unselected 5.679   dark  selected 5.765   (both clear)
+     light unselected 4.171   light selected 3.886   (both FAIL AA)
+
+   Dark is fine because the mix pulls toward black, away from the text. Light
+   fails, and alpha barely rescues it: --green on light --bg2 with NO tint at
+   all caps near 4.66:1, so 3% is the largest value that clears 4.5 on the
+   selected card (4.585) and every value from 4% up fails. That is the same
+   ceiling shape --green-2 had, which is why the rule this replaces also
+   landed on 3% - the old value was right, for a reason that outlived the
+   token it was written for.
+
+   So the light green tint keeps its reduction and the comparison to the
+   canvas is a knowing one: at 15% the canvas's own light variant does not
+   meet AA here, and its lighter GREEN (#1a7f37 vs our #14702c) would measure
+   worse still. Mirroring the canvas everywhere except this alpha.
+
+   Kept as history rather than deleted outright, because the measurements
+   below are still the record of what was wrong and someone will otherwise
+   re-derive them:
+
+     "#559 Bug 2, the tint recipe": badge backgrounds color-mix the grade's
+     own token toward transparent at 13.3%, composited over the card. On dark
+     that pulls the surface toward black while the text stays light, so they
+     diverge and contrast holds. On light the same mix pulls the surface
+     toward the TEXT colour, shrinking the gap. QA's full grade x card-state
+     sweep found the confirmed live defect was one badge - grade F, only on
+     the selected card (.csb2-sel) in light, 4.316:1; unselected cleared at
+     4.649. Selected renders --bg3, which in terminal light aliases to --bg2,
+     one step darker than unselected's --bg1, and that step is what put it
+     under. --txt3 on --bg2 caps at 4.703:1 with NO tint at all, the same
+     shape as --green-2's 4.752 ceiling, so alpha alone could not clear 4.5
+     with margin - hence text -> --txt for grade F.
+
+   __tests__/contrastTokens.test.mts pins the --txt2/--txt3 pair for the
+   .csb2-sig overlay, which is a different element and is untouched. */
+[data-design="terminal"][data-theme="light"] .csb2-health-badge.grade-a,
 [data-design="terminal"][data-theme="light"] .csb2-health-badge.grade-b {
-  background: color-mix(in srgb, var(--green-2) 3%, transparent) !important;
-}
-[data-design="terminal"][data-theme="light"] .csb2-health-badge.grade-c {
-  background: color-mix(in srgb, var(--txt2) 4%, transparent) !important;
-}
-/* Base rule, not theme-scoped: dark had the identical self-tint problem
-   (--txt3 text on a 13% tint of --txt3, 4.11:1) and was simply never fixed
-   when light was. DashboardTerminal.tsx no longer sets an inline `color`
-   for grade F, so this needs no !important to win. */
-[data-design="terminal"] .csb2-health-badge.grade-f {
-  color: var(--txt);
-}
-[data-design="terminal"][data-theme="light"] .csb2-health-badge.grade-f {
-  background: color-mix(in srgb, var(--txt3) 4%, transparent) !important;
+  background: color-mix(in srgb, var(--green) 3%, transparent) !important;
 }
 
 /* ── MARKET EVENTS STRIP ── */

--- a/components/DashboardTerminal.tsx
+++ b/components/DashboardTerminal.tsx
@@ -308,6 +308,17 @@ function TCoinSidebar() {
         const sel    = store.selectedCoin === id;
         const tbp    = d?.takerBuyRatio != null ? Math.round(d.takerBuyRatio * 100) : 50;
         const health = computeCoinHealth(d);
+        /* #614: the canvas paints this badge in TWO states, not the five
+           computeCoinHealth() returns. Dashboard 2a.dc.html:377 is
+           `gradeCol: r[4][0] <= 'B' ? GREEN : TXT` - A and B green, C/D/F
+           plain text - and 2a-light-theme.dc.html:366 is the same rule.
+           So there is no amber for A, no --green-2 for B and no --orange
+           for D. #614 asked what value terminal's --orange should take;
+           the answer is that the badge has no orange state to give one to.
+           This is terminal-only: DashboardTerminal renders solely under
+           mode === 'terminal' (app/dashboard/page.tsx:519), so
+           health.color still drives the current design untouched. */
+        const gradeStrong = health.grade <= 'B';
         const badgeCol = coinBadgeColor(id);
         const sig    = sidebarSignalFor(d, t);
 
@@ -326,14 +337,23 @@ function TCoinSidebar() {
                 <span className={`csb2-health-badge grade-${health.grade.toLowerCase()}`} style={{
                   fontSize: 'var(--fs-caption)', fontWeight: 800, lineHeight: 1,
                   padding: '2px 4px', borderRadius: 0,
-                  // Grade F's own colour is --txt3 - text painted in the same
-                  // token as its own tint reads 4.11:1 in dark by construction
-                  // (the self-tint pattern design ruled on for PerpSpotCard).
-                  // Left unset here so the .grade-f CSS rule below can set it
-                  // to --txt without needing !important to beat this inline
-                  // style, the way the light-only fix at globals.css had to.
-                  ...(health.grade !== 'F' && { color: health.color }),
-                  background: withAlpha(health.color, '22'),
+                  color: gradeStrong ? 'var(--green)' : 'var(--txt)',
+                  /* 15%, the canvas's own alpha, not withAlpha('22')'s 13.3%.
+                     For C/D/F the tint token is NOT the text token - the
+                     canvas tints with --txt2 (rgba(139,143,148,.15)) and
+                     paints the text --txt - so those three measure 11.2:1 or
+                     better everywhere and need no override. A/B is still a
+                     self-tint (green on green) and light still fails AA at
+                     15%; globals.css reduces that one case to 3% and carries
+                     the measurements. Dark keeps 15% in both states.
+                     One knowing divergence: the light canvas leaves the
+                     neutral literal at the DARK --txt2 (#8b8f94) while it
+                     does swap GREEN's rgba for the light one - so it is
+                     either a deliberate theme-invariant tint or a missed
+                     line. var(--txt2) is used here because it is governed
+                     and follows the theme; flagged on the PR for QA to rule
+                     on rather than settled silently. */
+                  background: `color-mix(in srgb, ${gradeStrong ? 'var(--green)' : 'var(--txt2)'} 15%, transparent)`,
                   border: `1px solid var(--bdr)`,
                   letterSpacing: '.04em', flexShrink: 0,
                 }}>


### PR DESCRIPTION
## Summary

Closes #614. The terminal dashboard's coin health badge now uses the canvas's two-state colour rule instead of production's five-tier ladder. `--orange` is gone from the badge — not given a terminal value, because the design has no orange state to give one to.

## What changed

**`components/DashboardTerminal.tsx`** — the badge computes its own colour rather than taking `health.color`:

| grade | text | background |
|---|---|---|
| A, B | `--green` | `--green` at 15% |
| C, D, F | `--txt` | `--txt2` at 15% |

Matching `Dashboard 2a.dc.html:377` — `gradeCol: r[4][0] <= 'B' ? GREEN : TXT` — and `2a-light-theme.dc.html:366`.

`lib/marketStore.ts`'s five-branch map is **untouched**. `DashboardTerminal` renders only under `mode === 'terminal'` (`app/dashboard/page.tsx:519`), so the current design keeps its existing amber/green-2/txt2/orange/txt3 ladder exactly as it was.

**`app/globals.css`** — three of the four terminal `.csb2-health-badge` overrides deleted, one kept and rescoped.

Deleted, because what they patched no longer exists: `grade-c` background (light), `grade-f` `color: var(--txt)` (both themes), `grade-f` background (light). Those existed to rescue a *self-tint* — text and background painted from the same token, so on light the surface moved toward the text instead of away. Under the canvas's rule C/D/F paint `--txt` and tint `--txt2`, two different tokens, and now measure 11.2:1–12.5:1 across both themes and both card states.

Kept, rescoped from `grade-b` to `grade-a, grade-b`: the light green tint reduction, still at 3%.

## Why the 3% stays

A/B is *still* a self-tint — the canvas tints green with green. Measured at the canvas's own 15%:

```
dark  unselected 5.679   dark  selected 5.765    clear
light unselected 4.171   light selected 3.886    FAIL AA
```

Alpha barely rescues it. `--green` on light `--bg2` with **no tint at all** caps near 4.66:1, so 3% is the largest value clearing 4.5 on the selected card (4.585); every value from 4% up fails. That is the same ceiling shape `--green-2` had — so the rule this replaces already had the right value, for a reason that outlived the token it was written for. I nearly deleted it.

This is a knowing divergence from the canvas: at 15% the canvas's own light variant does not meet AA here, and its lighter `GREEN` (`#1a7f37` vs our `#14702c`) would measure worse still. Consistent with #559, where design darkened accent/green/red/amber precisely to clear 4.5:1.

**One other divergence, ruled on by QA before merge:** the light canvas leaves the neutral tint at `rgba(139,143,148,.15)` — the *dark* `--txt2` — while swapping GREEN's rgba for the light one. Implemented as `var(--txt2)` so it is governed and follows the theme, rather than mirroring the literal.

## How to test (QA)

On the `qa` environment, `/dashboard?design=terminal`, rail coin cards.

1. **Dark, grade A or B badge** — letter is green, background a faint green tint. No gold/amber on A.
2. **Dark, grade C, D or F** — letter is plain light text, background a faint neutral grey tint. **D is not orange.** All three are the same colour as each other.
3. **Light theme, grade A or B** — still green, on a much fainter tint than dark. Letter must stay comfortably readable on both an unselected card and the selected (highlighted) one.
4. **Light theme, grade C/D/F** — near-black letter on a faint grey tint, on both card states.
5. **Current design** (`/dashboard` with no `?design=terminal`) — badges unchanged: A gold, B green, C grey, D orange, F muted. This PR must not alter it.

Grades follow score thresholds in `lib/marketStore.ts` (A ≥78, B ≥60, C ≥42, D ≥25, else F), so seeing every state may need waiting for coins to move or forcing a fixture.

## Risk level

**Low.** Terminal-only, one component and one CSS block; no data, API or current-design change.

Unverified: contrast figures are computed from token values (sRGB, WCAG 2.x formula) against composited card backgrounds, not sampled from a rendered browser. The composite assumes the badge sits directly on `--bg1` (unselected) / `--bg2` (selected, via `--bg3` aliasing in terminal light) with nothing between. If a card gains another layer behind the badge, re-measure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
