### PR TITLE
fix(arena): name the liquidation clusters as BTC's in the AI prompt

### DIFF
--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -779,7 +779,11 @@ function ArenaContent() {
     const exchangeNetFlow = store.btcExchangeNetFlow != null
       ? (store.btcExchangeNetFlow >= 0 ? '+' : '') + '$' + Math.abs(store.btcExchangeNetFlow).toFixed(1) + 'M'
         + (store.btcExchangeNetFlow > 50 ? ' (inflow - sell pressure)' : store.btcExchangeNetFlow < -50 ? ' (outflow - accumulation)' : ' (neutral)')
-      : 'AI will search';
+      /* Same dead fallback as liqLevels below, and beyond #637's literal
+         scope - fixed anyway because leaving one of two identical instances
+         in the same function is how the anti-chop toggle ended up with its
+         background converted and its own boxShadow not. */
+      : 'Not available';
 
     /* Stablecoin flow */
     const stablecoinFlow = store.stablecoinSupply != null
@@ -790,9 +794,17 @@ function ArenaContent() {
       : '-';
 
     /* Liquidation levels */
+    /* "Not available" rather than 'AI will search' (#637). The fallback was a
+       standing instruction to go and look, and Quick mode has no tools to
+       look with - so it spent tokens telling the model to do something it
+       cannot do, and in Deep mode invited a web-searched number to stand in
+       for our own missing data. That is the same reasoning that deleted the
+       retail-sentiment block on 2026-07-31; its removal comment sits eight
+       lines above the LIQUIDATION CLUSTERS header in lib/grok.ts and the
+       pattern survived directly beneath it. */
     const liqLevels = store.btcLiqLevels && store.btcLiqLevels.length > 0
       ? store.btcLiqLevels.slice(0, 4).map(l => '$' + l.price.toLocaleString() + ' ' + l.side).join(' | ')
-      : 'AI will search';
+      : 'Not available';
 
     /* BTC dom trend */
     const btcDomTrend = store.btcDomHistory && store.btcDomHistory.length >= 3

--- a/lib/grok.ts
+++ b/lib/grok.ts
@@ -279,7 +279,18 @@ export function buildPrompt(ctx: GrokContext): string {
     // Quick mode has no tools, so it was a standing instruction the model
     // could not act on, spending tokens to say nothing. Restore alongside a
     // source that actually answers, not as a search prompt.
-    '=== LIQUIDATION CLUSTERS ===',
+    /* BTC in the header, because the data is BTC's whatever coin is being
+       analysed (#637): ctx.liqLevels is built from store.btcLiqLevels, and
+       the string it carries is bare prices and sides with no coin in it. An
+       analysis of SOL was handed a section titled LIQUIDATION CLUSTERS
+       containing BTC's, with nothing marking whose they were - and a model
+       asked for a per-coin read will weave those levels in rather than
+       reject them. Every sibling field in this prompt already names its
+       scope: "CB Premium (Coinbase BTC - Binance BTC)" at :240, "BTC
+       exchange net flow" at :268, "BTC Put/Call Ratio" and "BTC Max Pain
+       Strike" at :232-233. This one was the gap in an otherwise careful
+       set. */
+    '=== BTC LIQUIDATION CLUSTERS (BTC-wide, not the analysed coin) ===',
     ctx.liqLevels,
     '',
     '=== MACRO EVENTS - RELEASED (LAST 72H) + UPCOMING (48H) ===',


### PR DESCRIPTION
## Summary

Closes #637. The AI prompt's liquidation-clusters section now names its scope, and two dead search-instruction fallbacks become honest "Not available".

## The header

`ctx.liqLevels` is built from `store.btcLiqLevels` (`app/arena/page.tsx:792`) and the string it produces is bare prices and sides — `'$113,400 long | $115,800 short'` — with no coin in it. The section header said only `=== LIQUIDATION CLUSTERS ===`.

So an arena read for SOL handed the model **BTC's** clusters under an unqualified heading. The failure isn't a wrong label on a screen a human can sanity-check; it's a plausible sentence about SOL built on BTC's liquidation map.

**Every sibling field in that prompt already names its scope:**

```
grok.ts:240   CB Premium (Coinbase BTC − Binance BTC)
grok.ts:268   BTC exchange net flow (24h)
grok.ts:232   BTC Put/Call Ratio
grok.ts:233   BTC Max Pain Strike
              btcDominance — scope in the key name
```

This was the single gap in an otherwise careful set, which is why it reads as an oversight rather than a decision.

## The fallbacks

`'AI will search'` is a standing instruction to go and look. **Quick mode has no tools to look with**, so it spent tokens telling the model to do something it cannot do — and in Deep mode it invited a web-searched number to stand in for our own missing data.

That is the same reasoning that deleted the retail-sentiment block on 2026-07-31. Its removal comment sits **eight lines above** the `LIQUIDATION CLUSTERS` header, and the pattern survived directly beneath it.

**One is beyond the issue's scope:** `exchangeNetFlow` (`:782`) had the identical fallback two lines up. Fixed anyway — leaving one of two identical instances in the same function is exactly how the anti-chop toggle ended up with its `background` converted and its own `boxShadow` not.

## How to test (QA)

1. `/arena?design=terminal`, run a read on a **non-BTC** coin. The AI's answer must not attribute BTC liquidation levels to that coin — previously it had no way to know they weren't its own.
2. `/api/version` reports `coinglass: false`, so both fields currently take the fallback: they should read **"Not available"**, not "AI will search".
3. Quick mode specifically — that's the mode with no tools, where the old string was pure waste.

## Risk level

**Low.** Prompt text and two fallback strings; no data, no contract, no shape change. Nothing parses either value.

Worth noting for review: this changes what the model is told, so it changes model output. That is the intent — the previous text was making an unqualified claim about whose data it was — but it means the effect is only observable in an actual generated read, not in the four gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
