### PR TITLE
feat(scoring): a partial score says what it was built from

### DIFF
--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -979,7 +979,15 @@ function ArenaContent() {
         if (!coin?.price) return '-';
         const res = computeDistributionScore(distInputsFromCoin(coin));
         if (!res) return 'Not applicable - no 24h run-up (profit-taking needs prior strength)';
-        return `${res.score}/100 - ${res.label}${res.reasons.length ? ' · ' + res.reasons.join(', ') : ''}`;
+        /* #661: a partial score says so here too. This string is read as a
+           conclusion - "62/100 - Distribution" - and 55 of those 100 points sit
+           behind `!= null` guards, so a gap can turn a genuine Distribution
+           into Quiet. Appended only when incomplete, and the score is a floor:
+           every branch is `score += N`, so the missing inputs could only have
+           raised it. */
+        const gap = res.inputsPresent < res.inputsTotal
+          ? ` (from ${res.inputsPresent} of ${res.inputsTotal} inputs)` : '';
+        return `${res.score}/100 - ${res.label}${gap}${res.reasons.length ? ' · ' + res.reasons.join(', ') : ''}`;
       })(),
       setupScan: (() => {
         const sq = computeSqueezeScore(coin);
@@ -2720,6 +2728,14 @@ function ArenaContent() {
               <div style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: col, marginBottom: 2 }}>
                 {res.score >= 70 ? t('ARENA_DIST_WARN_PULLBACK') : t('ARENA_DIST_WARN_EARLY_WEAKNESS')}
                 <span style={{ fontWeight: 400, color: 'var(--txt3)', marginLeft: 6 }}>({res.score}/100)</span>
+                {/* #661: same disclosure as the tracker cards. Absent when the
+                    score used every input, so the note means something when it
+                    does appear. */}
+                {res.inputsPresent < res.inputsTotal && (
+                  <span style={{ fontWeight: 400, color: 'var(--txt3)', marginLeft: 6, fontFamily: 'var(--font-mono), monospace' }}>
+                    {t('SCORE_INPUTS_PARTIAL', { present: String(res.inputsPresent), total: String(res.inputsTotal) })}
+                  </span>
+                )}
               </div>
               <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt2)', lineHeight: 1.4 }}>
                 {res.reasons.join(' · ')}

--- a/components/AccumulationTracker.tsx
+++ b/components/AccumulationTracker.tsx
@@ -88,9 +88,9 @@ function scoreCoin(id: CoinId, d: CoinData | undefined): AccumRow | null {
      Modelled on lib/marketStore.ts:290, which already refuses to label unless
      >= 2 independent signals agree - the correct handling already exists in
      this repo, one file over from the two scorers that lack it.
-     NOT RENDERED YET. How a partial score presents itself is the owner's
-     ruling; this is the measurement that ruling needs, carried so the decision
-     can be made against real numbers instead of estimates. */
+     Rendered as of #661's ruling: show the score, disclose the completeness.
+     Not withheld and not re-weighted - a partial score keeps its signal while
+     admitting the gap. The chip appears only when present < total. */
   const INPUTS = [d.change, d.cvdDivergence, d.takerBuyRatio, d.oiTrend, d.fundingRate, d.bnWhaleLongRatio, d.volRatio];
   const inputsPresent = INPUTS.filter(v => v != null).length;
 
@@ -194,6 +194,28 @@ export default function AccumulationTracker() {
                     {reason}
                   </span>
                 ))}
+                {/* #661: the score renders, and says what it was built from -
+                    the owner's ruling was disclose, not withhold or re-weight.
+                    Only when incomplete. A row that always ended "7 of 7"
+                    would train people to stop reading it, which is why
+                    `partial` and data-spark are omitted when there is nothing
+                    to report.
+                    Both scorers are purely additive - every branch is
+                    `score += N` - so a missing input can only have LOWERED the
+                    number. The score is therefore a floor, which is what the
+                    tooltip says. */}
+                {r.inputsPresent < r.inputsTotal && (
+                  <Tip width={250} text={t('SCORE_INPUTS_PARTIAL_TIP', { present: String(r.inputsPresent), total: String(r.inputsTotal) })}>
+                    <span style={{
+                      fontFamily: 'var(--font-mono), monospace',
+                      fontSize: 'var(--fs-caption)', fontWeight: 600, color: 'var(--txt3)',
+                      background: 'transparent', border: '0.5px dashed var(--bdr)',
+                      borderRadius: 5, padding: '1px 6px', whiteSpace: 'nowrap',
+                    }}>
+                      {t('SCORE_INPUTS_PARTIAL', { present: String(r.inputsPresent), total: String(r.inputsTotal) })}
+                    </span>
+                  </Tip>
+                )}
               </span>
               <span className="at-price" style={{
                 fontFamily: 'var(--font-mono), monospace', fontSize: 'var(--fs-data)', color: 'var(--txt2)',

--- a/components/DistributionTracker.tsx
+++ b/components/DistributionTracker.tsx
@@ -19,6 +19,10 @@ interface DistRow {
   price: number;
   change: number;
   reasons: string[];
+  /** #661: what the score was built from. Threaded through from
+   *  computeDistributionScore so the row can disclose an incomplete one. */
+  inputsPresent: number;
+  inputsTotal: number;
 }
 
 function inputsFromCoin(d: CoinData): DistributionInputs {
@@ -38,7 +42,10 @@ function scoreCoin(id: CoinId, d: CoinData | undefined): DistRow | null {
   if (!d?.price) return null;
   const res = computeDistributionScore(inputsFromCoin(d));
   if (!res) return null;
-  return { id, score: res.score, price: d.price, change: d.change ?? 0, reasons: res.reasons };
+  return {
+    id, score: res.score, price: d.price, change: d.change ?? 0, reasons: res.reasons,
+    inputsPresent: res.inputsPresent, inputsTotal: res.inputsTotal,
+  };
 }
 
 const MIN_SCORE = 45;
@@ -120,6 +127,27 @@ export default function DistributionTracker() {
                     {reason}
                   </span>
                 ))}
+                {/* #661: disclose, do not withhold. This card matters more
+                    than the accumulation one because its output is a LABEL -
+                    Distribution / Early distribution / Quiet at 70 and 45 -
+                    and 55 of 100 points sit behind `!= null` guards. A large
+                    enough gap does not weaken the claim, it inverts it: a
+                    genuine Distribution presents as Quiet.
+                    Shown only when incomplete, and the score is a floor -
+                    every branch is `score += N`, so a missing input could only
+                    have raised it. */}
+                {r.inputsPresent < r.inputsTotal && (
+                  <Tip width={250} text={t('SCORE_INPUTS_PARTIAL_TIP', { present: String(r.inputsPresent), total: String(r.inputsTotal) })}>
+                    <span style={{
+                      fontFamily: 'var(--font-mono), monospace',
+                      fontSize: 'var(--fs-caption)', fontWeight: 600, color: 'var(--txt3)',
+                      background: 'transparent', border: '0.5px dashed var(--bdr)',
+                      borderRadius: 5, padding: '1px 6px', whiteSpace: 'nowrap',
+                    }}>
+                      {t('SCORE_INPUTS_PARTIAL', { present: String(r.inputsPresent), total: String(r.inputsTotal) })}
+                    </span>
+                  </Tip>
+                )}
               </span>
               <span style={{
                 fontFamily: 'var(--font-mono), monospace', fontSize: 'var(--fs-caption)', color: 'var(--txt2)',

--- a/lib/labelDefaults.en.json
+++ b/lib/labelDefaults.en.json
@@ -1464,6 +1464,8 @@
   "SIGNAL_ACCURACY_TIP_COUNT": "How many times this signal fired in the backtested window - low counts mean less statistical confidence.",
   "SIGNAL_ACCURACY_AVG_RETURN": "avg {sign}{value}% at 24h",
   "SIGNAL_ACCURACY_FOOTER_NOTE": "Win Rate = % of signals where price moved in the expected direction after 12h or 24h",
+  "SCORE_INPUTS_PARTIAL": "{present} of {total} inputs",
+  "SCORE_INPUTS_PARTIAL_TIP": "This score was built from {present} of its {total} inputs. The rest were unavailable, so the score is a floor - the missing inputs could only have raised it.",
   "ACCUMULATION_TRACKER_TITLE": "Accumulation Tracker",
   "ACCUMULATION_TRACKER_TOOLTIP": "Scores every coin for stealth accumulation: price still flat while CVD shows absorption, taker buys dominate, open interest builds, whale positioning leans long, and funding stays calm (crowd not in yet). High score = smart money loading before the move.",
   "ACCUMULATION_TRACKER_SUBTITLE": "quiet coins being loaded - before the pump",

--- a/lib/labelKeys.ts
+++ b/lib/labelKeys.ts
@@ -719,6 +719,11 @@ export const LABEL_KEYS = [
   'SIGNAL_ACCURACY_TIP_WIN_RATE_12H', 'SIGNAL_ACCURACY_TIP_WIN_RATE_24H', 'SIGNAL_ACCURACY_TIP_COUNT',
   'SIGNAL_ACCURACY_AVG_RETURN', 'SIGNAL_ACCURACY_FOOTER_NOTE',
   // AccumulationTracker
+  /* #661: shown only when a score was computed from fewer inputs than it has.
+     Absent when complete - a card that always says "7 of 7" trains people to
+     stop reading it, the same reason `partial` and data-spark are omitted when
+     there is nothing to report. */
+  'SCORE_INPUTS_PARTIAL', 'SCORE_INPUTS_PARTIAL_TIP',
   'ACCUMULATION_TRACKER_TITLE', 'ACCUMULATION_TRACKER_TOOLTIP', 'ACCUMULATION_TRACKER_SUBTITLE',
   'ACCUMULATION_TRACKER_EMPTY',
   // DistributionTracker


### PR DESCRIPTION
## Summary

The owner's #661 ruling, implemented: **show the score, disclose the completeness.** Not withhold, not re-weight. `inputsPresent`/`inputsTotal` were already carried unrendered from #664, so this is the presentation half.

## Where it appears

| Surface | Form |
|---|---|
| Accumulation card (`/scanner`) | dashed `N of M inputs` chip beside the reasons, with tooltip |
| Distribution card (`/scanner`) | same |
| Arena pullback panel | `N of M inputs` beside the score |
| Arena distribution read | `(from N of M inputs)` in the text |

## Absent when complete

A row that always ended `7 of 7` would train people to stop reading it — the same reason `partial` is omitted from `/api/market/snapshot`'s healthy response and `data-spark` reports `empty` rather than annotating every render. **A marker that is always there carries no information.**

## The tooltip claims the score is a floor, and that is checked

> *"This score was built from N of its M inputs. The rest were unavailable, so the score is a floor — the missing inputs could only have raised it."*

Verified rather than assumed: **every branch in both scorers is `score += N`, with no subtractions.** A missing input can only have lowered the number, so the displayed score is a lower bound. If either scorer ever gains a negative contribution, that sentence becomes false and needs revisiting.

## Why distribution got all three surfaces

Its output is a **label** — `Distribution` / `Early distribution` / `Quiet` at 70 and 45 — and 55 of its 100 points sit behind `!= null` guards. A large enough gap doesn't weaken the claim, it **inverts** it: a genuine `Distribution` presents as `Quiet`. QA's point that a completeness marker matters more on a label than on a number is right, because a label reads as a conclusion.

## Deliberately not done — and it's a finding, not an omission

`app/api/telegram/alert/route.ts:1387` passes:

```js
priceBelowVwap: null, // not derived server-side
```

So **that call site runs at 7 of 8 inputs permanently, by construction.** Adding the note there would print it on every single alert — exactly the always-on marker this change exists to avoid.

But the disclosure isn't the real problem there. **The alert fires at `res.score >= 70` on a score that is systematically deflated**, so it under-fires: real distributions that would clear 70 with VWAP present never reach it. With `whaleLongRatio` also null while `partial:["lsr"]` is live on staging, that site can be at **6 of 8**, missing up to 20 points against a fixed threshold.

That's a live behaviour question, not a formatting one. Raising it separately rather than patching over it.

## How to test (QA)

On **staging**, `/scanner`:

1. **Accumulation and Distribution cards** — a row shows a dashed `N of M inputs` chip only when some input was unavailable. Rows built from everything show **no chip**.
2. Hover the chip for the explanation.
3. `/arena` — the pullback warning panel and the distribution read carry the same note, under the same condition.
4. **With all feeds healthy, no chip should appear anywhere.** If one appears on every row, that's either a feed genuinely down (check `partial` on `/api/market/snapshot`) or the condition is inverted.

`partial:["lsr"]` is currently live on staging, which nulls `bnWhaleLongRatio` — so I'd expect chips to appear there and not on prod. That difference is itself a check.

## Risk level

**Low.** Additive rendering behind a condition; no scoring logic changed, no thresholds moved. Two label keys added to `labelKeys.ts` and `labelDefaults.en.json`. Gates: lint 0, `tsc` 0, `npm test` 0 (534), `build` 0.

**Not verified by me:** how it looks with a chip present, since I have no environment with a partial feed. The condition is one comparison, but the visual — a fifth chip in a row that already holds four reasons — is unmeasured, and mobile is where that row is tightest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
