### PR TITLE
fix(dashboard): rail grade badge and footer take their CSS sizes; sparkline gets a state handle

### DIFF
--- a/components/DashboardTerminal.tsx
+++ b/components/DashboardTerminal.tsx
@@ -354,7 +354,15 @@ function TCoinSidebar() {
               <span className="csb2-name">{id.toUpperCase()}</span>
               {d?.price && (
                 <span className={`csb2-health-badge grade-${health.grade.toLowerCase()}`} style={{
-                  fontSize: 'var(--fs-caption)', fontWeight: 800, lineHeight: 1,
+                  /* No inline font-size. globals.css:556 sets mono 9.5px for
+                     this badge and an inline declaration outranks any selector,
+                     so var(--fs-caption)'s 12px was silently winning and the
+                     rule was dead. Third time this shape has bitten: #629, #633
+                     (where !important beat OUR inline border-radius: 0), now
+                     here. This component only ever renders under
+                     mode === 'terminal', so there is no second design to keep
+                     at 12px - the stylesheet is the right home for the size. */
+                  fontWeight: 800, lineHeight: 1,
                   padding: '2px 4px', borderRadius: 0,
                   color: gradeStrong ? 'var(--green)' : 'var(--txt)',
                   /* 15%, the canvas's own alpha, not withAlpha('22')'s 13.3%.
@@ -409,9 +417,14 @@ function TCoinSidebar() {
         style={{
           display: 'block', width: '100%', background: 'none', border: 'none',
           borderTop: '1px solid var(--bdr)', padding: '7px 0',
-          fontSize: 'var(--fs-caption)', color: 'var(--txt3)', cursor: 'pointer',
-          letterSpacing: '0.04em', textAlign: 'center', textDecoration: 'none',
-          textTransform: 'uppercase',
+          /* Same dead-rule cause as the grade badge above. globals.css:563
+             sets mono 10.5px / .06em / uppercase; all three were being
+             outranked inline - the size by --fs-caption's 12px and the
+             tracking by 0.04em. text-transform agreed, which is why the
+             footer READ correct while measuring wrong, and why QA's
+             textContent-vs-innerText check mattered here. */
+          color: 'var(--txt3)', cursor: 'pointer',
+          textAlign: 'center', textDecoration: 'none',
         }}
       >
         {t('DASH_SIDEBAR_MORE_COINS_TERMINAL', { count: COINS.length - shown })}

--- a/components/Sparkline24h.tsx
+++ b/components/Sparkline24h.tsx
@@ -34,13 +34,23 @@ export default function Sparkline24h({ coin, width = 40, height = 14, bars = fal
        window's own range, so a flat coin shows short bars rather than noise
        amplified to full height. No data yields nothing rather than a row of
        equal stubs, which would read as "flat" instead of "unknown". */
-    if (points.length === 0) return <div style={{ width, height }} aria-hidden="true" />;
+    /* data-spark says which state this is from outside the component. Both
+       branches below are <div>s, so a probe for <svg> reports "absent" whether
+       the bars drew or not - QA measured svgPresent: false and correctly said
+       they could not tell the two apart. They can now: data-spark="empty" is
+       the no-data path, data-spark="bars" plus 8 children is a live render.
+       Second time a measurement could not see this element (the first looked
+       for sub-4px children, which a polyline has none of). The component was
+       right both times and unmeasurable both times, so the fix is a handle
+       rather than a behaviour change. */
+    if (points.length === 0) return <div data-spark="empty" style={{ width, height }} aria-hidden="true" />;
     const step = points.length / barCount;
     const sampled = Array.from({ length: barCount }, (_, i) => points[Math.min(points.length - 1, Math.floor(i * step))]);
     const lo = Math.min(...sampled), hi = Math.max(...sampled);
     const span = hi - lo || 1;
     return (
       <div
+        data-spark="bars"
         style={{ display: 'flex', alignItems: 'flex-end', gap: 1, height, width }}
         aria-hidden="true"
       >


### PR DESCRIPTION
## Summary

The two rail findings from QA's re-measure of `03df94a`, plus the discriminator QA asked for on the sparkline. All three have the same root: **a correct rule that nothing could see.**

## What changed

| File | Change |
|---|---|
| `components/DashboardTerminal.tsx` | dropped inline `font-size` from `.csb2-health-badge` and `.csb2-more`; also `.csb2-more`'s inline `letter-spacing` and `text-transform` |
| `components/Sparkline24h.tsx` | added `data-spark="bars" \| "empty"` to the bars variant |

## Why — the sizes

An inline declaration outranks any selector, so `globals.css:556` (mono 9.5px) and `:563` (mono 10.5px / .06em / uppercase) **could never apply.** Both elements computed 12px from `var(--fs-caption)` inline. The rules weren't losing a specificity contest; they were dead code.

`DashboardTerminal` renders only under `mode === 'terminal'` (`app/dashboard/page.tsx:519`), so there is **no second design that needed 12px** and no reason for the size to live at the component. The stylesheet is where every other rail size already lives — `.csb2-name`, `.csb2-price`, `.csb2-chg`, `.csb2-sig`.

One detail worth keeping: `.csb2-more`'s inline `text-transform` **agreed** with the CSS. That's why the footer read correct while measuring wrong — only the size and the tracking disagreed. QA's `textContent` vs `innerText` check was catching a real thing in a place where the case was genuinely fine.

**Third instance of this collision.** #629, then #633 — where an `!important` beat *our* inline `border-radius: 0`, the same conflict pointed the other way — and now this. The pattern isn't "inline styles are wrong"; it's that this component sets some typography inline and some in CSS, and the split isn't marked anywhere.

## Why — the sparkline attribute

QA reported `svgPresent: false` and said they couldn't separate "no data" from "failed to render" from outside. **They couldn't, and no probe would have.** The bars variant returns a `<div>` in *both* branches and never emits an `<svg>` at all, so that measurement reads "absent" whichever happened.

- `data-spark="empty"` — the no-data path
- `data-spark="bars"` with 8 children — a live render

Second time this element has been unmeasurable: the first probe looked for sub-4px children, which an SVG polyline has none of. **The component was correct both times.** So this is a handle, not a behaviour change — no render logic moved.

On whether it *should* populate on qa: the series comes from `/api/market/klines` (live Binance/Bybit REST), which is independent of the partial Supabase data behind #657. It should populate there. If `data-spark="empty"` on every card, that route is the thing to look at, not the component.

## How to test (QA)

On **staging**, `/dashboard?design=terminal`:

1. **Grade badge** beside each rail symbol — mono, ~9.5px. Was 12px sans.
2. **Footer** — `+43 MORE COINS` mono ~10.5px with visibly wider tracking (.06em, was .04em). Case is unchanged; it was already correct.
3. **Sparkline** between the percentage and the signal — eight thin vertical bars. If blank, read `data-spark` on the div: `bars` means it rendered and the columns are too faint (a `--txt4` question), `empty` means no series arrived.
4. Nothing else on the rail should move — `.csb2-name`, `.csb2-price`, `.csb2-chg`, `.csb2-sig` were already correct at your last measure and none of their rules were touched.

## Risk level

**Low.** Three declarations removed and one attribute added; no logic, no data path, no new tokens. Gates: lint 0, `tsc` 0, `npm test` 0, `build` 0.

**Not verified by me:** the rendered computed sizes. The specificity argument is deterministic — remove the inline and the only remaining declaration is the CSS one — but I have not measured 9.5 and 10.5 in a browser, and that is exactly the step that would have caught the original defect. Worth a computed-style read rather than an eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
