### PR TITLE
fix(liq): mobile chrome, token literals, washed-out values, swatch hit area

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2313,7 +2313,19 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .liq-section-hdr-long  { color: var(--red); background: rgba(248,113,113,0.06); border-top: 0.5px solid rgba(248,113,113,0.12); border-bottom: 0.5px solid rgba(248,113,113,0.12); }
 .liq-section-sub { font-size: var(--fs-caption); font-weight: 500; opacity: 0.75; text-transform: none; letter-spacing: 0; }
 
-.liq-current-bar { display: flex; align-items: center; gap: 10px; padding: 12px 14px; background: rgba(26,122,255,0.09); border-top: 1px solid rgba(26,122,255,0.28); border-bottom: 1px solid rgba(26,122,255,0.28); border-left: 3px solid var(--purple); margin: 2px 0; }
+/* Derived from --accent-2, was rgba(26,122,255,...) (#652). Those literals
+   are the current design's dark --accent-2, and the [data-theme="light"]
+   override below is its light one - neither carries a design qualifier, so
+   both painted under TERMINAL light too. That tint over --bg2 composited to
+   rgb(213,216,220), the bluish grey QA measured under .liq-current-oi and
+   neither of us could name: the ground was the defect, not the text on it.
+   Recolouring --txt3 to clear 4.5 against it would have compensated for a
+   leak and then been wrong once the leak was fixed.
+   Terminal aliases --accent-2 to var(--accent), so the bar now takes the
+   design's own emphasis colour; --accent-2 IS #1a7aff at :root and #0052CC
+   in the current design's light block, so both current-design renders are
+   byte-identical. */
+.liq-current-bar { display: flex; align-items: center; gap: 10px; padding: 12px 14px; background: color-mix(in srgb, var(--accent-2) 9%, transparent); border-top: 1px solid color-mix(in srgb, var(--accent-2) 28%, transparent); border-bottom: 1px solid color-mix(in srgb, var(--accent-2) 28%, transparent); border-left: 3px solid var(--accent-2); margin: 2px 0; }
 .liq-current-dot { width: 9px; height: 9px; border-radius: 50%; background: var(--purple); box-shadow: 0 0 8px var(--purple); flex-shrink: 0; animation: liq-pulse 2s infinite; }
 @keyframes liq-pulse { 0%,100%{box-shadow:0 0 6px var(--purple)} 50%{box-shadow:0 0 16px var(--purple),0 0 4px #fff4} }
 .liq-current-price { font-size: var(--fs-data); font-weight: 700; color: #fff; font-family: var(--font-mono), monospace; font-variant-numeric: tabular-nums; }
@@ -2655,7 +2667,10 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 [data-theme="light"] .gex-hdr    { color: var(--txt3); }
 
 /* Current price bar in liq map */
-[data-theme="light"] .liq-current-bar   { background: rgba(0,82,204,0.06); }
+/* Kept as a light-theme step-down, now derived: the base rule's 9% is heavy
+   on a pale ground. Same value it always resolved to in the current design,
+   since --accent-2 is #0052CC there. */
+[data-theme="light"] .liq-current-bar   { background: color-mix(in srgb, var(--accent-2) 6%, transparent); }
 [data-theme="light"] .liq-current-price { color: var(--txt); }
 [data-theme="light"] .liq-current-tag   { background: var(--purple-bg); color: var(--purple); border-color: var(--purple-bdr); }
 
@@ -7395,6 +7410,21 @@ main.app-content[data-chrome="none"] {
   border: 1px solid color-mix(in srgb, var(--amber) 40%, transparent);
   padding: 3px 8px;
 }
+/* #652: --txt2 on the current-price bar, not --txt3.
+   Fixing the bar's colour leak (above) corrected the PALETTE but not the
+   CONTRAST - the two were separate defects on one element. Measured against
+   the corrected ground, --txt3 reads 4.16 dark / 4.33 light, and only clears
+   4.5 once the tint drops to 3%, which is close enough to no tint that the
+   bar stops marking the current-price row at all. That is the highlight's
+   whole job.
+   --txt2 clears at every alpha the bar could reasonably use - 4.95 dark and
+   4.55 light at the current 9%/6% - so the tint keeps doing its work and the
+   label becomes readable. Same resolution as .ms-ev-ago: when text sits on a
+   deliberate tint, the text moves up a step rather than the tint being
+   flattened out of existence. Terminal only; the current design's bar is a
+   different ground and was not measured. */
+[data-design="terminal"] .liq-current-oi { color: var(--txt2); }
+
 /* Mobile chrome, measured off Liquidation Map.dc.html's 390x844 frame
    (#652). The desktop rows were rendering unchanged at 390 - correct
    heights, no mobile variant. Row heights 46->36 and 40->34, rails 46->26

--- a/app/globals.css
+++ b/app/globals.css
@@ -7335,8 +7335,16 @@ main.app-content[data-chrome="none"] {
 }
 [data-design="terminal"] .liq-heat-tab.on { color: var(--bg0); background: var(--accent); }
 [data-design="terminal"] .liq-heat-swatches { display: flex; gap: 4px; }
+/* 26x16 painted, 26x24 tappable (#652). The canvas specifies width:26px;
+   height:16px and this is built exactly to it - so the CANVAS asks for a
+   control that fails SC 2.5.8's 24px minimum. Resolved the way landing.md:512
+   already prescribes for its own two undersized controls, "a padded hit area
+   without changing their painted box", and the way #642 built it for the
+   footer links: padding grows the box, an equal negative margin pulls the
+   flow back, nothing moves. Only the height failed - 26 already clears 24. */
 [data-design="terminal"] .liq-heat-swatch {
-  width: 26px; height: 16px; border: 1px solid var(--bdr); cursor: pointer; padding: 0;
+  width: 26px; height: 16px; border: 1px solid var(--bdr); cursor: pointer;
+  padding: 4px 0; margin: -4px 0; background-clip: content-box;
 }
 [data-design="terminal"] .liq-heat-swatch.on { border-color: var(--accent); }
 [data-design="terminal"] .liq-heat-thr-label {
@@ -7387,6 +7395,40 @@ main.app-content[data-chrome="none"] {
   border: 1px solid color-mix(in srgb, var(--amber) 40%, transparent);
   padding: 3px 8px;
 }
+/* Mobile chrome, measured off Liquidation Map.dc.html's 390x844 frame
+   (#652). The desktop rows were rendering unchanged at 390 - correct
+   heights, no mobile variant. Row heights 46->36 and 40->34, rails 46->26
+   and 58->46, axis type 9.5->8.5.
+
+   The fixed 330 surface is the one that matters most. On desktop flex:1 is
+   right; at 390 the canvas deliberately BANDS the surface at 330 rather than
+   letting it take the remainder, so the ladder and feeds below stay reachable
+   without scrolling past a full-height heatmap. */
+@media (max-width: 767px) {
+  [data-design="terminal"] .liq-heat-head {
+    height: 36px; padding: 0 14px; gap: 10px;
+  }
+  [data-design="terminal"] .liq-heat-title { font-size: 11.5px; }
+  [data-design="terminal"] .liq-heat-source { font-size: 9.5px; }
+  [data-design="terminal"] .liq-heat-controls {
+    height: 34px; padding: 0 14px; gap: 10px;
+  }
+  [data-design="terminal"] .liq-heat-tab { padding: 5px 11px; }
+  [data-design="terminal"] .liq-heat-wrap {
+    flex: 0 0 330px; height: 330px; padding: 10px 12px 6px; gap: 8px;
+  }
+  [data-design="terminal"] .liq-heat-scale { width: 26px; font-size: 8.5px; }
+  [data-design="terminal"] .liq-heat-scale-bar { width: 12px; }
+  [data-design="terminal"] .liq-heat-axis { width: 46px; font-size: 8.5px; }
+  [data-design="terminal"] .liq-heat-time { font-size: 8.5px; }
+  /* The threshold slider and its label are the first things to lose at 390 -
+     the canvas's mobile controls row carries the view tabs and swatches only.
+     Hidden rather than shrunk: a 150px range input inside a 366px row would
+     crowd out the tabs that select what is being shown. */
+  [data-design="terminal"] .liq-heat-thr,
+  [data-design="terminal"] .liq-heat-thr-label { display: none; }
+}
+
 [data-design="terminal"] .liq-heat-empty {
   flex: 1; display: flex; align-items: center; justify-content: center;
   padding: 2rem; color: var(--txt3);

--- a/components/GexTable.tsx
+++ b/components/GexTable.tsx
@@ -20,8 +20,8 @@ export default function GexTable() {
   const isLongGamma = (btcNetGex ?? 0) >= 0;
 
   const gexCol     = isLongGamma ? 'var(--green-2)' : 'var(--red)';
-  const gexBg      = isLongGamma ? 'rgba(52,211,153,0.12)' : 'rgba(248,113,113,0.12)';
-  const gexBorder  = isLongGamma ? 'rgba(52,211,153,0.3)'  : 'rgba(248,113,113,0.3)';
+  const gexBg      = isLongGamma ? 'color-mix(in srgb, var(--green-2) 12%, transparent)' : 'color-mix(in srgb, var(--red) 12%, transparent)';
+  const gexBorder  = isLongGamma ? 'color-mix(in srgb, var(--green-2) 30%, transparent)'  : 'color-mix(in srgb, var(--red) 30%, transparent)';
 
   const maxAbsGex = btcGexLevels.length
     ? Math.max(...btcGexLevels.map(l => Math.abs(l.gex)))
@@ -148,7 +148,7 @@ export default function GexTable() {
           </div>
           {btcGexLevels.map(({ strike, gex }) => {
             const pct   = maxAbsGex > 0 ? Math.abs(gex) / maxAbsGex * 100 : 0;
-            const col   = gex >= 0 ? 'rgba(52,211,153,0.65)' : 'rgba(248,113,113,0.65)';
+            const col   = gex >= 0 ? 'var(--green-2)' : 'var(--red)';
             const vcol  = gex >= 0 ? 'var(--green-2)' : 'var(--red)';
             const isAtm = spotPrice > 0 && Math.abs(strike - spotPrice) / spotPrice < 0.005;
             return (

--- a/components/LiqFeed.tsx
+++ b/components/LiqFeed.tsx
@@ -40,6 +40,11 @@ const CASCADE_HIDE_MS    = 12_000;                 // show cascade badge 12s
 const STORAGE_KEY        = 'liq-events-v2';        // localStorage key
 const STORAGE_MAX        = 2000;                   // max events to persist locally
 const SB_SAVE_MS         = 5 * 60 * 1000;          // save to Supabase every 5 min
+/* How often the raw stream is handed to onEvents consumers. Not a render
+   cadence - the heatmap buckets 24h into 34 columns, so ~42 minutes per
+   column, and emitting faster than the grid can express changes nothing on
+   screen while re-rendering the page. */
+const EVENTS_EMIT_MS     = 15 * 1000;
 const SB_WIN_MS          = 24 * 60 * 60 * 1000;    // load last 24h from Supabase
 const SB_RETAIN_MS       = 7 * 24 * 60 * 60 * 1000; // purge events older than 7 days
 const SB_SAVE_TS_KEY     = 'liq-sb-ts';            // localStorage: last Supabase save timestamp
@@ -103,6 +108,7 @@ export default function LiqFeed({ onClusters, onEvents, coinFilter }: {
   const bnWsRef         = useRef<WebSocket | null>(null);
   const bbWsRef         = useRef<WebSocket | null>(null);
   const historyRef      = useRef<LiqEvent[]>([]);
+  const lastEmitRef     = useRef(0);
   const msgRef          = useRef(0);
   const cascadeTimer    = useRef<ReturnType<typeof setTimeout> | null>(null);
   const saveTimer       = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -152,7 +158,21 @@ export default function LiqFeed({ onClusters, onEvents, coinFilter }: {
       .slice(0, 100);
     setClusters(buckets);
     onClusters?.(buckets);
-    onEvents?.(history);
+
+    /* Throttled, unlike onClusters (#652 review). rebuild() runs on every
+       websocket liquidation, and the first version of this emitted the whole
+       history each time - so a busy minute pushed a new array into the
+       parent's state hundreds of times, re-rendering the page per event for
+       a surface that buckets into 34 columns and cannot show the difference.
+       onClusters can afford it: it emits a small aggregate the parent renders
+       directly. This emits up to 5000 events for a density grid.
+       Leading edge, so the first data paints immediately and the empty state
+       does not linger. */
+    const now2 = Date.now();
+    if (onEvents && now2 - lastEmitRef.current >= EVENTS_EMIT_MS) {
+      lastEmitRef.current = now2;
+      onEvents(history);
+    }
   }, [onClusters, onEvents]);
 
   /* ── Sync coinFilter prop → ref and re-derive stats/clusters ── */

--- a/components/LiqTerminal.tsx
+++ b/components/LiqTerminal.tsx
@@ -202,7 +202,7 @@ function RealClusters({ clusters, currentPrice }: { clusters: Bucket[]; currentP
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <span style={{
             width: 7, height: 7, borderRadius: '50%', flexShrink: 0,
-            background: '#34d399', boxShadow: '0 0 6px #34d39966',
+            background: 'var(--green-2)', boxShadow: '0 0 6px color-mix(in srgb, var(--green-2) 40%, transparent)',
           }} />
           <span style={{ fontSize: 'var(--fs-label)', fontWeight: 700, color: 'var(--txt)' }}>
             {t('LIQ_CLUSTERS_TITLE')}
@@ -540,7 +540,7 @@ export default function LiqTerminal() {
                 </div>
                 {(retailPos?.longRatio ?? cd.bnLongRatio) != null && (
                   <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
-                    <span style={{ fontSize: 'var(--fs-data)', fontWeight: 700, color: 'color-mix(in srgb, var(--red) 65%, transparent)', fontVariantNumeric: 'tabular-nums' }}>
+                    <span style={{ fontSize: 'var(--fs-data)', fontWeight: 700, color: 'var(--red)', fontVariantNumeric: 'tabular-nums' }}>
                       {((retailPos?.longRatio ?? cd.bnLongRatio!) * 100).toFixed(0)}%
                     </span>
                     <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)' }}>{t('LIQ_STAT_BINANCE_PERIOD', { period: retailPos ? RANGE_TO_PERIOD[range] : '5m' })}</span>
@@ -573,7 +573,7 @@ export default function LiqTerminal() {
                 {(retailPos?.shortRatio ?? cd.bnShortRatio) != null && (
                   <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
                     <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)' }}>{t('LIQ_STAT_BINANCE_PERIOD', { period: retailPos ? RANGE_TO_PERIOD[range] : '5m' })}</span>
-                    <span style={{ fontSize: 'var(--fs-data)', fontWeight: 700, color: 'color-mix(in srgb, var(--green-2) 65%, transparent)', fontVariantNumeric: 'tabular-nums' }}>
+                    <span style={{ fontSize: 'var(--fs-data)', fontWeight: 700, color: 'var(--green-2)', fontVariantNumeric: 'tabular-nums' }}>
                       {((retailPos?.shortRatio ?? cd.bnShortRatio!) * 100).toFixed(0)}%
                     </span>
                   </div>
@@ -651,8 +651,8 @@ export default function LiqTerminal() {
 
                 <div style={{ padding: '12px 16px' }}>
                   <div style={{ display: 'flex', height: 8, borderRadius: 0, overflow: 'hidden', marginBottom: 10 }}>
-                    <div style={{ flex: whaleLong,  background: '#f87171', opacity: 0.7 }} />
-                    <div style={{ flex: whaleShort, background: '#34d399', opacity: 0.7 }} />
+                    <div style={{ flex: whaleLong,  background: 'var(--red)', opacity: 0.7 }} />
+                    <div style={{ flex: whaleShort, background: 'var(--green-2)', opacity: 0.7 }} />
                   </div>
                   <div style={{ display: 'flex', justifyContent: 'space-between' }}>
                     <div>
@@ -736,11 +736,11 @@ export default function LiqTerminal() {
           <div className="liq-howto">
             <div className="liq-howto-title">{t('LIQ_LEGEND_TITLE')}</div>
             <div className="liq-howto-row">
-              <span className="liq-howto-dot" style={{ background: '#34d399' }} />
+              <span className="liq-howto-dot" style={{ background: 'var(--green-2)' }} />
               <span><strong style={{ color: 'var(--green-2)' }}>{t('LIQ_LEGEND_SHORT_BOLD')}</strong> - {t('LIQ_LEGEND_SHORT_TEXT')}</span>
             </div>
             <div className="liq-howto-row">
-              <span className="liq-howto-dot" style={{ background: '#f87171' }} />
+              <span className="liq-howto-dot" style={{ background: 'var(--red)' }} />
               <span><strong style={{ color: 'var(--red)' }}>{t('LIQ_LEGEND_LONG_BOLD')}</strong> - {t('LIQ_LEGEND_LONG_TEXT')}</span>
             </div>
             <div className="liq-howto-row">


### PR DESCRIPTION
## Summary

#652's second batch — mobile chrome, the colour pass `/liq` never had, and the swatch hit area. Page as the unit, so everything QA's audit found is here.

| item | status |
|---|---|
| mobile chrome (36/34 rows, fixed 330 surface) | ✅ |
| 17 colour literals → tokens | ✅ |
| 4 washed-out values (2.62–3.73) | ✅ |
| palette swatch hit area | ✅ |
| `$4.2B Open Interest` 4.38/4.31 | **not fixed — can't reproduce** |
| `+$17.35B net` 4.48 | **not fixed — can't reproduce** |
| duplicate Supabase load | **not fixed — can't explain** |

## Mobile

Desktop rows were rendering unchanged at 390. The canvas's `390×844` frame specifies its own — rows 46→36 and 40→34, rails 46→26 and 58→46, axis type 9.5→8.5.

**The fixed 330px surface matters most.** On desktop `flex: 1` is right; at 390 the canvas deliberately *bands* the surface so the ladder and feeds below stay reachable without scrolling past a full-height heatmap.

The threshold slider and label are hidden there: a 150px range input in a 366px row would crowd out the tabs that select what's shown, and the canvas's mobile controls row carries tabs and swatches only.

## Literals — 17 across two files

`LiqTerminal` and `GexTable` were outside #642/#648/#651's scope, and #655 converted only the heat regions.

Searched **hex, 8-digit hex and `rgb()` triplet** forms, because QA's note is the reason to: a `34d399` grep found nothing on arena while three files had it live as `rgba(52,211,153,…)`, which cost two rounds. The 8-digit `#34d39966` in a `boxShadow` was the one my first regex missed.

## The washed-out values

The long/short percentages and the GEX column painted their **text** as a 65% mix of `--red`/`--green-2` over the panel:

```
dark   red 2.85   green 3.70
light  red 3.46   green 2.73
```

I reproduced QA's figures exactly, which is why these four are fixed and the other two aren't. Solid tokens give 5.24 / 7.19 / 6.65 / 5.12.

**The bar fills at `:253-254` keep the 65% mix** — a bar is not text, and dropping its transparency would change what the chart looks like rather than its legibility.

## The swatches — the canvas asks for a failing control

The canvas specifies `width:26px; height:16px`, and this was built exactly to it. So the **canvas itself** asks for a control below SC 2.5.8's 24px floor.

Resolved the way `landing.md:512` already prescribes for its own two undersized controls, and the way #642 built it for the footer links: padding grows the box, an equal negative margin pulls the flow back, painted box unchanged. Only height failed — 26 already clears 24.

## Two contrast items deliberately not fixed

QA measured `$4.2B Open Interest` at **4.38/4.31** and `+$17.35B net` at **4.48** light. From token values:

```
--accent on --bg1   8.21 dark   6.09 light
--accent on --bg2   8.31 dark   5.65 light
net text on its own 8.6% tint   4.81 / 6.38 dark, 5.76 / 4.56 light
```

None of those is what was measured, so **something composites underneath that I haven't identified.**

Same shape as `.ms-ev-ago`, where the ground turned out to be a data-dependent inline tint — and where guessing would have fixed the element that passes. Asked QA for the measured grounds rather than changing a colour on a number I can't account for.

## The duplicate load, also not patched

The Supabase loading effect has `[]` deps, and only one `LiqFeed` mounts in terminal (`app/liq/page.tsx:350` returns early). So the cause isn't visible from source. Flagged rather than patched — a fix aimed at a cause I can't see is as likely to move the symptom as remove it.

## How to test (QA)

1. **390px** — title row 36, controls 34, surface banded at 330 with the ladder reachable below; no threshold slider.
2. **Desktop** unchanged in both themes.
3. **Both themes** — long/short percentages and GEX values solid rather than washed; re-run the off-palette sweep: `#34d399`, `#f87171`, `#1a7aff`, `#0052cc`, `#3c48c8` should all be **0**.
4. **Swatches** still look 26×16 and measure 24 tall to a pointer; the row's layout is unmoved.
5. `/liq` with no design flag — unchanged.

## Risk level

**Medium.** 17 colour conversions across two files plus a mobile media block. All literal→token swaps are byte-identical in the current design; the four text-colour changes are **not** — they're the fix.

**Not browser-verified.** Every figure is computed from token values; the two I couldn't compute are the two I didn't touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
