### PR TITLE
fix(alerts): scale the distribution gate to what the inputs could score

### DIFF
--- a/__tests__/distributionScoreableMax.test.mts
+++ b/__tests__/distributionScoreableMax.test.mts
@@ -1,0 +1,119 @@
+/* lib/distribution.ts's `scoreableMax` and the gate that uses it (#673).
+ *
+ * The Telegram alert compared a partial score against a fixed 70 - a bar set
+ * for a complete score. Because every branch in the scorer ADDS and none
+ * subtract, that could only ever suppress true alerts, never create false
+ * ones, which is the failure that leaves no trace: a missed alert and a quiet
+ * market are the same observation.
+ *
+ * Tested here rather than reasoned about, because the last piece of gate logic
+ * that shipped on reasoning alone (lib/pool.ts's rate-limit stop, #667) turned
+ * out to be untestable by construction and nobody could have known.
+ *
+ * No network, no DB - computeDistributionScore is a pure function.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { computeDistributionScore, type DistributionInputs } from '../lib/distribution.ts';
+
+/** Every input present and every section at its maximum. */
+const FULL: DistributionInputs = {
+  change24hPct:   5,          // clears MIN_RUNUP_PCT
+  cvdDivergence:  'bearish',  // 25
+  takerBuyRatio:  0.35,       // 15, and enables the vol pair
+  oiTrend:        'weak_up',  // 20
+  whaleLongRatio: 0.40,       // 15
+  fundingRatePct: 0.05,       // 15
+  volRatio:       2,          // 10 with takerBuyRatio <= 0.48
+  priceBelowVwap: true,       // 5
+};
+
+test('with every input present, scoreableMax is 100 and the gate is the old fixed 70', () => {
+  const res = computeDistributionScore(FULL);
+  assert.ok(res);
+  assert.equal(res.scoreableMax, 100);
+  assert.equal(res.scoreableMax * 0.70, 70,
+    'at full data the scaled gate must equal the constant it replaced, or this is a behaviour change rather than a fix');
+});
+
+test('the section maxima sum past the cap, so losing VWAP alone changes nothing', () => {
+  /* 25+15+20+15+15+10+5 = 105 against a cap of 100. That 5 points of headroom
+     is why this defect was invisible: the Telegram caller has passed
+     priceBelowVwap: null since it was written and was still scoring out of a
+     true 100. #673 as first filed said 95, and that was wrong. */
+  const res = computeDistributionScore({ ...FULL, priceBelowVwap: null });
+  assert.ok(res);
+  assert.equal(res.scoreableMax, 100);
+});
+
+test('the gate only moves once a second input drops', () => {
+  const res = computeDistributionScore({ ...FULL, priceBelowVwap: null, whaleLongRatio: null });
+  assert.ok(res);
+  assert.equal(res.scoreableMax, 85, '105 - 5 (vwap) - 15 (whale) = 85');
+  assert.equal(Number((res.scoreableMax * 0.70).toFixed(1)), 59.5);
+});
+
+test('a score the fixed 70 would swallow clears the scaled gate', () => {
+  /* THE CASE THE ISSUE IS ABOUT. lsr down and no VWAP, so scoreableMax is 85,
+     and this coin fires three of its five reachable sections: cvd 25 + taker 15
+     + oi 20 = 60. Sixty is 71% of what was scoreable and would have been a
+     clear Distribution on full data - and the fixed gate never sees it.
+
+     My first version of this test used FULL minus two inputs and asserted the
+     score fell short of 70. It scores 85, because every remaining section is at
+     maximum, so the fixed gate WOULD have fired. The test caught that; the
+     swallowed case needs a coin that is distributing without maxing everything,
+     which is what a real one looks like. */
+  const res = computeDistributionScore({
+    ...FULL,
+    priceBelowVwap: null,   // server-side caller never has it
+    whaleLongRatio: null,   // lsr unavailable
+    fundingRatePct: 0,      // a real reading, below the +0.01 tier - scores 0
+    volRatio:       1.0,    // below the 1.5 spike tier - the pair scores 0
+  });
+  assert.ok(res);
+  assert.equal(res.scoreableMax, 85, 'funding and volRatio are PRESENT but unscoring - still reachable points');
+  assert.equal(res.score, 60, 'cvd 25 + taker 15 + oi 20');
+  assert.ok(res.score < 70, 'the fixed gate swallows it');
+  assert.ok(res.score >= res.scoreableMax * 0.70,
+    `${res.score} must clear the scaled gate ${(res.scoreableMax * 0.70).toFixed(1)}`);
+});
+
+test('the vol-pair section needs BOTH of its inputs', () => {
+  const noVol   = computeDistributionScore({ ...FULL, volRatio: null });
+  const noTaker = computeDistributionScore({ ...FULL, takerBuyRatio: null });
+  assert.ok(noVol && noTaker);
+  assert.equal(noVol.scoreableMax, 95, 'losing volRatio costs the 10-point pair: 105 - 10, capped at 100 -> 95');
+  /* takerBuyRatio gates its own 15 AND the 10-point pair: 105 - 15 - 10 = 80. */
+  assert.equal(noTaker.scoreableMax, 80);
+});
+
+test('scoreableMax never exceeds 100 and never goes negative', () => {
+  const empty: DistributionInputs = {
+    change24hPct: 5, cvdDivergence: null, takerBuyRatio: null, oiTrend: null,
+    whaleLongRatio: null, fundingRatePct: null, volRatio: null, priceBelowVwap: null,
+  };
+  const res = computeDistributionScore(empty);
+  assert.ok(res);
+  assert.equal(res.scoreableMax, 0, 'no scoreable input means nothing could have been scored');
+  assert.equal(res.score, 0);
+  /* AND THIS IS WHY THE CALLER NEEDS A FLOOR. `0 >= 0 * 0.70` is true, so
+     scaling ALONE would let a coin with no data through - something the fixed
+     `< 70` blocked for free. Writing this assertion is what found it.
+     app/api/telegram/alert/route.ts requires scoreableMax >= 60 before it
+     applies the ratio, so this case is rejected on the first condition. */
+  assert.ok(res.score >= res.scoreableMax * 0.70,
+    'the ratio alone passes a no-data score - the caller must gate on scoreableMax first');
+  assert.ok(res.scoreableMax < 60, 'and the caller floor of 60 is what rejects it');
+});
+
+test('the scorer is still additive-only, which is what makes the score a floor', () => {
+  /* Every claim above depends on it, and #672's tooltip states it to users.
+     A future penalty branch invalidates both silently. */
+  const partial = computeDistributionScore({ ...FULL, whaleLongRatio: null });
+  const full    = computeDistributionScore(FULL);
+  assert.ok(partial && full);
+  assert.ok(partial.score <= full.score,
+    'removing an input raised the score - the scorer has gained a subtraction and the "floor" claim is now false');
+});

--- a/app/api/telegram/alert/route.ts
+++ b/app/api/telegram/alert/route.ts
@@ -1387,7 +1387,42 @@ async function checkDistribution(
           volRatio: avg20 > 0 ? vols[vols.length - 1] / avg20 : null,
           priceBelowVwap: null, // not derived server-side
         });
-        if (!res || res.score < 70) return;
+        /* #673: scale the gate to what these inputs could actually score.
+           Owner's ruling, 2026-09-03 - not a lower constant.
+
+           This caller passes `priceBelowVwap: null` above, and whaleLongRatio
+           is empty whenever the Binance lsr endpoint is down (#657). A fixed 70
+           was a bar set for a complete score being applied to a partial one, so
+           the gate silently TIGHTENED as feeds dropped: a genuinely
+           distributing coin scored lower and never fired.
+
+           Because every branch in the scorer adds and none subtract, this can
+           only ever have suppressed true alerts - it could not produce false
+           ones. That is the hard failure to notice, since a missed alert and a
+           quiet market are the same observation.
+
+           EXPECT MORE ALERTS TO FIRE, especially while lsr is unavailable.
+           That is the bug being fixed, not a regression. Before reverting this
+           because volume rose, check `scoreableMax` on the scores that fired -
+           if it is below 100, they are alerts the fixed threshold was
+           swallowing.
+
+           Scaling rather than a constant matters because it self-corrects: at
+           full data scoreableMax is 100 and this is exactly the old `< 70`. */
+        /* MIN_SCOREABLE first, and it is not belt-and-braces. Scaling alone
+           has a hole at the bottom: with no scoreable inputs at all,
+           scoreableMax is 0 and `0 >= 0 * 0.70` is TRUE, so a coin with no data
+           would alert - which the fixed `< 70` blocked for free. A unit test
+           caught that before this shipped.
+
+           Requiring 60 of the 105 possible points to be reachable is the
+           marketStore.ts:290 pattern: refuse to make the claim when too little
+           was measurable, rather than making it from thin evidence. It admits
+           the real degraded case (85, lsr down) and rejects the pathological
+           ones. */
+        const MIN_SCOREABLE = 60;
+        if (!res || res.scoreableMax < MIN_SCOREABLE) return;
+        if (res.score < res.scoreableMax * 0.70) return;
 
         const key = `distribution_${coin}`;
         if (onCooldown(key, CD.distribution)) return;

--- a/lib/distribution.ts
+++ b/lib/distribution.ts
@@ -30,6 +30,10 @@ export interface DistributionScore {
    *  a partial score must be distinguishable from a complete one. */
   inputsPresent: number;
   inputsTotal:   number;
+  /** #673: the highest score these inputs could have produced, capped at 100.
+   *  A caller gating on an absolute threshold must scale it by this, or it is
+   *  comparing a partial score against a bar set for a complete one. */
+  scoreableMax: number;
 }
 
 /* Gate: profit-taking is only meaningful after strength. Coins that haven't run
@@ -99,7 +103,35 @@ export function computeDistributionScore(d: DistributionInputs): DistributionSco
   ];
   const inputsPresent = INPUTS.filter(v => v != null).length;
 
-  return { score: capped, reasons, label, inputsPresent, inputsTotal: INPUTS.length };
+  /* #673: POINTS, not inputs. inputsPresent counts fields; a threshold needs
+     the score those fields could have reached, and the sections are not equal -
+     cvd is worth 25 and VWAP 5.
+
+     Each term is a section's maximum, added only when the input gating that
+     section is present. Section 6 needs BOTH volRatio and takerBuyRatio, so it
+     is unreachable if either is missing.
+
+     THE CAP IS NOT COSMETIC. The section maxima sum to 105 while `score` is
+     capped at 100, so there are 5 points of headroom: losing VWAP alone leaves
+     the reachable maximum at 100 and changes nothing. The gate only moves once
+     a SECOND input drops.
+
+     That headroom is why this was invisible, and why #673 as I first wrote it
+     was wrong - I said the Telegram caller had been scoring out of 95 since it
+     was written. It has been scoring out of a true 100. The defect is real but
+     it only bites when something else is also missing, which is the current
+     staging state rather than the permanent baseline. */
+  const scoreableMax = Math.min(100,
+    (d.cvdDivergence  != null ? 25 : 0) +
+    (d.takerBuyRatio  != null ? 15 : 0) +
+    (d.oiTrend        != null ? 20 : 0) +
+    (d.whaleLongRatio != null ? 15 : 0) +
+    (d.fundingRatePct != null ? 15 : 0) +
+    (d.volRatio != null && d.takerBuyRatio != null ? 10 : 0) +
+    (d.priceBelowVwap != null ? 5 : 0),
+  );
+
+  return { score: capped, reasons, label, inputsPresent, inputsTotal: INPUTS.length, scoreableMax };
 }
 
 export function distributionColor(score: number): string {


### PR DESCRIPTION
## Summary

The owner's #673 ruling: **compare against 70% of what the inputs could actually score**, not a fixed 70. `computeDistributionScore` now returns `scoreableMax`; the Telegram gate scales by it. Seven unit tests.

## First — #673's arithmetic was wrong, and it was mine

I filed it saying the caller had been scoring **out of 95** since it was written. It has been scoring out of a true **100**:

```
section maxima  25 + 15 + 20 + 15 + 15 + 10 + 5 = 105
score is capped at                                100
```

Five points of headroom. **Losing VWAP alone leaves the reachable maximum at 100 and changes nothing.** The gate only moves once a *second* input drops — which is today's staging state with lsr unavailable, not the permanent baseline I described.

The defect is real; my account of its size was not. That headroom is also the reason nobody saw it.

## Why points, not inputs

QA's review point. `inputsPresent`/`inputsTotal` from #672 count **fields** — a threshold needs the **score those fields could have reached**, and the sections aren't equal: cvd is 25, VWAP is 5. Section 6 needs *both* `volRatio` and `takerBuyRatio`, so it's unreachable if either is missing.

## `MIN_SCOREABLE = 60` is a second condition, not decoration

Scaling alone has a hole at the bottom:

```js
scoreableMax === 0   →   0 >= 0 * 0.70   →   true   →   ALERT
```

**A coin with no data would have alerted** — something the fixed `< 70` blocked for free. Writing the test assertion is what found it; I had written that case up as "degrades safely" in a comment and it did not.

Requiring 60 of the 105 possible points to be reachable is the `marketStore.ts:290` pattern — refuse the claim when too little was measurable. It admits the real degraded case (85, lsr down) and rejects the pathological ones.

## Expect more alerts

That's the bug being fixed, and it's said in the code where someone tuning alert volume will read it. **Before reverting on volume, check `scoreableMax` on the scores that fired** — below 100 means the fixed threshold was swallowing them.

## The tests

| | |
|---|---|
| full data → `scoreableMax` 100, scaled gate **equals** the old 70 | so the fix can't silently become a behaviour change |
| losing VWAP alone changes nothing | pins the cap headroom that made this invisible |
| second input drops → 85, gate 59.5 | |
| a real swallowed coin (60 of 85) clears the scaled gate | the case the issue is about |
| the vol pair needs both inputs | |
| no inputs → `scoreableMax` 0, and the floor rejects it | the regression above |
| the scorer is still additive-only | #672's tooltip tells users the score is a floor; a penalty branch makes that false silently |

One of them caught my own error while writing it: my first "swallowed case" used `FULL` minus two inputs and asserted the score fell short of 70. It scores 85 — every remaining section at maximum — so the fixed gate *would* have fired. A swallowed coin has to be one that's distributing without maxing everything, which is what a real one looks like.

## How to test (QA)

**This cannot be exercised from outside.** Server-side, fires on its own schedule, and you've flagged it unverifiable — that hasn't changed.

1. `npm test` — 541 passing, 7 new.
2. On a deployed build, watch whether distribution alerts appear at all while `partial:["lsr"]` is live. **The prediction is that they start to.** If none appear, either no coin is distributing or the prediction is wrong, and those are not distinguishable from outside either.
3. Nothing user-visible changes on any page — `scoreableMax` is a new field nothing renders.

## Risk level

**Medium.** It changes when real alerts fire, on a path neither of us can exercise. Gates: lint 0, `tsc` 0, `npm test` 0 (541), `build` 0.

**Not verified:** that any alert fires, or that volume rises. The arithmetic is tested; the behaviour is a prediction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
