### PR TITLE
fix(api): bound the symbol fan-out instead of opening every request at once

### DIFF
--- a/__tests__/pool.test.mts
+++ b/__tests__/pool.test.mts
@@ -1,0 +1,140 @@
+/* lib/pool.ts - the bounded worker pool shared by the symbol fan-outs (#665).
+ *
+ * The branch under test is the one that has never fired in practice: the
+ * rate-limit stop. Both hand-rolled copies this file replaced
+ * (snapshot/route.ts, rsi/route.ts) have carried that same untested branch
+ * since they were written, because exercising it needs an upstream willing to
+ * ban you.
+ *
+ * It does not. `runPool` takes `work` and `isFatal` as parameters, so a fake
+ * `work` that throws HttpStatusError(429) on a chosen item proves the whole
+ * contract with no network, no timers beyond a short sleep, and no upstream:
+ * counts are directly observable rather than inferred.
+ *
+ * Written because QA's review of #667 pointed out that shipping the SHARED
+ * version with the same untested branch carries the gap forward into every
+ * future caller rather than one route.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+/* Relative with the extension: run under `node --test`, which resolves neither
+   tsconfig paths nor Next's `@/` alias. */
+import { runPool, HttpStatusError, isRateLimitStatus, DEFAULT_CONCURRENCY } from '../lib/pool.ts';
+
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+test('never runs more than `limit` items at once', async () => {
+  const items = Array.from({ length: 30 }, (_, i) => i);
+  let inFlight = 0, peak = 0;
+
+  await runPool(items, 4, async () => {
+    inFlight++;
+    peak = Math.max(peak, inFlight);
+    await sleep(5);
+    inFlight--;
+  });
+
+  assert.equal(peak, 4, `peak concurrency ${peak}, expected exactly 4`);
+});
+
+test('the old shape is what this replaces - all 30 at once', async () => {
+  /* Not a test of runPool. It pins the behaviour #665 was about, so the
+     assertion above is visibly a change rather than an arbitrary number. */
+  const items = Array.from({ length: 30 }, (_, i) => i);
+  let inFlight = 0, peak = 0;
+
+  await Promise.allSettled(items.map(async () => {
+    inFlight++; peak = Math.max(peak, inFlight); await sleep(5); inFlight--;
+  }));
+
+  assert.equal(peak, 30, 'the unbounded shape should open every item at once');
+});
+
+test('a fatal error stops the run and reports it', async () => {
+  const items = Array.from({ length: 40 }, (_, i) => i);
+  const attempted: number[] = [];
+
+  const stopped = await runPool(items, 4, async (i) => {
+    attempted.push(i);
+    await sleep(2);
+    if (i === 5) throw new HttpStatusError(429, 'rate limited');
+  }, isRateLimitStatus);
+
+  assert.equal(stopped, true, 'a fatal error must be reported to the caller');
+  assert.ok(
+    attempted.length < items.length,
+    `stopped after ${attempted.length}/${items.length} - the pool drained the list instead of stopping`,
+  );
+});
+
+test('an ordinary error does NOT stop the run', async () => {
+  const items = Array.from({ length: 20 }, (_, i) => i);
+  const attempted: number[] = [];
+
+  const stopped = await runPool(items, 4, async (i) => {
+    attempted.push(i);
+    if (i % 3 === 0) throw new Error('one bad symbol');
+  }, isRateLimitStatus);
+
+  assert.equal(stopped, false);
+  assert.equal(
+    attempted.length, 20,
+    'one failing item must not lose the rest - the allSettled tolerance this replaced',
+  );
+});
+
+test('items already in flight finish when a fatal fires', async () => {
+  /* The stop is cooperative: a worker checks the flag between items, it does
+     not abort work already started. Anything that has begun must complete, or
+     a partial write could be left half-applied. */
+  const items = Array.from({ length: 12 }, (_, i) => i);
+  let started = 0, finished = 0;
+
+  await runPool(items, 4, async (i) => {
+    started++;
+    await sleep(10);
+    if (i === 0) throw new HttpStatusError(418, 'banned');
+    finished++;
+  }, isRateLimitStatus);
+
+  assert.equal(
+    finished, started - 1,
+    `${started} started, ${finished} finished - every non-throwing item that began must complete`,
+  );
+});
+
+test('with no isFatal, nothing is fatal', async () => {
+  const items = [1, 2, 3];
+  const stopped = await runPool(items, 2, async () => {
+    throw new HttpStatusError(429, 'rate limited');
+  });
+  assert.equal(stopped, false, 'the default predicate must treat every failure as ordinary');
+});
+
+test('isRateLimitStatus recognises the three stop codes and nothing else', () => {
+  for (const s of [418, 429, 403]) {
+    assert.equal(isRateLimitStatus(new HttpStatusError(s, `${s}`)), true, `${s} should stop the pool`);
+  }
+  /* 404 and 500 are about the one symbol asked for; spending the remaining
+     requests is correct for those and wrong for the three above. */
+  for (const s of [400, 404, 418 - 1, 500, 502]) {
+    assert.equal(isRateLimitStatus(new HttpStatusError(s, `${s}`)), false, `${s} should not stop the pool`);
+  }
+  assert.equal(isRateLimitStatus(new Error('429 in the message')), false,
+    'a plain Error must not stop the pool just because its text looks like a status');
+});
+
+test('an empty list runs nothing and does not hang', async () => {
+  let calls = 0;
+  const stopped = await runPool([], DEFAULT_CONCURRENCY, async () => { calls++; });
+  assert.equal(calls, 0);
+  assert.equal(stopped, false);
+});
+
+test('a limit larger than the list does not spawn idle workers past the end', async () => {
+  const items = [1, 2, 3];
+  let calls = 0;
+  await runPool(items, 50, async () => { calls++; });
+  assert.equal(calls, 3, 'each item must run exactly once regardless of the limit');
+});

--- a/app/api/market/account-ratio/route.ts
+++ b/app/api/market/account-ratio/route.ts
@@ -29,7 +29,7 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const { data, ok, total } = await bybitFanout(
+    const { data, ok, total, stopped } = await bybitFanout(
       `bybit:account-ratio:${period}`,
       120_000,
       (sym) => `https://api.bybit.com/v5/market/account-ratio?category=linear&symbol=${sym}&period=${period}&limit=1`,
@@ -43,10 +43,17 @@ export async function GET(req: NextRequest) {
       },
     );
 
-    reportHealth('bybit:account-ratio', 'market', true, `${ok}/${total}`, ok);
+    reportHealth('bybit:account-ratio', 'market', !stopped, stopped ? `${ok}/${total} then rate-limited` : `${ok}/${total}`, ok);
     /* `ok`/`total` are in the body on purpose: a caller and a probe can both see
        a partial fan-out. An empty one cannot reach here - bybitFanout throws. */
-    return NextResponse.json({ data, ok, total, ts: Date.now() }, {
+    /* `stopped` distinguishes a rate-limit abort from symbols failing one at a
+       time (#665). `ok: 12, total: 49` reads identically for both, and they call
+       for opposite responses - back off for the TTL, versus investigate a patchy
+       upstream. Omitted when false so the healthy response is unchanged and
+       `'stopped' in body` is a valid check, the same convention
+       /api/market/snapshot uses for `partial`. Reported unhealthy too: a run cut
+       short by a ban is not a success with fewer rows. */
+    return NextResponse.json({ data, ok, total, ...(stopped ? { stopped: true } : {}), ts: Date.now() }, {
       headers: { 'Cache-Control': 'public, s-maxage=120, stale-while-revalidate=600' },
     });
   } catch (e) {

--- a/app/api/market/agg-trades/route.ts
+++ b/app/api/market/agg-trades/route.ts
@@ -46,7 +46,7 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const { data, ok, total } = await symbolFanout(
+    const { data, ok, total, stopped } = await symbolFanout(
       SYMBOLS,
       `binance:agg-trades:${limit}`,
       60_000,
@@ -56,8 +56,15 @@ export async function GET(req: NextRequest) {
       (body) => (Array.isArray(body) ? body : null),
     );
 
-    reportHealth('binance:agg-trades', 'market', true, `${ok}/${total}`, ok);
-    return NextResponse.json({ data, ok, total, ts: Date.now() }, {
+    reportHealth('binance:agg-trades', 'market', !stopped, stopped ? `${ok}/${total} then rate-limited` : `${ok}/${total}`, ok);
+    /* `stopped` distinguishes a rate-limit abort from symbols failing one at a
+       time (#665). `ok: 12, total: 49` reads identically for both, and they call
+       for opposite responses - back off for the TTL, versus investigate a patchy
+       upstream. Omitted when false so the healthy response is unchanged and
+       `'stopped' in body` is a valid check, the same convention
+       /api/market/snapshot uses for `partial`. Reported unhealthy too: a run cut
+       short by a ban is not a success with fewer rows. */
+    return NextResponse.json({ data, ok, total, ...(stopped ? { stopped: true } : {}), ts: Date.now() }, {
       headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300' },
     });
   } catch (e) {

--- a/app/api/market/funding-rate/route.ts
+++ b/app/api/market/funding-rate/route.ts
@@ -35,7 +35,7 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const { data, ok, total } = await symbolFanout(
+    const { data, ok, total, stopped } = await symbolFanout(
       SYMBOLS,
       `binance:funding-rate:${limit}`,
       900_000,
@@ -44,8 +44,15 @@ export async function GET(req: NextRequest) {
       (body) => (Array.isArray(body) ? body : null),
     );
 
-    reportHealth('binance:funding-rate', 'market', true, `${ok}/${total}`, ok);
-    return NextResponse.json({ data, ok, total, ts: Date.now() }, {
+    reportHealth('binance:funding-rate', 'market', !stopped, stopped ? `${ok}/${total} then rate-limited` : `${ok}/${total}`, ok);
+    /* `stopped` distinguishes a rate-limit abort from symbols failing one at a
+       time (#665). `ok: 12, total: 49` reads identically for both, and they call
+       for opposite responses - back off for the TTL, versus investigate a patchy
+       upstream. Omitted when false so the healthy response is unchanged and
+       `'stopped' in body` is a valid check, the same convention
+       /api/market/snapshot uses for `partial`. Reported unhealthy too: a run cut
+       short by a ban is not a success with fewer rows. */
+    return NextResponse.json({ data, ok, total, ...(stopped ? { stopped: true } : {}), ts: Date.now() }, {
       headers: { 'Cache-Control': 'public, s-maxage=900, stale-while-revalidate=1800' },
     });
   } catch (e) {

--- a/app/api/market/open-interest/route.ts
+++ b/app/api/market/open-interest/route.ts
@@ -32,7 +32,7 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const { data, ok, total } = await bybitFanout(
+    const { data, ok, total, stopped } = await bybitFanout(
       `bybit:open-interest:${intervalTime}:${limit}`,
       120_000,
       (sym) => `https://api.bybit.com/v5/market/open-interest?category=linear&symbol=${sym}&intervalTime=${intervalTime}&limit=${limit}`,
@@ -43,8 +43,15 @@ export async function GET(req: NextRequest) {
       (body) => (body as { result?: { list?: unknown[] } })?.result?.list ?? null,
     );
 
-    reportHealth('bybit:open-interest', 'market', true, `${ok}/${total}`, ok);
-    return NextResponse.json({ data, ok, total, ts: Date.now() }, {
+    reportHealth('bybit:open-interest', 'market', !stopped, stopped ? `${ok}/${total} then rate-limited` : `${ok}/${total}`, ok);
+    /* `stopped` distinguishes a rate-limit abort from symbols failing one at a
+       time (#665). `ok: 12, total: 49` reads identically for both, and they call
+       for opposite responses - back off for the TTL, versus investigate a patchy
+       upstream. Omitted when false so the healthy response is unchanged and
+       `'stopped' in body` is a valid check, the same convention
+       /api/market/snapshot uses for `partial`. Reported unhealthy too: a run cut
+       short by a ban is not a success with fewer rows. */
+    return NextResponse.json({ data, ok, total, ...(stopped ? { stopped: true } : {}), ts: Date.now() }, {
       headers: { 'Cache-Control': 'public, s-maxage=120, stale-while-revalidate=600' },
     });
   } catch (e) {

--- a/lib/bybitFanout.ts
+++ b/lib/bybitFanout.ts
@@ -37,6 +37,17 @@ export interface FanoutResult {
    *  empty result must never look like a successful one. */
   ok: number;
   total: number;
+  /** True when the run was cut short by a rate-limit stop (418/429/403) rather
+   *  than by individual symbols failing (#665, QA's review of #667).
+   *
+   *  Without this, `ok: 12, total: 49` is ambiguous: it reads identically for
+   *  "we were banned on the 13th request and stopped deliberately" and "37
+   *  symbols each failed on their own". Those call for opposite responses -
+   *  back off for the TTL, versus look at why the upstream is patchy.
+   *
+   *  Same reason /api/market/snapshot reports `banned` separately from a short
+   *  map, and the same reason `partial` exists on its response at all. */
+  stopped: boolean;
 }
 
 /**
@@ -104,7 +115,7 @@ export async function symbolFanout(
      * already banned this IP once (#228). */
     const data: Record<string, unknown> = {};
 
-    await runPool(symbols, DEFAULT_CONCURRENCY, async (sym) => {
+    const stopped = await runPool(symbols, DEFAULT_CONCURRENCY, async (sym) => {
       const r = await fetch(buildUrl(sym), { cache: 'no-store' });
       if (!r.ok) throw new HttpStatusError(r.status, `${sym} ${r.status}`);
       const v = pick(await r.json());
@@ -119,6 +130,6 @@ export async function symbolFanout(
       throw new Error(`fan-out returned nothing for all ${symbols.length} symbols`);
     }
 
-    return { data, ok: Object.keys(data).length, total: symbols.length };
+    return { data, ok: Object.keys(data).length, total: symbols.length, stopped };
   });
 }

--- a/lib/bybitFanout.ts
+++ b/lib/bybitFanout.ts
@@ -21,6 +21,7 @@
  */
 import { cached } from './apiCache';
 import { BYBIT_SYMS } from './coins';
+import { runPool, DEFAULT_CONCURRENCY, HttpStatusError, isRateLimitStatus } from './pool';
 
 /** Every symbol this app tracks on Bybit. A closed set, which is what keeps the
  *  cache key space finite - see the note in app/api/market/klines/route.ts. */
@@ -44,10 +45,15 @@ export interface FanoutResult {
  * @param buildUrl given a symbol, the upstream URL to call
  * @param pick     extract the bit worth keeping from one symbol's response
  *
- * `allSettled`, not `all`: one symbol failing must not lose the other 49. That
- * is the same reasoning as /api/market/snapshot's three-way split, and the same
- * trap - so the caller is told how many succeeded rather than being handed a
- * quietly short map.
+ * One symbol failing must not lose the other 49 - the same reasoning as
+ * /api/market/snapshot's three-way split, and the same trap, so the caller is
+ * told how many succeeded rather than being handed a quietly short map.
+ *
+ * This said "`allSettled`, not `all`" until #665. The tolerance it describes is
+ * unchanged; runPool swallows an ordinary per-item failure exactly as
+ * `allSettled` did. What changed is that the requests are now BOUNDED - the old
+ * shape opened all ~45 at once, which is what produced the missing symbols this
+ * text promised the caller would be told about.
  */
 export async function bybitFanout(
   key: string,
@@ -77,18 +83,33 @@ export async function symbolFanout(
   pick: (body: unknown) => unknown,
 ): Promise<FanoutResult> {
   return cached(key, ttlMs, async () => {
-    const settled = await Promise.allSettled(
-      symbols.map(async (sym) => {
-        const r = await fetch(buildUrl(sym), { cache: 'no-store' });
-        if (!r.ok) throw new Error(`${sym} ${r.status}`);
-        return [sym, pick(await r.json())] as const;
-      }),
-    );
-
+    /* Bounded, not `symbols.map` inside allSettled (#665).
+     *
+     * That fired every symbol simultaneously - ~45 requests from one server IP
+     * in one burst, at hosts that rate-limit per IP. Losers threw and landed
+     * ABSENT from `data`, which the pages render as a blank cell, so the
+     * symptom was an arbitrary few symbols missing and a DIFFERENT few on the
+     * next run. A mapping bug or an upstream gap would have blanked the same
+     * ones every time; that non-determinism is what identified this.
+     *
+     * `allSettled` was never the problem and the reasoning in the doc comment
+     * above still holds - one symbol failing must not lose the other 49. The
+     * defect was the WIDTH of the burst. runPool keeps that tolerance and adds
+     * the bound,
+     * plus the 418/429/403 stop that the two hand-rolled pools in
+     * snapshot/route.ts and rsi/route.ts already had and this path did not.
+     *
+     * Two of the four callers point at Binance - funding-rate at fapi and
+     * agg-trades at api.binance.com on a 60s TTL - which is the host that
+     * already banned this IP once (#228). */
     const data: Record<string, unknown> = {};
-    for (const s of settled) {
-      if (s.status === 'fulfilled' && s.value[1] != null) data[s.value[0]] = s.value[1];
-    }
+
+    await runPool(symbols, DEFAULT_CONCURRENCY, async (sym) => {
+      const r = await fetch(buildUrl(sym), { cache: 'no-store' });
+      if (!r.ok) throw new HttpStatusError(r.status, `${sym} ${r.status}`);
+      const v = pick(await r.json());
+      if (v != null) data[sym] = v;
+    }, isRateLimitStatus);
 
     /* Throwing on a total wipeout rather than caching an empty map. `cached()`
        does not store a rejection, so a refused upstream is retried by the next

--- a/lib/pool.ts
+++ b/lib/pool.ts
@@ -67,8 +67,18 @@ export async function runPool<T>(
  *  a message string. The two older copies encoded this as a bespoke Error
  *  subclass per route, which is what made them un-shareable. */
 export class HttpStatusError extends Error {
-  constructor(public readonly status: number, message: string) {
+  /* Declared and assigned rather than a `constructor(public readonly status)`
+     parameter property. That shorthand EMITS code rather than only annotating,
+     so Node's type-stripping refuses it - `node --test` fails the whole file
+     with ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX before a single test runs. Next's
+     SWC build handles it either way, so the shorthand would have worked in
+     production and been untestable, which is the wrong trade for the one
+     module here whose failure branch needs tests most. */
+  readonly status: number;
+
+  constructor(status: number, message: string) {
     super(message);
+    this.status = status;
     this.name = 'HttpStatusError';
   }
 }

--- a/lib/pool.ts
+++ b/lib/pool.ts
@@ -1,0 +1,81 @@
+/* Fixed-size worker pool, shared (#665).
+ *
+ * This existed TWICE before this file did - app/api/market/snapshot/route.ts
+ * and app/api/market/rsi/route.ts each define their own worker pool AND their
+ * own `class BinanceBackoff`, each with a comment explaining why the pool is
+ * necessary. It was copied rather than extracted, and copying is exactly what
+ * stopped it travelling: four routes going through lib/bybitFanout.ts fanned
+ * out with `symbols.map` inside `Promise.allSettled` - every symbol at once,
+ * no pool, no backoff - at hosts that rate-limit per IP.
+ *
+ * A second copy proves the idea was understood twice and still did not reach
+ * the callers that needed it. So this is the extraction, not a third copy.
+ *
+ * The stop condition is a PREDICATE rather than an exception class, because
+ * the two existing copies both hard-code `instanceof BinanceBackoff` and that
+ * is why neither could serve Bybit. What counts as "stop everything" is the
+ * caller's knowledge, not the pool's.
+ */
+
+/** Concurrency the Binance paths already chose, adopted rather than re-picked.
+ *  See snapshot/route.ts:63 - a value with a reason behind it beats a new one
+ *  with none. */
+export const DEFAULT_CONCURRENCY = 12;
+
+/**
+ * Runs `work` over `items`, at most `limit` at a time.
+ *
+ * Ordinary failures are swallowed - one bad item must not lose the rest, which
+ * is the same reasoning as the `allSettled` in symbolFanout. A failure the
+ * caller marks FATAL via `isFatal` stops every worker immediately: spending the
+ * remaining requests into an active ban only extends it, and a ban on a shared
+ * server IP is lost data for every visitor at once rather than for one.
+ *
+ * @returns true if the run was stopped early by a fatal error.
+ */
+export async function runPool<T>(
+  items: readonly T[],
+  limit: number,
+  work: (item: T) => Promise<void>,
+  isFatal: (e: unknown) => boolean = () => false,
+): Promise<boolean> {
+  let next = 0;
+  let stopped = false;
+
+  const worker = async () => {
+    for (;;) {
+      if (stopped) return;
+      const i = next++;
+      if (i >= items.length) return;
+      try {
+        await work(items[i]);
+      } catch (e) {
+        if (isFatal(e)) { stopped = true; return; }
+        /* Ordinary miss - the caller's `work` decides what that means for its
+           own output. The pool's only job is to keep going. */
+      }
+    }
+  };
+
+  await Promise.all(
+    Array.from({ length: Math.max(1, Math.min(limit, items.length)) }, worker),
+  );
+  return stopped;
+}
+
+/** Carries the HTTP status so a caller's `isFatal` can read it without parsing
+ *  a message string. The two older copies encoded this as a bespoke Error
+ *  subclass per route, which is what made them un-shareable. */
+export class HttpStatusError extends Error {
+  constructor(public readonly status: number, message: string) {
+    super(message);
+    this.name = 'HttpStatusError';
+  }
+}
+
+/* 429 is the warning and 418 is the ban that follows it on Binance. Bybit
+   answers 403 when a per-IP limit is exceeded. None of the three is about the
+   symbol that happened to be asked for, so all three mean stop rather than
+   skip. */
+export const isRateLimitStatus = (e: unknown): boolean =>
+  e instanceof HttpStatusError && (e.status === 418 || e.status === 429 || e.status === 403);


### PR DESCRIPTION
## Summary

Closes the defect on #665. `symbolFanout` now runs through a bounded worker pool with a rate-limit stop, extracted to `lib/pool.ts`. **Four routes fixed by one change** — `account-ratio`, `open-interest`, `funding-rate`, `agg-trades`.

## What is and isn't claimed

**This is a defect by inspection, not by reproduction.** `symbols.map` inside `Promise.allSettled` opens ~45 sockets at once at hosts that rate-limit per IP; `snapshot/route.ts:63` pools the identical job at `CONCURRENCY = 12` and documents why. That stands on its own.

**It is not claimed that this explains `/scanner`'s blank cells.** It was found chasing them, and QA has since withdrawn those measurements — the probe returned composite blocks rather than per-symbol rows, so which symbols blank in which column is currently unknown. A later run showed 49/49 present with real values, which is consistent both with "no race today" and with a cached answer read five times, and separates neither.

I had asserted the causal link in the first version of this commit. **Amended it out before opening this PR** rather than shipping a claim whose evidence had been retracted. The causal question is open; the fix does not rest on it.

## The sharpest fact

Two of the four callers point at **Binance, not Bybit** — `funding-rate` at `fapi`, `agg-trades` at `api.binance.com` on a **60s TTL**. That is the host that already banned this IP once (#228), and it was the least protected of the four. I'd been treating this as a Bybit problem because that's where the symptom appeared.

## Why a new file rather than a third copy

The pool already existed **twice** — `snapshot/route.ts:117` and `rsi/route.ts:196` — each with its own `class BinanceBackoff`, each with a comment explaining why it's necessary. **It was copied rather than extracted, and copying is what stopped it travelling:** the idea was understood twice and still never reached the four routes on the shared helper. A fourth copy here would have repeated exactly that.

The stop condition is a **predicate** rather than an exception class. Both existing copies hard-code `instanceof BinanceBackoff`, which is precisely why neither could serve Bybit — what counts as "stop everything" is the caller's knowledge, not the pool's.

Concurrency 12 is **adopted** from `snapshot/route.ts:63`, not re-picked. A value with a reason behind it beats a new one with none.

`allSettled`'s tolerance is preserved: `runPool` swallows an ordinary per-item failure exactly as before, so one dead symbol still cannot lose the other 49. Only the **width** changed, plus the 418/429/403 stop this path never had. I also corrected the JSDoc that still promised `allSettled`, since it no longer does.

## Not in this PR, deliberately

Migrating `snapshot/route.ts` and `rsi/route.ts` onto `lib/pool.ts`. Both work correctly today and neither is part of this defect. Bundling a refactor of the app's **primary market route** with a behaviour fix makes both harder to review and harder to revert independently.

Worth its own PR, and the thing that migration was missing — a shared helper to migrate *to* — now exists. Say the word and I'll take it.

## How to test (QA)

This is a **throughput change, not a data change.** Correctness is unchanged when nothing is rate-limiting, which is the expected case.

1. `/scanner` — `Long %` and `Short %` render as they do now.
2. `/funding` — funding rates render as they do now.
3. `/liq` — open-interest-derived values render as they do now.
4. `/api/market/account-ratio?period=1h` still returns 49/49.

The absence of a visible change **is** the pass condition. If anything renders *less* than before, that is a regression and this should come out.

## Risk level

**Medium.** One shared helper, four routes, all of them market data on live pages. Gates: lint 0, `tsc` 0, `npm test` 0, `build` 0.

**Not verified by me:** behaviour under an actual rate-limit. The 418/429/403 stop has never fired in my testing because nothing rate-limited me — so the happy path is exercised and the stop path is reasoned, not observed. That is the same limitation the two existing copies have had since they were written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
