### PR TITLE
fix(dashboard): stop scoring a coin as "Price flat" when the price move is unknown

### DIFF
--- a/components/AccumulationTracker.tsx
+++ b/components/AccumulationTracker.tsx
@@ -16,11 +16,28 @@ interface AccumRow {
   price: number;
   change: number;
   reasons: string[];
+  /** #661: how many of the score's inputs had data, and how many there are.
+   *  Carried so a partial score is distinguishable from a complete one.
+   *  Not yet displayed - see the note at the return in scoreCoin. */
+  inputsPresent: number;
+  inputsTotal: number;
 }
 
 function scoreCoin(id: CoinId, d: CoinData | undefined): AccumRow | null {
   if (!d?.price) return null;
-  const chg = Math.abs(d.change ?? 0);
+
+  /* Refuse to score without a price change, rather than defaulting it (#661).
+     This was `Math.abs(d.change ?? 0)`, and 0 is the one value that is not a
+     neutral default here - it sits in the centre of the "flat" band. A coin
+     with no change data therefore did three wrong things at once: it survived
+     the > 3.5 filter that exists to exclude it, it took the MAXIMUM 20 of
+     section 1, and it pushed the literal string 'Price flat' into the reasons
+     the card renders. Missing data did not weaken the claim, it manufactured
+     the strongest one.
+     Same handling as lib/distribution.ts:36, which returns null when its own
+     gating input is absent instead of substituting a value. */
+  if (d.change == null) return null;
+  const chg = Math.abs(d.change);
   // Already moving hard - the accumulation window is over
   if (chg > 3.5) return null;
 
@@ -59,7 +76,28 @@ function scoreCoin(id: CoinId, d: CoinData | undefined): AccumRow | null {
   // Bonus - volume waking up without a price move yet
   if (d.volRatio != null && d.volRatio >= 1.3) { score += 5; reasons.push(`Vol ${d.volRatio.toFixed(1)}x`); }
 
-  return { id, score: Math.min(100, score), price: d.price, change: d.change ?? 0, reasons };
+  /* How many of the score's independent inputs actually had data (#661).
+     47 of the 100 points sit behind `!= null` guards - takerBuyRatio 12,
+     fundingRate 15, bnWhaleLongRatio 15, volRatio 5 - against a MIN_SCORE of
+     45, so more than the display threshold can drop out with nothing in the
+     output to say it did.
+     Counted from the inputs rather than incremented inside the branches on
+     purpose: this measures how much was KNOWN, not how much FIRED. A funding
+     rate that was read and scored nothing is complete data; an absent one is
+     not, and the two are indistinguishable from the score alone.
+     Modelled on lib/marketStore.ts:290, which already refuses to label unless
+     >= 2 independent signals agree - the correct handling already exists in
+     this repo, one file over from the two scorers that lack it.
+     NOT RENDERED YET. How a partial score presents itself is the owner's
+     ruling; this is the measurement that ruling needs, carried so the decision
+     can be made against real numbers instead of estimates. */
+  const INPUTS = [d.change, d.cvdDivergence, d.takerBuyRatio, d.oiTrend, d.fundingRate, d.bnWhaleLongRatio, d.volRatio];
+  const inputsPresent = INPUTS.filter(v => v != null).length;
+
+  return {
+    id, score: Math.min(100, score), price: d.price, change: d.change, reasons,
+    inputsPresent, inputsTotal: INPUTS.length,
+  };
 }
 
 const MIN_SCORE = 45;

--- a/lib/distribution.ts
+++ b/lib/distribution.ts
@@ -26,6 +26,10 @@ export interface DistributionScore {
   score:   number;    // 0–100
   reasons: string[];
   label:   'Distribution' | 'Early distribution' | 'Quiet';
+  /** #661: how many of the eight inputs had data. Carried, not yet displayed -
+   *  a partial score must be distinguishable from a complete one. */
+  inputsPresent: number;
+  inputsTotal:   number;
 }
 
 /* Gate: profit-taking is only meaningful after strength. Coins that haven't run
@@ -79,7 +83,23 @@ export function computeDistributionScore(d: DistributionInputs): DistributionSco
   const label: DistributionScore['label'] =
     capped >= 70 ? 'Distribution' : capped >= 45 ? 'Early distribution' : 'Quiet';
 
-  return { score: capped, reasons, label };
+  /* Input completeness (#661). 55 of the 100 points sit behind `!= null`
+     guards here - takerBuyRatio 15, whaleLongRatio 15, fundingRatePct 15, and
+     the volRatio/takerBuyRatio pair 10 - against labels at 70 and 45.
+     That matters more here than in the accumulation tracker, because the
+     output is a LABEL. Dropping 55 moves a genuine 'Distribution' to 'Quiet',
+     which is not a weakened claim but the opposite one.
+     `!= null` rather than truthiness: priceBelowVwap === false is data, and
+     a funding rate of exactly 0 is a reading, not an absence.
+     NOT RENDERED YET - the presentation of a partial score is the owner's
+     ruling. See components/AccumulationTracker.tsx for the twin. */
+  const INPUTS = [
+    d.change24hPct, d.cvdDivergence, d.takerBuyRatio, d.oiTrend,
+    d.whaleLongRatio, d.fundingRatePct, d.volRatio, d.priceBelowVwap,
+  ];
+  const inputsPresent = INPUTS.filter(v => v != null).length;
+
+  return { score: capped, reasons, label, inputsPresent, inputsTotal: INPUTS.length };
 }
 
 export function distributionColor(score: number): string {


### PR DESCRIPTION
## Summary

QA's items 1 and 2 from #661: the `?? 0` bug (no ruling needed — it's a bug) and input-completeness counts on the two ungated scorers. Item 3 is filed as #663; item 4 is diagnosed on #657.

## What changed

| File | Change |
|---|---|
| `components/AccumulationTracker.tsx` | refuses to score when `d.change` is null; carries `inputsPresent` / `inputsTotal` |
| `lib/distribution.ts` | carries `inputsPresent` / `inputsTotal` |

## Why — the `?? 0`

```js
:23  const chg = Math.abs(d.change ?? 0);
:24  if (chg > 3.5) return null;
:31  if (chg <= 1) { score += 20; reasons.push('Price flat'); }
```

**0 is the one value that is not a neutral default here** — it is the centre of the band the scorer is hunting for. A coin with no change data:

1. **survived** the `> 3.5` filter that exists to exclude it — the filter cannot exclude what it reads as 0
2. took the **maximum** 20 points of section 1
3. pushed the literal `'Price flat'` into `reasons`, which the card renders

Missing data didn't weaken the claim. It manufactured the strongest one **and attached a specific assertion about the market that was never observed.** #661 was filed about a number with no label to check; this one has a label and the label is wrong.

The fix is `return null` — the same handling `lib/distribution.ts:36` already applies to its own gating input.

## Why — the counts

| scorer | droppable | threshold | consequence |
|---|---|---|---|
| `AccumulationTracker` | 47 | shown at ≥45 | more than the display threshold can vanish |
| `lib/distribution.ts` | 55 | labels at 70 / 45 | a genuine `Distribution` reads as `Quiet` |

The second is worse: its output is a **label**, so a large enough drop doesn't produce a weaker claim, it produces the **opposite** one.

Counted from the inputs rather than incremented inside the scoring branches, deliberately — this measures **how much was known, not how much fired.** A funding rate that was read and scored nothing is complete data; an absent one isn't, and the score alone cannot distinguish them. `!= null` rather than truthiness, because `priceBelowVwap === false` is data and a funding rate of exactly `0` is a reading.

Modelled on `lib/marketStore.ts:290`, which already withholds its label unless ≥2 independent signals agree. **The correct handling was already in the repo, one file over from the two that lacked it** — third time tonight that has been the shape.

## Not in this PR

**Nothing is rendered.** How a partial score presents itself is the owner's ruling, as is whether the `>= 2` floor becomes the house pattern. This carries the measurement that ruling needs so it can be made against real numbers rather than estimates.

Also untouched: `AbsorptionDetector`'s 15 points behind `c1h.length >= 5`. That is a structural check on a candle array rather than an absent-field guard, and arguably correct as written — it cannot compute the contribution at all.

## How to test (QA)

On **staging**, `/dashboard`:

1. **Accumulation card** — no row should show a `Price flat` reason for a coin whose 24h change is blank elsewhere on the page. That combination was previously reachable and is the defect.
2. **Rows may disappear** relative to before. That is intended: those rows were appearing on an inflated score built from a fabricated "flat" reading.
3. **Distribution card** — unchanged in appearance. Only its returned object gained two fields; nothing reads them yet.
4. `distribution.ts` is shared by the dashboard card, the arena chip, the AI context and the server-side Telegram alert — worth confirming the arena chip and an alert still render, since the interface changed.

## Risk level

**Low–Medium.** The refusal changes which rows appear, which is user-visible and intended. Gates: lint 0, `tsc` 0, `npm test` 0, `build` 0.

**Not verified by me:** how often `d.change` is actually null in practice. If it is common, the Accumulation card will be noticeably emptier — that is correct behaviour, but it is a visible change and I could not measure the frequency without a populated environment. Worth a look before this goes further than staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
