### PR TITLE
docs: the deploy duty follows capability, not who moved the branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,8 +75,16 @@ against `/api/version`. So the premise this table rests on does not hold.
 decide, not ours to infer from a corrected premise.** Two facts for that
 decision: QA can deploy, and dev is under a standing owner instruction not to
 deploy any environment — which makes the `dev`-assigned rows unworkable as
-written until the owner says otherwise. Until then, whoever moves a branch is
-still responsible for the deploy following it, and for saying so.
+written until the owner says otherwise.
+
+**Until then: whoever moves a branch says so immediately, and whoever can run
+the deploy runs it.** A branch that has moved while its service has not is the
+failure this whole section exists to prevent — it does not matter which session
+closes the gap, only that neither waits for the other. The earlier wording made
+the mover responsible for the deploy, which assigned dev a duty the paragraph
+above says dev may not perform; a rule that resolves to "responsible for a thing
+you may not do" gets ignored rather than followed. Dev caught it on the PR that
+introduced it.
 
 | Deploy | Who | Notes |
 |---|---|---|


### PR DESCRIPTION
## Summary

Follow-up to #680, which dev caught while reviewing it. One sentence in `CLAUDE.md`'s "Who DEPLOYS" section assigned a duty to whoever the paragraph above says cannot perform it.

## What changed

```diff
- Until then, whoever moves a branch is still responsible for the deploy
- following it, and for saying so.
+ Until then: whoever moves a branch says so immediately, and whoever can run
+ the deploy runs it.
```

Plus two sentences saying why the earlier wording was replaced, kept in place rather than deleted — same convention as #680 itself.

## Why

**Read literally, the old sentence assigned dev the deploy**, since dev moves `dev` → `qa`. The paragraph two lines above establishes that dev is under a standing owner instruction not to deploy any environment.

So the document resolved to *"dev is responsible for a thing dev may not do"* — the shape of rule that gets ignored rather than followed, which is worse than saying nothing.

**The thing the section protects is unchanged**: no silent gap between a branch and its service. The new wording states that directly instead of routing it through an assignment nobody can honour. It is also what actually happened tonight — dev moved `dev` → `qa` twice and said so, I deployed both times within a minute and quoted `/api/version`.

**Wording is dev's, from their review of #680.** I took it as offered; it is better than mine and they found the problem.

## How to test (QA)

Read `CLAUDE.md`, section **"Who DEPLOYS — dev runs the non-prod deploys"**.

1. The four-row deploy table is unchanged.
2. The **Production** paragraph is unchanged — prod stays QA-only and owner-approved.
3. No sentence in the section makes the branch-mover responsible for the deploy.
4. `git diff origin/dev -- CLAUDE.md` touches one hunk in one file.

## Risk level

**Low.** Documentation only, one paragraph.

It still does not settle who deploys — that remains the owner's call, and this PR deliberately does not infer it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
