### PR TITLE
test(qa): canvas-measure must refuse a diff whose two walks started differently

### DIFF
--- a/qa/canvas-measure.mjs
+++ b/qa/canvas-measure.mjs
@@ -156,6 +156,35 @@ show('LIVE', liveWalk);
 if (!canvasWalk.error && !liveWalk.error) {
   const cb = canvasWalk.bands.filter(b => b.full), lb = liveWalk.bands.filter(b => b.full);
   console.log(`\n### Band count — canvas ${cb.length}, live ${lb.length}`);
+
+  /* REFUSE to compare two walks that started at different levels.
+     The canvas walk begins at the 1440 frame, which contains the nav and the
+     ticker. The live walk deliberately begins at the CONTENT root, because
+     including the shell's drawer, FAB, chat panel and consent bar made the
+     live side report bands the canvas frame does not contain.
+     Each choice is right alone and wrong together: on /dashboard the canvas
+     template collapses everything but its chrome, so the canvas side was two
+     chrome bands and the live side two content bands, and the diff printed
+     "MISSING" against the nav and ticker of a page that plainly has both.
+     A structural mismatch rendered as a finding.
+     Zero shared band heights with both sides non-empty is the signature. */
+  const heightOverlap = cb.filter(c => lb.some(l => l.h === c.h)).length;
+  /* Two signatures, both meaning the roots disagree:
+     - the live walk found bands but NONE full-width, so there is nothing to
+       line up against the canvas's full-width chrome (this is /dashboard);
+     - both sides have full-width bands and not one height is shared. */
+  const liveHasNoFullBands = lb.length === 0 && liveWalk.bands.length > 0;
+  if (cb.length && (liveHasNoFullBands || (lb.length && heightOverlap === 0))) {
+    console.log('');
+    console.log('NOT COMPARABLE - the two walks did not start at the same level.');
+    console.log('  canvas root: the 1440 frame, including nav and ticker chrome');
+    console.log('  live root:   the content root, which excludes that chrome');
+    console.log('No band height appears on both sides, so any per-row diff would be an');
+    console.log('artefact of where each walk began, not a difference between designs.');
+    console.log('');
+    console.log('Use qa/canvas-diff.mjs for this route until the roots are reconciled.');
+    process.exit(0);
+  }
   const n = Math.max(cb.length, lb.length);
   for (let i = 0; i < n; i++) {
     const c = cb[i], l = lb[i];


### PR DESCRIPTION
## Summary

Run against `/dashboard`, `qa/canvas-measure.mjs` reported the **nav and the ticker as MISSING** from a page that plainly has both. The tool now refuses to print that diff.

## What changed

`NOT COMPARABLE` plus the two root descriptions, and an early exit, when the two walks did not begin at the same level. Two signatures trigger it:

- the live walk found bands but **none full-width**, so there is nothing to line up against the canvas's full-width chrome
- both sides have full-width bands and **share no height**

## Why

The cause is structural, not a defect in the page.

- the **canvas** walk starts at the 1440 frame, which contains nav and ticker
- the **live** walk starts at the content root — a deliberate earlier fix, because including the shell's drawer, FAB, chat panel and consent bar made the live side report bands the canvas frame does not contain

**Each choice is right on its own and wrong together.** On `/dashboard` it is worse than a level mismatch: this file's own header already records that the canvas template collapses everything but its chrome when loaded without data. So the canvas side was two chrome bands, the live side two content bands, and the overlap was zero:

```
### CANVAS      0  h=44  LIQUIDITYHQ OVERVIEW ARENA …     <- nav
                1  h=34  BTC 115,284.50 +1.42% ETH …      <- ticker
### LIVE        0  h=820 dash-main   Market Read …
                1  h=935 dash-right  Coins 50 firing …

### Band count - canvas 2, live 0
   0  canvas 44  live -  MISSING   LIQUIDITYHQ OVERVIEW ARENA
   1  canvas 34  live -  MISSING   BTC 115,284.50 +1.42% ETH
```

**Two confident rows pointing at elements that are right there.** That is the failure mode `qa/` has produced four separate times today — a stale palette, a width subtraction called overflow, a fixed wait sampling mid-load, and a rule map that came back empty. Same shape: output that reads as a measurement and is an artefact of the instrument.

## What this deliberately does not do

**It does not reconcile the roots.** That needs a decision — should the canvas side skip its chrome, or the live side include it? — and either answer changes what every previous run of this tool meant. Refusing to print a meaningless diff is correct on its own and does not foreclose that choice.

## How to test (QA)

```
MSYS_NO_PATHCONV=1 node qa/canvas-measure.mjs --route /dashboard \
  --base https://liquidity-hq-qa.onrender.com
```

1. Prints `NOT COMPARABLE`, both root descriptions, and a pointer to `qa/canvas-diff.mjs`.
2. Prints **no per-band rows** and no `MISSING`.
3. The `### CANVAS` and `### LIVE` sections above it are unchanged — the walks still run and their output is still shown; only the diff is withheld.

A route where both walks find full-width bands sharing at least one height still prints the diff exactly as before.

## Risk level

**Low.** QA tooling only. It can only suppress output, never change a measurement.

Worth stating: this makes `canvas-measure` **less** useful on `/dashboard`, not more — it previously produced an answer there and now declines to. The answer it produced was wrong, so that is the intended direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
