### PR TITLE
docs: an empty sweep and a clean codebase produce identical output

### DIFF
--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -771,8 +771,19 @@ new RegExp(`…\b${cls}\b`)              // \b in a template literal is BACKSPAC
 
 The first was `qa/mobile-audit.mjs`'s dead-rule detector under-reporting; the
 other two were `__tests__/terminalTypographyOwnership`'s sweep **matching
-nothing at all** and therefore declaring the codebase clean. A regex literal is
-safe; the moment a pattern is built from a string — because it interpolates a
+nothing at all** and therefore declaring the codebase clean.
+
+**The distinction between those two matters more than the bug.** Under-reporting
+means some cases were missed; the third instance meant the rule map came back
+near-empty, so the sweep **reported on an empty set** — it did not miss some
+collisions, it compared the codebase against nothing and called it clean. A run
+that examines zero things and a codebase with zero defects produce byte-identical
+output. That is why every sweep in this repo now carries an arming assertion (`the
+rule map has > 20 entries`, `the file walk found > 50 files`) alongside its
+positive control: the control proves the check *can* fail, the arming assertion
+proves it had something to look at.
+
+A regex literal is safe; the moment a pattern is built from a string — because it interpolates a
 variable — every backslash needs doubling, and nothing warns you. **Build
 patterns from plain strings with explicit `\\`, never from template
 literals**, and assume any new string-built matcher is broken until a positive


### PR DESCRIPTION
## Summary

Follow-up to #687, taking dev's point from that review. The backslash entry conflated two failure modes that deserve separating.

## What changed

`docs/HANDOVER.md` §14 only. One paragraph added to the entry beginning *"A backslash dies inside a quoted string"*.

## Why

I wrote that the three instances were "under-reporting" and "matching nothing at all" as if they were the same defect at different severities. **They are not.**

Under-reporting means some cases were missed. The third instance — `'\s'` collapsing to the letter `s` — meant the rule map came back **near-empty**, so the sweep compared the codebase against nothing and called it clean. It did not miss some collisions; it examined zero things.

**A run that examines zero things and a codebase with zero defects produce byte-identical output.** That is §14's theme in its purest form, and the entry was burying it.

The paragraph also records why two different guards are needed and why both now appear on every sweep here:

- a **positive control** proves the check *can* fail
- an **arming assertion** (`RULES.length > 20`, `files.length > 50`) proves it had something to look at

Neither substitutes for the other. The ownership sweep in `__tests__/terminalTypographyOwnership` carries both, which is why its zero is worth reading.

## How to test (QA)

Read `docs/HANDOVER.md` §14, the entry beginning *"A backslash dies inside a quoted string"*. The new paragraph sits after the code block and before *"A regex literal is safe…"*, and it names both guards.

The code block itself is unchanged and must still show the **buggy** single-backslash forms — `'\s'` and `` `\b` ``. That was the thing to check on #687 and it stays the thing to check here.

## Risk level

**Low.** Documentation only, one file, one paragraph. Credit where due: this is dev's observation from reviewing #687, and it is sharper than the version it replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
