### PR TITLE
fix(liquidation-map): the ladder head cannot overflow, and the ladder is mountable

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -7443,13 +7443,27 @@ main.app-content[data-chrome="none"] {
 [data-design="terminal"] .liq-lad-title {
   font-family: var(--font-mono), monospace; font-size: 10px; font-weight: 700;
   letter-spacing: .16em; text-transform: uppercase; color: var(--txt2);
+  flex-shrink: 0; white-space: nowrap;
 }
+/* The meta is the one that gives way. Three items compete for a fixed 28px row
+   whose width varies with the viewport, and the meta is the only one whose
+   content grows - "8 LEVELS - $327M STACKED" on the canvas, but the level count
+   and the stacked total both come from live data and neither has a bound.
+
+   So it shrinks and ellipsises while the title and legend hold their size.
+   Without this the row either wraps out of a 28px box or pushes the legend off
+   the end, and which one happens depends on data nobody has seen yet - QA
+   flagged the fit as the most likely thing to be wrong on #674 and neither of
+   us can render it, since liq_events is empty in both environments. Removing
+   the failure mode is cheaper than measuring it. */
 [data-design="terminal"] .liq-lad-meta {
   font-family: var(--font-mono), monospace; font-size: 10px; letter-spacing: .1em; color: var(--txt3);
+  min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 [data-design="terminal"] .liq-lad-legend {
   margin-left: auto; display: flex; align-items: center; gap: 14px;
   font-family: var(--font-mono), monospace; font-size: 9.5px; letter-spacing: .1em; color: var(--txt3);
+  flex-shrink: 0; white-space: nowrap;
 }
 [data-design="terminal"] .liq-lad-legend > span { display: flex; align-items: center; gap: 6px; }
 [data-design="terminal"] .liq-lad-key { width: 14px; height: 6px; flex-shrink: 0; }

--- a/components/LiqTerminal.tsx
+++ b/components/LiqTerminal.tsx
@@ -163,7 +163,18 @@ function BandRow({ b }: { b: Band }) {
   );
 }
 
-function RealClusters({ clusters, currentPrice }: { clusters: Bucket[]; currentPrice: number }) {
+/* Exported so a fixture harness can render the ladder with seed buckets.
+   liq_events is empty in BOTH environments - QA measured production showing the
+   same "building" state as staging - so neither of us has seen this component
+   draw a row, and its layout is unverified for that reason rather than because
+   nobody looked.
+
+   Exported rather than adding a fixture mode to the page: a `?fixture=` flag
+   would put fabricated liquidation levels on a real route, which is the thing
+   #635 and #661 both ruled against. The component takes plain props, so a
+   harness can mount it with whatever rows it likes and nothing synthetic ever
+   reaches a visitor. */
+export function RealClusters({ clusters, currentPrice }: { clusters: Bucket[]; currentPrice: number }) {
   const { t } = useLabels();
   if (clusters.length === 0) {
     return (


### PR DESCRIPTION
## Summary

Two small things aimed at the same problem: **the cluster ladder's layout is unverified and neither session can render it**, because `liq_events` is empty in both environments.

## 1. The head cannot overflow

You flagged the fit as the most likely thing to be wrong on #674 — three items competing for a fixed 28px row. Rather than measure it, the failure mode is removed:

```css
.liq-lad-title   flex-shrink: 0; white-space: nowrap;
.liq-lad-meta    min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
.liq-lad-legend  flex-shrink: 0; white-space: nowrap;
```

**The meta is the item that gives way**, because it is the only one whose content grows without bound. The canvas reads `8 LEVELS · $327M STACKED`, but the level count and the stacked total both come from live data and neither has a ceiling.

Without this the row either wraps out of its box or pushes the legend off the end — and **which one happens depends on data nobody has seen**. That is not a thing worth predicting.

## 2. `RealClusters` is exported

So a fixture harness can mount the ladder with seed rows and settle the layout without waiting for real liquidations.

**Exported rather than adding a `?fixture=` flag to the page.** A flag would put fabricated liquidation levels on a real route, which is exactly what #635 and #661 both ruled against. The component takes plain props — `clusters`, `currentPrice` — so a harness can render whatever rows it likes and nothing synthetic ever reaches a visitor.

The fixture itself is yours; `qa/` is your directory and you floated the idea. This just makes it possible without an app-side compromise.

## What this does not fix

**The empty feed.** Your finding stands unchanged: the primary liquidation sockets close on production, the code fails over correctly, and no frames were observed on the fallback in a 60-second window — with the caveat you stated, that a quiet minute is ordinary and this is not evidence the feature is broken.

Also unchanged: whether an automated browser is treated differently by those endpoints than a real visitor. That would make the measurement unrepresentative and neither of us can rule it out.

## How to test (QA)

1. `/liq?design=terminal` — **no visible change**, since clusters are empty everywhere. That is the expected result.
2. With rows present (a harness, or a live burst): narrow the window. The title and legend hold; the middle `N LEVELS · $X STACKED` truncates with an ellipsis rather than wrapping or clipping the legend.
3. Both themes, and 390.

## Risk level

**Low.** Three CSS properties and an `export` keyword. No logic, no data path.

**Not verified:** the truncation behaviour itself, for the same reason the original layout is unverified — there are no rows to render. The properties are standard and the failure they prevent is well-understood, but I have not watched it happen.

Gates: lint 0, `tsc` 0, `npm test` 0 (541), `build` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
