### PR TITLE
fix(liquidation-map): green foreground gets its own value on composited tints

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -121,6 +121,9 @@
      Worth collapsing into --green deliberately at some point. Two greens for
      one meaning is the reason this got missed in the first place. */
   --green-2:   #34d399;
+  /* #652: green foreground on a composited tint. Aliases --green-2 everywhere
+     except terminal light, where the composited grounds pull it under 4.5. */
+  --green-fg:  var(--green-2);
   /* Weaker-signal tier (e.g. "slightly high funding" vs "very high") - a
      paler version of --green/--red so the two tiers stay visually distinct. */
   --green-soft: #86efac;
@@ -5622,6 +5625,9 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
      - terminal's --txt3 is the identical #7c828a literal, so the same
      composited-surface failure applies here too. */
   --txt-dash: #848a92;
+  /* #652: matches lib/terminalTokens.ts. Dark's green passes on every ground
+     it meets, so this is --green; terminal light takes its own darker value. */
+  --green-fg: #3fb950;
   /* #546 C9: derived tints for --green/--red, same pattern as the already-
      existing --accent-bg/--accent-bdr. Undeclared here, .chg-up/.chg-dn's
      background/border (app/globals.css:786-787) fell through to the current
@@ -5794,6 +5800,7 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
   --bg3: var(--bg2);
   --bg4: var(--bg1);
   --green-2:    var(--green);
+  --green-fg:   #0f5a22;
   --green-soft: var(--green);
   --red-soft:   var(--red);
   --txt-dim:    var(--txt2);

--- a/components/GexTable.tsx
+++ b/components/GexTable.tsx
@@ -19,7 +19,7 @@ export default function GexTable() {
   const gexLoaded = btcNetGex !== null && btcGexLevels.length > 0;
   const isLongGamma = (btcNetGex ?? 0) >= 0;
 
-  const gexCol     = isLongGamma ? 'var(--green-2)' : 'var(--red)';
+  const gexCol     = isLongGamma ? 'var(--green-fg)' : 'var(--red)';
   const gexBg      = isLongGamma ? 'color-mix(in srgb, var(--green-2) 12%, transparent)' : 'color-mix(in srgb, var(--red) 12%, transparent)';
   const gexBorder  = isLongGamma ? 'color-mix(in srgb, var(--green-2) 30%, transparent)'  : 'color-mix(in srgb, var(--red) 30%, transparent)';
 
@@ -149,7 +149,7 @@ export default function GexTable() {
           {btcGexLevels.map(({ strike, gex }) => {
             const pct   = maxAbsGex > 0 ? Math.abs(gex) / maxAbsGex * 100 : 0;
             const col   = gex >= 0 ? 'var(--green-2)' : 'var(--red)';
-            const vcol  = gex >= 0 ? 'var(--green-2)' : 'var(--red)';
+            const vcol  = gex >= 0 ? 'var(--green-fg)' : 'var(--red)';
             const isAtm = spotPrice > 0 && Math.abs(strike - spotPrice) / spotPrice < 0.005;
             return (
               <div key={strike} className={`gex-row${isAtm ? ' gex-row-atm' : ''}`}>

--- a/components/LiqTerminal.tsx
+++ b/components/LiqTerminal.tsx
@@ -708,7 +708,7 @@ export default function LiqTerminal() {
             <div className="liq-current-bar">
               <span className="liq-current-dot" />
               <span className="liq-current-price">{fmtP(cd.price)}</span>
-              <span className="liq-current-chg" style={{ color: (cd.change ?? 0) >= 0 ? 'var(--green-2)' : 'var(--red)' }}>
+              <span className="liq-current-chg" style={{ color: (cd.change ?? 0) >= 0 ? 'var(--green-fg)' : 'var(--red)' }}>
                 {(cd.change ?? 0) >= 0 ? '▲' : '▼'}{Math.abs(cd.change ?? 0).toFixed(2)}%
               </span>
               <span className="liq-current-tag">{t('LIQ_HEATMAP_LIVE_TAG')}</span>

--- a/lib/terminalTokens.ts
+++ b/lib/terminalTokens.ts
@@ -58,6 +58,13 @@ export const TERMINAL_COLORS = {
      placeholder actually renders on. Design's ruling: a dedicated value
      for this one use, not a change to --txt3 itself. */
   '--txt-dash': '#848a92',
+  /* #652: green FOREGROUND on a composited tint. Dark's --green passes on
+     every ground it meets, so this is simply --green there; terminal light's
+     #14702c does not - 4.35 on its own 12% chip tint, 4.19 on the
+     current-price bar's accent wash. Dedicated value for the composited case,
+     exactly as --txt-dash above, rather than moving --green and shifting every
+     green in the light theme to fix three elements on one screen. */
+  '--green-fg': '#3fb950',
 } as const;
 
 /** The same 18 tokens under `[data-design="terminal"][data-theme="light"]`
@@ -104,6 +111,7 @@ export const TERMINAL_COLORS_LIGHT = {
   '--border-input': '#75797e',  // Input and secondary-button border
   '--fr-slight-long': '#7C5E2E',
   '--txt-dash':     '#4f5257',
+  '--green-fg':     '#0f5a22',   // see the dark entry - 5.87 / 5.66 on the two tints
 } as const;
 
 /* The seventeenth value: the FLAT cell in the hours expectancy grid.


### PR DESCRIPTION
## Summary

The last three `/liq` failures. A governed `--green-fg` token, taken by the three elements that paint green text on a tinted ground.

## Measured

| element | before | ground |
|---|---|---|
| `.gex-net-chip` | **4.05** | its own 12% green tint |
| `.gex-value` | **4.36** | |
| `.liq-current-chg` | **4.38** | the current-price bar's accent wash |

`#14702c` on a 12% self-tint over `--bg1` is **4.35**; on the bar's 9% accent wash over `--bg2`, **4.19**. `#0f5a22` measures **5.87** and **5.66**, and 6.92 on bare `--bg1`.

## `--green` does not move

It passes everywhere else it is used, so changing it would shift **every green in the light theme** to fix three elements on one screen — the trade `qa/TERMINAL_REDESIGN_STATE.md` already rejected for `--txt3`.

This is the `--txt-dash` precedent again: a dedicated value for a composited ground. **Third time today that shape has been the answer.**

`--green-fg` is `--green-2` in every scope except terminal light, so the current design and terminal dark are **byte-identical**.

## The colour stays inline, deliberately

It is chosen from data — green when positive, `--red` when negative — which is the case #681's ownership check explicitly scopes out. Moving a data-driven ternary into a stylesheet means two rules and a class toggle to express one conditional.

## The token test earned itself

Declared in `lib/terminalTokens.ts` for both themes so `mobile-audit` governs it automatically (#645), and in `globals.css`'s terminal blocks to match.

`__tests__/contrastTokens` **failed** when I had added it to the token file with only an alias in the stylesheet — exactly the drift it exists to stop, on its first real exercise since #645. I would not have caught that by reading.

## How to test (QA)

`/liq?design=terminal` in **light**: the GEX net chip, per-strike values and the current-price change % are readable green rather than washed out. Dark unchanged; no design flag unchanged.

## Risk level

**Low.** One new token, three call sites. Gates: lint 0, `tsc` 0, `npm test` 0 (554), `build` 0.

**Not verified by me:** the rendered page. Composite arithmetic is measured against the real tokens; I have not seen a light-theme chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y