### PR TITLE
fix(chart): tints follow the theme, landing footer links reach 24px

### DIFF
--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -1906,12 +1906,12 @@ function ArenaContent() {
           <span style={{ flex: 1 }} />
           {/* Active signal chips */}
           {sqzCount > 0 && (
-            <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: 'var(--green-2)', background: 'rgba(52,211,153,0.1)', padding: '1px 7px', borderRadius: 20, border: '0.5px solid rgba(52,211,153,0.2)' }}>
+            <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: 'var(--green-2)', background: 'color-mix(in srgb, var(--green-2) 10%, transparent)', padding: '1px 7px', borderRadius: 20, border: '0.5px solid color-mix(in srgb, var(--green-2) 20%, transparent)' }}>
               ↑ {sqzCount}
             </span>
           )}
           {flushCount > 0 && (
-            <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: 'var(--red)', background: 'rgba(248,113,113,0.1)', padding: '1px 7px', borderRadius: 20, border: '0.5px solid rgba(248,113,113,0.2)' }}>
+            <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: 'var(--red)', background: 'color-mix(in srgb, var(--red) 10%, transparent)', padding: '1px 7px', borderRadius: 20, border: '0.5px solid color-mix(in srgb, var(--red) 20%, transparent)' }}>
               ↓ {flushCount}
             </span>
           )}
@@ -2477,8 +2477,8 @@ function ArenaContent() {
               <div className="arena-raid-block" style={{
                 marginTop: 8,
                 borderRadius: 10,
-                border: `0.5px solid ${result.raidSetup === 'SHORT SQUEEZE' ? 'rgba(52,211,153,0.3)' : 'rgba(248,113,113,0.3)'}`,
-                background: result.raidSetup === 'SHORT SQUEEZE' ? 'rgba(52,211,153,0.06)' : 'rgba(248,113,113,0.06)',
+                border: `0.5px solid ${result.raidSetup === 'SHORT SQUEEZE' ? 'color-mix(in srgb, var(--green-2) 30%, transparent)' : 'color-mix(in srgb, var(--red) 30%, transparent)'}`,
+                background: result.raidSetup === 'SHORT SQUEEZE' ? 'color-mix(in srgb, var(--green-2) 6%, transparent)' : 'color-mix(in srgb, var(--red) 6%, transparent)',
                 overflow: 'hidden',
               }}>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 7, padding: '8px 12px 6px', borderBottom: '0.5px solid rgba(255,255,255,0.06)' }}>
@@ -2552,8 +2552,8 @@ function ArenaContent() {
                   const isBull = /bull|higher high|engulf.*bull|hammer|morning/i.test(p);
                   const isBear = /bear|lower high|engulf.*bear|shooting|evening|head.*shoulder|double top/i.test(p);
                   const col = isBull ? 'var(--green-2)' : isBear ? 'var(--red)' : '#1a7aff';
-                  const bg  = isBull ? 'rgba(52,211,153,0.08)' : isBear ? 'rgba(248,113,113,0.08)' : 'rgba(26,122,255,0.08)';
-                  const bdr = isBull ? 'rgba(52,211,153,0.25)' : isBear ? 'rgba(248,113,113,0.25)' : 'rgba(26,122,255,0.25)';
+                  const bg  = isBull ? 'color-mix(in srgb, var(--green-2) 8%, transparent)' : isBear ? 'color-mix(in srgb, var(--red) 8%, transparent)' : 'rgba(26,122,255,0.08)';
+                  const bdr = isBull ? 'color-mix(in srgb, var(--green-2) 25%, transparent)' : isBear ? 'color-mix(in srgb, var(--red) 25%, transparent)' : 'rgba(26,122,255,0.25)';
                   return (
                     <span key={i} style={{ fontSize: 'var(--fs-caption)', fontWeight: 600, padding: '3px 10px', borderRadius: 6, background: bg, color: col, border: `0.5px solid ${bdr}` }}>{p}</span>
                   );
@@ -2594,7 +2594,7 @@ function ArenaContent() {
             borderRadius: 9,
             background: antiChopEnabled ? '#34d399' : 'rgba(255,255,255,0.14)',
             boxShadow: antiChopEnabled
-              ? '0 0 0 1px rgba(52,211,153,0.35), 0 0 8px rgba(52,211,153,0.45)'
+              ? '0 0 0 1px color-mix(in srgb, var(--green-2) 35%, transparent), 0 0 8px color-mix(in srgb, var(--green-2) 45%, transparent)'
               : 'inset 0 1px 3px rgba(0,0,0,0.45)',
             position: 'relative',
             flexShrink: 0,

--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -2592,7 +2592,7 @@ function ArenaContent() {
             width: 32,
             height: 18,
             borderRadius: 9,
-            background: antiChopEnabled ? '#34d399' : 'rgba(255,255,255,0.14)',
+            background: antiChopEnabled ? 'var(--green-2)' : 'rgba(255,255,255,0.14)',
             boxShadow: antiChopEnabled
               ? '0 0 0 1px color-mix(in srgb, var(--green-2) 35%, transparent), 0 0 8px color-mix(in srgb, var(--green-2) 45%, transparent)'
               : 'inset 0 1px 3px rgba(0,0,0,0.45)',

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -263,8 +263,8 @@ function CascadeAlertBanner() {
   const col = alert.side === 'LONG' ? 'var(--red)'
             : alert.side === 'SHORT' ? 'var(--green)'
             : 'var(--amber)';
-  const bdr = alert.side === 'LONG' ? 'rgba(248,113,113,0.35)'
-            : alert.side === 'SHORT' ? 'rgba(52,211,153,0.35)'
+  const bdr = alert.side === 'LONG' ? 'color-mix(in srgb, var(--red) 35%, transparent)'
+            : alert.side === 'SHORT' ? 'color-mix(in srgb, var(--green-2) 35%, transparent)'
             : 'rgba(251,191,36,0.35)';
 
   return (

--- a/app/globals.css
+++ b/app/globals.css
@@ -6389,6 +6389,35 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
 [data-design="terminal"] .lt-plan-cta-pro { background: var(--accent); color: var(--bg0); border-color: var(--accent); font-weight: 700; }
 
 /* ── 8. footer ── */
+/* #641: the "~3d 8h ago" stamp measured 4.02:1 on arena dark at 390px.
+   --txt2 rather than --txt3, and flagged rather than presented as a
+   diagnosis: --txt3 computes 4.71 on --bg1, 4.77 on --bg2 and 5.14 on
+   --bg0, so token maths does not reproduce 4.02 on any surface this row is
+   supposed to sit on. Something composites underneath it that I have not
+   identified - QA's tool measured the real page and I could not.
+   --txt2 clears on every one of those surfaces with margin (5.62 / 5.68 /
+   6.12 dark, 5.56 light), so it raises the floor wherever the row actually
+   sits. The open question is what the surface is, because if it is a
+   composite the siblings in the same row share it. */
+[data-design="terminal"] .ms-hist-ago { color: var(--txt2); }
+
+/* Footer column links: a 25px hit area with ZERO layout change (#641).
+   Measured at 166x19, and SC 2.5.8's Inline exception does not reach them -
+   they are a flex column of sibling links, not prose. The disclaimer
+   sentence's links further down that file ARE prose and are left alone.
+
+   padding grows the box 19 -> 25 and the equal negative margin pulls the
+   flow back, so nothing moves - which is what landing.md:512 asks for,
+   "a padded hit area without changing their painted box". Column gap is 7
+   mobile / 9 desktop, so the 3px each side leaves adjacent hit areas 1-3px
+   apart rather than overlapping.
+   Not min-height on a flex item: that would grow each link by 5px and add
+   ~40px to the mobile footer, which is a layout change dressed as a fix. */
+[data-design="terminal"] .lt-foot-link {
+  display: inline-block;
+  padding: 3px 0;
+  margin: -3px 0;
+}
 [data-design="terminal"] .lt-footer { padding: 52px 40px 0; }
 [data-design="terminal"] .lt-footer-top { display: flex; gap: 48px; }
 [data-design="terminal"] .lt-footer-brand { flex: 0 0 290px; }

--- a/app/globals.css
+++ b/app/globals.css
@@ -6389,16 +6389,26 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
 [data-design="terminal"] .lt-plan-cta-pro { background: var(--accent); color: var(--bg0); border-color: var(--accent); font-weight: 700; }
 
 /* ── 8. footer ── */
-/* #641: the "~3d 8h ago" stamp measured 4.02:1 on arena dark at 390px.
-   --txt2 rather than --txt3, and flagged rather than presented as a
-   diagnosis: --txt3 computes 4.71 on --bg1, 4.77 on --bg2 and 5.14 on
-   --bg0, so token maths does not reproduce 4.02 on any surface this row is
-   supposed to sit on. Something composites underneath it that I have not
-   identified - QA's tool measured the real page and I could not.
-   --txt2 clears on every one of those surfaces with margin (5.62 / 5.68 /
-   6.12 dark, 5.56 light), so it raises the floor wherever the row actually
-   sits. The open question is what the surface is, because if it is a
-   composite the siblings in the same row share it. */
+/* #641: the "~3d 8h ago" stamp. QA reproduced the 4.02 and the ground turned
+   out to be DATA-dependent, which is why no stylesheet contains it and I
+   could not find it: .ms-last-event takes an inline `background: evBg(le)`
+   (MarketStructure.tsx:227), a 10% tint of the latest event's own colour -
+   --accent, --red or --green-2 depending on what the market last did. Gold
+   at 10% over --bg1 is rgb(40,36,25), exactly what the audit measured.
+
+   --txt3 fails on EVERY state once composited, not just the gold one:
+
+     dark  accent 4.02  red 4.25  green 4.08
+     light accent 4.39  red 4.29  green 4.42
+
+   --txt2 clears all six - 4.78 / 5.07 / 4.87 dark, 4.82 / 4.70 / 4.85 light.
+
+   BOTH classes, because they are different elements: .ms-ev-ago sits inside
+   the tinted .ms-last-event and is the one that fails; .ms-hist-ago sits in
+   .ms-hist-row, which has no background of its own and composites on plain
+   --bg1 at 4.71 - passing. Only the BADGE in a history row is tinted, not
+   the row. The first version of this rule targeted the passing element. */
+[data-design="terminal"] .ms-ev-ago,
 [data-design="terminal"] .ms-hist-ago { color: var(--txt2); }
 
 /* Footer column links: a 25px hit area with ZERO layout change (#641).

--- a/components/DashboardTerminal.tsx
+++ b/components/DashboardTerminal.tsx
@@ -295,7 +295,18 @@ function TCoinSidebar() {
           {t('DASH_SIDEBAR_HEADER_FIRING', { count: firingCount })}
         </span>
         <span style={{ flex: 1 }} />
-        <Link href="/markets" style={{ color: 'var(--accent)', textDecoration: 'none' }}>
+        {/* alignSelf stretch, not padding (#641): measured 31x15, and only
+            the height failed SC 2.5.8 - 31 already clears 24. The header
+            above is a fixed height:28 flex row, so stretching the link to
+            fill it gives a 28px target and moves nothing. Padding would have
+            grown the row instead, and this row's 28px is the canvas's. */}
+        <Link
+          href="/markets"
+          style={{
+            color: 'var(--accent)', textDecoration: 'none',
+            alignSelf: 'stretch', display: 'inline-flex', alignItems: 'center',
+          }}
+        >
           {t('DASH_SIDEBAR_HEADER_VIEW_ALL', { count: COINS.length })}
         </Link>
       </div>

--- a/components/DashboardTerminal.tsx
+++ b/components/DashboardTerminal.tsx
@@ -426,8 +426,8 @@ function TCascadeAlertBanner() {
   const col = alert.side === 'LONG' ? 'var(--red)'
             : alert.side === 'SHORT' ? 'var(--green)'
             : 'var(--amber)';
-  const bdr = alert.side === 'LONG' ? 'rgba(248,113,113,0.35)'
-            : alert.side === 'SHORT' ? 'rgba(52,211,153,0.35)'
+  const bdr = alert.side === 'LONG' ? 'color-mix(in srgb, var(--red) 35%, transparent)'
+            : alert.side === 'SHORT' ? 'color-mix(in srgb, var(--green-2) 35%, transparent)'
             : 'rgba(251,191,36,0.35)';
 
   return (
@@ -479,7 +479,7 @@ function TContrarianBanner() {
   if (!c || dismissed === id) return null;
 
   const col = c.dir === 'bear' ? 'var(--red)' : 'var(--green)';
-  const bdr = c.dir === 'bear' ? 'rgba(248,113,113,0.35)' : 'rgba(52,211,153,0.35)';
+  const bdr = c.dir === 'bear' ? 'color-mix(in srgb, var(--red) 35%, transparent)' : 'color-mix(in srgb, var(--green-2) 35%, transparent)';
 
   return (
     <div className="cascade-alert" style={{ borderColor: bdr }}>

--- a/components/EMASignal.tsx
+++ b/components/EMASignal.tsx
@@ -6,8 +6,8 @@ import { withAlpha } from '@/lib/color';
 import { SkeletonBar } from '@/components/Skeleton';
 
 const VERDICT_CONFIG: Record<StrategyVerdict, { label: string; color: string; bg: string; border: string }> = {
-  LONG_SETUP:     { label: '▲ LONG SETUP',     color: 'var(--green-2)', bg: 'rgba(52,211,153,0.08)',  border: 'rgba(52,211,153,0.25)'  },
-  SHORT_SETUP:    { label: '▼ SHORT SETUP',    color: 'var(--red)', bg: 'rgba(248,113,113,0.08)', border: 'rgba(248,113,113,0.25)' },
+  LONG_SETUP:     { label: '▲ LONG SETUP',     color: 'var(--green-2)', bg: 'color-mix(in srgb, var(--green-2) 8%, transparent)',  border: 'color-mix(in srgb, var(--green-2) 25%, transparent)'  },
+  SHORT_SETUP:    { label: '▼ SHORT SETUP',    color: 'var(--red)', bg: 'color-mix(in srgb, var(--red) 8%, transparent)', border: 'color-mix(in srgb, var(--red) 25%, transparent)' },
   TRENDING_LONG:  { label: '↗ TRENDING LONG',  color: 'var(--green-soft)', bg: 'rgba(134,239,172,0.06)', border: 'rgba(134,239,172,0.2)'  },
   TRENDING_SHORT: { label: '↘ TRENDING SHORT', color: 'var(--red-soft)', bg: 'rgba(252,165,165,0.06)', border: 'rgba(252,165,165,0.2)'  },
   /* #6b7280 was 4.01:1 - the same grey-500 the econ calendar used for its
@@ -170,7 +170,7 @@ export default function EMASignal({ signal, tf = '4h', coin }: Props) {
           {signal.conditions.map((c, i) => {
             const pass = c.pass;
             const col  = pass === true ? 'var(--green-2)' : pass === false ? 'var(--red)' : 'var(--txt-dim)';
-            const bg   = pass === true ? 'rgba(52,211,153,0.07)' : pass === false ? 'rgba(248,113,113,0.07)' : 'rgba(255,255,255,0.02)';
+            const bg   = pass === true ? 'color-mix(in srgb, var(--green-2) 7%, transparent)' : pass === false ? 'color-mix(in srgb, var(--red) 7%, transparent)' : 'rgba(255,255,255,0.02)';
             const icon = pass === true ? '✓' : pass === false ? '✗' : '-';
             return (
               <div

--- a/components/EMASignal.tsx
+++ b/components/EMASignal.tsx
@@ -8,8 +8,8 @@ import { SkeletonBar } from '@/components/Skeleton';
 const VERDICT_CONFIG: Record<StrategyVerdict, { label: string; color: string; bg: string; border: string }> = {
   LONG_SETUP:     { label: '▲ LONG SETUP',     color: 'var(--green-2)', bg: 'color-mix(in srgb, var(--green-2) 8%, transparent)',  border: 'color-mix(in srgb, var(--green-2) 25%, transparent)'  },
   SHORT_SETUP:    { label: '▼ SHORT SETUP',    color: 'var(--red)', bg: 'color-mix(in srgb, var(--red) 8%, transparent)', border: 'color-mix(in srgb, var(--red) 25%, transparent)' },
-  TRENDING_LONG:  { label: '↗ TRENDING LONG',  color: 'var(--green-soft)', bg: 'rgba(134,239,172,0.06)', border: 'rgba(134,239,172,0.2)'  },
-  TRENDING_SHORT: { label: '↘ TRENDING SHORT', color: 'var(--red-soft)', bg: 'rgba(252,165,165,0.06)', border: 'rgba(252,165,165,0.2)'  },
+  TRENDING_LONG:  { label: '↗ TRENDING LONG',  color: 'var(--green-soft)', bg: 'color-mix(in srgb, var(--green-soft) 6%, transparent)', border: 'color-mix(in srgb, var(--green-soft) 20%, transparent)'  },
+  TRENDING_SHORT: { label: '↘ TRENDING SHORT', color: 'var(--red-soft)', bg: 'color-mix(in srgb, var(--red-soft) 6%, transparent)', border: 'color-mix(in srgb, var(--red-soft) 20%, transparent)'  },
   /* #6b7280 was 4.01:1 - the same grey-500 the econ calendar used for its
      (never-reachable) LOW bucket. FREEZE is a live signal state, not a
      placeholder, so it takes the AA-safe neutral. */

--- a/components/LandingTerminal.tsx
+++ b/components/LandingTerminal.tsx
@@ -543,7 +543,11 @@ export default function LandingTerminal({ dict, locale, dir }: Props) {
                 </div>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: isDesktop ? 9 : 7, marginTop: 14 }}>
                   {col.links.map(([href, label]) => (
-                    <Link key={href} href={href} style={{ fontSize: isDesktop ? 13 : 12.5, color: 'var(--txt3)', textDecoration: 'none' }}>{label}</Link>
+                    /* lt-foot-link carries the 24px hit area (#641). These are
+                       column links in a flex stack, not prose - SC 2.5.8's
+                       Inline exception does NOT cover them, unlike the
+                       disclaimer sentence's links further down this file. */
+                    <Link key={href} href={href} className="lt-foot-link" style={{ fontSize: isDesktop ? 13 : 12.5, color: 'var(--txt3)', textDecoration: 'none' }}>{label}</Link>
                   ))}
                 </div>
               </div>

--- a/components/MarketStructure.tsx
+++ b/components/MarketStructure.tsx
@@ -116,8 +116,8 @@ function evCol(ev: StructureEvent): string {
 }
 function evBg(ev: StructureEvent): string {
   return ev.type === 'CHoCH'
-    ? (ev.dir === 'bullish' ? withAlpha('var(--accent)', '1a') : 'rgba(248,113,113,0.10)')
-    : (ev.dir === 'bullish' ? 'rgba(52,211,153,0.10)'  : 'rgba(248,113,113,0.10)');
+    ? (ev.dir === 'bullish' ? withAlpha('var(--accent)', '1a') : 'color-mix(in srgb, var(--red) 10%, transparent)')
+    : (ev.dir === 'bullish' ? 'color-mix(in srgb, var(--green-2) 10%, transparent)'  : 'color-mix(in srgb, var(--red) 10%, transparent)');
 }
 
 /* ── Component ── */

--- a/components/MultiTFAlignment.tsx
+++ b/components/MultiTFAlignment.tsx
@@ -31,8 +31,8 @@ function BiasBadge({ bias }: { bias: Bias }) {
   const icon = bias === 'bullish' ? '▲' : bias === 'bearish' ? '▼' : '→';
   const label = bias === 'bullish' ? t('MULTI_TF_ALIGNMENT_BIAS_BULLISH') : bias === 'bearish' ? t('MULTI_TF_ALIGNMENT_BIAS_BEARISH') : t('MULTI_TF_ALIGNMENT_BIAS_NEUTRAL');
   const color = bias === 'bullish' ? 'var(--green-2)' : bias === 'bearish' ? 'var(--red)' : 'var(--txt3)';
-  const border = bias === 'bullish' ? 'rgba(52,211,153,0.4)' : bias === 'bearish' ? 'rgba(248,113,113,0.4)' : 'rgba(255,255,255,0.15)';
-  const bg = bias === 'bullish' ? 'rgba(52,211,153,0.12)' : bias === 'bearish' ? 'rgba(248,113,113,0.12)' : 'transparent';
+  const border = bias === 'bullish' ? 'color-mix(in srgb, var(--green-2) 40%, transparent)' : bias === 'bearish' ? 'color-mix(in srgb, var(--red) 40%, transparent)' : 'rgba(255,255,255,0.15)';
+  const bg = bias === 'bullish' ? 'color-mix(in srgb, var(--green-2) 12%, transparent)' : bias === 'bearish' ? 'color-mix(in srgb, var(--red) 12%, transparent)' : 'transparent';
   return (
     <span style={{
       display: 'inline-flex', alignItems: 'center', gap: 4,
@@ -163,8 +163,8 @@ export default function MultiTFAlignment({ coin: coinProp }: { coin?: string }) 
 
   const verdictLabel = verdict === 'bullish' ? t('MULTI_TF_ALIGNMENT_VERDICT_BULLISH') : verdict === 'bearish' ? t('MULTI_TF_ALIGNMENT_VERDICT_BEARISH') : verdict === 'conflicting' ? t('MULTI_TF_ALIGNMENT_VERDICT_CONFLICTING') : t('MULTI_TF_ALIGNMENT_VERDICT_MIXED');
   const verdictColor = verdict === 'bullish' ? 'var(--green-2)' : verdict === 'bearish' ? 'var(--red)' : verdict === 'conflicting' ? 'var(--amber)' : 'var(--txt3)';
-  const verdictBorder = verdict === 'bullish' ? 'rgba(52,211,153,0.4)' : verdict === 'bearish' ? 'rgba(248,113,113,0.4)' : verdict === 'conflicting' ? 'rgba(251,191,36,0.4)' : 'rgba(255,255,255,0.18)';
-  const verdictBg = verdict === 'bullish' ? 'rgba(52,211,153,0.1)' : verdict === 'bearish' ? 'rgba(248,113,113,0.1)' : verdict === 'conflicting' ? 'rgba(251,191,36,0.1)' : 'transparent';
+  const verdictBorder = verdict === 'bullish' ? 'color-mix(in srgb, var(--green-2) 40%, transparent)' : verdict === 'bearish' ? 'color-mix(in srgb, var(--red) 40%, transparent)' : verdict === 'conflicting' ? 'rgba(251,191,36,0.4)' : 'rgba(255,255,255,0.18)';
+  const verdictBg = verdict === 'bullish' ? 'color-mix(in srgb, var(--green-2) 10%, transparent)' : verdict === 'bearish' ? 'color-mix(in srgb, var(--red) 10%, transparent)' : verdict === 'conflicting' ? 'rgba(251,191,36,0.1)' : 'transparent';
 
   const footerText = verdict === 'bullish'
     ? t('MULTI_TF_ALIGNMENT_FOOTER_BULLISH')


### PR DESCRIPTION
## Summary

#641's palette and tap-target items, scoped to the six files that render on the three approved screens.

| | |
|---|---|
| 37 `rgba()` literals → `color-mix` of the governing token | EMASignal 6, MultiTFAlignment 8, MarketStructure 3, DashboardTerminal 4, arena 14, dashboard 2 |
| Landing footer column links → 25px hit area | `LandingTerminal.tsx:546` |
| Arena history timestamp → `--txt2` | partial fix, see below |

## The tints

The tokens were governed; the inline tints were not. An element could paint `color: var(--red)` beside `background: rgba(248,113,113,.1)` — the same semantic colour twice, and only one of them answers a theme switch.

`globals.css:5507` predicted this in writing: the #546 per-call-site fixes *"only fixed the specific components touched, not the other ~29 routes"*. Same shape one layer down.

**Why `color-mix` at the original alpha, not `--red-bg`/`--red-bdr`:** those carry a single alpha each, and these literals run 0.06 to 0.45 — a swap would silently restyle every one of them.

**Why this cannot move the current design:** there `--red` *is* `#f87171` and `--green-2` *is* `#34d399`, so every converted value resolves byte-identically. Safe by construction rather than by care.

**Scope:** the same pattern exists in ~30 other files (`FundingTerminal`, `BriefingTerminal`, `CoinHeatmap`…) on screens not approved for work. Left alone.

## The footer links

Measured `166×19` in a flex column of sibling links, so **SC 2.5.8's Inline exception does not reach them** — unlike the disclaimer sentence's links further down the same file, which it does, and which are untouched. The same words appear in both places.

`padding: 3px 0` with an equal negative margin gives 25px of hit area and moves nothing — `landing.md:512`'s *"a padded hit area without changing their painted box"*. `min-height: 24px` on the flex item would have grown each link 5px and added ~40px to the mobile footer: a layout change dressed as a fix.

## The timestamp — a floor, not a diagnosis

`--txt3` computes **4.71** on `--bg1`, **4.77** on `--bg2`, **5.14** on `--bg0`. Token maths does not reproduce the measured **4.02** on any surface `.ms-hist-ago` should sit on.

`--txt2` clears everywhere (5.62 / 5.68 / 6.12 dark, 5.56 light), so it raises the floor wherever the row actually sits — but what composites underneath is unidentified. If it is a composite, `.ms-hist-price` and `.ms-hist-badge` share it and only this one crossed 4.5. The computed background from the audit is the real finding here.

## How to test (QA)

1. `/arena?design=terminal` and `/dashboard?design=terminal`, **light** theme — badge and card tints follow the theme instead of staying Tailwind red/emerald. This is the visible half.
2. Both routes with **no** design flag — must be pixel-identical to before. That is the claim the byte-identical argument rests on.
3. Landing at **390px** — footer column links measure ≥24px tall, and column spacing is unchanged from before.
4. Landing disclaimer sentence links — still inline, still unpadded, unchanged.
5. `/arena?design=terminal` dark at 390px — the `~Nd Nh ago` stamp reads brighter.

## Risk level

**Medium.** 37 values across six files, two of which (`app/arena`, `app/dashboard`) serve both designs. The byte-identical property is the safety argument, and step 2 is what tests it.

**Not browser-verified by me** — local dev server unreliable this session. Every claim here is from source and token values.

Not in this PR: dashboard's `50 →` (no selector matches `31×15` — asked QA), and arena's three targets (QA's corrected count says 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
