### PR TITLE
fix(dashboard): align the terminal rail's typography, sparkline and mobile count

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -537,6 +537,34 @@ body::after {
   background: color-mix(in srgb, var(--green) 3%, transparent) !important;
 }
 
+/* Rail row typography, measured off Dashboard 2a.dc.html (#656). The build
+   inherited the current design's sizes, which run 12-15px against the
+   canvas's 9.5-11.5, and TWO of the five rendered in Plex Sans where the
+   canvas specifies mono - the grade badge and the change. On a column of
+   aligned numerals that is the difference between a column and a ragged
+   edge, which is what the owner is seeing as "needs more alignment".
+   Terminal only: .csb2-* is shared, and the current design's rail keeps its
+   own scale. */
+[data-design="terminal"] .csb2-name {
+  font-size: 11.5px; font-weight: 600; letter-spacing: .05em;
+}
+[data-design="terminal"] .csb2-price { font-size: 11.5px; }
+[data-design="terminal"] .csb2-chg {
+  font-family: var(--font-mono), monospace; font-size: 10.5px;
+}
+[data-design="terminal"] .csb2-sig { font-size: 10.5px; }
+[data-design="terminal"] .csb2-health-badge {
+  font-family: var(--font-mono), monospace; font-size: 9.5px;
+}
+
+/* Canvas footer: "+21 MORE COINS", mono 10.5, centred, no glyph. The build
+   carried a sans 12px "▼ +43 more coins" - the count differs correctly (it
+   is data) but the case, size and the added caret do not. */
+[data-design="terminal"] .csb2-more {
+  font-family: var(--font-mono), monospace;
+  font-size: 10.5px; letter-spacing: .06em; text-transform: uppercase;
+}
+
 /* ── MARKET EVENTS STRIP ── */
 
 /* ── CASCADE ALERT ── */

--- a/components/DashboardTerminal.tsx
+++ b/components/DashboardTerminal.tsx
@@ -29,6 +29,7 @@ import { withAlpha } from '@/lib/color';
 import Sparkline24h from '@/components/Sparkline24h';
 import CoinIcon from '@/components/CoinIcon';
 import { SkeletonBar } from '@/components/Skeleton';
+import { useIsDesktop } from '@/lib/useIsDesktop';
 import { useLabels } from '@/lib/labels';
 import type { LabelKey } from '@/lib/labelKeys';
 import PerpSpotCard from '@/components/PerpSpotCard';
@@ -144,6 +145,11 @@ const OI_TREND_META: Record<string, { txtKey: LabelKey; subKey: LabelKey; col: s
 };
 
 const SIDEBAR_DEFAULT = 7;
+/* The canvas shortens the rail on mobile: Dashboard 2a.dc.html:288 renders
+   sidebarCoinsM, defined at :391 as sidebarCoins.slice(0, 5), where desktop
+   uses sidebarCoinsShown at 7 (#656). Five rows on a 390 viewport leaves the
+   sections below it reachable without scrolling past a full list. */
+const SIDEBAR_DEFAULT_MOBILE = 5;
 
 interface VolRegimeState { regime: 'low' | 'neutral' | 'high'; percentile: number }
 
@@ -278,7 +284,9 @@ function TCoinSidebar() {
   const watchlist = settings.watchlist ?? [];
   const pinned = watchlist.filter((id): id is CoinId => (COINS as string[]).includes(id));
   const rest    = COINS.filter(id => !watchlist.includes(id));
-  const visibleCoins = [...pinned, ...rest].slice(0, SIDEBAR_DEFAULT);
+  const isDesktop = useIsDesktop();
+  const shown = isDesktop ? SIDEBAR_DEFAULT : SIDEBAR_DEFAULT_MOBILE;
+  const visibleCoins = [...pinned, ...rest].slice(0, shown);
   const firingCount = COINS.filter(cid => sidebarSignalFor(store.coins[cid], t) !== null).length;
 
   return (
@@ -380,7 +388,7 @@ function TCoinSidebar() {
               <span className={`csb2-chg ${up ? 'chg-up' : 'chg-dn'}`}>
                 {up ? '▲' : '▼'} {Math.abs(chg).toFixed(2)}%
               </span>
-              <Sparkline24h coin={id} width={SPARK_W} height={14} />
+              <Sparkline24h coin={id} width={SPARK_W} height={12} bars />
               {sig && (
                 <span className="csb2-sig" style={{ color: sig.col }}>
                   {sig.text}
@@ -397,6 +405,7 @@ function TCoinSidebar() {
 
       <Link
         href="/markets"
+        className="csb2-more"
         style={{
           display: 'block', width: '100%', background: 'none', border: 'none',
           borderTop: '1px solid var(--bdr)', padding: '7px 0',
@@ -405,7 +414,7 @@ function TCoinSidebar() {
           textTransform: 'uppercase',
         }}
       >
-        {t('DASH_SIDEBAR_MORE_COINS', { count: COINS.length - SIDEBAR_DEFAULT })}
+        {t('DASH_SIDEBAR_MORE_COINS_TERMINAL', { count: COINS.length - shown })}
       </Link>
       </div>
     </>

--- a/components/Sparkline24h.tsx
+++ b/components/Sparkline24h.tsx
@@ -5,7 +5,17 @@ import Sparkline from './Sparkline';
 
 const REFRESH_MS = 5 * 60_000;
 
-export default function Sparkline24h({ coin, width = 40, height = 14 }: { coin: string; width?: number; height?: number }) {
+/* `bars` renders the canvas's histogram instead of the default polyline
+   (#656). Dashboard 2a.dc.html:167 draws the rail's sparkline as eight 2px
+   columns at height 12 in --txt4, not a line.
+   An opt-in variant rather than a change to Sparkline: the polyline is also
+   used by MarketsTerminal, and QA's finding that "the element does not
+   exist" came from measuring for sub-4px children - an SVG polyline has
+   none, so the sparkline read as absent when it was only a different form.
+   Nothing was missing; the two implementations simply disagree. */
+export default function Sparkline24h({ coin, width = 40, height = 14, bars = false, barCount = 8 }: {
+  coin: string; width?: number; height?: number; bars?: boolean; barCount?: number;
+}) {
   const [points, setPoints] = useState<number[]>(() => getSparkline24h(coin));
 
   useEffect(() => {
@@ -18,6 +28,35 @@ export default function Sparkline24h({ coin, width = 40, height = 14 }: { coin: 
     const t = setInterval(load, REFRESH_MS);
     return () => { alive = false; clearInterval(t); };
   }, [coin]);
+
+  if (bars) {
+    /* Sample the series down to barCount columns and scale each against the
+       window's own range, so a flat coin shows short bars rather than noise
+       amplified to full height. No data yields nothing rather than a row of
+       equal stubs, which would read as "flat" instead of "unknown". */
+    if (points.length === 0) return <div style={{ width, height }} aria-hidden="true" />;
+    const step = points.length / barCount;
+    const sampled = Array.from({ length: barCount }, (_, i) => points[Math.min(points.length - 1, Math.floor(i * step))]);
+    const lo = Math.min(...sampled), hi = Math.max(...sampled);
+    const span = hi - lo || 1;
+    return (
+      <div
+        style={{ display: 'flex', alignItems: 'flex-end', gap: 1, height, width }}
+        aria-hidden="true"
+      >
+        {sampled.map((v, i) => (
+          <div
+            key={i}
+            style={{
+              width: 2,
+              height: Math.max(2, Math.round(((v - lo) / span) * height)),
+              background: 'var(--txt4)',
+            }}
+          />
+        ))}
+      </div>
+    );
+  }
 
   return <Sparkline points={points} width={width} height={height} />;
 }

--- a/lib/labelDefaults.en.json
+++ b/lib/labelDefaults.en.json
@@ -503,6 +503,7 @@
   "DASH_SIDEBAR_SIG_FUNDING_SLIGHTLY_LOW": "Funding slightly low",
   "DASH_SIDEBAR_SIG_FUNDING_NEUTRAL": "Funding neutral",
   "DASH_SIDEBAR_MORE_COINS": "▼ +{count} more coins",
+  "DASH_SIDEBAR_MORE_COINS_TERMINAL": "+{count} more coins",
   "DASH_SIDEBAR_STATUS_BACKUP": "Backup",
   "DASH_SIDEBAR_STATUS_LIVE": "Live",
   "DASH_SIDEBAR_STATUS_CONNECTING": "Connecting",

--- a/lib/labelKeys.ts
+++ b/lib/labelKeys.ts
@@ -338,6 +338,10 @@ export const LABEL_KEYS = [
   // liq_events has no server-side writer - see LiqHeatmap's header.
   'LIQ_HEAT_TITLE', 'LIQ_HEAT_SOURCE', 'LIQ_HEAT_SOURCE_TIP',
   'LIQ_HEAT_TZ', 'LIQ_HEAT_CAP_NOTE',
+  // Terminal drops the caret: the canvas footer reads "+21 MORE COINS"
+  // and the link goes to /markets rather than expanding in place, so a
+  // ▼ promises an interaction that does not happen (#656).
+  'DASH_SIDEBAR_MORE_COINS_TERMINAL',
   'LIQ_HEAT_NO_EVENTS', 'LIQ_HEAT_THRESHOLD', 'LIQ_HEAT_REFRESH_TITLE',
   'LIQ_HEAT_TAB_HEATMAP', 'LIQ_HEAT_TAB_LADDER', 'LIQ_HEAT_PALETTE_TITLE',
   'ARENA_SNAP_VOL_LABEL', 'ARENA_SNAP_VOL_NOTE',


### PR DESCRIPTION
## Summary

#656 items 1, 2, 3 and 5. **Item 4 is answered but deliberately not built** — see below.

| # | item | status |
|---|---|---|
| 1 | rail row typography — sizes + two wrong families | ✅ |
| 2 | sparkline | ✅ — **and the issue's diagnosis needed correcting** |
| 3 | footer copy | ✅ (header needed nothing) |
| 4 | macro cards taller than canvas | **answered, not built — owner's call** |
| 5 | mobile shows 7, canvas shows 5 | ✅ |

## 1. Typography

Built ran 12–15px against the canvas's 9.5–11.5, and **two of the five rendered in Plex Sans where the canvas specifies mono** — the grade badge and `csb2-chg`. On a column of aligned numerals that is the difference between a column and a ragged edge.

Terminal-scoped; `.csb2-*` is shared and the current design keeps its scale.

## 2. The sparkline was not absent

The row renders `Sparkline24h` at 36×14, and `Sparkline` draws an **SVG `<polyline>`** — so a sweep for elements narrower than 4px finds none, and the element reads as missing when it is only a *different form*.

The canvas draws eight 2px columns at height 12 in `--txt4`. Added as an **opt-in `bars` variant** rather than changing `Sparkline`, because `MarketsTerminal` renders the polyline too and nothing there asked for histogram bars.

Bars scale against the window's own range, so a flat coin shows short bars rather than noise amplified to full height. No data renders **nothing** rather than a row of equal stubs — equal stubs would read as *"flat"* when the truth is *"unknown"*.

## 3. Footer only — the header needed nothing

`DASH_SIDEBAR_HEADER_FIRING` already renders through a span with `text-transform: uppercase`, so `50 firing` is already `50 FIRING` on screen. Recorded so it isn't "fixed" twice.

The footer keeps its count and loses its caret: the canvas reads `+21 MORE COINS`, and the link **navigates to `/markets`** rather than expanding in place — so a `▼` promises an interaction that doesn't happen. New terminal-only key; the current design's string is untouched, same shape as #589.

## 4. The macro cards — answered, and it is not a trim

I checked what the extra height *is*, as asked. Both cards carry **content the canvas doesn't have**:

| card | canvas | build adds |
|---|---|---|
| Perp vs spot (~60 → 234) | label + one value row | verdict pill, `reading.explanation` prose, and an entire **Spot Absorption** section behind `absorption?.available` |
| Macro backdrop (~178 → 227) | 5 rows | a **6th row** (Gold/Oil ratio) and a signal badge |

So this is the same class the owner has now ruled on twice — briefing's six panels and the liq feeds — *"keep them, just restyle to terminal colors."*

**Not built, in either direction.** I haven't trimmed, because the established ruling is keep. I also haven't declared it settled, because QA's read was that this specific case should go back to the owner, and they're asleep. The conservative action while that's open is to change nothing: no content is lost, and the height difference is the accepted outcome if the ruling holds.

If the owner confirms, this item closes with no code. If they want the rail compressed, it's a separate decision about which of those four blocks goes.

## 5. Mobile

`Dashboard 2a.dc.html:288` uses `sidebarCoinsM` — `slice(0, 5)` at `:391` — against desktop's 7. Now `useIsDesktop()`-gated, and the footer's "+N more" count rises to match.

## How to test (QA)

1. `/dashboard?design=terminal`, **both themes** — rail symbols, prices, changes and grades all monospace, on one vertical rhythm. This is the item the owner described.
2. Each row shows **eight small bars**, not a line. A coin with no sparkline data shows empty space, not stubs.
3. Footer reads `+N MORE COINS` — uppercase, mono, **no caret**.
4. **390px** — five coins, footer count risen accordingly.
5. `/dashboard` with no design flag — unchanged, including the caret and the 7-coin list.

## Risk level

**Low.** Typography is terminal-scoped CSS; the sparkline variant is opt-in with one caller; the mobile slice reuses the existing `useIsDesktop` hook.

**Not browser-verified.** Every value is read from `Dashboard 2a.dc.html`. The bar sparkline's appearance depends on real series data I can't generate locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
