### PR TITLE
fix(scanner): the coin-heatmap tile's ramp crossed two palettes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -7477,6 +7477,28 @@ main.app-content[data-chrome="none"] {
    different ground and was not measured. */
 [data-design="terminal"] .liq-current-oi { color: var(--txt2); }
 
+/* #698: the coin-heatmap tile's text in terminal.
+   The tile's colour ramp was built for the CURRENT design - text lightens as
+   the tile saturates (#86efac, #fee2e2), so severity is carried by the tile
+   while the number stays readable, 8.6:1 to 9.6:1 across the ramp. In terminal
+   --green-soft and --red-soft alias flat to --green/--red, so that lightening
+   does not happen and the strongest tiles put a mid-tone signal colour on a
+   saturated tint of itself: 3.51 worst, 26 failures on /scanner (#698).
+
+   Terminal takes --txt and lets the tint carry direction, which is what
+   /correlation already shipped on #570 - 2368 failing cells fixed exactly that
+   way, now measuring 2450 with zero failures on production. It clears every
+   ground on this ramp by 7.8:1 or better and, unlike a stronger foreground,
+   cannot be reopened by a stronger tint - the tint strength here is
+   data-driven, so there is no value that is safe by construction.
+
+   Direction is not lost with the colour: the tile tint and the +/- sign both
+   still carry it, which is also what keeps this clear of WCAG 1.4.1.
+
+   The current design is untouched - --heat-fg is unset there, so each span
+   falls back to its own ramp colour. */
+[data-design="terminal"] .chm-tile { --heat-fg: var(--txt); }
+
 /* ── CLUSTER LADDER (region 5) ──────────────────────────────────────────
    Measured off Liquidation Map.dc.html:119-149. The canvas grid is
    100px 62px 1fr 72px 72px 78px with a 28px head and 1px hairlines.

--- a/components/CoinHeatmap.tsx
+++ b/components/CoinHeatmap.tsx
@@ -21,11 +21,11 @@ const CAT: Record<Cat, readonly CoinId[]> = {
 };
 
 function changeColor(chg: number | null): { bg: string; text: string } {
-  if (chg == null) return { bg: 'rgba(255,255,255,0.04)', text: 'var(--txt-dim)' };
-  if (chg >=  10) return { bg: 'rgba(52,211,153,0.30)',  text: 'var(--green-2)' };
-  if (chg >=   5) return { bg: 'rgba(52,211,153,0.22)',  text: 'var(--green-soft)' };
-  if (chg >=   2) return { bg: 'rgba(52,211,153,0.13)',  text: 'var(--green-soft)' };
-  if (chg >=   0) return { bg: 'rgba(52,211,153,0.07)',  text: 'var(--green)' };
+  if (chg == null) return { bg: 'color-mix(in srgb, var(--txt) 4%, transparent)', text: 'var(--txt-dim)' };
+  if (chg >=  10) return { bg: 'color-mix(in srgb, var(--green-2) 30%, transparent)',  text: 'var(--green-2)' };
+  if (chg >=   5) return { bg: 'color-mix(in srgb, var(--green-2) 22%, transparent)',  text: 'var(--green-soft)' };
+  if (chg >=   2) return { bg: 'color-mix(in srgb, var(--green-2) 13%, transparent)',  text: 'var(--green-soft)' };
+  if (chg >=   0) return { bg: 'color-mix(in srgb, var(--green-2) 7%, transparent)',  text: 'var(--green)' };
   /* The red ramp used to darken the text (#fca5a5 -> #f87171 -> #ef4444 ->
      #dc2626) at the same time as it made the tile background a more opaque red
      (0.07 -> 0.38). Both moving together collapses the contrast exactly where
@@ -37,10 +37,10 @@ function changeColor(chg: number | null): { bg: string; text: string } {
      The green side has the same shape but does not fail (its worst bucket is
      5.71:1) because green is inherently light; left as-is rather than churning
      a passing palette, but the same rule applies if that ramp is ever extended. */
-  if (chg >= -2)  return { bg: 'rgba(248,113,113,0.07)', text: 'var(--red-soft)' };
-  if (chg >= -5)  return { bg: 'rgba(248,113,113,0.15)', text: 'var(--red-soft)' };
-  if (chg >= -10) return { bg: 'rgba(248,113,113,0.25)', text: 'var(--red-soft)' };
-  return              { bg: 'rgba(248,113,113,0.38)',     text: '#fee2e2' };
+  if (chg >= -2)  return { bg: 'color-mix(in srgb, var(--red) 7%, transparent)', text: 'var(--red-soft)' };
+  if (chg >= -5)  return { bg: 'color-mix(in srgb, var(--red) 15%, transparent)', text: 'var(--red-soft)' };
+  if (chg >= -10) return { bg: 'color-mix(in srgb, var(--red) 25%, transparent)', text: 'var(--red-soft)' };
+  return              { bg: 'color-mix(in srgb, var(--red) 38%, transparent)',     text: '#fee2e2' };
 }
 
 function fmtPrice(p: number): string {
@@ -149,12 +149,12 @@ export default function CoinHeatmap() {
           <Tip text={t('COIN_HEATMAP_TOOLTIP')}>{t('COIN_HEATMAP_TITLE')}</Tip>
         </span>
         {positiveCount > 0 && (
-          <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, padding: '2px 7px', borderRadius: 20, color: 'var(--green-2)', background: 'rgba(52,211,153,0.1)', border: '0.5px solid rgba(52,211,153,0.25)' }}>
+          <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, padding: '2px 7px', borderRadius: 20, color: 'var(--green-2)', background: 'color-mix(in srgb, var(--green-2) 10%, transparent)', border: '0.5px solid color-mix(in srgb, var(--green-2) 25%, transparent)' }}>
             ↑ {positiveCount}
           </span>
         )}
         {negativeCount > 0 && (
-          <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, padding: '2px 7px', borderRadius: 20, color: 'var(--red)', background: 'rgba(248,113,113,0.1)', border: '0.5px solid rgba(248,113,113,0.25)' }}>
+          <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, padding: '2px 7px', borderRadius: 20, color: 'var(--red)', background: 'color-mix(in srgb, var(--red) 10%, transparent)', border: '0.5px solid color-mix(in srgb, var(--red) 25%, transparent)' }}>
             ↓ {negativeCount}
           </span>
         )}
@@ -203,17 +203,20 @@ export default function CoinHeatmap() {
           return (
             <div
               key={c}
+              className="chm-tile"
               style={{
                 background: bg,
                 borderRadius: 8,
                 padding: '10px 8px',
                 display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 3,
                 border: `0.5px solid ${withAlpha(text, '22')}`,
+                /* #698: terminal overrides --heat-fg to --txt; the current design
+                   leaves it unset so each span falls back to its ramp colour. */
                 transition: 'background .2s',
                 cursor: 'default',
               }}
             >
-              <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 800, color: text, letterSpacing: '.04em' }}>
+              <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 800, color: `var(--heat-fg, ${text})`, letterSpacing: '.04em' }}>
                 {c.toUpperCase()}
               </span>
               {/* Always rendered, even with no price yet. Conditionally
@@ -226,11 +229,11 @@ export default function CoinHeatmap() {
                   as little as 2.43:1 on the redder tiles. It is a live price,
                   not decoration. The caption size already sets it apart from
                   the percentage above it, so it takes the tile colour flat. */}
-              <span style={{ fontSize: 'var(--fs-caption)', color: text, fontVariantNumeric: 'tabular-nums' }}>
+              <span style={{ fontSize: 'var(--fs-caption)', color: `var(--heat-fg, ${text})`, fontVariantNumeric: 'tabular-nums' }}>
                 {coin?.price != null ? `$${fmtPrice(coin.price)}` : '-'}
               </span>
               <span style={{
-                fontSize: 'var(--fs-label)', fontWeight: 700, color: text,
+                fontSize: 'var(--fs-label)', fontWeight: 700, color: `var(--heat-fg, ${text})`,
                 fontVariantNumeric: 'tabular-nums', lineHeight: 1,
               }}>
                 {chg != null ? `${sign}${chg.toFixed(1)}%` : '-'}

--- a/components/CoinHeatmap.tsx
+++ b/components/CoinHeatmap.tsx
@@ -203,7 +203,15 @@ export default function CoinHeatmap() {
           return (
             <div
               key={c}
-              className="chm-tile"
+              /* Only tiles WITH a value take the terminal override. QA's review
+                 of #701: --heat-fg: var(--txt) applied to every tile would
+                 override the no-data branch's --txt-dim too, so an empty
+                 tile would read as prominently as one carrying a price.
+                 That is #692's loss pointed the other way - contrast up,
+                 meaning down - and --txt-dim was the signal that a tile has
+                 nothing to say. It was never in the failing set, so it keeps
+                 its own colour by simply not getting the class. */
+              className={chg == null ? undefined : "chm-tile"}
               style={{
                 background: bg,
                 borderRadius: 8,


### PR DESCRIPTION
## Summary

All 26 of `/scanner`'s dark failures are `CoinHeatmap`'s tiles. **Two causes, and the first is the one neither of us had seen.**

## The tints were the current design's palette

`rgba(52,211,153,…)` and `rgba(248,113,113,…)` — the **current design's** `--green-2` and `--red` — while the text resolves through terminal's tokens. **Terminal was painting the tile in one palette and its number in another.**

That is why your measured grounds (`rgb(30,78,62)`, `rgb(77,44,46)`) did not correspond to anything in terminal's own palette. Third instance of this shape today, after #693's impact badge and #682's audit palettes.

## Tokenising alone does not fix it

The ramp **lightens the text as the tile saturates** — `#86efac` then `#fee2e2` — so severity rides on the tile while the number stays readable, 8.6:1 to 9.6:1 in the current design.

**In terminal, `--green-soft` and `--red-soft` alias flat to `--green`/`--red`**, so that lightening never happens. The strongest tiles put a mid-tone signal colour on a saturated wash of itself. The mechanism the current design relies on is simply not there.

## So terminal takes your option 3

Measured after, terminal dark, **ground: the tile's own tint over `--bg1`**:

```
green 30%   8.74      red 38%   8.71
green 22%  10.37      red 25%  10.93
green 13%  12.36      red 15%  12.72
```

against the 3.51–4.23 that failed. It cannot be reopened by a stronger tint, which matters because the tint strength is data-driven.

**Direction survives the colour** — the tile tint and the `+`/`-` sign both still carry it, which is also what keeps this clear of WCAG 1.4.1.

## Current design byte-identical

`--heat-fg` is unset there, so each span falls back to its own ramp colour.

A fallback rather than a class per bucket because the text colour is data-driven — a stylesheet version needs one rule per ramp step. `var(--heat-fg, <ramp>)` lets terminal override all three spans with one declaration. Same shape as `--ec-muted` on #693.

## How to test (QA)

`/scanner?design=terminal` in **dark**: tile symbol, price and percentage are white on the coloured tile rather than a deeper shade of the tile's own colour. **Strongest movers are the ones to check** — they had the worst contrast. Light unchanged; no design flag byte-identical.

## Risk level

**Low–Medium.** Nine tint literals tokenised, one CSS hook. Gates: lint 0, `tsc` 0, `npm test` 0 (555), `build` 0.

**Not verified by me:** the rendered tiles. Arithmetic is against the real tokens; I have not seen one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
