### PR TITLE
fix(chart): the neutral state's borders take --border-input

### DIFF
--- a/components/MultiTFAlignment.tsx
+++ b/components/MultiTFAlignment.tsx
@@ -17,7 +17,14 @@ function getBias(rsi: number | null): Bias {
 function barFill(bias: Bias): string {
   if (bias === 'bullish') return 'var(--green-2)';
   if (bias === 'bearish') return 'var(--red)';
-  return 'rgba(255,255,255,0.18)';
+  /* --border-input, not a white literal (#653). The two arms above name a
+     token and the neutral arm named nothing, so it could not follow a theme:
+     white at 18% over --bg1 composites to 1.74:1 in dark and 1.04:1 in
+     light. --border-input is the governed neutral boundary and measures
+     3.05 / 3.62. NOT --mark-idle, whose comment says "signal marker when NOT
+     firing" and would be the semantic fit - it measures 1.20, worse than the
+     white it would replace. */
+  return 'var(--border-input)';
 }
 
 function valColor(bias: Bias): string {
@@ -31,7 +38,7 @@ function BiasBadge({ bias }: { bias: Bias }) {
   const icon = bias === 'bullish' ? '▲' : bias === 'bearish' ? '▼' : '→';
   const label = bias === 'bullish' ? t('MULTI_TF_ALIGNMENT_BIAS_BULLISH') : bias === 'bearish' ? t('MULTI_TF_ALIGNMENT_BIAS_BEARISH') : t('MULTI_TF_ALIGNMENT_BIAS_NEUTRAL');
   const color = bias === 'bullish' ? 'var(--green-2)' : bias === 'bearish' ? 'var(--red)' : 'var(--txt3)';
-  const border = bias === 'bullish' ? 'color-mix(in srgb, var(--green-2) 40%, transparent)' : bias === 'bearish' ? 'color-mix(in srgb, var(--red) 40%, transparent)' : 'rgba(255,255,255,0.15)';
+  const border = bias === 'bullish' ? 'color-mix(in srgb, var(--green-2) 40%, transparent)' : bias === 'bearish' ? 'color-mix(in srgb, var(--red) 40%, transparent)' : 'var(--border-input)';
   const bg = bias === 'bullish' ? 'color-mix(in srgb, var(--green-2) 12%, transparent)' : bias === 'bearish' ? 'color-mix(in srgb, var(--red) 12%, transparent)' : 'transparent';
   return (
     <span style={{
@@ -163,7 +170,7 @@ export default function MultiTFAlignment({ coin: coinProp }: { coin?: string }) 
 
   const verdictLabel = verdict === 'bullish' ? t('MULTI_TF_ALIGNMENT_VERDICT_BULLISH') : verdict === 'bearish' ? t('MULTI_TF_ALIGNMENT_VERDICT_BEARISH') : verdict === 'conflicting' ? t('MULTI_TF_ALIGNMENT_VERDICT_CONFLICTING') : t('MULTI_TF_ALIGNMENT_VERDICT_MIXED');
   const verdictColor = verdict === 'bullish' ? 'var(--green-2)' : verdict === 'bearish' ? 'var(--red)' : verdict === 'conflicting' ? 'var(--amber)' : 'var(--txt3)';
-  const verdictBorder = verdict === 'bullish' ? 'color-mix(in srgb, var(--green-2) 40%, transparent)' : verdict === 'bearish' ? 'color-mix(in srgb, var(--red) 40%, transparent)' : verdict === 'conflicting' ? 'color-mix(in srgb, var(--amber) 40%, transparent)' : 'rgba(255,255,255,0.18)';
+  const verdictBorder = verdict === 'bullish' ? 'color-mix(in srgb, var(--green-2) 40%, transparent)' : verdict === 'bearish' ? 'color-mix(in srgb, var(--red) 40%, transparent)' : verdict === 'conflicting' ? 'color-mix(in srgb, var(--amber) 40%, transparent)' : 'var(--border-input)';
   const verdictBg = verdict === 'bullish' ? 'color-mix(in srgb, var(--green-2) 10%, transparent)' : verdict === 'bearish' ? 'color-mix(in srgb, var(--red) 10%, transparent)' : verdict === 'conflicting' ? 'color-mix(in srgb, var(--amber) 10%, transparent)' : 'transparent';
 
   const footerText = verdict === 'bullish'


### PR DESCRIPTION
## Summary

Closes #653. Three white literals in `MultiTFAlignment` become `var(--border-input)` — `barFill`'s neutral return, the bias border's neutral arm, and `verdictBorder`'s mixed arm.

## Measured, as borders on `--bg1`

| | dark | light |
|---|---|---|
| white 15% (what `:34` had) | 1.56 | **1.03** |
| white 18% (`:20`, `:166`) | 1.74 | **1.04** |
| `--mark-idle` | 1.20 | 1.29 |
| `--bdr` | 1.14 | 1.24 |
| **`--border-input`** | **3.05** | **3.62** |

In light the value being replaced wasn't subtle, it was nothing.

## `--mark-idle` is the trap, and it's worth recording

Its comment reads *"Signal marker when NOT firing"* — semantically this exact state. It measures **1.20**, worse than the white it would replace.

A name that fits while the value doesn't. Same shape as `Binance perp` naming the fallback rather than the source, and the BTC-scoped sources sitting in per-coin slots. **Taking the name on trust would have shipped a fix that made dark slightly worse while looking principled.**

## No new token

`--border-input` is already governed in both themes and already in `mobile-audit`'s palette, since #645 made that tool derive from `lib/terminalTokens.ts` rather than copy it. So this is covered by the conformance check the moment it lands.

## Scope: three, not nine

The issue estimated nine. The other whites in these two files are not the neutral arm of anything:

| file | line | what it actually is |
|---|---|---|
| `MultiTFAlignment` | 75 | row hairline — `last ? 'none' : …` |
| | 89 | progress-track background |
| | 98 | 1px divider tick |
| | 231 | panel surface + its border |
| `EMASignal` | 173 | background **tint** of a coloured ternary — siblings are 7% mixes, and the ruling was borders only |
| | 205 | panel surface, paired with `border: var(--bdr)` |

Hairlines, tracks and surfaces — closer to `--bdr2`/`--bg2` than to a signal state. Converting them to a boundary token would be this issue's own category error pointed the other way.

`:173` is the one I'd flag for a second look: it *is* the neutral arm of a coloured ternary, but it's a background tint rather than a border, and the ruling said borders only. Left alone deliberately, not missed.

## This one is not byte-identical

Every previous conversion in this effort left the current design untouched by construction — `--red` *is* `#f87171` at `:root`, `--accent-2` *is* `#5aa3ff`. **This one isn't.** `--border-input` is not the white it replaces in any theme, so the neutral chips change appearance in **all four** theme/design combinations.

That's the intent, and it needs measuring rather than assuming.

## How to test (QA)

1. `/arena?design=terminal` and `/dashboard?design=terminal`, **both themes** — multi-timeframe verdict in its **Mixed** state and a bias row **Neutral**: the chip outline is a visible grey boundary, not a near-invisible wash. **Light is where the difference is largest.**
2. Both routes with **no** design flag — these change too. Check rather than assume.
3. Bullish and bearish states unchanged in all four combinations — they were never touched.

## Risk level

**Low mechanically, medium visually.** Three values, no logic. But it's the first non-byte-identical conversion, on two approved screens that are currently clean, so the rendered pass is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
