### PR TITLE
test(qa): platform-audit must prove a page scrolls, not just measure it wider

### DIFF
--- a/qa/platform-audit.mjs
+++ b/qa/platform-audit.mjs
@@ -173,7 +173,27 @@ const PAGE_EVAL = ({ tokens, radiusExempt }) => {
 
   return {
     scanned,
-    overflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+    /* PROVEN scrollable, not merely wider. `html { overflow-x: hidden }` in
+       app/globals.css clips the closed nav drawer while scrollWidth still
+       reports its extents, so the subtraction alone reports an overflow
+       nobody can reach. It did: /dashboard and /liq each showed a non-zero
+       `ovf` here on 2026-09-03 while qa/mobile-audit.mjs - which tries to
+       scroll and checks the offset sticks - reported horizontalOverflow
+       false for both. Four of sixty mobile loads were flagged and none of
+       them scrolled. mobile-audit learned this on #641; this file had not.
+       Report both: the honest boolean drives the count, and the raw extents
+       stay for whoever wants to know something is wider than the viewport
+       even though nobody can reach it. */
+    overflow: (() => {
+      const de = document.documentElement;
+      if (de.scrollWidth <= de.clientWidth) return 0;
+      const before = de.scrollLeft;
+      de.scrollLeft = 99999; window.scrollTo(99999, window.scrollY);
+      const moved = de.scrollLeft > 1 || window.scrollX > 1;
+      de.scrollLeft = before; window.scrollTo(0, window.scrollY);
+      return moved ? de.scrollWidth - de.clientWidth : 0;
+    })(),
+    widerThanViewport: document.documentElement.scrollWidth - document.documentElement.clientWidth,
     offDistinct: Object.keys(off).length,
     offTop: Object.entries(off).sort((a,b)=>b[1]-a[1]).slice(0,4),
     radiusTotal: Object.values(radius).reduce((a,c)=>a+c,0),
@@ -213,7 +233,7 @@ for (const vp of VIEWPORTS) {
       rows.push(rec);
       if (!JSON_OUT) {
         const f = rec.error ? `ERROR ${rec.error}` :
-          `ovf ${String(rec.overflow).padStart(4)}  off ${String(rec.offDistinct).padStart(3)}  rad ${String(rec.radiusTotal).padStart(3)}  contrast ${String(rec.contrastFails).padStart(3)}  <24px ${String(rec.subMin).padStart(2)}  empty ${String(rec.empties).padStart(2)}`;
+          `ovf ${String(rec.overflow).padStart(4)}${rec.overflow === 0 && rec.widerThanViewport > 0 ? '(w' + rec.widerThanViewport + ')' : ''}  off ${String(rec.offDistinct).padStart(3)}  rad ${String(rec.radiusTotal).padStart(3)}  contrast ${String(rec.contrastFails).padStart(3)}  <24px ${String(rec.subMin).padStart(2)}  empty ${String(rec.empties).padStart(2)}`;
         console.log(`${vp.padEnd(7)} ${theme.padEnd(5)} ${route.padEnd(18)} ${f}`);
         /* Name the empties. A bare count cannot be acted on - which field is
            blank is the whole question - and the labels are what turn an audit


### PR DESCRIPTION
## Summary

Split out of #685, which merged before this commit reached it. `qa/platform-audit.mjs` computed overflow as `scrollWidth - clientWidth`. **That is width, not overflow** — and it has been reproducing a finding I already retracted.

## What changed

`ovf` counts only what actually scrolls: try to scroll, check the offset sticks, restore. When content is wider but unreachable the column reads `0` and appends the raw extent as `(wNNN)`, so nothing is lost.

## Why

`html { overflow-x: hidden }` in `app/globals.css` clips the closed nav drawer while `scrollWidth` still reports its extents. The subtraction therefore flags pages nobody can scroll.

The 120-load run on `qa` `33f5eee` flagged **4 of 60** mobile loads — `/dashboard` and `/liq`, both themes. Checked against `qa/mobile-audit.mjs` on the same build:

```
/dashboard   horizontalOverflow=false   contentWiderThanViewport=true   678 vs 390
/liq         horizontalOverflow=false   contentWiderThanViewport=true   477 vs 390
```

**None of the four scrolls. The honest count is 0 of 60.**

This is the phantom 334px `/dashboard` overflow from #641 — reported by me, retracted by me. `mobile-audit` was taught to prove scrollability then; **this file was never brought along, so it has been repeating the retraction on every run since.**

**Consequence recorded on #559:** that issue's headline "mobile overflows on 50/60" was measured with the unfixed comparison, so an unknown share of those 50 were the same clipped drawer. I have said so there rather than quietly reporting an improvement against a number that was never sound.

## How to test (QA)

```
MSYS_NO_PATHCONV=1 node qa/platform-audit.mjs --base https://liquidity-hq-qa.onrender.com \
  --routes /dashboard,/liq --viewports mobile --themes dark
```

1. Both rows read `ovf 0(wNNN)` — zero overflow, unreachable width in brackets. Expect roughly `(w288)` and `(w87)`; the exact numbers move with data.
2. The summary says `overflowing 0 of 2`.
3. Cross-check with `node qa/mobile-audit.mjs "<same url>" --theme dark` — its `horizontalOverflow` must agree with the `ovf` column. Two tools, different code paths, same answer.

A page that genuinely scrolls sideways reports a non-zero `ovf` with **no** bracket.

## Risk level

**Low.** QA tooling only — nothing under `app/`, `components/` or `lib/`.

One thing to know: **overflow counts before and after this are not comparable**, for the same reason the palette counts in #682 are not. The old number included pages that cannot be scrolled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
