### PR TITLE
refactor(api): one worker pool, not three

### DIFF
--- a/app/api/market/rsi/route.ts
+++ b/app/api/market/rsi/route.ts
@@ -38,6 +38,7 @@ import { apiError } from '@/lib/apiError';
 import { BINANCE_SYMS, BYBIT_SYMS } from '@/lib/coins';
 import { rateLimit, getClientIp } from '@/lib/rateLimit';
 import { cached } from '@/lib/apiCache';
+import { runPool, HttpStatusError } from '@/lib/pool';
 import { reportHealth, healthError } from '@/lib/apiHealth';
 import { computeRSI14 } from '@/lib/rsi';
 
@@ -140,9 +141,19 @@ function buildJobs(fast: boolean): Job[] {
   return jobs;
 }
 
-/* Raised when Binance answers 418 (IP banned) or 429 (rate limited). Carries
-   no data - its only job is to stop the pool, see runPool. */
-class BinanceBackoff extends Error {}
+/* 418 (IP banned) or 429 (rate limited) - neither is about the symbol asked
+   for, so both stop the pool rather than skipping one job.
+
+   This was a local error class until #665, and snapshot/route.ts defined an
+   identical one. Two copies of the same stop condition, each hard-coded into
+   its own pool, is what kept either pool from being shared - and the four
+   routes on lib/bybitFanout.ts got no pool at all as a result.
+
+   Deliberately NOT lib/pool.ts's isRateLimitStatus, which also treats 403 as
+   fatal on Bybit's behalf. Binance does not rate-limit with 403, so adopting it
+   here would convert an ordinary per-symbol miss into a whole-batch abort. */
+const isBinanceBackoff = (e: unknown): boolean =>
+  e instanceof HttpStatusError && (e.status === 418 || e.status === 429);
 
 /* Closes, newest last, from whichever exchange shape came back. Returns null
    rather than throwing so one dead symbol cannot take down the batch - the
@@ -162,7 +173,7 @@ async function fetchCloses(job: Job, ep: Endpoint): Promise<number[] | null> {
        ban is measured in minutes to days. Distinguish from an ordinary miss
        so runPool can stop rather than continue. */
     if (res.status === 418 || res.status === 429) {
-      throw new BinanceBackoff(`Binance ${res.status}`);
+      throw new HttpStatusError(res.status, `Binance ${res.status}`);
     }
     if (!res.ok) return null;
     const body = await res.json();
@@ -175,7 +186,7 @@ async function fetchCloses(job: Job, ep: Endpoint): Promise<number[] | null> {
     if (!Array.isArray(body)) return null;
     return body.map((k: string[]) => parseFloat(k[4]));
   } catch (e) {
-    if (e instanceof BinanceBackoff) throw e;
+    if (e instanceof HttpStatusError) throw e;
     return null;
   } finally {
     clearTimeout(tid);
@@ -191,40 +202,23 @@ async function fetchCloses(job: Job, ep: Endpoint): Promise<number[] | null> {
  * requests into an active ban only extends it, so the pool stops and the
  * partial result is cached - backing off for the TTL is the correct response
  * to a ban, not something to retry around. */
-async function runPool(
+async function runRsiPool(
   jobs: Job[], ep: Endpoint, out: RsiMap,
 ): Promise<{ ok: number; banned: boolean }> {
-  let next = 0;
-  let ok   = 0;
-  let banned = false;
+  let ok = 0;
 
-  async function worker() {
-    for (;;) {
-      if (banned) return;
-      const i = next++;
-      if (i >= jobs.length) return;
-      const job = jobs[i];
+  const banned = await runPool(jobs, CONCURRENCY, async (job) => {
+    const closes = await fetchCloses(job, ep);
+    /* Same guard the client applied: fewer than 15 closes cannot produce a
+       14-period RSI, and a partially-listed coin returns a short array rather
+       than an error. */
+    if (!closes || closes.length < 15) return;
+    const rsi = computeRSI14(closes);
+    if (rsi === null) return;
+    (out[job.coin] ??= {})[job.field] = rsi;
+    ok++;
+  }, isBinanceBackoff);
 
-      let closes: number[] | null;
-      try {
-        closes = await fetchCloses(job, ep);
-      } catch (e) {
-        if (e instanceof BinanceBackoff) { banned = true; return; }
-        continue;
-      }
-
-      /* Same guard the client applied: fewer than 15 closes cannot produce a
-         14-period RSI, and a partially-listed coin returns a short array
-         rather than an error. */
-      if (!closes || closes.length < 15) continue;
-      const rsi = computeRSI14(closes);
-      if (rsi === null) continue;
-      (out[job.coin] ??= {})[job.field] = rsi;
-      ok++;
-    }
-  }
-
-  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, jobs.length) }, worker));
   return { ok, banned };
 }
 
@@ -260,7 +254,7 @@ async function buildGroup(fast: boolean): Promise<RsiMap> {
   const allJobs = buildJobs(fast);
   const jobs = ep ? allJobs : allJobs.filter(j => j.bybit);
 
-  const { ok, banned } = await runPool(jobs, ep ?? BN_ENDPOINTS[0], out);
+  const { ok, banned } = await runRsiPool(jobs, ep ?? BN_ENDPOINTS[0], out);
 
   /* Reported per group so a partial outage is visible: the slow group failing
      while the fast one succeeds means Binance is rate-limiting the heavier

--- a/app/api/market/snapshot/route.ts
+++ b/app/api/market/snapshot/route.ts
@@ -46,6 +46,7 @@ import { apiError } from '@/lib/apiError';
 import { BINANCE_SYMS } from '@/lib/coins';
 import { rateLimit, getClientIp } from '@/lib/rateLimit';
 import { cached } from '@/lib/apiCache';
+import { runPool, HttpStatusError } from '@/lib/pool';
 import { reportHealth, healthError } from '@/lib/apiHealth';
 import { computeKlineMetrics, type KlineMetrics } from '@/lib/klineMetrics';
 
@@ -76,8 +77,20 @@ interface LsrEntry {
   bnWhaleLongRatio?: number; bnWhaleShortRatio?: number;
 }
 
-/** 418 = IP banned, 429 = rate limited. Neither is about the symbol asked for. */
-class BinanceBackoff extends Error {}
+/** 418 = IP banned, 429 = rate limited. Neither is about the symbol asked for.
+ *
+ *  This was a local `class BinanceBackoff extends Error {}` until #665. The
+ *  identical class existed in rsi/route.ts, and having it twice is what kept
+ *  the pool below from being shareable - both copies stopped on
+ *  `instanceof BinanceBackoff`, so neither could serve a non-Binance caller.
+ *
+ *  Deliberately NOT lib/pool.ts's `isRateLimitStatus`, which also treats 403
+ *  as fatal for Bybit's sake. Binance does not use 403 for rate limiting, so
+ *  adopting it here would turn what is currently an ordinary per-symbol miss
+ *  into a whole-batch abort on this route. Same pool, same error type, the
+ *  caller's own stop condition - which is the point of the predicate. */
+const isBinanceBackoff = (e: unknown): boolean =>
+  e instanceof HttpStatusError && (e.status === 418 || e.status === 429);
 
 async function get(url: string, timeoutMs = 8000): Promise<unknown | null> {
   const ac = new AbortController();
@@ -86,11 +99,11 @@ async function get(url: string, timeoutMs = 8000): Promise<unknown | null> {
     const res = await fetch(url, {
       cache: 'no-store', signal: ac.signal, headers: { 'User-Agent': 'Mozilla/5.0' },
     });
-    if (res.status === 418 || res.status === 429) throw new BinanceBackoff(`Binance ${res.status}`);
+    if (res.status === 418 || res.status === 429) throw new HttpStatusError(res.status, `Binance ${res.status}`);
     if (!res.ok) return null;
     return await res.json();
   } catch (e) {
-    if (e instanceof BinanceBackoff) throw e;
+    if (e instanceof HttpStatusError) throw e;
     return null;
   } finally {
     clearTimeout(tid);
@@ -99,9 +112,10 @@ async function get(url: string, timeoutMs = 8000): Promise<unknown | null> {
 
 /* Cheap probe so a dead edge is found once, not 90 times.
  *
- * Swallows BinanceBackoff deliberately. A 418 on the ping means this IP is
- * banned, which is a reason to report "no reachable host" and return an empty
- * section - not to throw and take the other two sections down with it. Letting
+ * Swallows the 418/429 HttpStatusError deliberately. A 418 on the ping means
+ * this IP is banned, which is a reason to report "no reachable host" and return
+ * an empty section - not to throw and take the other two sections down with it.
+ * Letting
  * it propagate is what made the ticker come back empty *and* rejected while
  * klines and ratios were fine. */
 async function resolveHost(hosts: readonly string[], pingPath: string): Promise<string | null> {
@@ -112,23 +126,6 @@ async function resolveHost(hosts: readonly string[], pingPath: string): Promise<
     } catch { /* banned or rate-limited on this edge - try the next */ }
   }
   return null;
-}
-
-/* Fixed-size worker pool that stops the moment Binance signals a limit -
-   spending the remaining requests into an active ban only extends it. */
-async function pool<T>(items: T[], limit: number, work: (item: T) => Promise<void>): Promise<boolean> {
-  let next = 0, banned = false;
-  const worker = async () => {
-    for (;;) {
-      if (banned) return;
-      const i = next++;
-      if (i >= items.length) return;
-      try { await work(items[i]); }
-      catch (e) { if (e instanceof BinanceBackoff) { banned = true; return; } }
-    }
-  };
-  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
-  return banned;
 }
 
 async function buildTicker(): Promise<Record<string, TickerEntry>> {
@@ -187,7 +184,7 @@ async function buildKlines(): Promise<Record<string, KlineMetrics>> {
   const out: Record<string, KlineMetrics> = {};
   if (!fut && !spot) { reportHealth('binance:klines', 'market', false, 'no reachable host'); return out; }
 
-  const banned = await pool(SYMS, CONCURRENCY, async ([coin, sym]) => {
+  const banned = await runPool(SYMS, CONCURRENCY, async ([coin, sym]) => {
     const url = fut
       ? `${fut}/fapi/v1/klines?symbol=${sym}&interval=15m&limit=100`
       : `${spot}/api/v3/klines?symbol=${sym}&interval=15m&limit=100`;
@@ -195,7 +192,7 @@ async function buildKlines(): Promise<Record<string, KlineMetrics>> {
     if (!Array.isArray(raw)) return;
     const m = computeKlineMetrics(raw as string[][]);
     if (m) out[coin] = m;
-  });
+  }, isBinanceBackoff);
 
   reportHealth('binance:klines', 'market', Object.keys(out).length > 0 && !banned,
     banned ? `418/429 after ${Object.keys(out).length}/${SYMS.length}`
@@ -208,7 +205,7 @@ async function buildLsr(): Promise<Record<string, LsrEntry>> {
   const out: Record<string, LsrEntry> = {};
   if (!host) { reportHealth('binance:lsr', 'market', false, 'no reachable futures host'); return out; }
 
-  const banned = await pool(SYMS, CONCURRENCY, async ([coin, sym]) => {
+  const banned = await runPool(SYMS, CONCURRENCY, async ([coin, sym]) => {
     const [g, w] = await Promise.all([
       get(`${host}/futures/data/globalLongShortAccountRatio?symbol=${sym}&period=5m&limit=1`),
       get(`${host}/futures/data/topLongShortPositionRatio?symbol=${sym}&period=5m&limit=1`),
@@ -219,7 +216,7 @@ async function buildLsr(): Promise<Record<string, LsrEntry>> {
     if (gi) { e.bnLongRatio = parseFloat(gi.longAccount || '0.5'); e.bnShortRatio = parseFloat(gi.shortAccount || '0.5'); }
     if (wi) { e.bnWhaleLongRatio = parseFloat(wi.longAccount || '0.5'); e.bnWhaleShortRatio = parseFloat(wi.shortAccount || '0.5'); }
     if (Object.keys(e).length) out[coin] = e;
-  });
+  }, isBinanceBackoff);
 
   reportHealth('binance:lsr', 'market', Object.keys(out).length > 0 && !banned,
     banned ? `418/429 after ${Object.keys(out).length}/${SYMS.length}` : `${Object.keys(out).length}/${SYMS.length}`);

--- a/lib/pool.ts
+++ b/lib/pool.ts
@@ -1,7 +1,7 @@
 /* Fixed-size worker pool, shared (#665).
  *
  * This existed TWICE before this file did - app/api/market/snapshot/route.ts
- * and app/api/market/rsi/route.ts each define their own worker pool AND their
+ * and app/api/market/rsi/route.ts each defined their own worker pool AND their
  * own `class BinanceBackoff`, each with a comment explaining why the pool is
  * necessary. It was copied rather than extracted, and copying is exactly what
  * stopped it travelling: four routes going through lib/bybitFanout.ts fanned
@@ -10,6 +10,10 @@
  *
  * A second copy proves the idea was understood twice and still did not reach
  * the callers that needed it. So this is the extraction, not a third copy.
+ *
+ * Both originals now import from here and their duplicate classes are gone, so
+ * there is exactly one worker pool in the codebase. If you are adding a fifth
+ * caller, the thing to bring is a PREDICATE, not another pool.
  *
  * The stop condition is a PREDICATE rather than an exception class, because
  * the two existing copies both hard-code `instanceof BinanceBackoff` and that


### PR DESCRIPTION
## Summary

The follow-up you named after #667 landed. `snapshot/route.ts` and `rsi/route.ts` now import `runPool` from `lib/pool.ts`; **both local pools and both `class BinanceBackoff` declarations are deleted.** There is now exactly one worker pool in the codebase.

No behaviour change is intended.

## Why this is the point rather than tidying

The duplication wasn't incidental to #665 — **it was the mechanism.** Both copies stopped on `instanceof BinanceBackoff`, a private class per file, so neither could serve a Bybit caller even if someone had thought to try. Four routes on the shared fan-out got no pool at all as a result.

#667 added the shared version and deliberately left the originals, so the codebase briefly had three. This removes the two.

## Semantics preserved, deliberately

Both routes keep their **own** `isBinanceBackoff` (418/429) rather than adopting `lib/pool.ts`'s `isRateLimitStatus`, which also treats **403** as fatal on Bybit's behalf.

Binance does not rate-limit with 403. Adopting the wider predicate would convert what is currently an ordinary per-symbol miss into a **whole-batch abort on the app's primary market route** — a real behaviour change smuggled inside a refactor. Same pool, same error type, different stop condition, which is exactly what the predicate parameter is for.

`rsi`'s pool is not a plain wrapper — it counts successes and writes into the caller's map. It keeps that, renamed `runRsiPool`, with the shared pool inside. The 15-closes guard and the null-RSI skip moved verbatim.

## Two stale comments fixed

- `snapshot`'s `resolveHost` said it *"swallows BinanceBackoff"* — a class that no longer exists
- `lib/pool.ts`'s header described the two copies in the **present tense**

Both would have been wrong the moment this merged. Given this PR's subject is knowledge that doesn't travel, shipping it with two comments describing a codebase that no longer exists seemed like the wrong way to land it.

`lib/pool.ts` now ends with the line that matters for the next person: **if you are adding a fifth caller, the thing to bring is a predicate, not another pool.**

## How to test (QA)

Structural change, no intended behaviour difference. **The absence of a visible change is the pass condition.**

1. `/dashboard`, `/scanner`, `/arena` — same values as before.
2. `/api/market/rsi` — same coin/field map.
3. `/api/market/snapshot` — `ticker`, `klines` and `lsr` as they are now. `partial:["lsr"]` on staging is #657 and unrelated to this.
4. `/api/market/account-ratio?period=1h` — still `49/49`, no `stopped` key.

`snapshot` is the app's spine, so if anything is going to regress it will be visible immediately and everywhere rather than subtly.

## Risk level

**Medium.** Two routes rewritten, one of them the primary market route. Gates: lint 0, `tsc` 0, `npm test` 0 (446), `build` 0.

**Not verified by me:** the 418/429 stop, same as #667 — it cannot be exercised without an upstream willing to ban us. What is different now is that both routes run the pool `__tests__/pool.test.mts` covers, where before they ran two untested copies of it. That is the actual gain here, more than the deleted lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
