### PR TITLE
docs(qa): record the dialog measurement for the three built screens

### DIFF
--- a/qa/CANVAS_MIRROR_TASK.md
+++ b/qa/CANVAS_MIRROR_TASK.md
@@ -232,7 +232,32 @@ sweep: an ad-hoc script produced three false positives in one session
 (a phantom 334px overflow, a phantom 1.14:1, and a missed tint) against
 committed tools that had already solved each trap.
 
-Dialogs on all three screens are still **unmeasured**.
+### Dialogs — measured 2026-09-03, on `qa` at `97b8552`
+
+`qa/dialog-audit.mjs`, terminal design, dark and light:
+
+| screen | surfaces | result |
+|---|---|---|
+| `/dashboard` | Ask-AI panel (66 nodes), nav drawer (25 nodes) | clean, both themes |
+| `/arena` | Ask-AI panel (66 nodes), nav drawer (25 nodes) | clean, both themes |
+| `/` (landing) | **none exist** | see below |
+
+Landing returned `did NOT open — UNVERIFIED, not passing` for both, which is the
+tool being correctly conservative rather than a finding. The real answer is that
+landing has no dialog surfaces at all: `app/globals.css:4529-4541` hides
+`.nav-drawer`, `.gchat-fab` and `.gchat-panel` under `body.landing` with
+`display: none !important`, and `components/LandingTerminal.tsx` contains no
+click handlers and no modal state. **"Not applicable" and "not tested" look
+identical in that output — check which one it is before recording either.**
+
+The audit's own caveat still stands and is worth repeating: its triggers are an
+allow-list of known non-destructive openers, so **a dialog not on that list is
+unmeasured, not passing** — including anything behind a destructive control. Its
+`Coin selector` trigger reports "not present on this route" on all three, which
+has not been chased.
+
+So dialogs are covered for the three built screens, and the modal surface of the
+other 14 routes remains entirely unmeasured.
 
 ### How to read these numbers
 


### PR DESCRIPTION
## Summary

Records the dialog measurement for the three built screens in `qa/CANVAS_MIRROR_TASK.md`, replacing the line that said dialogs were still unmeasured.

## What changed

One section. The doc previously ended the three-screen note with *"Dialogs on all three screens are still **unmeasured**."* — that is now the result.

## Why

Dialogs were the only surface in "dark + light + dialogs + mobile" never measured on any of the three screens, and the doc had recorded it as an open gap. `qa/dialog-audit.mjs` exists precisely because a closed dialog is absent or zero-sized in the DOM, so every other sweep silently skips the entire modal surface of the product.

Measured on `qa` at `97b8552`, terminal design, dark and light:

| screen | surfaces | result |
|---|---|---|
| `/dashboard` | Ask-AI panel (66 nodes), nav drawer (25 nodes) | clean, both themes |
| `/arena` | Ask-AI panel (66 nodes), nav drawer (25 nodes) | clean, both themes |
| `/` (landing) | none exist | see below |

**Landing's rows are the reason this needed writing down.** The tool returned `did NOT open — UNVERIFIED, not passing` for both surfaces, which is correct conservatism, not a finding. Landing genuinely has no dialogs: `app/globals.css:4529-4541` hides `.nav-drawer`, `.gchat-fab` and `.gchat-panel` under `body.landing` with `display: none !important`, and `components/LandingTerminal.tsx` has no click handlers and no modal state.

**"Not applicable" and "not tested" are the same string in that output.** Someone will hit that again on a route with no dialogs, and it is equally easy to record a false pass or a false defect from it. That distinction is the main thing this section adds.

The audit's own caveat is repeated rather than dropped: its triggers are an allow-list of known non-destructive openers, so **a dialog not on that list is unmeasured, not passing** — including anything behind a destructive control. Its `Coin selector` trigger reports "not present on this route" on all three screens; that has not been chased and the doc says so.

## How to test (QA)

Docs only. No build, no runtime effect.

Read the "Dialogs" section of `qa/CANVAS_MIRROR_TASK.md`:

1. It names both surfaces per screen with node counts and a per-theme result.
2. It states landing has **no** dialog surfaces and cites `app/globals.css:4529-4541` as the reason — confirm that rule still lists `.nav-drawer`, `.gchat-fab` and `.gchat-panel`.
3. It keeps the allow-list caveat, and records the unchased `Coin selector` trigger rather than omitting it.
4. The old "still unmeasured" sentence is gone.

## Risk level

**Low.** Markdown only. The measurements are reproducible: `node qa/dialog-audit.mjs --base https://liquidity-hq-qa.onrender.com --route /arena --themes dark,light`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
