### PR TITLE
test(qa): name every failing element, not the worst four

### DIFF
--- a/qa/platform-audit.mjs
+++ b/qa/platform-audit.mjs
@@ -126,6 +126,17 @@ const PAGE_EVAL = ({ tokens, radiusExempt, emptySource }) => {
   const isChrome = el => !!el.closest('.nav-menu, .gchat-panel, .app-bar, .nav-drawer, .pf-footer, .mobile-tab-bar');
 
   const off = {}, radius = {}, emptyLabels = []; let contrastFails = 0, subMin = 0, empties = 0, scanned = 0;
+  /* Every failing element, not the worst four. A count cannot be acted on -
+     #684 needed to know WHICH 23 cells failed on /econ-calendar, and the
+     answer turned out to be 20 impact badges nobody had considered plus 4
+     cells from the one row that had been guessed at. Two candidate mechanisms
+     were proposed from source reading and neither was the main cause.
+     Capped at 30: enough to characterise a page, few enough that a badly
+     broken screen does not bury the report. Each entry carries the foreground,
+     the COMPOSITED ground, the opacity and the element's own and parent's
+     selector - opacity because a 0.45 fade is invisible in a colour pair, and
+     the composited ground because the failing surface is usually a translucent
+     overlay that appears in no stylesheet. */
   const worstContrast = [];
   const BAD = new RegExp(emptySource);
 
@@ -157,7 +168,7 @@ const PAGE_EVAL = ({ tokens, radiusExempt, emptySource }) => {
         const need = (px>=24 || (px>=18.66&&bold)) ? 3 : 4.5;
         const fg = parse(s.color);
         if (fg) { const bg = bgOf(el); const ratio = cr(over(fg,bg), bg);
-          if (ratio < need) { contrastFails++; if (worstContrast.length < 4) worstContrast.push({ t: t.slice(0,20), ratio:+ratio.toFixed(2), px:s.fontSize }); } }
+          if (ratio < need) { contrastFails++; if (worstContrast.length < 30) worstContrast.push({ t: t.slice(0,20), ratio:+ratio.toFixed(2), px:s.fontSize, fg: s.color, sel: el.tagName.toLowerCase() + (el.className && typeof el.className === 'string' && el.className.trim() ? '.' + el.className.trim().split(/\s+/).join('.') : ''), par: el.parentElement ? (el.parentElement.tagName.toLowerCase() + (el.parentElement.className && typeof el.parentElement.className === 'string' && el.parentElement.className.trim() ? '.' + el.parentElement.className.trim().split(/\s+/).join('.') : '')) : '', op: s.opacity, ground: 'rgb(' + Math.round(bg.r) + ',' + Math.round(bg.g) + ',' + Math.round(bg.b) + ')' }); } }
         if (BAD.test(t)) {
           empties++;
           /* A count with no identity is not actionable - "72 empty fields" says


### PR DESCRIPTION
## Summary

`qa/platform-audit.mjs` recorded the **worst four** contrast failures per page and discarded the rest. #684 needed to know *which* 23 cells were failing on `/econ-calendar`, and four samples could not answer it.

## What changed

Up to **30** failures per page load instead of 4, and each entry now carries the foreground colour, the **composited** ground, the computed opacity, and the element's own and its parent's selector.

## Why

Two mechanisms had been proposed for `/econ-calendar`'s 23-dark-vs-0-light split, both from careful source reading:

- a white `rgba(255,255,255,0.025)` overlay on the `isNext` row — asymmetric, right direction, but only one row
- a `0.45` opacity fade on past events — severe, but symmetric, so it could not produce a 23/0 split

**Neither was the main cause.** Measured:

```
19x  span "high"      fg rgb(240,82,77)    ground rgb(52,34,36)   4.31
 1x  span "high"      fg rgb(240,82,77)    ground rgb(57,39,40)   4.04
 4x  --txt3 cells     fg rgb(124,130,138)  ground rgb(26,27,29)   4.46
```

**20 of 23 are the impact badge** — `--red` `#f0524d` on its own red wash, which nobody had considered. The remaining 4 confirm the overlay candidate at 4.46 against its predicted 4.45. The fade was not firing at all: every failing element measured `opacity: 1`, because all 19 events are in the future.

None of that is reachable from a count and four samples.

**The extra fields are the ones that did the work:**

- **opacity** — a `0.45` fade is invisible in a foreground/background pair, and ruling it out required seeing `1` on all 23
- **the composited ground** — `rgb(52,34,36)` is not a token and appears in no stylesheet; it is `--red` washed over a card. Without it the badge failures look like a mystery rather than the same shape as `/liq`'s `.gex-net-chip`, which #688 had just fixed

Capped at 30 rather than uncapped: enough to characterise a page, few enough that one badly broken screen does not bury the rest of a 120-load run.

## How to test (QA)

```
MSYS_NO_PATHCONV=1 node qa/platform-audit.mjs --base https://liquidity-hq-qa.onrender.com \
  --routes /econ-calendar --viewports desktop --themes dark --json
```

Read `worstContrast`:

1. Roughly **20 entries** whose `t` is `"high"` with `fg rgb(240, 82, 77)` — not four entries total.
2. Every entry has a non-empty `ground` and an `op`.
3. `sel` and `par` name the element and its parent, so a finding can be filed against something.

## Risk level

**Low.** QA tooling only — no `app/`, `components/` or `lib/`. Output-only; counts, checks and exit codes are unchanged.

Report size grows on badly-failing pages. That is the point, and 30 is the ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
