### PR TITLE
fix(arena): the conflicting arm's amber follows the token too

### DIFF
--- a/components/MultiTFAlignment.tsx
+++ b/components/MultiTFAlignment.tsx
@@ -163,8 +163,8 @@ export default function MultiTFAlignment({ coin: coinProp }: { coin?: string }) 
 
   const verdictLabel = verdict === 'bullish' ? t('MULTI_TF_ALIGNMENT_VERDICT_BULLISH') : verdict === 'bearish' ? t('MULTI_TF_ALIGNMENT_VERDICT_BEARISH') : verdict === 'conflicting' ? t('MULTI_TF_ALIGNMENT_VERDICT_CONFLICTING') : t('MULTI_TF_ALIGNMENT_VERDICT_MIXED');
   const verdictColor = verdict === 'bullish' ? 'var(--green-2)' : verdict === 'bearish' ? 'var(--red)' : verdict === 'conflicting' ? 'var(--amber)' : 'var(--txt3)';
-  const verdictBorder = verdict === 'bullish' ? 'color-mix(in srgb, var(--green-2) 40%, transparent)' : verdict === 'bearish' ? 'color-mix(in srgb, var(--red) 40%, transparent)' : verdict === 'conflicting' ? 'rgba(251,191,36,0.4)' : 'rgba(255,255,255,0.18)';
-  const verdictBg = verdict === 'bullish' ? 'color-mix(in srgb, var(--green-2) 10%, transparent)' : verdict === 'bearish' ? 'color-mix(in srgb, var(--red) 10%, transparent)' : verdict === 'conflicting' ? 'rgba(251,191,36,0.1)' : 'transparent';
+  const verdictBorder = verdict === 'bullish' ? 'color-mix(in srgb, var(--green-2) 40%, transparent)' : verdict === 'bearish' ? 'color-mix(in srgb, var(--red) 40%, transparent)' : verdict === 'conflicting' ? 'color-mix(in srgb, var(--amber) 40%, transparent)' : 'rgba(255,255,255,0.18)';
+  const verdictBg = verdict === 'bullish' ? 'color-mix(in srgb, var(--green-2) 10%, transparent)' : verdict === 'bearish' ? 'color-mix(in srgb, var(--red) 10%, transparent)' : verdict === 'conflicting' ? 'color-mix(in srgb, var(--amber) 10%, transparent)' : 'transparent';
 
   const footerText = verdict === 'bullish'
     ? t('MULTI_TF_ALIGNMENT_FOOTER_BULLISH')


### PR DESCRIPTION
## Summary

Closes #647's last live finding. `MultiTFAlignment`'s `conflicting` arm now derives its border and fill from `var(--amber)` like the two arms beside it.

```jsx
166  verdict === 'conflicting' ? 'rgba(251,191,36,0.4)'  →  color-mix(… var(--amber) 40% …)
167  verdict === 'conflicting' ? 'rgba(251,191,36,0.1)'  →  color-mix(… var(--amber) 10% …)
```

Its own **text** at `:165` already used `var(--amber)`. Token for the text, literal for the tint, one expression — and correct in dark only because terminal dark `--amber` *is* `#fbbf24`. `globals.css:5568` documents that exact situation for another token: *"right by coincidence, not by decision."*

## Third instance of one shape

| # | construct | what got missed |
|---|---|---|
| #642 | attribute pair | anti-chop toggle's `background` converted, its own `boxShadow` not |
| #648 | duplicate literal | `EMASignal`'s `rgb()`-triplet twin of a hex already fixed |
| here | ternary arms | two of three converted, the third left |

QA's read of why is the useful one: **a ternary's arms look like separate values while sharing one expression**, so converting two of three feels finished.

## A finding for #647's parked whites, not fixed here

Sweeping this file for the same pattern shows it is systematic — **every** coloured ternary converts its coloured arms and leaves the odd one as a white literal:

```
:20   bias neutral      → rgba(255,255,255,0.18)
:34   bias neutral      → rgba(255,255,255,0.15)
:166  verdict mixed     → rgba(255,255,255,0.18)   (same line as this fix)
```

That matters for how #647 categorises the whites. These are **not** scrims or chart ink — they are the *neutral arm of a coloured ternary*, paired with `--txt3` text, doing the same job `--green-2`/`--red`/`--amber` do in the other arms. So at least some of the 24 whites are the same leak wearing a colour nobody flagged, and in terminal **light** a `rgba(255,255,255,0.15)` border on a pale ground is close to invisible.

Not converting them here: #647 parks the whites pending a decision on which are deliberate, and turning a white border into `--txt3` changes appearance rather than preserving it. This is evidence for that decision, not a pre-emption of it — and picking the odd arm out of this fix is deliberate, given the whole PR is about not doing that.

## How to test (QA)

1. `/arena?design=terminal`, **light**, multi-timeframe verdict in its **Conflicting** state — border and fill are warm against the light ground, not the dark theme's amber. Re-run `mobile-audit.mjs --theme light`: `#fbbf24` should be **0**.
2. **Dark** unchanged — `color-mix` of `#fbbf24` at 40%/10% reproduces the literals exactly.
3. `/arena` with no design flag — unchanged, `--amber` is `#fbbf24` at `:root`.

## Risk level

**Low.** Two values in one component, byte-identical in dark and in the current design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
