### PR TITLE
docs: correct the deploy table's stated premise about Render MCP access

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,10 +61,22 @@ this rule instead. Dev merges its own feature branches into `dev` and promotes
 
 **Who DEPLOYS — dev runs the non-prod deploys. Changed 2026-08-10.**
 This used to read "dev may deploy nothing … dev does not touch `staging` at all",
-and that was true until the owner changed it. The reason is practical: **Render
-MCP access sits in the dev session and not in QA's**, so QA physically cannot
-trigger a deploy. The old rule meant every promotion stalled waiting for someone
-with a dashboard.
+and that was true until the owner changed it. The old rule meant every promotion
+stalled waiting for someone with a dashboard.
+
+**The stated reason for the change was wrong, and the correction is recorded
+rather than quietly deleted.** This paragraph read: *"Render MCP access sits in
+the dev session and not in QA's, so QA physically cannot trigger a deploy."*
+**QA has the Render MCP tools.** On 2026-09-03 the QA session triggered both the
+`liquidity-hq-qa` and `liquidity-hq-staging` deploys itself and verified each
+against `/api/version`. So the premise this table rests on does not hold.
+
+**The table below is left as the owner set it, because who deploys is theirs to
+decide, not ours to infer from a corrected premise.** Two facts for that
+decision: QA can deploy, and dev is under a standing owner instruction not to
+deploy any environment — which makes the `dev`-assigned rows unworkable as
+written until the owner says otherwise. Until then, whoever moves a branch is
+still responsible for the deploy following it, and for saying so.
 
 | Deploy | Who | Notes |
 |---|---|---|


### PR DESCRIPTION
## Summary

`CLAUDE.md`'s "Who DEPLOYS" section justifies assigning the `qa` and `staging` deploys to dev with a factual claim that is not true. This corrects the claim and leaves the table alone.

## What changed

One paragraph in `CLAUDE.md`. The sentence

> Render MCP access sits in the dev session and not in QA's, so QA physically cannot trigger a deploy.

is replaced by a correction that quotes it rather than deleting it, records that QA has the Render MCP tools, and names the two facts the owner needs to re-decide the assignment.

**The deploy table itself is unchanged.** So is the production paragraph, and every other rule.

## Why

**The premise is false, and it is load-bearing** — it is the entire stated reason the `qa` and `staging` rows say "dev".

It cost something today. `qa` moved to `4a326eb` at 06:37Z and the qa service kept serving `52fbf9c` because each session believed the other was deploying: dev's message said *"Deploy is yours"*, the table says dev's. **That is the "branch moved, service did not" failure this same file warns about three paragraphs earlier** — the one it says happened three times on 2026-08-09. QA triggered both deploys (`dep-dachdb0ae00c73fb0gog`, `dep-dachlc15efls73efvbo0`) and verified each against `/api/version`.

**I did not change who deploys.** That is the owner's call, and a corrected premise is not a mandate — it just means the decision should be made on true information. Two facts for it:

- QA can trigger deploys, so nothing is physically blocked either way.
- Dev reports a standing owner instruction not to deploy any environment, which makes the dev-assigned rows unworkable as written until the owner says otherwise.

## How to test (QA)

Read `CLAUDE.md`, section **"Who DEPLOYS — dev runs the non-prod deploys"**.

1. The four-row deploy table is byte-identical to before — `dev`, `qa`, `staging`, `prod` rows all unchanged.
2. The paragraph above it no longer asserts QA cannot deploy; it quotes the old sentence as the thing being corrected.
3. The **Production** paragraph below the table is unchanged — prod is still QA-only and owner-approved, dev still never.
4. Nothing outside that one paragraph changed: `git diff origin/dev -- CLAUDE.md` touches one hunk.

## Risk level

**Low.** Documentation only, one file, one paragraph. No code, no config, no workflow.

The one thing it does *not* do is settle who deploys — that is deliberately left open for the owner, so anyone reading this expecting a new rule will not find one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
