### PR TITLE
test(qa): give platform-audit the same design/theme settle gate as mobile-audit

### DIFF
--- a/qa/platform-audit.mjs
+++ b/qa/platform-audit.mjs
@@ -259,6 +259,34 @@ for (const vp of VIEWPORTS) {
            two identical consecutive reads, checked every 1.5s, capped at 30s.
            The cap is the honest part - a page that never settles is reported
            at whatever it reached, not waited on forever. */
+        /* Settle the DESIGN AND THEME before anything else. The empties poll
+           below waits for content; this waits for the page to stop being two
+           designs at once.
+
+           qa/mobile-audit.mjs returned 263 contrast failures on / in light on
+           qa 2ef168c and 0 on an immediate re-run of the identical command.
+           Nothing in that build touches the landing page: it was sampled
+           mid-transition, one design's colours applied and the other's not.
+           This file has the same exposure and had no such gate - the exact
+           'two tools measuring the same thing, only one corrected' shape that
+           left a retracted overflow finding publishing here for weeks (#686).
+
+           Watches the inputs, not the output: a full walk is too expensive to
+           sample twice, but a transition necessarily moves the design
+           attribute, the theme attribute or the body background. The theme
+           assertion is separate - a run that never applied the requested theme
+           is perfectly stable and measuring the wrong thing. */
+        const settled = await page.waitForFunction((want) => {
+          const de = document.documentElement;
+          const key = de.getAttribute('data-design') + '|' + de.getAttribute('data-theme') +
+                      '|' + getComputedStyle(document.body).backgroundColor;
+          const s = (window.__paSettle ||= { last: null, n: 0 });
+          s.n = key === s.last ? s.n + 1 : 0;
+          s.last = key;
+          return s.n >= 2 && de.getAttribute('data-theme') === want;
+        }, theme, { timeout: 45000, polling: 1000 }).then(() => true).catch(() => false);
+        if (!settled) rec.unsettled = true;
+
         {
           const countEmpties = () => page.evaluate((src) => {
             const re = new RegExp(src);
@@ -296,7 +324,7 @@ for (const vp of VIEWPORTS) {
       rows.push(rec);
       if (!JSON_OUT) {
         const f = rec.error ? `ERROR ${rec.error}` :
-          `ovf ${String(rec.overflow).padStart(4)}${rec.overflow === 0 && rec.widerThanViewport > 0 ? '(w' + rec.widerThanViewport + ')' : ''}  off ${String(rec.offDistinct).padStart(3)}  rad ${String(rec.radiusTotal).padStart(3)}  contrast ${String(rec.contrastFails).padStart(3)}  <24px ${String(rec.subMin).padStart(2)}  empty ${String(rec.empties).padStart(2)}`;
+          `ovf ${String(rec.overflow).padStart(4)}${rec.overflow === 0 && rec.widerThanViewport > 0 ? '(w' + rec.widerThanViewport + ')' : ''}  off ${String(rec.offDistinct).padStart(3)}  rad ${String(rec.radiusTotal).padStart(3)}  contrast ${String(rec.contrastFails).padStart(3)}  <24px ${String(rec.subMin).padStart(2)}  empty ${String(rec.empties).padStart(2)}` + (rec.unsettled ? '  UNSETTLED' : '');
         console.log(`${vp.padEnd(7)} ${theme.padEnd(5)} ${route.padEnd(18)} ${f}`);
         /* Name the empties. A bare count cannot be acted on - which field is
            blank is the whole question - and the labels are what turn an audit
@@ -342,6 +370,16 @@ console.log(`with off-palette       ${measured.filter(r => r.offDistinct > 0).le
 console.log(`with radius violations ${measured.filter(r => r.radiusTotal > 0).length}   (total ${sum('radiusTotal')}, circular <=24px exempt per radius-ruling.md)`);
 console.log(`with sub-24px targets  ${measured.filter(r => r.subMin > 0).length}   (total ${sum('subMin')})`);
 console.log(`with empty fields      ${measured.filter(r => r.empties > 0).length}   (total ${sum('empties')})`);
+
+/* A run that never settled is not a clean run, and a flag nobody prints is
+   the same defect one level up. */
+const unsettled = measured.filter(r => r.unsettled);
+if (unsettled.length) {
+  console.log('');
+  console.log(unsettled.length + ' of ' + measured.length + ' loads NEVER SETTLED within 45s -');
+  console.log('their design or theme was still changing when measured. Treat these rows as suspect:');
+  for (const r of unsettled.slice(0, 8)) console.log('  ' + r.route + ' ' + r.viewport + ' ' + r.theme);
+}
 
 if (errored.length) {
   console.log(`\n${errored.length} of ${rows.length} loads errored and are EXCLUDED from every count above:`);


### PR DESCRIPTION
## Summary

#697 fixed a mid-transition sampling bug in `qa/mobile-audit.mjs`. **`qa/platform-audit.mjs` has the same exposure and had no such gate.** This gives it one.

## What changed

Before measuring, wait until the root's `data-design`, the root's `data-theme` and the body's composited background hold steady across two reads, **and** the requested theme is actually on the root. A load that never settles within 45s is flagged `unsettled`, marked `UNSETTLED` on its row, and listed in the summary.

## Why

#697's evidence, restated because it is the whole reason:

```
run 1   /?design=terminal  --theme light   contrast 263
run 2   identical command, identical build  contrast 0
```

The page was sampled mid-transition — one design's colours applied, the other's not. **`platform-audit` walks the same pages the same way and could return the same number**, with nothing in its output to say so.

**This is the shape that already cost this project weeks.** `mobile-audit` learned to *prove* horizontal overflow on #641; `platform-audit` did not, and kept publishing a finding QA had already retracted until #686 caught it. Fixing one tool and leaving its twin is exactly how that happened, so both move together this time.

## Two design choices worth stating

**It watches the inputs, not the output.** A full walk is far too expensive to sample twice, but any transition necessarily moves one of those three values and a settled page moves none — so the cheap proxy is sound where the direct check is impractical.

**The theme assertion is separate and load-bearing.** A run that never applied the requested theme is perfectly stable *and* measuring the wrong thing; stability alone would pass it. Dev raised the mirror-image risk on #697 — a persisted counter settling on stale state — and confirmed it cannot happen here because each invocation navigates fresh.

**Surfacing `unsettled` matters as much as recording it.** A flag nobody prints is the same defect one level up, and this file has already shipped a summary that read as clean while measuring nothing (#682).

## How to test (QA)

```
MSYS_NO_PATHCONV=1 node qa/platform-audit.mjs --base https://liquidity-hq-qa.onrender.com \
  --routes / --viewports desktop --themes dark,light
```

1. Run twice. **Both runs report the same contrast count** — expect 6 on `/` desktop, which are the owner-ruled `--txt4` route strings at 1.88:1, not a defect (recorded on #559).
2. **Neither row carries `UNSETTLED`**, and no summary block names unsettled loads.
3. `/` at `--viewports mobile` reports 0 — the mobile layout does not render those route strings. Both numbers are correct.

## Risk level

**Low.** QA tooling only. Adds 1–2s per load normally, up to 45s in the worst case.

Same caveat as #697: **this does not make previous measurements wrong, it makes them unrepeatable** — most loads settle well inside the old fixed wait, which is why it took six artefacts to surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
