### PR TITLE
test(qa): wait for the design and theme to settle before measuring contrast

### DIFF
--- a/qa/mobile-audit.mjs
+++ b/qa/mobile-audit.mjs
@@ -94,6 +94,39 @@ await page.waitForFunction(() => {
 }, { timeout: 180000 }).catch(() => {});
 await page.waitForTimeout(6000);
 
+/* Then wait for the DESIGN AND THEME to stop moving, because 6000ms is a
+   guess and a guess is what produced the number below.
+
+   Measuring /?design=terminal in light on qa 2ef168c returned 263 contrast
+   failures. A re-run of the identical command returned 0. Nothing in that
+   build touches the landing page - it carried an econ-calendar change and two
+   QA scripts - so 263 was the page sampled mid-transition, with one design's
+   colours already applied and the other's not yet. Reported as-is it would
+   have read as a catastrophic regression on a screen that had been signed
+   off minutes earlier.
+
+   The stable proxy is cheap: the two root attributes plus the body's
+   composited background. A transition moves at least one of them, and a
+   settled page moves none. Full contrast is far too expensive to sample
+   twice, which is why this watches the inputs rather than the output. */
+const settled = await page.waitForFunction((want) => {
+  const de = document.documentElement;
+  const key = de.getAttribute('data-design') + '|' + de.getAttribute('data-theme') +
+              '|' + getComputedStyle(document.body).backgroundColor;
+  const s = (window.__maSettle ||= { last: null, n: 0 });
+  s.n = key === s.last ? s.n + 1 : 0;
+  s.last = key;
+  /* The requested theme must actually be on the root as well: a run that
+     never applied it is stable and wrong, which is the same failure one
+     level down. */
+  return s.n >= 2 && de.getAttribute('data-theme') === want;
+}, theme, { timeout: 45000, polling: 1000 }).then(() => true).catch(() => false);
+
+if (!settled) {
+  console.error('mobile-audit: design/theme never settled within 45s on ' + url +
+                ' (theme=' + theme + '). Measuring anyway - treat this run as suspect.');
+}
+
 const result = await page.evaluate(TOKENS => {
   const TOK = Object.fromEntries(TOKENS.map(t => [t, 1]));
   /* Same 0-1 vs 0-255 scaling as parse(): a `color(srgb ...)` declaration


### PR DESCRIPTION
## Summary

`qa/mobile-audit.mjs` waited a fixed 6000ms after load, then measured. That is a guess, and the guess produced a number: **263 contrast failures on `/` in light that were not there.**

## What changed

After the existing dashboard-transition guard and the 6000ms wait, poll until:

- the root's `data-design`, the root's `data-theme` and the body's composited background hold steady across two consecutive reads, **and**
- the requested theme is actually on the root

If that never happens within 45s, measure anyway and print a loud warning naming the run as suspect.

## Why

```
run 1   /?design=terminal  --theme light   contrast 263   subMin 8
run 2   identical command, identical build  contrast 0    subMin 4
```

`2ef168c` carries an econ-calendar change and two QA scripts. **Nothing in it touches the landing page.** The 263 was the page sampled mid-transition, with one design's colours applied and the other's not yet.

Reported as measured it would have read as a **catastrophic regression on a screen signed off minutes earlier**, and the obvious next move would have been hunting a cause in a build that has none.

**Sixth instrument artefact today and the first caught before anything was written down** — the previous five each got as far as a report or a filed finding. That is only because a 263 is implausible enough to re-run. A drift from 3 to 9 would have been believed.

## Why it watches the inputs

A full contrast walk is far too expensive to sample twice. But a design or theme transition **necessarily** moves one of those three values, and a settled page moves none of them — so the cheap proxy is sound where the expensive direct check is impractical.

The theme assertion is separate and matters on its own: **a run that never applied the requested theme is perfectly stable and measuring the wrong thing.** That is the same failure one level down, and stability alone would not catch it.

This is the same defect as the fixed 4500ms in `platform-audit` (#689), in a different tool, found the same way — a number that changed when nothing changed.

## How to test (QA)

```
node qa/mobile-audit.mjs "https://liquidity-hq-qa.onrender.com/?design=terminal" --theme light
```

1. Run it twice. **Both runs report the same `contrastFailureCount`** — expect 0 on `2ef168c`.
2. The JSON's `theme` reads `light` and `design` reads `terminal`.
3. Repeat with `--theme dark`; same stability.

Any run that prints `design/theme never settled within 45s` on stderr should be **discarded, not reported** — that is the warning doing its job.

## Risk level

**Low.** QA tooling only. It can add up to 45s per run in the worst case and normally adds 1–2s.

Worth stating plainly: **this does not make previous measurements wrong.** It makes them unrepeatable, which is a different and quieter problem — most runs settled well inside 6000ms, which is why this took until the sixth artefact to surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
