### PR TITLE
fix(dashboard): close the five measured canvas gaps on the terminal dashboard

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -7242,7 +7242,13 @@ main.app-content[data-chrome="none"] {
 [data-design="terminal"] .ps-coin-trigger-dot,
 [data-design="terminal"] .ps-coin-opt-dot,
 [data-design="terminal"] .auth-avatar-btn,
-[data-design="terminal"] .coin-icon,
+/* .coin-icon removed (#630/#631). CoinIcon sets border-radius inline on
+   every render path - `square ? 0 : '50%'` - so its default already keeps
+   the rail's 16px marks round without a rule, and this entry's !important
+   was overruling the component's own square request on the 26px mark.
+   The list is also too blunt for the ruling it enforces: 50% is permitted
+   on inherently circular glyphs at 24px or under, and a selector cannot
+   tell a 16px icon from a 26px one. The component can. */
 [data-design="terminal"] .tj-lev-slider::-webkit-slider-thumb,
 [data-design="terminal"] .tj-lev-slider::-moz-range-thumb {
   border-radius: 50% !important;

--- a/app/globals.css
+++ b/app/globals.css
@@ -6938,6 +6938,44 @@ main.app-content[data-chrome="none"] {
 [data-design="terminal"] .dash-main > .dash-conditions-row > * + * {
   border-left: 1px solid var(--bdr);
 }
+
+/* #630: the RAIL is banded too. #607 did this for .dash-main and stopped
+   there, so the main column read as one continuous surface while the rail
+   beside it still read as a stack of boxes - which is why the page looked
+   nearly right rather than right.
+
+   Dashboard 2a.dc.html:171 draws each rail row as
+   `padding:9px 14px; border-bottom:1px solid #131618; background:{{ c.selBg }}`
+   with selBg from :381 - `transparent`, or `rgba(217,166,38,.05)` when
+   selected. #131618 IS --bdr2 and #d9a626 IS --accent, both exactly, so this
+   is tokens rather than transcribed literals.
+
+   `border: 0` first because the base rule sets border-left-width: 2px, which
+   a border-bottom shorthand alone would leave standing. */
+[data-design="terminal"] .csb2-card {
+  padding: 9px 14px;
+  background: transparent;
+  border: 0; border-bottom: 1px solid var(--bdr2);
+}
+[data-design="terminal"] .csb2-card.csb2-sel {
+  background: color-mix(in srgb, var(--accent) 5%, transparent);
+  /* The base rule raises the selected card with --nm-raise. A neumorphic
+     shadow is the opposite of this design - flat, hairlines only. */
+  box-shadow: none;
+}
+/* Hover is the one state the frames cannot specify - they are static, and
+   this row is clickable, so it needs an affordance. A faint neutral tint
+   rather than a second accent state, so it never reads as "selected": the
+   same 4% --txt2 mix the badge overlays already use. */
+[data-design="terminal"] .csb2-card:hover {
+  background: color-mix(in srgb, var(--txt2) 4%, transparent);
+}
+[data-design="terminal"] .csb2-card.csb2-sel:hover {
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+}
+
+/* #630: 12px 20px, per the canvas's selected-coin row. */
+[data-design="terminal"] .dash-main > .scc-card { padding: 12px 20px; }
 [data-design="terminal"] .dash-conditions-row .av-rail-panel { background: transparent; }
 /* Kept as the radius floor for .scc-card. Under terminal the only .scc-card
    that renders is the one inside .dash-main above (app/dashboard/page.tsx's

--- a/components/CoinIcon.tsx
+++ b/components/CoinIcon.tsx
@@ -4,15 +4,28 @@ import type { CoinId } from '@/lib/marketStore';
 import { withAlpha } from '@/lib/color';
 
 /** Crypto coin icon - locally bundled real logo for every supported coin (public/coin-icons/{coin}.png). */
-export default function CoinIcon({ coin, size = 22, color, bg }: { coin: CoinId; size?: number; color?: string; bg?: string }) {
+/* `square` exists because the radius is set INLINE below, and an inline style
+ * beats a stylesheet rule without !important - so a terminal-scoped CSS
+ * override would have silently done nothing. That is exactly how #629's first
+ * attempt at hiding the price ticker failed, and the lesson is the same one:
+ * when the component sets the value, the component owns the decision.
+ *
+ * Opt-in rather than derived from `size`, so the current design's own 26px
+ * marks are untouched - the project's radius ruling (50% only on inherently
+ * circular glyphs, <=24px) is what makes the terminal's 26px one wrong, and
+ * only that call site is being corrected here. The frames keep their 16px
+ * rail marks round, so this is not "squares everywhere". */
+export default function CoinIcon({ coin, size = 22, color, bg, square = false }: { coin: CoinId; size?: number; color?: string; bg?: string; square?: boolean }) {
+  const radius = square ? 0 : '50%';
   const [failed, setFailed] = useState(false);
   const src = `/coin-icons/${coin}.png`;
   // Every supported coin has a bundled icon file, so this should never trigger. If a file is
-  // ever missing, fall back to a plain neutral circle - never a letter/text abbreviation.
+  // ever missing, fall back to a plain neutral shape in the same silhouette as
+  // the icon it replaces - never a letter/text abbreviation.
   if (failed) {
     return (
       <span className="coin-icon" style={{
-        width: size, height: size, borderRadius: '50%', flexShrink: 0,
+        width: size, height: size, borderRadius: radius, flexShrink: 0,
         background: bg ?? 'rgba(255,255,255,0.07)',
         border: `0.5px solid ${color ? withAlpha(color, '44') : 'rgba(255,255,255,0.1)'}`,
         display: 'inline-block',
@@ -32,7 +45,7 @@ export default function CoinIcon({ coin, size = 22, color, bg }: { coin: CoinId;
       alt={coin}
       width={size}
       height={size}
-      style={{ borderRadius: '50%', flexShrink: 0, display: 'block' }}
+      style={{ borderRadius: radius, flexShrink: 0, display: 'block' }}
       onError={() => setFailed(true)}
     />
   );

--- a/components/DashboardTerminal.tsx
+++ b/components/DashboardTerminal.tsx
@@ -732,7 +732,12 @@ function TSelectedCoinCard() {
       className="scc-card"
       title={t('DASH_SELECTED_COIN_OPEN_ARENA', { coin: id.toUpperCase() })}
     >
-      <CoinIcon coin={id} size={26} color={badgeCol} bg={withAlpha(badgeCol, '24')} />
+      {/* square (#630): the canvas draws this one at 26x26 with a 1px border
+          and NO border-radius, and the project's radius ruling allows 50%
+          only on inherently circular glyphs at 24px or under. The rail's
+          16px marks stay round - the frames draw those with
+          border-radius:50% - so this is the single 26px mark, not a sweep. */}
+      <CoinIcon coin={id} size={26} color={badgeCol} bg={withAlpha(badgeCol, '24')} square />
       <div className="scc-id">
         <span className="scc-ticker">{id.toUpperCase()}</span>
         <span className="scc-price">{d?.price ? '$' + fmtPrice(d.price, dec) : '-'}</span>

--- a/components/TerminalNav.tsx
+++ b/components/TerminalNav.tsx
@@ -178,10 +178,17 @@ export default function TerminalNav({ onOpenDrawer }: TerminalNavProps) {
       {/* Desktop 44px bar */}
       <header className="tnav">
         <Link href="/dashboard" className="tnav-brand">
-          {/* tone/radius fixed rather than theme-derived: the frames use one
-              logo asset in both the dark and light variants, and radius 0 is
-              the design's blanket rule - it has no round elements. */}
-          <BrandMark size={20} tone="mono" radiusPct={0} compact />
+          {/* tone="dark", NOT "mono" (#630). The mark's blue IS the design -
+              BrandMark's own header records that the handoff's logo.png
+              decodes to #2E7BFF/#6FD3FF/#1C3E76 and that frame 7a references
+              it three times, which is why the colour check exempts it rather
+              than "fixing" the component. mono paints the tile #080C15
+              against a #08090a nav, so the mark all but vanished and read as
+              a missing logo. LandingTerminal, already shipped and verified,
+              uses tone="dark" radiusPct={0} - this now matches it.
+              radius 0 is the design's blanket rule; compact is BrandMark's
+              own guidance for <=24px, where three thin bars turn to mush. */}
+          <BrandMark size={20} tone="dark" radiusPct={0} compact />
           <span className="tnav-wordmark">{t('TNAV_WORDMARK')}</span>
         </Link>
 
@@ -237,7 +244,7 @@ export default function TerminalNav({ onOpenDrawer }: TerminalNavProps) {
 
       {/* Mobile 38px header */}
       <header className="tnav-mhead">
-        <BrandMark size={18} tone="mono" radiusPct={0} compact />
+        <BrandMark size={18} tone="dark" radiusPct={0} compact />
         <span className="tnav-mbrand">{screenNameFor(pathname, t)}</span>
         <span className="tnav-mscreen" />
         {session && (

--- a/lib/labelDefaults.en.json
+++ b/lib/labelDefaults.en.json
@@ -537,7 +537,7 @@
   "DASH_COIN_SIGNALS_HEADER": "Coin Signals - {coin}",
   "DASH_BEST_SETUP_TODAY_HEADER": "Best Setup Today",
   "DASH_PLAYBOOK_HEADER": "Playbook",
-  "TNAV_WORDMARK": "LiquidityHQ",
+  "TNAV_WORDMARK": "LIQUIDITYHQ",
   "TNAV_ARIA_LABEL": "Main navigation",
   "TNAV_MORE_ARIA": "Open navigation menu",
   "TNAV_DESK_LABEL": "Overview",


### PR DESCRIPTION
## Summary

Closes #630. Five measured gaps against `Dashboard 2a.dc.html`, each fixed against the frame rather than by eye. Two of them turned out to hinge on the same failure mode as #629 — an inline style silently beating CSS.

## The five

**1. The nav mark — present all along, but effectively invisible.** `TerminalNav` has rendered `<BrandMark>` since #627; the query that found it "absent" looked for `.tnav-brand img`, and the element is an `<svg>`. The *effect* was real though: I passed `tone="mono"`, which paints the tile `#080C15` on a `#08090a` nav.

`BrandMark`'s own header records that the blue **is** the design — the handoff's `logo.png` decodes to `#2E7BFF`/`#6FD3FF`/`#1C3E76`, and frame 7a references it three times, which is why the colour check exempts the mark rather than "fixing" the component. `LandingTerminal`, already shipped and verified, uses `tone="dark" radiusPct={0}`. The nav now matches it.

**2. Wordmark string.** Canvas draws `LIQUIDITYHQ`; computed `text-transform` was `none`, so it is the string. `landing.md` is explicit that uppercase here is real text, not a transform — so the label value changed, not the CSS.

**3. The rail is banded now.** The biggest visual gap. `Dashboard 2a.dc.html:171`:

```
padding:9px 14px; border-bottom:1px solid #131618; background:{{ c.selBg }}
```

with `selBg` at `:381` — `transparent`, or `rgba(217,166,38,.05)` selected. **`#131618` is exactly `--bdr2`; `#d9a626` is exactly `--accent`** — so this is tokens, not transcribed literals. The base rule's `border-left-width: 2px` and its `--nm-raise` shadow both had to go: a neumorphic raise is the opposite of a flat hairline design.

**4. The 26px mark is square — and this could not be done in CSS.** `CoinIcon` sets `borderRadius: '50%'` **inline**, so a terminal-scoped rule would have lost the same specificity contest that made #629's first `display: none` a no-op. It takes a `square` prop instead. Opt-in, so the current design's 26px marks are untouched; the rail's 16px marks stay round because the frames draw them round.

**5. Selected-coin padding** — canvas `12px 20px`, built `11px 14px`.

## One addition the frames cannot specify

The rail rows are clickable and the frames are static, so hover has no canvas answer. It gets a faint neutral tint (`--txt2` at 4%, the mix already used for badge overlays) rather than a second accent state — it must never read as "selected". Selected-hover goes to 8% accent. Flagged rather than slipped in.

## How to test (QA)

`/dashboard?design=terminal` at 1440:

1. Nav shows a **blue** mark left of the wordmark, and the wordmark reads `LIQUIDITYHQ` in caps.
2. The rail reads as banded rows continuous with the main column — bottom hairline only, no boxes, no per-row fill.
3. Only the selected row carries a faint amber tint. Hovering an unselected row gives a neutral tint that does not look like selection.
4. The selected-coin mark is a **26px square**; the rail's small coin marks are still **round**.
5. Selected-coin row padding measures `12px 20px`.

`/dashboard` with **no** design flag: rail cards, round 26px marks, unchanged.

## Risk level

**Medium.** `CoinIcon` is shared across the app, so item 4 touches a component many screens render — but the prop defaults to `false` and only `DashboardTerminal`'s one call site passes it, so every other call is byte-identical.

**Not verified in a browser.** The local dev server died twice and a startup poll timed out — the same resource exhaustion making `npm run build` crash with `0xC0000142` when chained. Every value here is read off the frame and the token file; none is sampled from a rendered page. Given items 1 and 4 were both cases of *looking* correct in source while being wrong on screen, this needs a real measurement before it is believed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
