### PR TITLE
test(lib): fail when a lib module is written in a shape tests cannot load

### DIFF
--- a/__tests__/libStrippable.test.mts
+++ b/__tests__/libStrippable.test.mts
@@ -1,0 +1,97 @@
+/* Every lib/ module must survive Node's type-stripping (#663, #665).
+ *
+ * THE DEFECT THIS EXISTS FOR is not a bug in any module - it is a module
+ * written in a shape that cannot be tested at all, where every gate says fine:
+ *
+ *     class HttpStatusError extends Error {
+ *       constructor(public readonly status: number, message: string) { … }
+ *     }
+ *
+ * A constructor parameter property looks like an annotation and is not - it
+ * EMITS code. Next builds with SWC, which compiles it happily, so lint, tsc,
+ * the build and production all pass. `node --test` cannot load the file at
+ * all:
+ *
+ *     ✖ __tests__\pool.test.mts   code: 'ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX'
+ *
+ * Four gates green and the module permanently untestable. And with no test
+ * written against it, there is no symptom whatsoever - which is why this is
+ * checked rather than written down. lib/pool.ts hit it, and it surfaced only
+ * because a review asked for tests on a branch that had none.
+ *
+ * WHY stripTypeScriptTypes RATHER THAN IMPORTING each module: importing runs
+ * module-level code - clients constructed, env read, timers started - so a
+ * suite that imported all of lib/ would be testing side effects it has no
+ * business triggering, and could hang. This parses and strips, executing
+ * nothing.
+ *
+ * It also tests the actual property (does this load under the test runner)
+ * rather than a proxy for it (does the source contain a banned keyword), so it
+ * cannot drift from what it is protecting. Parameter properties are the case
+ * hit so far; enums, namespaces and decorators fail the same way and are
+ * caught by the same check without needing to be enumerated here.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import * as nodeModule from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/* Cast rather than a named import: `stripTypeScriptTypes` is experimental, and
+   this repo's @types/node does not declare it, so the named import is a tsc
+   error (TS2305) even though the function is present at runtime. */
+const strip = (nodeModule as unknown as {
+  stripTypeScriptTypes?: (source: string) => string;
+}).stripTypeScriptTypes;
+
+const LIB = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'lib');
+
+function tsFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((name) => {
+    const full = path.join(dir, name);
+    if (statSync(full).isDirectory()) return tsFiles(full);
+    return name.endsWith('.ts') && !name.endsWith('.d.ts') ? [full] : [];
+  });
+}
+
+const files = tsFiles(LIB);
+
+test('the check itself is armed', () => {
+  /* Two ways this suite could pass while testing nothing, both worth failing
+     loudly for. An empty file list makes every assertion below vacuous, and a
+     missing strip API makes each one a no-op - the same "an empty result from a
+     broken check is indistinguishable from a clean run" trap that this whole
+     class of defect is about, which would be a poor thing for this file in
+     particular to fall into.
+
+     If Node ever drops or renames the experimental API, this fails and someone
+     decides what to do. It does not quietly stop protecting anything. */
+  assert.equal(typeof strip, 'function',
+    'node:module.stripTypeScriptTypes is unavailable - this suite would pass without checking anything');
+  assert.ok(files.length > 10, `found ${files.length} lib modules, expected the directory to be populated`);
+});
+
+for (const file of files) {
+  const rel = path.relative(path.join(LIB, '..'), file).replace(/\\/g, '/');
+
+  test(`${rel} strips without emit-generating syntax`, () => {
+    if (typeof strip !== 'function') return;   // reported by 'the check itself is armed'
+    const source = readFileSync(file, 'utf8');
+    try {
+      strip(source);
+    } catch (e) {
+      const code = (e as { code?: string }).code;
+      if (code === 'ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX') {
+        assert.fail(
+          `${rel} uses TypeScript that emits runtime code (parameter property, enum, ` +
+          `namespace or decorator). It compiles in production and cannot be loaded by ` +
+          `node --test, so nothing under __tests__ can ever import it. Declare and ` +
+          `assign instead - see the note at the top of lib/pool.ts.\n  ${(e as Error).message}`,
+        );
+      }
+      /* Any other parse failure is a different problem and not this test's
+         business to adjudicate - tsc already covers syntax validity. */
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Turns the `lib/` rule I wrote on #663 into something checked rather than remembered. 88 modules parsed, all passing; `npm test` goes 446 → 534.

## The defect this exists for

`lib/pool.ts` shipped with:

```ts
constructor(public readonly status: number, message: string) { … }
```

A parameter property **emits runtime code**. SWC compiles it, so:

| | |
|---|---|
| `npm run lint` | pass |
| `npx tsc --noEmit` | pass |
| `npm run build` | pass |
| production | works |
| `node --test` | **cannot load the file** |

**Four gates green and the module permanently untestable** — with no symptom at all unless someone happens to write a test against it. It surfaced only because QA's review of #667 asked for tests on a branch that had none, which is not a process that catches the next one.

## Swept before writing it

No other parameter property, enum, namespace or decorator exists anywhere in `lib/`. **The rule is satisfied today at zero cost** — this is a ratchet, not a cleanup.

## Why parsing rather than importing

Importing runs module-level code — clients constructed, env read, timers started. A suite that imported all of `lib/` would trigger side effects it has no business triggering and could hang. `stripTypeScriptTypes` executes nothing.

It also tests the **actual property** — does this load under the test runner — rather than a proxy for it, like "does the source contain a banned keyword". Enums, namespaces and decorators fail identically and are caught without being enumerated, so the check cannot drift from what it protects.

## Verified with a positive control, not a clean run

Reintroducing the parameter property into a copy of `lib/pool.ts` turns the run red on exactly that file:

```
✖ lib/__tmp_probe.ts strips without emit-generating syntax
ℹ pass 88   ℹ fail 1
```

**A checker that reports nothing is indistinguishable from a clean codebase until you make it report something.** That's the trap QA hit building #666's detector — every `CSSStyleRule` has a truthy empty `cssRules`, so it returned `[]` against a page built to contain one dead rule. It would be a poor trap for this file in particular to fall into.

For the same reason the suite asserts it is **armed**: if the experimental API is dropped or renamed, or the file list comes back empty, the run fails loudly instead of passing while checking nothing.

## How to test (QA)

1. `npm test` — 534 passing.
2. To see it work: add `constructor(public readonly x: number) {}` to any `lib/` module and re-run. That file fails with a message naming the fix. Revert.
3. Nothing else changes — no app code, no route, no runtime behaviour.

## Risk level

**Low.** One new test file, no source touched.

**One thing to know:** `stripTypeScriptTypes` is experimental and reached through a cast, because this repo's `@types/node` doesn't declare it while the function exists at runtime. Node prints an `ExperimentalWarning` on stderr during the run — noise, not a failure. If Node changes the API, the armed-check test fails and someone decides what to do; it will not silently stop protecting anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
