### PR TITLE
docs: three more silent-detector failures from 2026-09-03

### DIFF
--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -760,6 +760,53 @@ each copy explaining why it was needed. Copying is what stopped it spreading: a
 comment only reaches someone already reading that function. Prefer a check over a
 convention, because a convention has to be recalled at the moment of writing.
 
+**A backslash dies inside a quoted string, and the detector goes silent.** Three
+instances in one session, all in checks whose failure mode is *finding nothing*:
+
+```js
+if (!/[.#]/.test(sel)) …            // fine - a regex literal
+new RegExp('(^|;|\s)' + prop)       // '\s' is just the letter s
+new RegExp(`…\b${cls}\b`)              // \b in a template literal is BACKSPACE
+```
+
+The first was `qa/mobile-audit.mjs`'s dead-rule detector under-reporting; the
+other two were `__tests__/terminalTypographyOwnership`'s sweep **matching
+nothing at all** and therefore declaring the codebase clean. A regex literal is
+safe; the moment a pattern is built from a string — because it interpolates a
+variable — every backslash needs doubling, and nothing warns you. **Build
+patterns from plain strings with explicit `\\`, never from template
+literals**, and assume any new string-built matcher is broken until a positive
+control says otherwise.
+
+**A measurement over the wrong field gives a confident wrong answer, not an
+obviously broken one.** Investigating `/econ-calendar`'s 72 blank cells, a probe
+read `e.date || e.time || e.datetime`. The field is `isoDate`. Every event fell
+back to epoch and read as *past*, so the run reported "19 past, 19 missing
+actual" — a fabricated defect that pointed at the **opposite** conclusion from
+the truth, which is that all 19 events are in the future and their blank
+`actual` is correct. It was caught only because a printed sample row showed a
+September 4 date under a "past" heading. **Print a sample of what you measured,
+not just the aggregate** — the aggregate cannot show you that you read the wrong
+key. The same shape produced `rsi symbols=2` from counting the two top-level
+keys `{rsi, ts}` instead of the 46 inside `rsi`.
+
+**A hex grep reads prose.** Sweeping `qa/` for stale palettes, a grep for
+`#6a6e73` and `#1a7f37` matched `qa/token-surfaces.mjs` — in a *comment*
+documenting the previous stale-palette incident. The real drift there was four
+different values, found only by parsing the object literal by brace depth.
+Files in this repo deliberately record their own history in place, which makes
+grep-for-a-value structurally unreliable on them. `app/globals.css` has the same
+property and it has caused this before (#641).
+
+**Two tools measuring the same thing must be reconciled, or the weaker one keeps
+publishing.** `qa/mobile-audit.mjs` proves horizontal overflow by scrolling and
+checking the offset sticks; `qa/platform-audit.mjs` computed
+`scrollWidth - clientWidth`. `html { overflow-x: hidden }` clips the closed nav
+drawer while `scrollWidth` still reports its extents, so the second tool flagged
+four mobile loads that cannot scroll — reproducing a phantom overflow QA had
+already reported and retracted on #641, on every run for weeks afterward.
+**When a check is corrected, grep for every other copy of the same comparison.**
+
 ---
 
 ## 15. How we work — the two-session model


### PR DESCRIPTION
## Summary

Four more entries in `docs/HANDOVER.md` §14, "The failure that looks like success" — all from 2026-09-03, all sharing that section's shape: **the symptom is indistinguishable from the healthy state.**

## What changed

`docs/HANDOVER.md` only. Four paragraphs appended to §14, before §15.

## Why

**A backslash dies inside a quoted string, and the detector goes silent.** Three instances in one session, across both sessions' work:

```js
if (!/[.#]/.test(sel)) …            // fine - a regex literal
new RegExp('(^|;|\s)' + prop)       // '\s' is just the letter s
new RegExp(`…\b${cls}\b`)              // \b in a template literal is BACKSPACE
```

The first made `mobile-audit`'s dead-rule check under-report. The other two made the typography ownership sweep **match nothing at all** — and therefore report a clean codebase. All three are checks whose failure mode is finding nothing.

**A measurement over the wrong field gives a confident wrong answer.** A probe read `e.date || e.time || e.datetime` when the field is `isoDate`. Everything fell back to epoch and read as *past*, producing "19 past, 19 missing actual" — a plausible defect pointing at the **opposite** conclusion from the truth. Caught only because a printed sample row showed a September 4 date under a "past" heading. Same shape as `rsi symbols=2`, which counted the two top-level keys instead of the 46 inside `rsi`.

**A hex grep reads prose.** Sweeping `qa/` for stale palettes, a grep matched `token-surfaces.mjs` — inside a *comment* documenting the previous stale-palette incident. Files here deliberately record their own history in place, which makes grep-for-a-value structurally unreliable on them.

**Two tools measuring the same thing must be reconciled, or the weaker one keeps publishing.** `mobile-audit` proves overflow by scrolling; `platform-audit` subtracted widths. The second reproduced a phantom overflow QA had already retracted, on every run for weeks (#686).

## How to test (QA)

Read `docs/HANDOVER.md` §14. The four entries follow the "the correct pattern already existing in-repo does not mean it travelled" paragraph and precede §15.

**The one thing to check rather than skim:** the code block must show the **buggy** single-backslash forms — `'\s'` and `` `\b` ``. If it renders `'\s'`, that is the *corrected* form and the entry's point has been inverted. I made exactly that mistake writing it and caught it on re-read.

## Risk level

**Low.** Documentation only, one file, one section. No code, no tooling, no config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
