### PR TITLE
docs: record the failure-that-looks-like-success class from 2026-09-03

### DIFF
--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -697,6 +697,65 @@ Context for the move off the desktop GUI.
   cause and deploying to dev does not help. Any change to `/news` reaches production
   unverified; say so in the PR rather than letting the reader assume it was checked.
 
+### The failure that looks like success — 2026-09-03
+
+Six defects in one session shared a shape: **the symptom is indistinguishable from
+the healthy state**, so the thing you check to find them returns the same answer
+either way. Each is cheap to avoid once named.
+
+**A TypeScript parameter property makes a `lib/` module permanently untestable.**
+
+```ts
+constructor(public readonly status: number, message: string) {}
+```
+
+SWC compiles this, so it works in production. Node's type-stripping **refuses the
+whole file** — the shorthand emits code rather than only annotating — so any
+`__tests__/*.test.mts` importing that module dies with
+`ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX` before a single test runs. **Lint, `tsc` and
+`npm run build` all pass.** The only symptom is a test file that will not load.
+Declare the field separately and assign in the body.
+
+**A CSS rule an inline style outranks is dead, not overridden.** It can never
+apply, and no source read shows that — `globals.css` said the rail badge was
+9.5px mono for as long as the rule existed while it rendered 12px sans. Three
+defects shipped this way (#629, #633, #660). `qa/mobile-audit.mjs` now reports
+`deadRules` for exactly this.
+
+**An empty result from a broken detector looks like a clean page.** The first
+version of that check returned `[]` against the real site *and* against a page
+built to contain one known dead rule — modern Chrome gives every `CSSStyleRule` a
+truthy empty `cssRules`, so a `if (r.cssRules) recurse` walk collects nothing.
+**Validate any new check against a known positive before trusting a clean run.**
+
+**A number computed from a subset of its inputs renders as a complete number.**
+`AccumulationTracker` could drop 47 points against a display threshold of 45;
+`lib/distribution.ts` can drop 55 against labels at 70 and 45, which turns a
+genuine `Distribution` into `Quiet` — the opposite claim, not a weaker one.
+`?? 0` on a missing price change was worse still: the coin survived a filter meant
+to exclude it, took the maximum of its section, and asserted `'Price flat'` in
+rendered text. **A neutral-looking default is often the strongest possible claim.**
+
+**A loading state and a missing source render identically.** A 15-second wait on
+`/liq` caught `LIQ_NO_OI_DATA` and produced a report that the page was broken in
+production. Polling to 60s showed 154 rows. **Poll until the page settles; never
+conclude absence from one sample.** The same confusion made "not applicable" and
+"not tested" identical in the dialog audit, and made a null `.liq-heat-wrap` look
+like a defect when it was the empty-state path.
+
+**Three identical measurements can be one measurement.** Three scanner runs
+returned the same five blank symbols, which looked like proof it was not a race —
+but `s-maxage=120, stale-while-revalidate=600` meant all three read one cached
+answer. **Variation confirms; stability inside a cache window proves nothing.**
+
+**The correct pattern already existing in-repo does not mean it travelled.**
+Four times in one session the right handling was present and documented at the
+place that got it right — `--border-input`, `marketStore`'s `>= 2` signal floor,
+`pool()` — and absent everywhere else. `pool()` existed **twice**, hand-copied,
+each copy explaining why it was needed. Copying is what stopped it spreading: a
+comment only reaches someone already reading that function. Prefer a check over a
+convention, because a convention has to be recalled at the moment of writing.
+
 ---
 
 ## 15. How we work — the two-session model

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -719,8 +719,9 @@ Declare the field separately and assign in the body.
 **A CSS rule an inline style outranks is dead, not overridden.** It can never
 apply, and no source read shows that — `globals.css` said the rail badge was
 9.5px mono for as long as the rule existed while it rendered 12px sans. Three
-defects shipped this way (#629, #633, #660). `qa/mobile-audit.mjs` now reports
-`deadRules` for exactly this.
+defects shipped this way (#629, #633, #660). This is what `qa/mobile-audit.mjs`'s
+`deadRules` check is for (#666) — written after the third, because no source
+read finds them.
 
 **An empty result from a broken detector looks like a clean page.** The first
 version of that check returned `[]` against the real site *and* against a page
@@ -750,8 +751,11 @@ answer. **Variation confirms; stability inside a cache window proves nothing.**
 
 **The correct pattern already existing in-repo does not mean it travelled.**
 Four times in one session the right handling was present and documented at the
-place that got it right — `--border-input`, `marketStore`'s `>= 2` signal floor,
-`pool()` — and absent everywhere else. `pool()` existed **twice**, hand-copied,
+place that got it right, and absent everywhere else: `--border-input`, a governed
+neutral nobody reached for; `marketStore`'s `>= 2` signal floor, which two other
+scorers lacked; `pool()`; and terminal typography, where `globals.css:6976`
+documents one inline-vs-stylesheet collision at the rule itself and reaches
+nobody writing the next component. `pool()` existed **twice**, hand-copied,
 each copy explaining why it was needed. Copying is what stopped it spreading: a
 comment only reaches someone already reading that function. Prefer a check over a
 convention, because a convention has to be recalled at the moment of writing.


### PR DESCRIPTION
## Summary

Adds a subsection to `docs/HANDOVER.md` §14 recording **six defects from one session that share one shape**: the symptom is indistinguishable from the healthy state, so the check you would run to find them returns the same answer either way.

## Why this is worth a doc rather than six issues

Each cost real time, each is cheap to avoid once named, and none of them is findable by the method that would normally find it. They are not related by subject — CSS, TypeScript, scoring, caching — only by that property.

The **TypeScript one is the most valuable** and has no home anywhere else:

```ts
constructor(public readonly status: number, message: string) {}
```

SWC compiles it, so it works in production. Node's type-stripping refuses the entire file, so **any test importing that module dies before running**. `npm run lint`, `tsc` and `npm run build` all pass. The only symptom is a test file that will not load — and with no test written, there is no symptom at all. It surfaced only because a review asked for tests on a branch that had none.

The others, briefly:

- **A CSS rule an inline style outranks is dead, not overridden** — three defects shipped this way; `qa/mobile-audit.mjs` now reports `deadRules`
- **An empty result from a broken detector looks like a clean page** — that check's first version returned `[]` against the real site *and* a known-positive page
- **A score computed from a subset of its inputs renders as a complete score** — 47 droppable against a threshold of 45, and `?? 0` made missing data produce the *strongest* claim
- **A loading state and a missing source render identically** — a 15s wait produced a report that a page was broken in production; polling to 60s showed 154 rows
- **Three identical measurements can be one measurement** — inside `stale-while-revalidate=600`, three runs read one cached answer

Plus the meta-finding: **four times in one session the correct pattern already existed in-repo, documented at the place that got it right, and had not travelled.** `pool()` existed twice, hand-copied, each copy explaining why it was needed. Copying is what stopped it spreading — a comment only reaches someone already reading that function.

## How to test (QA)

Docs only. No build, no runtime effect.

1. Read the new subsection at the end of §14 (before "## 15. How we work").
2. Each entry names a concrete instance and the check that distinguishes the two states — not a general principle.
3. The TypeScript entry states which tools pass (`lint`, `tsc`, `build`) and which fails (`node --test`), because that asymmetry is the whole finding.
4. Verify it independently if you like: put `constructor(public readonly x: number) {}` in a `lib/` module and import it from a `.test.mts` file — `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX` before any test runs.

## Risk level

**Low.** Markdown only. No claim in it rests on a measurement that was later withdrawn — the retracted ones from tonight (a phantom overflow, a phantom 1.14:1, a scanner blank list, an lsr→scanner causal chain) are deliberately **not** included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
