### PR TITLE
fix(chart): flat badge background and the pricing cross, both owner-ruled

### DIFF
--- a/components/LandingTerminal.tsx
+++ b/components/LandingTerminal.tsx
@@ -431,7 +431,17 @@ export default function LandingTerminal({ dict, locale, dir }: Props) {
             <ul style={{ listStyle: 'none', margin: '22px 0 0', padding: 0 }}>
               {dict.pricing.free.features.map((f, i) => (
                 <li key={i} style={{ display: 'flex', gap: 12, alignItems: 'center', padding: '9px 0', borderBottom: '1px solid var(--bdr2)' }}>
-                  <span style={{ width: 12, fontSize: 12, fontFamily: 'var(--font-mono), monospace', color: f.included ? 'var(--green)' : 'var(--txt4)' }}>{f.included ? '✓' : '✕'}</span>
+                  <span style={{ width: 12, fontSize: 12, fontFamily: 'var(--font-mono), monospace', /* --txt3, not --txt4 (#639, owner ruled). landing.md:506 exempts
+                       this ✕ from 4.5:1 as "non-essential decoration paired
+                       with a text label" - but the clause revokes itself if
+                       the glyph "ever becomes the only carrier of meaning",
+                       and it has: f.text below names the FEATURE and never
+                       its inclusion, so the ✕ plus a colour shift are the
+                       only signals, and colour alone is not a carrier. The
+                       exemption's own condition, not an override of it.
+                       The route strings in the card footers keep --txt4 -
+                       same clause, and their pairing genuinely holds. */
+                    color: f.included ? 'var(--green)' : 'var(--txt3)' }}>{f.included ? '✓' : '✕'}</span>
                   <span style={{ fontSize: 13.5, color: f.included ? 'var(--txt)' : 'var(--txt3)' }}>{f.text}</span>
                 </li>
               ))}

--- a/components/MarketStructure.tsx
+++ b/components/MarketStructure.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { CoinId, BINANCE_SYMS, BYBIT_SYMS } from '@/lib/marketStore';
 import { bybitSymbolPriceFactor } from '@/lib/coins';
 import { withAlpha } from '@/lib/color';
+import { useDesignMode } from '@/components/DesignModeProvider';
 import { SkeletonBar } from '@/components/Skeleton';
 import { useLabels } from '@/lib/labels';
 import { detectStructureSignals, structureState, type PACandle } from '@/lib/priceAction';
@@ -125,6 +126,19 @@ interface Props { coin: CoinId; onData?: (d: MSData | null) => void }
 
 export default function MarketStructure({ coin, onData }: Props) {
   const { t } = useLabels();
+  /* #644, owner's ruling: in terminal the event badges paint a FLAT --bg1
+     rather than a tint of their own colour, so the text is not sitting on a
+     wash of itself. All six states then clear AA - 8.21/5.24/7.19 dark,
+     6.09/6.65/5.12 light - and the direction colour survives, which is what
+     the alternatives cost.
+     Terminal only. The current design's version of this badge measures
+     1.68-3.52 across its light theme, far worse, but it is a live page on a
+     screen not approved for work - recorded on #644, not changed here.
+     Set inline rather than in CSS because the background is an inline style;
+     a stylesheet rule would lose to it without !important, which is the
+     specificity trap #629 and #630 both hit from opposite directions. */
+  const terminal = useDesignMode() === 'terminal';
+  const badgeBg = (ev: StructureEvent) => (terminal ? 'var(--bg1)' : evBg(ev));
   const [data,    setData]    = useState<MSData | null>(null);
   const [loading, setLoading] = useState(true);
   const [err,     setErr]     = useState('');
@@ -225,7 +239,7 @@ export default function MarketStructure({ coin, onData }: Props) {
       {/* ── Last event ── */}
       {le && (
         <div className="ms-last-event" style={{ borderColor: withAlpha(evCol(le), '33'), background: evBg(le) }}>
-          <span className="ms-ev-badge" style={{ background: evBg(le), color: evCol(le), border: `0.5px solid ${withAlpha(evCol(le), '44')}` }}>
+          <span className="ms-ev-badge" style={{ background: badgeBg(le), color: evCol(le), border: `0.5px solid ${withAlpha(evCol(le), '44')}` }}>
             {le.type} <span className="ms-dir-glyph">{le.dir === 'bullish' ? '▲' : '▼'}</span>
           </span>
           <span className="ms-ev-price">${fmtP(le.price)}</span>
@@ -257,7 +271,7 @@ export default function MarketStructure({ coin, onData }: Props) {
         <div className="ms-history">
           {d.events.slice(1, 5).map((ev, i) => (
             <div key={i} className="ms-hist-row">
-              <span className="ms-hist-badge" style={{ background: evBg(ev), color: evCol(ev) }}>
+              <span className="ms-hist-badge" style={{ background: badgeBg(ev), color: evCol(ev) }}>
                 {ev.type} <span className="ms-dir-glyph">{ev.dir === 'bullish' ? '▲' : '▼'}</span>
               </span>
               <span className="ms-hist-price">${fmtP(ev.price)}</span>

--- a/design-handoff-dir/specs/landing.md
+++ b/design-handoff-dir/specs/landing.md
@@ -348,6 +348,13 @@ DATA      FEATURE_META in LandingContent.tsx, paired with dict.features.cards.
 CONTROLS  The WHOLE CARD is a link — it is an <a>, not a div with a link inside.
           Affordance is carried by: the "OPEN →" in accent, the route string,
           and a hover state. Not by colour alone.
+          NOTE (#639, 2026-09-03): listing the route string as an affordance
+          reads against the accessibility clause below, which calls it
+          non-essential decoration and exempts it from 4.5:1 at --txt4.
+          The owner ruled the accessibility clause wins: the route string is
+          decoration, its pairing holds, and it STAYS at --txt4. Affordance
+          here rests on "OPEN →" and the hover. Recorded so the tension is
+          not rediscovered as a bug report against correct code.
 STATES    hover  card ground → --bg1; "OPEN →" underline; 120ms ease
           focus  2px outline --accent offset -2px (inset, so it is not clipped
                  by the 1px grid gap)
@@ -504,6 +511,22 @@ The same applies to `lib/labelKeys.ts` DB-driven labels: any panel whose text ca
 | `--red` on `--bg1` | verdict when bearish |
 
 `--txt4` is used only for the excluded-feature `✕` and the route string in card footers. Both are **non-essential decoration paired with a text label**, so they are exempt from 4.5:1 — but if either ever becomes the only carrier of meaning, it must be re-tokened. Flag it rather than darkening it.
+
+> **AMENDED 2026-09-03 (#639), owner's ruling.** The exemption is **revoked for
+> the `✕`** and stands for the route string.
+>
+> The `✕`'s pairing lapsed without anyone editing this clause. The pricing row
+> renders the glyph beside `f.text`, and `f.text` names the **feature**, never
+> whether it is included — so the `✕` plus a colour shift on the label are the
+> only carriers, and colour alone is not one. That is exactly the condition
+> above, so the `✕` is now **`--txt3`** in `LandingTerminal.tsx`. It is not a
+> departure from this clause; it is this clause firing.
+>
+> The route string keeps `--txt4`. Its pairing holds: the card carries
+> `OPEN →` in accent plus the feature name, and the route string genuinely is
+> decoration beside them.
+>
+> Do not "fix" the `✕` back to `--txt4` on the strength of the sentence above.
 
 **Do not apply alpha to a token to de-emphasise it.** The README notes this pattern has already produced sub-AA text five times. Size and weight carry de-emphasis; the token is already tuned to the line.
 


### PR DESCRIPTION
## Summary

The two remaining owner rulings, shipped together. Both are the design's own rules being applied, not overridden.

| # | change | ruling |
|---|---|---|
| #644 | terminal event badges paint flat `--bg1` | option D — the one neither of us listed |
| #639 item 1 | pricing `✕` → `--txt3` | re-token rather than add a label |
| #639 item 3 | route strings stay `--txt4` | **no code change** — `:506` beats `:349` |

## The badge

Text painted `evCol` on a 10% tint of `evCol`, sitting on `.ms-last-event` which is *also* a 10% tint of `evCol` — so it composited **~19% of its own colour underneath itself**:

```
dark    accent 5.81   red 4.18 FAIL   green 5.28
light   accent 4.61   red 4.80        green 3.93 FAIL
```

Flat `--bg1` clears all six — **8.21 / 5.24 / 7.19** dark, **6.09 / 6.65 / 5.12** light — *and keeps the direction colour*, which every other option cost. The parent keeps its `evBg` tint: the doubling was the defect, not the tint.

**`.ms-hist-badge` checked separately**, per QA's warning, rather than assumed to share the problem. It has no tinted parent, so it composites one 10% layer and fails **one** state — terminal light green at **4.47**, three hundredths short. The same treatment takes it to 5.12. Not named in the ruling; fixed because it is the same defect and the ruled mechanism closes it.

Set **inline**, because the background is an inline style — a stylesheet rule loses to it without `!important`. That is the specificity trap #629 and #630 hit from opposite directions.

**Terminal only.** The current design's version of this badge measures **1.68–3.52** across its light theme — far worse — but it is a live page on a screen not approved for work. Recorded on #644, deliberately untouched.

## The pricing cross

`landing.md:506` exempts it from 4.5:1 as *"non-essential decoration paired with a text label"* — and the same clause revokes itself if the glyph *"ever becomes the only carrier of meaning."*

It has. `f.text` names the **feature**, never its inclusion, so the `✕` plus a colour shift on the label are the only signals — and colour alone is not a carrier. **This is the clause firing, not an override of it.**

## The spec edits are half the change

- **`:506`** now records that the exemption is revoked for the `✕` and stands for the route string. Without it, the next reader sees `--txt3`, reads the clause, and reverts it.
- **`:349`** — *"affordance is carried by … the route string"* — is annotated with the ruling that `:506` wins and the route string stays at `--txt4`, so the contradiction doesn't resurface as a bug report against correct code.

## How to test (QA)

1. `/arena?design=terminal`, **both themes** — event badges are flat chips on the tinted row; text still gold/red/green by direction. The two failing states specifically: a **bearish** event in dark, a **bullish BOS** in light.
2. The history rows' badges below it — same flat treatment; light green was the 4.47 case.
3. `.ms-last-event` still shows its coloured wash behind the badge.
4. Landing pricing table — the `✕` on excluded rows is legible, `✓` still green.
5. Landing feature cards — route strings **unchanged** at `--txt4`. A change there is a regression.
6. `/arena` and `/` with no design flag — unchanged.

## Risk level

**Low.** One derived background in terminal, one token swap, two spec annotations.

All six badge figures are **computed, not observed** — QA asked for a rendered re-measure and I could not do one locally. That is the main thing review should confirm.

One process note: `tsc` returned 2 on the first run of this branch immediately after a `git stash pop`, then exited 0 on a clean re-run with no code change, and `npm run build` — which runs TypeScript itself — passed both times. Recording it rather than omitting it; it looks like a Windows file lock, not a code state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
