### PR TITLE
fix(chart): correct the terminal mobile nav CSS against the frames (#599 part 1)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5831,7 +5831,11 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
   }
   [data-design="terminal"] .tnav-tab {
     flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center;
-    gap: 3px; color: var(--txt3); text-decoration: none;
+    /* gap 6, not 3: Dashboard 2a.dc.html:301 sets gap:6px between the 19px
+       icon and its 9px label. Third value in this block that did not match
+       the frame it claims to mirror, after the 899 breakpoint and the
+       header's padding. */
+    gap: 6px; color: var(--txt3); text-decoration: none;
     /* 60px tall and a fifth of the viewport wide - comfortably past the 24x24
        WCAG 2.2 AA minimum without needing an overlay like #388's control. */
   }
@@ -5972,10 +5976,19 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
 }
 /* Mobile 38px header (README:82) - logo, screen name, status. */
 [data-design="terminal"] .tnav-mhead { display: none; }
-@media (max-width: 899px) {
+/* 767, not 899. #616 moved .tnav to min-width:768 and .tnav-tabs to
+   max-width:767 but left this one at 899, so 768-899px matched BOTH the
+   desktop bar and the mobile header and would have rendered two navs stacked
+   the moment a component wired these classes. Latent rather than live only
+   because nothing renders .tnav-mhead yet (#599). The three rules now share
+   one boundary, which is the point of having one. */
+@media (max-width: 767px) {
   [data-design="terminal"] .tnav-mhead {
     display: flex; align-items: center; gap: 10px;
-    height: 38px; padding: 0 12px;
+    /* padding 0 14px, not 12: Dashboard 2a.dc.html:235. Height, gap and the
+       bottom hairline all matched already; this one value did not. Same
+       shape of miss as the desktop bar's gap in #616. */
+    height: 38px; padding: 0 14px;
     background: var(--bg0); border-bottom: 1px solid var(--bdr);
   }
   [data-design="terminal"] .tnav-mbrand {


### PR DESCRIPTION
## Summary

Part 1 of #599, CSS only. #599 warns that the 18 `.tnav-*` rules are the second dead-CSS-awaiting-a-component case, that `.at-*` turned out to be a mostly-correct skeleton with eight wrong values, and that these should be checked against the frames **before** wiring. Checked. Three of the mobile block's values were wrong, and one of them is a real bug rather than a cosmetic miss.

The component and the AppShell wiring are deliberately **not** in this PR — see "Why split" below.

## What changed

| rule | was | now | source |
|---|---|---|---|
| `.tnav-mhead` media query | `max-width: 899px` | `max-width: 767px` | conflicts with `.tnav` |
| `.tnav-mhead` padding | `0 12px` | `0 14px` | `Dashboard 2a.dc.html:235` |
| `.tnav-tab` gap | `3px` | `6px` | `Dashboard 2a.dc.html:301` |

### The breakpoint is the one that mattered

#616 moved `.tnav` to `min-width: 768px` and `.tnav-tabs` to `max-width: 767px`, but left `.tnav-mhead` at 899. Those overlap: at **768–899px both match**, so the desktop 44px bar and the mobile 38px header would both render, stacked.

It is latent rather than live only because nothing renders `.tnav-mhead` yet — which is precisely the failure mode of dead CSS. It looks correct sitting in the file, and it breaks on the day someone wires it. All three rules now share one boundary, which is the point of having one.

## What was checked and found correct

Verified against `Dashboard 2a.dc.html` (dark frame — see the note on light frames below), so the negative results are recorded rather than re-derived later:

- `.tnav-mhead` height 38, gap 10, `border-bottom: 1px solid var(--bdr)` — `--bdr` is `#1f2225`, the frame's literal
- `.tnav-mbrand` 11px / 700 / `.14em` / `--txt` — matches the frame's `DESK` wordmark exactly
- `.tnav-mdot` 5×5 square, `--green`
- `.tnav-mstatus` 10px mono, `--txt2` (`#8b8f94` in the frame)
- `.tnav-tabs` height 60, `border-top: 1px solid var(--bdr)`; the frame uses `grid-template-columns: repeat(5,1fr)` where the CSS uses `flex` + `flex: 1`, equivalent for five items
- `.tnav-tab-label` 9px mono `.1em`

## Two things NOT changed, for QA to rule on

**1. `.tnav-mstatus` letter-spacing.** The rule sets `.1em`. The frame's mobile status sets **none**, while its desktop equivalent sets `.08em`. That asymmetry reads more like an omission in the frame than a decision, and unlike padding or gap there is no measurable intent to mirror. Left alone rather than quietly picking a side.

**2. `.tnav-mscreen` has no counterpart in the frame.** The frame's mobile header is: logo, one text element (the screen name, styled exactly as `.tnav-mbrand`), a plain `flex: 1` spacer, then status. `.tnav-mscreen` is a fourth element with `flex: 1` that the frame does not draw. It may be redundant with `.tnav-mbrand`. Not deleted, because whether the component needs a separate brand and screen-name pair is a wiring-time decision and part 2 will answer it.

## Note carried from QA's canvas sweep (#625)

The **light** frames are stale on colour: they still draw pre-#559 `--txt3 #6a6e73` (4.237:1) and `--red #cf222e` (4.420:1), which design has since moved to `#5e6267` (5.069) and `#9d1a23` (6.651). `--txt3` is the nav's own inactive-item colour, so every value here was taken from the **dark** frame and from tokens, never a light-frame hex.

## Why split from the wiring

The component touches all 18 terminal routes at once and has to retire `.mobile-tab-bar` for terminal in the same change, or every route gets two tab bars. Landing that on top of unverified geometry means a review that cannot separate "the nav is in the wrong place" from "the nav is wired wrong". These three values are cheap to confirm on their own and part 2 then rests on something checked.

## How to test (QA)

This PR changes **no rendered output** — every rule it touches is still wired to nothing. Verification is by reading, not by looking:

1. `grep -c "tnav-" app/globals.css` still returns the same rule count; `grep -rl "tnav-" app components --include=*.tsx` still returns no matches.
2. `.tnav` (`min-width: 768`), `.tnav-tabs` (`max-width: 767`) and `.tnav-mhead` (`max-width: 767`) now agree on one boundary — no width matches both a desktop and a mobile rule.
3. The two values against the frame: `Dashboard 2a.dc.html:235` `padding:0 14px`, `:301` `gap:6px`.
4. No terminal route changes at any width. Worth one spot-check at ~800px on `/dashboard?design=terminal` to confirm nothing moved.

## Risk level

**Low.** CSS-only, terminal-scoped, and every rule touched is currently rendered by nothing — the change cannot alter output until part 2 wires it.

Unverified: read against the frame and the token file, not sampled from a browser, since there is nothing on screen to sample. The 768–899px overlap is demonstrated from the media queries rather than observed rendering, for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
