### PR TITLE
test(qa): derive platform-audit's palette from source, and stop a failed run reading as clean

### DIFF
--- a/qa/platform-audit.mjs
+++ b/qa/platform-audit.mjs
@@ -14,6 +14,7 @@
  * time triples the wall clock for no isolation benefit here.
  */
 
+import { readFileSync } from 'node:fs';
 import { chromium, devices } from '@playwright/test';
 
 const arg = (name, dflt) => {
@@ -38,17 +39,55 @@ const DEFAULT_ROUTES = [
 ];
 const ROUTES = arg('--routes', '') ? arg('--routes', '').split(',') : DEFAULT_ROUTES;
 
-/* Dark terminal palette: the 15 documented tokens plus --amber (#542). */
-const DARK = ['#08090a','#141517','#111416','#1f2225','#131618','#16191b',
-  '#e8e9ea','#8b8f94','#7c828a','#3a3f45','#d9a626','#3fb950','#f0524d',
-  '#22262a','#5e646b','#fbbf24'];
-/* Light terminal palette, transcribed from specs/light-theme-tokens.md.
- * Three of these are NOT the dark value and were wrong in the first version of
- * this file: --amber #9a6a00, --mark-idle #d1cec9, --border-input #75797e.
- * Scoring light against dark values inflates every off-palette count. */
-const LIGHT = ['#f7f6f3','#ebe9e6','#e3e1dd','#d5d2cd','#dfdcd7','#e2dfda',
-  '#15181b','#585c61','#6a6e73','#aeaaa4','#8a5c00','#1a7f37','#cf222e',
-  '#9a6a00','#d1cec9','#75797e'];
+/* The governed palette is DERIVED from lib/terminalTokens.ts, not copied.
+ *
+ * It used to be two hand-written arrays, and by 2026-09-03 both had drifted
+ * from the source of truth - the light one badly enough to INVERT the check:
+ *
+ *   still allowed, but no longer tokens   #6a6e73 #8a5c00 #1a7f37 #cf222e #9a6a00
+ *   real tokens, reported as violations   --txt3 #5e6267  --accent #754e00
+ *                                         --green #14702c --red #9d1a23
+ *                                         --amber #755100 --fr-slight-long #7c5e2e
+ *                                         --txt-dash #4f5257
+ *
+ * The first two of those stale values are the ones design REPLACED because
+ * they failed AA - `--txt3` light #6a6e73 measured 3.93:1 on --bg2 and
+ * `--green` light #1a7f37 measured 3.89:1. So the audit was passing the values
+ * that fail and flagging the values that fixed them. A check that points the
+ * wrong way is worse than no check: acting on its output means reverting a
+ * correctness fix. The dark list had drifted less - two missing tokens
+ * (--fr-slight-long, --txt-dash) and no stale extras - but by the same
+ * mechanism.
+ *
+ * qa/mobile-audit.mjs already derives its palette for exactly this reason
+ * (#641); this file was not updated with it. Same approach, same guards: a
+ * copied list drifts, and a stale hex is invisible among live ones.
+ *
+ * terminalTokens.ts is a .ts module and this is a plain .mjs script with no
+ * loader, so read and extract rather than import. The shapes below are pinned
+ * to that file's actual declarations and throw loudly if it is restructured,
+ * rather than silently yielding an empty palette and reporting every screen as
+ * perfectly on-token. */
+const tokenSrc = readFileSync(new URL('../lib/terminalTokens.ts', import.meta.url), 'utf8');
+
+const mapOf = (name) => {
+  const open = tokenSrc.indexOf('export const ' + name + ' = {');
+  if (open === -1) throw new Error('platform-audit: no ' + name + ' in lib/terminalTokens.ts');
+  const close = tokenSrc.indexOf('\n} as const;', open);
+  if (close === -1) throw new Error('platform-audit: ' + name + ' has no closing "} as const;"');
+  const hexes = tokenSrc.slice(open, close).match(/'(#[0-9a-fA-F]{6})'/g) || [];
+  if (hexes.length < 10) throw new Error('platform-audit: ' + name + ' yielded ' + hexes.length + ' colours, expected >= 10');
+  return hexes.map((h) => h.slice(1, -1).toLowerCase());
+};
+const rampHexes = (tokenSrc.match(/color:\s*'(#[0-9a-fA-F]{6})'/g) || [])
+  .map((m) => m.slice(m.indexOf('#'), m.indexOf('#') + 7).toLowerCase());
+const flatCell = (/export const TERMINAL_FLAT_CELL = '(#[0-9a-fA-F]{6})'/.exec(tokenSrc) || [])[1];
+
+/* Mirrors TERMINAL_ALLOWED / TERMINAL_ALLOWED_LIGHT, same as mobile-audit:
+   the magma ramp is shared because the liquidation map is dark-only by design,
+   and TERMINAL_FLAT_CELL has no light value anywhere. */
+const DARK = [...mapOf('TERMINAL_COLORS'), flatCell, ...rampHexes].filter(Boolean);
+const LIGHT = [...mapOf('TERMINAL_COLORS_LIGHT'), ...rampHexes];
 
 const VIEWPORT_CFG = {
   desktop: { viewport: { width: 1440, height: 900 } },
@@ -171,14 +210,38 @@ await browser.close();
 
 if (JSON_OUT) { console.log(JSON.stringify(rows, null, 2)); process.exit(0); }
 
-const bad = rows.filter(r => !r.error);
-const sum = k => bad.reduce((a, r) => a + (r[k] || 0), 0);
+/* `measured`, not `bad` - these are the loads that produced a reading. Every
+   count below is over THESE, not over every attempted load, so a route that
+   failed to navigate contributes nothing and silently shrinks the denominator.
+   The old name said the opposite of what the filter does, which is how this
+   report came to look clean while measuring nothing. */
+const measured = rows.filter(r => !r.error);
+const errored  = rows.filter(r => r.error);
+const sum = k => measured.reduce((a, r) => a + (r[k] || 0), 0);
 console.log('\n' + '='.repeat(78));
 console.log(`routes ${ROUTES.length} x viewports ${VIEWPORTS.length} x themes ${THEMES.length} = ${rows.length} page loads`);
-console.log(`errors ${rows.filter(r => r.error).length}`);
-console.log(`overflowing            ${bad.filter(r => r.overflow > 0).length} of ${bad.length}`);
-console.log(`with contrast failures ${bad.filter(r => r.contrastFails > 0).length}   (total ${sum('contrastFails')})`);
-console.log(`with off-palette       ${bad.filter(r => r.offDistinct > 0).length}   (total distinct-instances ${sum('offDistinct')})`);
-console.log(`with radius violations ${bad.filter(r => r.radiusTotal > 0).length}   (total ${sum('radiusTotal')}, circular <=24px exempt per radius-ruling.md)`);
-console.log(`with sub-24px targets  ${bad.filter(r => r.subMin > 0).length}   (total ${sum('subMin')})`);
-console.log(`with empty fields      ${bad.filter(r => r.empties > 0).length}   (total ${sum('empties')})`);
+console.log(`measured ${measured.length} of ${rows.length}   errors ${errored.length}`);
+
+/* A run where nothing loaded prints six zeros and reads as a pass. That is
+   this project's most-repeated failure - a broken probe is indistinguishable
+   from a clean result - so say so, and exit non-zero so nothing downstream
+   can mistake it for a green run. */
+if (measured.length === 0) {
+  console.log('\nNOTHING WAS MEASURED. Every page load errored, so the counts below');
+  console.log('would all read zero for that reason alone. This is not a clean run.');
+  for (const r of errored.slice(0, 5)) console.log(`  ${r.route} ${r.viewport} ${r.theme}: ${String(r.error).slice(0, 100)}`);
+  process.exit(1);
+}
+
+console.log(`overflowing            ${measured.filter(r => r.overflow > 0).length} of ${measured.length}`);
+console.log(`with contrast failures ${measured.filter(r => r.contrastFails > 0).length}   (total ${sum('contrastFails')})`);
+console.log(`with off-palette       ${measured.filter(r => r.offDistinct > 0).length}   (total distinct-instances ${sum('offDistinct')})`);
+console.log(`with radius violations ${measured.filter(r => r.radiusTotal > 0).length}   (total ${sum('radiusTotal')}, circular <=24px exempt per radius-ruling.md)`);
+console.log(`with sub-24px targets  ${measured.filter(r => r.subMin > 0).length}   (total ${sum('subMin')})`);
+console.log(`with empty fields      ${measured.filter(r => r.empties > 0).length}   (total ${sum('empties')})`);
+
+if (errored.length) {
+  console.log(`\n${errored.length} of ${rows.length} loads errored and are EXCLUDED from every count above:`);
+  for (const r of errored.slice(0, 8)) console.log(`  ${r.route} ${r.viewport} ${r.theme}: ${String(r.error).slice(0, 100)}`);
+  process.exit(1);
+}

--- a/qa/spec-conformance.mjs
+++ b/qa/spec-conformance.mjs
@@ -37,8 +37,23 @@ const ROUTE = arg('--route', '/dashboard');
 const THEMES = arg('--themes', 'dark,light').split(',');
 const JSON_OUT = process.argv.includes('--json');
 
-const DARK = ['#08090a','#141517','#111416','#1f2225','#131618','#16191b','#e8e9ea','#8b8f94','#7c828a','#3a3f45','#d9a626','#3fb950','#f0524d','#22262a','#5e646b','#fbbf24'];
-const LIGHT = ['#f7f6f3','#ebe9e6','#e3e1dd','#d5d2cd','#dfdcd7','#e2dfda','#15181b','#585c61','#5e6267','#aeaaa4','#754e00','#14702c','#9d1a23','#755100','#d1cec9','#75797e','#4f5257'];
+/* DERIVED from lib/terminalTokens.ts, not written out here. The hand-written
+   version had drifted by 2026-09-03: the dark list was missing
+   --fr-slight-long and --txt-dash entirely, so both read as off-palette.
+   qa/mobile-audit.mjs took this approach on #641 for the same reason - a
+   copied list drifts, and a stale hex is invisible among live ones. */
+const specTokenSrc = readFileSync(new URL('../lib/terminalTokens.ts', import.meta.url), 'utf8');
+const specPalette = (name) => {
+  const open = specTokenSrc.indexOf('export const ' + name + ' = {');
+  if (open === -1) throw new Error('spec-conformance: no ' + name + ' in lib/terminalTokens.ts');
+  const close = specTokenSrc.indexOf('\n} as const;', open);
+  if (close === -1) throw new Error('spec-conformance: ' + name + ' has no closing "} as const;"');
+  const hexes = specTokenSrc.slice(open, close).match(/'(#[0-9a-fA-F]{6})'/g) || [];
+  if (hexes.length < 10) throw new Error('spec-conformance: ' + name + ' yielded ' + hexes.length + ' colours, expected >= 10');
+  return hexes.map((h) => h.slice(1, -1).toLowerCase());
+};
+const DARK  = specPalette('TERMINAL_COLORS');
+const LIGHT = specPalette('TERMINAL_COLORS_LIGHT');
 
 const PAGE_EVAL = ({ tokens }) => {
   const TOK = Object.fromEntries(tokens.map(t => [t.toLowerCase(), 1]));

--- a/qa/token-surfaces.mjs
+++ b/qa/token-surfaces.mjs
@@ -36,6 +36,7 @@
  * Run with MSYS_NO_PATHCONV=1 in Git Bash or /liq becomes a Windows path.
  */
 
+import { readFileSync } from 'node:fs';
 import { chromium, devices } from '@playwright/test';
 
 const arg = (name, dflt) => {
@@ -60,23 +61,34 @@ const ROUTES = arg('--routes', '') ? arg('--routes', '').split(',') : DEFAULT_RO
 
 /* Token name -> value, per theme. Values track globals.css, not the spec file:
    the spec is what we are checking, so it cannot also be the reference. */
+/* Token name -> value, per theme, DERIVED from lib/terminalTokens.ts.
+   It used to be written out by hand here, and by 2026-09-03 it had drifted:
+   light --accent #8a5c00, --red #cf222e, --amber #9a6a00 and --txt-dash
+   #5e6267 were all superseded values, and --fr-slight-long and (in dark)
+   --txt-dash were absent entirely.
+   That matters more here than in most places because of the rule below: an
+   unrecognised foreground is SKIPPED, not counted. A stale entry does not
+   produce a wrong number, it produces a MISSING one - and the tokens it
+   silently omits are precisely the ones most recently changed, which are the
+   ones a run is usually checking. The comment below already recorded that
+   happening once; deriving the values is the version that cannot happen
+   again. */
+const tokenSrc = readFileSync(new URL('../lib/terminalTokens.ts', import.meta.url), 'utf8');
+const paletteOf = (name) => {
+  const open = tokenSrc.indexOf('export const ' + name + ' = {');
+  if (open === -1) throw new Error('token-surfaces: no ' + name + ' in lib/terminalTokens.ts');
+  const close = tokenSrc.indexOf('\n} as const;', open);
+  if (close === -1) throw new Error('token-surfaces: ' + name + ' has no closing "} as const;"');
+  const out = {};
+  const re = /'(--[a-z0-9-]+)':\s*'(#[0-9a-fA-F]{6})'/g;
+  let m;
+  while ((m = re.exec(tokenSrc.slice(open, close))) !== null) out[m[1]] = m[2].toLowerCase();
+  if (Object.keys(out).length < 10) throw new Error('token-surfaces: ' + name + ' yielded ' + Object.keys(out).length + ' tokens, expected >= 10');
+  return out;
+};
 const PALETTE = {
-  dark: {
-    '--bg0': '#08090a', '--bg1': '#141517', '--bg2': '#111416',
-    '--bdr': '#1f2225', '--bdr2': '#131618', '--bdr3': '#16191b',
-    '--txt': '#e8e9ea', '--txt2': '#8b8f94', '--txt3': '#7c828a',
-    '--txt4': '#3a3f45', '--accent': '#d9a626', '--green': '#3fb950',
-    '--red': '#f0524d', '--mark-idle': '#22262a', '--border-input': '#5e646b',
-    '--amber': '#fbbf24',
-  },
-  light: {
-    '--bg0': '#f7f6f3', '--bg1': '#ebe9e6', '--bg2': '#e3e1dd',
-    '--bdr': '#d5d2cd', '--bdr2': '#dfdcd7', '--bdr3': '#e2dfda',
-    '--txt': '#15181b', '--txt2': '#585c61', '--txt3': '#5e6267',
-    '--txt4': '#aeaaa4', '--accent': '#8a5c00', '--green': '#14702c',
-    '--red': '#cf222e', '--amber': '#9a6a00', '--mark-idle': '#d1cec9',
-    '--border-input': '#75797e', '--txt-dash': '#5e6267',
-  },
+  dark:  paletteOf('TERMINAL_COLORS'),
+  light: paletteOf('TERMINAL_COLORS_LIGHT'),
 };
 
 /* An unrecognised foreground is SKIPPED, not counted — so a stale palette here


### PR DESCRIPTION
## Summary

`qa/platform-audit.mjs` hard-coded both terminal palettes and both had drifted from `lib/terminalTokens.ts`. The light one had drifted far enough to **invert the check**. Same PR also stops an all-errored run from printing a clean-looking table.

## What changed

**1. The palette is derived, not copied.** The two arrays are replaced by a parse of `lib/terminalTokens.ts`, the same approach and the same loud guards `qa/mobile-audit.mjs` already uses.

**2. The summary cannot read as clean when nothing was measured.** `bad` — which held the *good* rows — is renamed `measured`, the run prints `measured N of M`, errored loads are listed rather than silently excluded, and the process exits non-zero.

No behaviour change to any measurement itself.

## Why

**The light list was scoring the wrong way round:**

```
still allowed, no longer tokens    #6a6e73  #8a5c00  #1a7f37  #cf222e  #9a6a00
real tokens, flagged as violations --txt3 #5e6267   --accent #754e00
                                   --green #14702c  --red #9d1a23
                                   --amber #755100  --fr-slight-long #7c5e2e
                                   --txt-dash #4f5257
```

The first two stale values are the ones design **replaced because they failed AA** — `--txt3` light `#6a6e73` measured 3.93:1 on `--bg2`, `--green` light `#1a7f37` measured 3.89:1, both recorded in `qa/TERMINAL_REDESIGN_STATE.md`. So the audit passed the values that fail and flagged the values that fixed them. **Acting on its output meant reverting a correctness fix.** The dark list had drifted less — two tokens missing, no stale extras — by the same mechanism.

`mobile-audit.mjs` was fixed this way on #641 and this file was never brought along. Its comment already says why: *a copied list drifts, and a stale hex is invisible among live ones.*

**The summary change is the same defect one level up.** Every count was computed over non-errored rows, so a run where nothing loaded printed six zeros under an `errors 4` line and read as a pass. That happened here: a shell mangled `--routes /dashboard` into a Windows path, all four loads errored, and the output was:

```
errors 4
overflowing            0 of 0
with contrast failures 0   (total 0)
...
```

The variable holding the successful rows was named `bad`, which is how it survived being read.

## How to test (QA)

On any deployed environment:

1. `node qa/platform-audit.mjs --base https://liquidity-hq-qa.onrender.com --routes /liq --themes dark,light --viewports desktop`
   **Expect 1 contrast failure in dark and 4 in light.** These match `qa/mobile-audit.mjs` on the same build — two tools, different code paths, same answer.
2. `node qa/platform-audit.mjs --base https://example.invalid --routes /x --viewports desktop --themes dark`
   **Expect `NOTHING WAS MEASURED`, the errored load listed, and exit code 1** — not a table of zeros. Check with `echo $?`.
3. The header comment names the five stale values and the seven missing ones, so the diff can be checked against `lib/terminalTokens.ts` directly.

On Windows/Git Bash, prefix with `MSYS_NO_PATHCONV=1` or the leading `/` in `--routes` is rewritten to a filesystem path — that is what produced the failure in point 2 for real.

## Risk level

**Low.** QA tooling only, no `app/`, `components/` or `lib/` files touched. It cannot affect the product.

The one thing to know: **off-palette counts will change on the next full run**, and light-theme counts should drop substantially. That is the fix working, not a regression — the previous numbers were measured against a list containing five non-tokens.

Verified in both directions: the derived palettes contain the current tokens and none of the five stale ones, and the all-errored run exits 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
