### PR TITLE
docs(qa): correct the three-screen status and record what measurement found

### DIFF
--- a/qa/CANVAS_MIRROR_TASK.md
+++ b/qa/CANVAS_MIRROR_TASK.md
@@ -175,29 +175,64 @@ cannot see "present but built differently" per §7, so a fresh percentage would
 undersell what live verification already confirmed and oversell what it can't
 check (structural correctness, colour-as-data rules, states).
 
-| route | canvas labels present (838471c) | branch | status, 2026-09-02 |
+| route | canvas labels present (838471c) | branch | status, 2026-09-03 |
 |---|---|---|---|
 | `/learn` | 3/5 — 60% | `feature/learn-canvas-mirror` | untouched |
-| **`/`** (landing) | ~~25/49 — 51%~~ | `feature/landing-canvas-mirror` | **done, deployed, verified live** |
+| **`/`** (landing) | ~~25/49 — 51%~~ | `feature/landing-canvas-mirror` | **built, deployed** — open: #639 (two `--txt4` flags needing a design ruling), #641 (footer column links). |
 | `/econ-calendar` | 10/21 — 48% | `feature/econ-calendar-canvas-mirror` | untouched |
 | `/liq` | 9/20 — 45% | `feature/liq-canvas-mirror` | untouched — has a spec (`liquidation-map.md`) |
 | `/calc` | 4/9 — 44% | `feature/calc-canvas-mirror` | untouched |
 | `/news` | 3/8 — 38% | `feature/news-canvas-mirror` | untouched |
 | `/about` | 5/15 — 33% | `feature/about-canvas-mirror` | untouched |
-| **`/dashboard`** | ~~8/26 — 31%~~ | `feature/dashboard-canvas-mirror` | **done, deployed, verified live** — one open colour gap, #614 |
+| **`/dashboard`** | ~~8/26 — 31%~~ | `feature/dashboard-canvas-mirror` | **built, deployed** — #614 closed. Open: #635 (substitutions), #641 (tap target, tints). See the note below on what "done" does and does not mean here. |
 | `/faq` | 3/10 — 30% | `feature/faq-canvas-mirror` | untouched |
 | `/disclaimer` | 4/14 — 29% | `feature/disclaimer-canvas-mirror` | untouched |
 | `/markets` | 2/8 — 25% | `feature/markets-canvas-mirror` | untouched — has a spec (`markets.md`) |
 | `/journal` | 3/13 — 23% | `feature/journal-canvas-mirror` | untouched — has a spec (`journal.md`) |
 | `/alerts` | 3/13 — 23% | `feature/alerts-canvas-mirror` | untouched — has a spec (`alerts.md`) |
 | `/offline` | 2/10 — 20% | `feature/offline-canvas-mirror` | untouched |
-| **`/arena`** | ~~10/51 — 20%~~ | `feature/arena-canvas-mirror` | **done, deployed, verified live** — one open colour gap (#614, shared with dashboard), shell nav in progress (#616) |
+| **`/arena`** | ~~10/51 — 20%~~ | `feature/arena-canvas-mirror` | **built, deployed** — #614 and #616 both closed. Open: #637 (BTC liq levels in the per-coin AI prompt), #638, #639, #641. |
 | `/funding` | 3/19 — 16% | `feature/funding-canvas-mirror` | untouched — has a spec (`funding.md`) |
 | **`/briefing`** | 2/17 — 12%, and this is probably generous | `feature/briefing-canvas-mirror` | **retracted the colour-fix assignment same day — real gap, see #620.** briefing.md's fidelity note compares terminal against production, never against the canvas; both share the same `mb-*` structure and neither has anything the canvas draws (headline+prose+levels rail+candlestick chart+CTAs vs the built page's setups/gauges/chips/news-feed). Zero section overlap, confirmed by reading the canvas directly, not the spec's note. Rebuild-sized, not a colour pass. |
 
-**3 of 17 routes done as of 2026-09-02. 1 in progress. 13 untouched.
-This is not close to finished — do not read three done screens as the
+**3 of 17 routes built as of 2026-09-03. 14 untouched.
+This is not close to finished — do not read three built screens as the
 project being near done.**
+
+### "Built and deployed" is not "done" — read this before reporting status
+
+The three rows above were marked *done, deployed, verified live* on
+2026-09-02 and that was true of the work that had been done. It was not
+true of the screens. A measurement pass on 2026-09-03 against staging
+`365f574` found five open defects on them, none of which any earlier check
+could have caught:
+
+- Two colours with **no light-theme value at all** (#638) — literals, not
+  tokens, so nothing in the token layer could surface them.
+- `--txt4` carrying content it is not scoped for (#639), including one case
+  the design **exempts by name** whose exemption's own revocation condition
+  has since been met.
+- **160 hardcoded `rgba()` tints across 37 files** (#641), of which the
+  three screens own 37 on 21 lines. `globals.css` had already predicted
+  exactly this in a comment: governing the tokens did not reach the inline
+  literals.
+- **A contrast failure that only exists in some data states** (#642) — the
+  ground under one row comes from an inline `background` computed per
+  market-structure event, so it fails at 4.02/4.13/3.97 in three states and
+  passes in the fourth. Not reproducible from the stylesheet.
+- BTC-scoped data feeding a per-coin AI analysis with no scope disclosure
+  (#637).
+
+**The lesson for the remaining 14 routes:** a screen that mirrors its canvas
+structurally can still be wrong in ways structural comparison cannot see —
+theme coverage, token discipline, and data-dependent states. Budget a
+measurement pass per screen *after* the mirror work, and run
+`qa/mobile-audit.mjs` and `qa/dialog-audit.mjs` rather than writing a new
+sweep: an ad-hoc script produced three false positives in one session
+(a phantom 334px overflow, a phantom 1.14:1, and a missed tint) against
+committed tools that had already solved each trap.
+
+Dialogs on all three screens are still **unmeasured**.
 
 ### How to read these numbers
 


### PR DESCRIPTION
## Summary

Corrects the three-screen status in `qa/CANVAS_MIRROR_TASK.md` and records what a measurement pass found on them, so the remaining 14 routes don't repeat it.

## What changed

- The `/`, `/dashboard` and `/arena` rows said **"done, deployed, verified live"**. They now say **"built, deployed"** and list what is actually open on each.
- **#614 and #616 are closed** — the table still listed them as the outstanding work.
- New section: *"Built and deployed" is not "done"*, naming the five defect classes found on 2026-09-03 against staging `365f574`.

## Why

The table was being read as three finished screens, and I read it that way myself when I reported them complete. A measurement pass found five open defects (#637, #638, #639, #641, #642) that no structural canvas comparison could have surfaced:

- two colours with **no light-theme value at all** — literals, not tokens, so the token layer couldn't reveal them
- `--txt4` carrying content it isn't scoped for, including one case the design **exempts by name** whose exemption's own revocation condition has since been met
- **160 hardcoded `rgba()` tints across 37 files** — `globals.css` had already predicted this in a comment: governing the tokens never reached the inline literals
- a contrast failure that **only exists in some data states**, because the ground under one row is computed per market-structure event — 4.02/4.13/3.97 in three states, passing in the fourth, and not derivable from the stylesheet
- BTC-scoped data feeding a per-coin AI analysis with no scope disclosure

The note also tells whoever takes the next route to run `qa/mobile-audit.mjs` and `qa/dialog-audit.mjs` rather than write a fresh sweep. Mine produced three false positives in one session — a phantom 334px overflow, a phantom 1.14:1, and a missed tint — against committed tools that had already solved each trap and documented it in their own comments.

Dialogs on all three screens are recorded as **still unmeasured**, because they are.

## How to test (QA)

Docs only — no build, no runtime effect.

Read `qa/CANVAS_MIRROR_TASK.md`:

1. The three bolded rows (`/`, `/dashboard`, `/arena`) read **"built, deployed"**, not "done, deployed, verified live", and each names its open issues.
2. **#614 and #616 appear nowhere as open** — both are closed (`gh issue view 614`, `gh pr view 616`).
3. The summary line reads **"3 of 17 routes built as of 2026-09-03. 14 untouched."** — previously "3 of 17 routes done … 1 in progress. 13 untouched."
4. The new section after that line lists the five defect classes and points at the committed `qa/` tools.

Cross-check the issue numbers cited resolve to real open issues: #635, #637, #638, #639, #641.

## Risk level

**Low.** Markdown only, no code path touched. The claims are QA's own measurements against staging `365f574`; the defect counts (160 tints / 37 files) were independently reproduced by dev, who reported matching counts before making changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
