### PR TITLE
fix(dashboard): three dead terminal typography rules, and a check that keeps them dead

### DIFF
--- a/__tests__/correlationRamp.test.mts
+++ b/__tests__/correlationRamp.test.mts
@@ -97,40 +97,33 @@ test('the ramp is monotonic away from zero', () => {
   }
 });
 
-test('the null cell is --txt3, not --txt, and its margin is thin (#679)', () => {
-  /* NOT an assertion that it passes - it does not, on two of three dark
-     grounds. Recorded here so the numbers live next to the ones above rather
-     than in a comment, and so this file stops implying it covered them.
+test('the null cell clears 4.5:1 too, on --txt-dash (#679)', () => {
+  /* The null cell paints rgba(255,255,255,0.03) over the card. That overlay
+     lightens the ground toward the text, and --txt3 landed at 4.40 / 4.46 in
+     dark - so it takes --txt-dash instead, the value #559 created for exactly
+     this composited shape.
 
-         dark   --bg0 4.90  --bg1 4.40  --bg2 4.46
-         light  --bg0 5.70  --bg1 5.10  --bg2 4.74
+     --txt3 itself is NOT the problem and did not move: it passes on every bare
+     palette ground in both themes (dark 5.14 / 4.71 / 4.77). An earlier version
+     of this comment said it "clears by about 0.1 on --bg0 and spends that
+     margin on any raised surface" - both halves wrong, and the table above is
+     why. Fixing the token would have degraded three passing surfaces to rescue
+     one composited one, which qa/TERMINAL_REDESIGN_STATE.md already rejected. */
+  for (const { name, T } of THEMES) {
+    for (const ground of GROUNDS) {
+      const overlay = name === 'dark' ? '#ffffff' : '#000000';
+      const alpha   = name === 'dark' ? 3 : 4;
+      const c = ratio(hex(T['--txt-dash']), over(overlay, T[ground], alpha));
+      assert.ok(c >= 4.5, `${name} null cell on ${ground}: ${c.toFixed(2)}`);
+    }
+  }
+});
 
-     This is #679, and its cause is COMPOSITING, not the token. --txt3 passes on
-     every bare palette ground in both themes:
-
-         dark   --bg0 5.14  --bg1 4.71  --bg2 4.77
-         light  --bg0 5.68  --bg1 5.07  --bg2 4.70
-
-     What fails is --txt3 over a 3% WHITE OVERLAY on a card - a surface that is
-     not a palette member at all. The overlay lightens the ground toward --txt3
-     and eats the margin, in dark only.
-
-     An earlier version of this comment said --txt3 "clears AA by about 0.1 on
-     --bg0 and spends that margin on any raised surface". Both halves are wrong,
-     and the table above is why: bg0 is 5.14, and the raised surfaces pass. That
-     framing came from generalising two composited samples to the whole palette;
-     QA retracted it and I verified the retraction rather than swapping one
-     unchecked claim for another.
-
-     It matters because the wrong framing pointed at changing the token, which
-     qa/TERMINAL_REDESIGN_STATE.md already rejected: moving a value that passes
-     on three of four surfaces to fix one composited case degrades what works.
-     The precedent is the empty-cell dash taking its own #848a92 - a local
-     value for a local ground. QA measured the same 4.46 on /liq's current-price
-     label, which is the second instance of that same composited shape. */
+test('--txt3 would still fail there, so the swap is doing the work', () => {
+  /* Positive control for the fix itself. If --txt3 ever passes on this ground,
+     the reason for --txt-dash is gone and this should be revisited rather than
+     left as cargo. */
   const T = TERMINAL_COLORS as Record<string, string>;
-  const nullCell = over('#ffffff', T['--bg1'], 3);
-  const c = ratio(hex(T['--txt3']), nullCell);
-  assert.ok(c < 4.5, `expected the known #679 shortfall on --bg1, measured ${c.toFixed(2)}`);
-  assert.ok(c > 4.0, 'if this drops below 4.0 the token moved and #679 needs re-measuring');
+  const c = ratio(hex(T['--txt3']), over('#ffffff', T['--bg1'], 3));
+  assert.ok(c < 4.5, `--txt3 now measures ${c.toFixed(2)} on the null ground; --txt-dash may be unnecessary`);
 });

--- a/__tests__/correlationRamp.test.mts
+++ b/__tests__/correlationRamp.test.mts
@@ -105,11 +105,29 @@ test('the null cell is --txt3, not --txt, and its margin is thin (#679)', () => 
          dark   --bg0 4.90  --bg1 4.40  --bg2 4.46
          light  --bg0 5.70  --bg1 5.10  --bg2 4.74
 
-     This is #679: --txt3 clears AA by about 0.1 on --bg0 and spends that margin
-     on any raised surface. QA measured the same 4.46 on /liq's "current price"
-     label - different screen, live browser, different method, same token. It is
-     a palette question, not a correlation one, and spot-fixing it here would
-     make the token look healthier than it is. */
+     This is #679, and its cause is COMPOSITING, not the token. --txt3 passes on
+     every bare palette ground in both themes:
+
+         dark   --bg0 5.14  --bg1 4.71  --bg2 4.77
+         light  --bg0 5.68  --bg1 5.07  --bg2 4.70
+
+     What fails is --txt3 over a 3% WHITE OVERLAY on a card - a surface that is
+     not a palette member at all. The overlay lightens the ground toward --txt3
+     and eats the margin, in dark only.
+
+     An earlier version of this comment said --txt3 "clears AA by about 0.1 on
+     --bg0 and spends that margin on any raised surface". Both halves are wrong,
+     and the table above is why: bg0 is 5.14, and the raised surfaces pass. That
+     framing came from generalising two composited samples to the whole palette;
+     QA retracted it and I verified the retraction rather than swapping one
+     unchecked claim for another.
+
+     It matters because the wrong framing pointed at changing the token, which
+     qa/TERMINAL_REDESIGN_STATE.md already rejected: moving a value that passes
+     on three of four surfaces to fix one composited case degrades what works.
+     The precedent is the empty-cell dash taking its own #848a92 - a local
+     value for a local ground. QA measured the same 4.46 on /liq's current-price
+     label, which is the second instance of that same composited shape. */
   const T = TERMINAL_COLORS as Record<string, string>;
   const nullCell = over('#ffffff', T['--bg1'], 3);
   const c = ratio(hex(T['--txt3']), nullCell);

--- a/__tests__/terminalTypographyOwnership.test.mts
+++ b/__tests__/terminalTypographyOwnership.test.mts
@@ -41,22 +41,39 @@ const PROPS: Array<[css: string, jsx: string]> = [
   ['text-transform', 'textTransform'],
 ];
 
-/** class -> set of css properties a terminal rule sets on it. */
-function terminalRules(): Map<string, Set<string>> {
+/** A terminal rule's LAST compound selector, as the set of classes an element
+ *  must carry for that rule to apply, plus the typography properties it sets.
+ *
+ *  Compound selectors have to stay compound. `[data-design="terminal"]
+ *  .tnav-item.on` applies only to an element with BOTH classes - flattening it
+ *  to `.tnav-item` and `.on` separately credits `.on` with a font-weight it
+ *  does not own, and then every `className={`ps-preset${x ? ' on' : ''}`}` in
+ *  the codebase looks like a collision. That produced 8 false positives out of
+ *  31 on the first honest run, and a check that cries wolf gets switched off.
+ *
+ *  Only the last sequence matters: ancestors restrict WHICH elements match, so
+ *  ignoring them can over-report but never under-report, and over-reporting on
+ *  an ancestor is rare enough to accept against parsing full descendant paths. */
+interface Owned { need: string[]; props: Set<string> }
+
+function terminalRules(): Owned[] {
   const css = readFileSync(path.join(ROOT, 'app', 'globals.css'), 'utf8');
-  const out = new Map<string, Set<string>>();
+  const out: Owned[] = [];
   const rule = /\[data-design="terminal"\][^{}]*\{([^{}]*)\}/g;
   let m: RegExpExecArray | null;
   while ((m = rule.exec(css)) !== null) {
     const selector = css.slice(m.index, m.index + m[0].indexOf('{'));
     const body = m[1];
-    const classes = [...selector.matchAll(/\.([A-Za-z0-9_-]+)/g)].map(c => c[1]);
+    const props = new Set<string>();
     for (const [cssProp] of PROPS) {
-      if (!new RegExp(`(^|;|\\s)${cssProp}\\s*:`).test(body)) continue;
-      for (const cls of classes) {
-        if (!out.has(cls)) out.set(cls, new Set());
-        out.get(cls)!.add(cssProp);
-      }
+      if (new RegExp('(^|;|\\s)' + cssProp + '\\s*:').test(body)) props.add(cssProp);
+    }
+    if (props.size === 0) continue;
+    /* Each comma-separated selector contributes its own last compound group. */
+    for (const one of selector.split(',')) {
+      const last = one.trim().split(/\s+|>/).filter(Boolean).pop() ?? '';
+      const need = [...last.matchAll(/\.([A-Za-z0-9_-]+)/g)].map(c => c[1]);
+      if (need.length) out.push({ need, props });
     }
   }
   return out;
@@ -71,22 +88,64 @@ function tsxFiles(dir: string): string[] {
   });
 }
 
-/** Find `<tag className="… cls …" … style={{ … prop: … }}>` in either order. */
-function collisions(source: string, rules: Map<string, Set<string>>): string[] {
+/** Extract a whole `style={{ … }}` object by BRACE DEPTH, not by regex.
+ *
+ *  QA's review of #681 planted five shapes; the regex version, which captured
+ *  with `[^}]{0,600}`, missed two:
+ *
+ *      DETECTED  style={{ fontSize: 12 }}
+ *      DETECTED  style={{ color: up ? 'a' : 'b', fontSize: 12 }}
+ *      MISSED    style={{ transform: `translate(${x}px)`, fontSize: 12 }}
+ *      MISSED    style={{ ...(up ? { a: 1 } : { b: 2 }), fontSize: 12 }}
+ *
+ *  `[^}]` stops at the FIRST `}` whatever the nesting, so a template literal or
+ *  a nested object ends the capture before the property is reached. The ternary
+ *  survived only because it contains no braces - so the shapes that slipped
+ *  through were the ones that look most like the real code in this repo.
+ *
+ *  Depth counting handles both for free: `${` opens a brace its own `}` closes,
+ *  so the walk stays inside the object.
+ *
+ *  Known limit, stated rather than left to be found: a brace inside a string
+ *  literal is counted. That can only make a capture too LONG - a false positive
+ *  someone will look at, never a silent miss. */
+function styleObjectAt(src: string, styleIdx: number): string {
+  const open = src.indexOf('{', styleIdx);
+  if (open < 0) return '';
+  let depth = 0;
+  for (let i = open; i < src.length && i < open + 4000; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') { depth--; if (depth === 0) return src.slice(open, i + 1); }
+  }
+  return '';
+}
+
+const STYLE_AT = /style=\{\{/g;
+
+/** Collisions between a terminal-owned property and an inline style on the
+ *  same element, in either attribute order. */
+function collisions(source: string, rules: Owned[]): string[] {
   const hits: string[] = [];
-  for (const [cls, props] of rules) {
-    const patterns = [
-      new RegExp(`className=\\{?["\`][^"\`]*\\b${cls}\\b[^"\`]*["\`][^>]{0,600}?style=\\{\\{([^}]{0,600})`, 'gs'),
-      new RegExp(`style=\\{\\{([^}]{0,600}?)\\}\\}[^>]{0,600}?className=\\{?["\`][^"\`]*\\b${cls}\\b`, 'gs'),
-    ];
-    for (const re of patterns) {
-      let m: RegExpExecArray | null;
-      while ((m = re.exec(source)) !== null) {
-        for (const [cssProp, jsxProp] of PROPS) {
-          if (!props.has(cssProp)) continue;
-          if (new RegExp(`\\b${jsxProp}\\s*:`).test(m[1])) {
-            hits.push(`.${cls} — inline ${jsxProp} kills the terminal rule's ${cssProp}`);
-          }
+  const styles: Array<{ idx: number; obj: string }> = [];
+  let m: RegExpExecArray | null;
+  STYLE_AT.lastIndex = 0;
+  while ((m = STYLE_AT.exec(source)) !== null) {
+    styles.push({ idx: m.index, obj: styleObjectAt(source, m.index) });
+  }
+
+  for (const { need, props } of rules) {
+    /* EVERY class in the compound must be present, not any. */
+    const res = need.map(c => new RegExp('\\b' + c + '\\b'));
+    for (const { idx, obj } of styles) {
+      const before = source.slice(Math.max(0, idx - 600), idx);
+      const after  = source.slice(idx + obj.length, idx + obj.length + 600);
+      const attr = (before.match(/className=[^>]*$/) ?? [''])[0] + ' ' +
+                   (after.match(/^[^>]*className=[^>]*/) ?? [''])[0];
+      if (!res.every(r => r.test(attr))) continue;
+      for (const [cssProp, jsxProp] of PROPS) {
+        if (props.has(cssProp) && new RegExp('\\b' + jsxProp + '\\s*:').test(obj)) {
+          hits.push('.' + need.join('.') + ' — inline ' + jsxProp +
+                    " kills the terminal rule's " + cssProp);
         }
       }
     }
@@ -97,35 +156,57 @@ function collisions(source: string, rules: Map<string, Set<string>>): string[] {
 const RULES = terminalRules();
 
 test('the check is armed', () => {
-  /* A rule map that came back empty would make every file below pass while
-     testing nothing - the failure this whole class of defect is made of. */
-  assert.ok(RULES.size > 20, `only ${RULES.size} terminal classes set typography; the CSS parse probably broke`);
+  /* An empty rule list would make every file below pass while testing nothing
+     - the failure this whole class of defect is made of. */
+  assert.ok(RULES.length > 20, 'only ' + RULES.length + ' terminal typography rules parsed; the CSS walk probably broke');
 });
 
-test('it detects a planted collision', () => {
-  /* Positive control. A clean sweep proves only that it ran unless the sweep
-     is known to be able to fail. Built from a real class in the map, so this
-     stays valid if class names change. */
-  const [cls, props] = [...RULES.entries()].find(([, p]) => p.has('font-size'))!;
-  assert.ok(props.has('font-size'));
-  const planted = `<span className="${cls}" style={{ fontSize: 'var(--fs-caption)' }}>x</span>`;
-  assert.equal(collisions(planted, RULES).length, 1, `failed to detect a planted inline font-size on .${cls}`);
-  const reversed = `<span style={{ fontSize: '12px' }} className="${cls}">x</span>`;
-  assert.equal(collisions(reversed, RULES).length, 1, 'failed to detect the reversed attribute order');
+test('it detects a planted collision, in both attribute orders', () => {
+  /* Positive control, built from a real rule so it stays valid as classes
+     change. Without it, a clean sweep proves only that the sweep ran - and
+     twice already on this file it was running and matching nothing. */
+  const r = RULES.find(x => x.props.has('font-size') && x.need.length === 1)!;
+  const cls = r.need[0];
+  const fwd = '<span className="' + cls + '" style={{ fontSize: 12 }}>x</span>';
+  const rev = '<span style={{ fontSize: 12 }} className="' + cls + '">x</span>';
+  assert.equal(collisions(fwd, RULES).length, 1, 'missed the forward order on .' + cls);
+  assert.equal(collisions(rev, RULES).length, 1, 'missed the reversed order on .' + cls);
+});
+
+test('a nested object or template literal does not hide the property', () => {
+  /* QA's #681 review: the old regex captured with [^}] and stopped at the
+     first closing brace, so these two shapes - the ones that look most like
+     real code here - slipped through silently. */
+  const r = RULES.find(x => x.props.has('font-size') && x.need.length === 1)!;
+  const cls = r.need[0];
+  const tpl = '<span className="' + cls + '" style={{ transform: `translate(${x}px)`, fontSize: 12 }}>x</span>';
+  const spread = '<span className="' + cls + '" style={{ ...(up ? { a: 1 } : { b: 2 }), fontSize: 12 }}>x</span>';
+  assert.equal(collisions(tpl, RULES).length, 1, 'a template literal hid the property');
+  assert.equal(collisions(spread, RULES).length, 1, 'a nested object hid the property');
+});
+
+test('a compound rule does not accuse an element carrying only one of its classes', () => {
+  /* [data-design="terminal"] .tnav-item.on owns font-weight, but an element that
+     is merely .on does not match it. Flattening compounds produced 8 false
+     positives out of 31, and a check that cries wolf gets switched off. */
+  const compound = RULES.find(x => x.need.length > 1);
+  assert.ok(compound, 'no compound rule found; this guard is not testing anything');
+  const only = '<button className="ps-preset ' + compound!.need[compound!.need.length - 1] + '" style={{ fontWeight: 700 }}>x</button>';
+  assert.equal(collisions(only, RULES).length, 0, 'accused an element carrying only part of a compound selector');
 });
 
 test('no component sets a property inline that a terminal rule already owns', () => {
   const files = [...tsxFiles(path.join(ROOT, 'components')), ...tsxFiles(path.join(ROOT, 'app'))];
-  assert.ok(files.length > 50, `found only ${files.length} tsx files; the walk probably broke`);
+  assert.ok(files.length > 50, 'found only ' + files.length + ' tsx files; the walk probably broke');
 
   const found: string[] = [];
   for (const f of files) {
     for (const hit of collisions(readFileSync(f, 'utf8'), RULES)) {
-      found.push(`${path.relative(ROOT, f).replace(/\\/g, '/')}: ${hit}`);
+      found.push(path.relative(ROOT, f).replace(/\\/g, '/') + ': ' + hit);
     }
   }
   assert.deepEqual(found, [],
-    `${found.length} dead terminal rule(s). An inline style outranks every selector, so the CSS ` +
-    `rule can never apply - see #629, #633, #660. Move the value to globals.css, or if the ` +
-    `component genuinely needs it inline, delete the CSS rule so nothing claims to own it.`);
+    found.length + ' dead terminal rule(s). An inline style outranks every selector, so the ' +
+    'CSS rule can never apply - see #629, #633, #660. Move the value to globals.css, or if ' +
+    'the component genuinely needs it inline, delete the CSS rule so nothing claims to own it.');
 });

--- a/__tests__/terminalTypographyOwnership.test.mts
+++ b/__tests__/terminalTypographyOwnership.test.mts
@@ -1,0 +1,131 @@
+/* No inline style may set a property that a terminal CSS rule also sets (#663).
+ *
+ * An inline declaration outranks every selector, so when both exist the CSS
+ * rule is DEAD - not losing a specificity contest, unreachable. Three defects
+ * shipped that way (#629, #633, #660), and none was visible in source: the rule
+ * looked right in globals.css and the inline style looked right in the
+ * component. All three were found only by reading computed values.
+ *
+ * #663 argues that a convention cannot fix this, because a convention has to be
+ * recalled at the moment of writing by someone who has not read the file that
+ * got it right. This is the check version. It currently finds ZERO, so it is a
+ * ratchet rather than a cleanup - it exists to keep the fourth from shipping.
+ *
+ * SCOPE, deliberately narrow: typography properties only, and only classes that
+ * a [data-design="terminal"] rule actually styles. Colour and layout are
+ * legitimately set inline all over this codebase - from data, from state - and
+ * flagging those would bury the real case, which is the mistake #666's first
+ * version made in the other direction by flagging `button, input`.
+ *
+ * The reverse collision - a CSS `!important` beating a component's inline value,
+ * which is #633's shape - is NOT covered here. 53 terminal rules use
+ * `!important` across background, border, border-radius, color, display, margin
+ * and padding. That is a live exposure with no detector, and it is recorded on
+ * #663 rather than silently implied to be handled.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Properties where an inline value silently kills a stylesheet rule and the
+ *  result is a wrong-looking page nobody can explain from source. */
+const PROPS: Array<[css: string, jsx: string]> = [
+  ['font-size',      'fontSize'],
+  ['font-family',    'fontFamily'],
+  ['font-weight',    'fontWeight'],
+  ['letter-spacing', 'letterSpacing'],
+  ['text-transform', 'textTransform'],
+];
+
+/** class -> set of css properties a terminal rule sets on it. */
+function terminalRules(): Map<string, Set<string>> {
+  const css = readFileSync(path.join(ROOT, 'app', 'globals.css'), 'utf8');
+  const out = new Map<string, Set<string>>();
+  const rule = /\[data-design="terminal"\][^{}]*\{([^{}]*)\}/g;
+  let m: RegExpExecArray | null;
+  while ((m = rule.exec(css)) !== null) {
+    const selector = css.slice(m.index, m.index + m[0].indexOf('{'));
+    const body = m[1];
+    const classes = [...selector.matchAll(/\.([A-Za-z0-9_-]+)/g)].map(c => c[1]);
+    for (const [cssProp] of PROPS) {
+      if (!new RegExp(`(^|;|\\s)${cssProp}\\s*:`).test(body)) continue;
+      for (const cls of classes) {
+        if (!out.has(cls)) out.set(cls, new Set());
+        out.get(cls)!.add(cssProp);
+      }
+    }
+  }
+  return out;
+}
+
+function tsxFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap(name => {
+    const full = path.join(dir, name);
+    if (name === 'node_modules' || name === '.next') return [];
+    if (statSync(full).isDirectory()) return tsxFiles(full);
+    return name.endsWith('.tsx') ? [full] : [];
+  });
+}
+
+/** Find `<tag className="… cls …" … style={{ … prop: … }}>` in either order. */
+function collisions(source: string, rules: Map<string, Set<string>>): string[] {
+  const hits: string[] = [];
+  for (const [cls, props] of rules) {
+    const patterns = [
+      new RegExp(`className=\\{?["\`][^"\`]*\\b${cls}\\b[^"\`]*["\`][^>]{0,600}?style=\\{\\{([^}]{0,600})`, 'gs'),
+      new RegExp(`style=\\{\\{([^}]{0,600}?)\\}\\}[^>]{0,600}?className=\\{?["\`][^"\`]*\\b${cls}\\b`, 'gs'),
+    ];
+    for (const re of patterns) {
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(source)) !== null) {
+        for (const [cssProp, jsxProp] of PROPS) {
+          if (!props.has(cssProp)) continue;
+          if (new RegExp(`\\b${jsxProp}\\s*:`).test(m[1])) {
+            hits.push(`.${cls} — inline ${jsxProp} kills the terminal rule's ${cssProp}`);
+          }
+        }
+      }
+    }
+  }
+  return [...new Set(hits)];
+}
+
+const RULES = terminalRules();
+
+test('the check is armed', () => {
+  /* A rule map that came back empty would make every file below pass while
+     testing nothing - the failure this whole class of defect is made of. */
+  assert.ok(RULES.size > 20, `only ${RULES.size} terminal classes set typography; the CSS parse probably broke`);
+});
+
+test('it detects a planted collision', () => {
+  /* Positive control. A clean sweep proves only that it ran unless the sweep
+     is known to be able to fail. Built from a real class in the map, so this
+     stays valid if class names change. */
+  const [cls, props] = [...RULES.entries()].find(([, p]) => p.has('font-size'))!;
+  assert.ok(props.has('font-size'));
+  const planted = `<span className="${cls}" style={{ fontSize: 'var(--fs-caption)' }}>x</span>`;
+  assert.equal(collisions(planted, RULES).length, 1, `failed to detect a planted inline font-size on .${cls}`);
+  const reversed = `<span style={{ fontSize: '12px' }} className="${cls}">x</span>`;
+  assert.equal(collisions(reversed, RULES).length, 1, 'failed to detect the reversed attribute order');
+});
+
+test('no component sets a property inline that a terminal rule already owns', () => {
+  const files = [...tsxFiles(path.join(ROOT, 'components')), ...tsxFiles(path.join(ROOT, 'app'))];
+  assert.ok(files.length > 50, `found only ${files.length} tsx files; the walk probably broke`);
+
+  const found: string[] = [];
+  for (const f of files) {
+    for (const hit of collisions(readFileSync(f, 'utf8'), RULES)) {
+      found.push(`${path.relative(ROOT, f).replace(/\\/g, '/')}: ${hit}`);
+    }
+  }
+  assert.deepEqual(found, [],
+    `${found.length} dead terminal rule(s). An inline style outranks every selector, so the CSS ` +
+    `rule can never apply - see #629, #633, #660. Move the value to globals.css, or if the ` +
+    `component genuinely needs it inline, delete the CSS rule so nothing claims to own it.`);
+});

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -338,7 +338,7 @@ function EdgeSignals() {
       <div className="edge-card-label">
         <Tip text={t('DASH_EDGE_VWAP_TIP')}>{t('DASH_EDGE_VWAP_LABEL', { coin: coin.toUpperCase() })}</Tip>
       </div>
-      <div className="edge-card-value" style={{ color: vwapCol, fontSize: 'var(--fs-data)' }}>
+      <div className="edge-card-value" style={{ color: vwapCol }}>
         {price != null ? '$' + fmtPrice(price, COIN_DEC[coin]) : '-'}
       </div>
       {vwap != null && (
@@ -361,7 +361,7 @@ function EdgeSignals() {
       </div>
       {oiMeta ? (
         <>
-          <div className="edge-card-value" style={{ color: oiMeta.col, fontSize: 'var(--fs-data)' }}>{t(oiMeta.txtKey)}</div>
+          <div className="edge-card-value" style={{ color: oiMeta.col }}>{t(oiMeta.txtKey)}</div>
           <div className="edge-card-signal" style={{ color: oiMeta.col }}>{t(oiMeta.subKey)}</div>
         </>
       ) : (
@@ -396,7 +396,7 @@ function EdgeSignals() {
       <div className="edge-card-label">
         <Tip width={260} text={t('DASH_EDGE_SETUP_TIP')}>{t('DASH_EDGE_SETUP_LABEL', { coin: coin.toUpperCase() })}</Tip>
       </div>
-      <div className="edge-card-value" style={{ color: sqCol, fontSize: 'var(--fs-data)' }}>
+      <div className="edge-card-value" style={{ color: sqCol }}>
         {sq.score}
         <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 600, marginLeft: 6 }}>{sq.label}</span>
       </div>
@@ -413,7 +413,7 @@ function EdgeSignals() {
       <div className="edge-card-label">
         <Tip text={t('DASH_EDGE_CB_TIP')}>{t('DASH_EDGE_CB_LABEL')}</Tip>
       </div>
-      <div className="edge-card-value" style={{ color: cbCol, fontSize: 'var(--fs-data)' }}>
+      <div className="edge-card-value" style={{ color: cbCol }}>
         {cbPct != null ? (cbPct >= 0 ? '+' : '') + cbPct.toFixed(3) + '%' : '-'}
       </div>
       <div className="edge-card-signal" style={{ color: cbCol }}>

--- a/app/globals.css
+++ b/app/globals.css
@@ -2378,6 +2378,14 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
    and at 15px that ellipsises. This keeps the rail aligned in every state
    without forcing a word to compete with a number for width. */
 .edge-card-value { font-family: var(--font-mono), monospace; font-size: var(--fs-data); font-weight: 700; font-variant-numeric: tabular-nums; line-height: 1.1; letter-spacing: -0.3px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-height: calc(var(--fs-data) * 1.1); display: flex; align-items: center; }
+/* #663: the deliberately-smaller variant, as a class rather than an inline
+   font-size. Two cells in CoinMarketSnapshot carry words ("Rising", "Falling")
+   instead of a number and want --fs-label, and they were setting it inline -
+   which outranks every selector, so [data-design="terminal"] .at-snapcells
+   .edge-card-value's 14px could never apply to them. Lower specificity than
+   that terminal rule on purpose: the current design keeps 13px here, terminal
+   still gets its 14px. */
+.edge-card-value.is-label { font-size: var(--fs-label); }
 .edge-card-sub   { font-size: var(--fs-caption); color: var(--txt3); margin-top: 2px; line-height: 1.4; }
 .edge-card-signal { font-size: var(--fs-caption); font-weight: 600; margin-top: 2px; line-height: 1.25; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -2444,6 +2444,27 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .gex-row:last-child { border-bottom: none; }
 .gex-row:hover   { background: rgba(255,255,255,0.015); }
 .gex-row-atm     { background: rgba(255,255,255,0.03); }
+/* #679: the "<- current price" marker. It was a bare span with an inline
+   colour, so it could not be targeted at all and any rule written for it would
+   have been dead on arrival - #663's shape.
+
+   --txt3 on this row measures 4.40 dark / 4.32 light. The row is the failing
+   ingredient, not the token: .gex-row-atm composites a 3% white (4% black in
+   light) overlay ON TOP of the card, and that overlay lightens the ground
+   toward --txt3. --txt3 itself passes on every bare palette ground - 5.14 /
+   4.71 / 4.77 dark - so this is a local problem wanting a local value.
+
+   That is exactly what --txt-dash was created for on #559: "a dedicated value
+   for this one use, not a change to --txt3 itself", for a placeholder on a
+   composited tile measuring 4.30. Same shape, same answer. On this ground it
+   measures 4.90 dark and 5.51 light.
+
+   TERMINAL ONLY, deliberately. The current design's light theme aliases
+   --txt-dash to var(--txt3) (globals.css:2504), so pointing at it there would
+   change nothing while implying a fix. That theme's ground was never measured
+   and is not what #679 is about. */
+.gex-atm-marker { font-size: var(--fs-caption); margin-left: 4px; color: var(--txt3); }
+[data-design="terminal"] .gex-atm-marker { color: var(--txt-dash); }
 [data-theme="light"] .gex-row-atm { background: rgba(0,0,0,0.04); }
 .gex-strike      { font-size: var(--fs-caption); font-weight: 700; color: var(--txt2); }
 .gex-bar-wrap    { position: relative; height: 7px; border-radius: 3px; overflow: hidden; background: rgba(255,255,255,0.04); }

--- a/app/globals.css
+++ b/app/globals.css
@@ -7385,8 +7385,21 @@ main.app-content[data-chrome="none"] {
    already prescribes for its own two undersized controls, "a padded hit area
    without changing their painted box", and the way #642 built it for the
    footer links: padding grows the box, an equal negative margin pulls the
-   flow back, nothing moves. Only the height failed - 26 already clears 24. */
+   flow back, nothing moves. Only the height failed - 26 already clears 24.
+   The first version of this omitted box-sizing and therefore grew nothing;
+   see the note on the rule itself. */
 [data-design="terminal"] .liq-heat-swatch {
+  /* box-sizing: content-box is what makes the padding above actually DO
+     anything. globals.css:213 sets `* { box-sizing: border-box }` globally, and
+     under border-box a height of 16px INCLUDES the 4px padding - so the hit area
+     stayed 26x16 and the padding bought nothing. QA measured exactly that.
+
+     The rule was written correctly for content-box and silently did nothing
+     under the box model this project actually uses: it looked like the #642
+     footer-link fix and behaved like no fix at all. With content-box the box is
+     16 + 4 + 4 = 24 tall, the negative margin pulls the layout back so nothing
+     moves, and background-clip keeps the paint on the 16px content box. */
+  box-sizing: content-box;
   width: 26px; height: 16px; border: 1px solid var(--bdr); cursor: pointer;
   padding: 4px 0; margin: -4px 0; background-clip: content-box;
 }

--- a/components/CoinMarketSnapshot.tsx
+++ b/components/CoinMarketSnapshot.tsx
@@ -207,14 +207,14 @@ export default function CoinMarketSnapshot({ coin }: { coin: CoinId }) {
         </div>
         {oiMeta ? (
           <>
-            <div className="edge-card-value" style={{ color: oiMeta.col, fontSize: 'var(--fs-label)' }}>{t(oiMeta.txtKey)}</div>
+            <div className="edge-card-value is-label" style={{ color: oiMeta.col }}>{t(oiMeta.txtKey)}</div>
             <div className="edge-card-signal" style={{ color: 'var(--txt3)' }}>
               {t(oiMeta.subKey)}{!oi1h.loading && oi1h.pct != null ? t('COIN_MARKET_SNAPSHOT_OI_1H_PCT_SUFFIX', { pct: oi1hPctStr }) : ''}
             </div>
           </>
         ) : (
           <>
-            <div className="edge-card-value" style={{ color: oi1hCol, fontSize: 'var(--fs-label)' }}>
+            <div className="edge-card-value is-label" style={{ color: oi1hCol }}>
               {!oi1h.loading && oi1h.pct != null ? oi1hPctStr : (d?.oi != null ? t('COIN_MARKET_SNAPSHOT_OI_FLAT') : '-')}
             </div>
             <div className="edge-card-signal" style={{ color: 'var(--txt3)' }}>

--- a/components/CorrelationTerminal.tsx
+++ b/components/CorrelationTerminal.tsx
@@ -112,7 +112,13 @@ function cellColor(r: number | null, diag: boolean): string {
      same as the numeric cells below. 10.99:1 light, comfortable margin
      over dark's prior 5.43:1 too. */
   if (diag) return 'var(--txt)';
-  if (r == null) return 'var(--txt3)';
+  /* #679: --txt-dash, not --txt3. The null cell paints
+     rgba(255,255,255,0.03) over the card, and that overlay lightens the ground
+     toward --txt3 - 4.40 on --bg1, 4.46 on --bg2, dark. Same composited shape
+     as /liq's "<- current price" marker and as #559's empty-cell placeholder,
+     which is the token this was made for. 4.90 / 4.97 here. --txt3 is not the
+     problem and does not move: it passes on every bare ground. */
+  if (r == null) return 'var(--txt-dash)';
   return 'var(--txt)';
 }
 

--- a/components/DashboardTerminal.tsx
+++ b/components/DashboardTerminal.tsx
@@ -590,7 +590,7 @@ function TEdgeSignals() {
           <div className="edge-card-label">
             <Tip text={t('DASH_EDGE_VWAP_TIP')}>{t('DASH_EDGE_VWAP_LABEL', { coin: coin.toUpperCase() })}</Tip>
           </div>
-          <div className="edge-card-value" style={{ color: vwapCol, fontSize: 'var(--fs-data)' }}>
+          <div className="edge-card-value" style={{ color: vwapCol }}>
             {price != null ? '$' + fmtPrice(price, COIN_DEC[coin]) : '-'}
           </div>
           {vwap != null && (
@@ -611,7 +611,7 @@ function TEdgeSignals() {
           </div>
           {oiMeta ? (
             <>
-              <div className="edge-card-value" style={{ color: oiMeta.col, fontSize: 'var(--fs-data)' }}>{t(oiMeta.txtKey)}</div>
+              <div className="edge-card-value" style={{ color: oiMeta.col }}>{t(oiMeta.txtKey)}</div>
               <div className="edge-card-signal" style={{ color: oiMeta.col }}>{t(oiMeta.subKey)}</div>
             </>
           ) : (
@@ -637,7 +637,7 @@ function TEdgeSignals() {
           <div className="edge-card-label">
             <Tip width={260} text={t('DASH_EDGE_SETUP_TIP')}>{t('DASH_EDGE_SETUP_LABEL', { coin: coin.toUpperCase() })}</Tip>
           </div>
-          <div className="edge-card-value" style={{ color: sqCol, fontSize: 'var(--fs-data)' }}>
+          <div className="edge-card-value" style={{ color: sqCol }}>
             {sq.score}
             <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 600, marginLeft: 6 }}>{sq.label}</span>
           </div>
@@ -652,7 +652,7 @@ function TEdgeSignals() {
           <div className="edge-card-label">
             <Tip text={t('DASH_EDGE_CB_TIP')}>{t('DASH_EDGE_CB_LABEL')}</Tip>
           </div>
-          <div className="edge-card-value" style={{ color: cbCol, fontSize: 'var(--fs-data)' }}>
+          <div className="edge-card-value" style={{ color: cbCol }}>
             {cbPct != null ? (cbPct >= 0 ? '+' : '') + cbPct.toFixed(3) + '%' : '-'}
           </div>
           <div className="edge-card-signal" style={{ color: cbCol }}>

--- a/components/GexTable.tsx
+++ b/components/GexTable.tsx
@@ -155,7 +155,7 @@ export default function GexTable() {
               <div key={strike} className={`gex-row${isAtm ? ' gex-row-atm' : ''}`}>
                 <div className="gex-strike" style={isAtm ? { color: 'var(--txt)' } : {}}>
                   ${strike >= 1000 ? (strike / 1000).toFixed(0) + 'K' : strike}
-                  {isAtm && <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', marginLeft: 4 }}>{t('GEX_TABLE_CURRENT_PRICE_MARKER')}</span>}
+                  {isAtm && <span className="gex-atm-marker">{t('GEX_TABLE_CURRENT_PRICE_MARKER')}</span>}
                 </div>
                 <div className="gex-bar-wrap">
                   <div className="gex-bar-fill" style={{ width: `${pct}%`, background: col }} />


### PR DESCRIPTION
## Summary

#663's enforceable half. A check that fails when an inline style sets a typography property a terminal CSS rule also sets — and the **three live collisions it found on first run.**

## It found the class QA's runtime detector found on production

`.edge-card-value`, in three files. QA's `deadRules` check flagged the same class on **production**, from a browser, by reading computed values.

**Two methods — one static, one live — agreeing on the same class.** Neither found it by reading source, which is the whole argument of #663.

## What the collisions actually cost, measured

| sites | inline | terminal rule | effect |
|---|---|---|---|
| 8 | `var(--fs-data)` = **15px** | `.dash-main .edge-card-value` = **15px** | dead but **visually neutral** — which is why it survived |
| 2 | `var(--fs-label)` = **13px** | `.at-snapcells .edge-card-value` = **14px** | a real 1px divergence, invisible in source |

The first group is the interesting one: the rule could never apply and *nothing looked wrong*. That is the failure mode this issue is about.

## The current design is byte-identical

`globals.css:2380` already sets `font-size: var(--fs-data)` on the base class, so removing an inline copy of it changes nothing. `.is-label` sets exactly the 13px the inline value did.

**Only terminal changes, and only to what its own rules already asked for.** `.is-label` deliberately carries *lower* specificity than the terminal `.at-snapcells` rule, so the current design keeps 13px on the two word-valued cells while terminal gets its 14px — both intents survive.

## The test

A **ratchet** — it now finds zero. It carries a positive control that plants a collision on a real class taken from the parsed rule map and asserts it is caught in **both attribute orders**, because a passing sweep otherwise proves only that it executed.

Scope is typography on classes a terminal rule already styles. Colour and layout are legitimately inline throughout this codebase, and flagging them would bury the real case — the mistake #666's first version made in the other direction.

**Not covered, and stated in the file rather than implied:** the reverse collision, a CSS `!important` beating a component's inline value (#633's shape). **53 terminal rules use `!important` across 7 properties.** Live exposure, no detector.

## A self-inflicted bug worth recording

My scripted edit over-matched and added `.is-label` to two cells that carried `var(--fs-data)`, not `var(--fs-label)` — silently shrinking them 15px → 13px.

**The tests passed either way.** It was caught by auditing the diff for which token each removal actually carried. A check that verifies the end state does not verify that you changed the thing you meant to.

## Also in this branch

A correction to the `--txt3` comment #678 added. It repeated QA's #679 framing — *"clears AA by about 0.1 on `--bg0`"* — which QA has since retracted and I re-derived independently: `--txt3` passes on every bare palette ground (dark 5.14 / 4.71 / 4.77). Only the **composited** 3% white overlay fails, and only in dark. The assertion was always right; its explanation was not.

## How to test (QA)

`/dashboard` and `/dashboard?design=terminal`, both themes:

1. Edge-card values render as they do now.
2. **In terminal**, the two open-interest cells showing words rather than numbers move 13px → 14px, matching the rule that was always meant to apply.
3. Current design: no change anywhere.
4. `npm test` → 550.

## Risk level

**Low–Medium.** Ten inline declarations removed across three files, one CSS class added. Byte-identical in the current design by construction; terminal moves 1px on two cells.

**Not verified by me:** the rendered pages. The specificity argument is deterministic and the 15px/15px equivalence is arithmetic, but I have not seen either design after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
