### PR TITLE
fix(econ-calendar): drop the 0.45 stale fade - opacity cannot carry this

### DIFF
--- a/app/econ-calendar/page.tsx
+++ b/app/econ-calendar/page.tsx
@@ -269,8 +269,34 @@ export default function EconCalendarPage() {
                          outranks every selector (#663) - but an inline value that READS a
                          custom property still inherits, so the row can move all four at
                          once without a class toggle per cell. */
-                      ['--ec-muted' as string]: isNext ? 'var(--txt-dash)' : 'var(--txt3)',
-                      opacity: isPast && !e.actual ? 0.45 : 1,
+                      /* #692: NO opacity fade. It was 0.45, which put every
+                         cell in a stale row at ~1.9:1 in BOTH themes - the
+                         worst contrast on the screen, on rows that render real
+                         values.
+
+                         Opacity cannot be tuned out of this. Minimum opacity
+                         each token needs to hold 4.5:1, worst of --bg1/--bg2:
+
+                             --txt   50% dark  62% light
+                             --txt2  87%       94%
+                             --txt3  97%       98%
+                             --txt-dash 91%    87%
+
+                         Only --txt survives a fade anyone would notice; every
+                         muted token needs ~90%+, which is not a fade. So the
+                         mechanism is wrong rather than the value.
+
+                         Staleness now reads from --ec-muted instead: the row's
+                         muted text takes --txt-dash, which passes on every
+                         ground here, and the "-" placeholders already say the
+                         data never arrived. That is a WEAKER visual signal than
+                         a 45% fade and it is deliberate - #635's ruling was that
+                         an honest placeholder beats a confident wrong one, and
+                         an unreadable row is worse than a quiet one. If design
+                         wants the staleness louder, a background tint or a left
+                         border moves no text contrast at all. */
+                      ['--ec-muted' as string]: isNext || (isPast && !e.actual)
+                        ? 'var(--txt-dash)' : 'var(--txt3)',
                       minWidth: 680,
                     }}
                   >


### PR DESCRIPTION
## Summary

#692. `opacity: isPast && !e.actual ? 0.45 : 1` put every cell in a stale row at **~1.9:1 in both themes** — the worst contrast on the screen, on rows that render real values.

## Opacity cannot be tuned out of it

Minimum opacity each token needs to hold 4.5:1, worst of `--bg1`/`--bg2`:

| token | dark | light |
|---|---|---|
| `--txt` | 50% | 62% |
| `--txt2` | 87% | 94% |
| `--txt3` | **97%** | **98%** |
| `--txt-dash` | 91% | 87% |

**Only `--txt` survives a fade anyone would notice.** Every muted token needs ~90%+, which is not a fade. So the mechanism is wrong, not the value — there is no number to pick here.

## What replaces it

Staleness reads from `--ec-muted`: a stale row's muted text takes `--txt-dash`, which passes on every ground on this screen, and the `-` placeholders already say the data never arrived.

**That is a weaker visual signal than a 45% fade, and it is deliberate.** #635's ruling was that an honest placeholder beats a confident wrong one, and an unreadable row is worse than a quiet one.

**If design wants staleness louder, a background tint or a left border moves no text contrast at all** — noted in the comment so the next person has the option without rediscovering why opacity is not it.

## Latent, not live

All 23 of #684's failures measured `opacity: 1`, so this never appeared in those numbers. It fires when an event passes without an actual — and with `previous`/`estimate` already missing on 17 of 19, that is likely rather than hypothetical.

## How to test (QA)

Hard to reach on demand: it needs a past event with no actual value. `/econ-calendar?design=terminal`, both themes — **no row should render faded**. If one does, this did not apply.

The observable change today is none, which is the expected result while every event is still in the future.

## Risk level

**Low.** One property removed, one conditional widened. Gates: lint 0, `tsc` 0, `npm test` 0 (555), `build` 0.

**Not verified by me:** the stale state itself, for the same reason it was latent — I cannot make an event pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y