### PR TITLE
fix(scanner): the squeeze cells' text takes -fg, the tint keeps the base

### DIFF
--- a/components/MultiTFSqueezeView.tsx
+++ b/components/MultiTFSqueezeView.tsx
@@ -79,7 +79,11 @@ function cellColors(sig: TFSignal): { bg: string; text: string; border: string }
      #693 already answered on other screens.
 
      Measured, ground = the cell's own tint over --bg1, at the three alphas
-     this ramp uses:
+     this ramp uses. THE ALPHAS ARE HEX BYTES, NOT PERCENTAGES - 0x28 is 15.7%,
+     0x16 is 8.6%, 0x0c is 4.7%. Read as percent they give ratios about a factor
+     of two out, turning a passing colour into a failing one; QA hit exactly that
+     reviewing this and was one step from reporting dark green as broken. The
+     unit belongs beside the number, like the ground beside a ratio:
 
                      dark                      light
          a   base -> -fg            base -> -fg

--- a/components/MultiTFSqueezeView.tsx
+++ b/components/MultiTFSqueezeView.tsx
@@ -74,10 +74,31 @@ function cellColors(sig: TFSignal): { bg: string; text: string; border: string }
   if (sig.dir === 'NEUTRAL') return { bg: 'transparent', text: 'var(--txt-dim)', border: 'transparent' };
   const isFlush = sig.dir === 'FLUSH';
   const base    = isFlush ? 'var(--red)' : 'var(--green-2)';
+  /* #698: the TEXT takes the -fg variant, the tint keeps the base. Both used to
+     be `base`, which is signal colour on a wash of itself - the shape #688 and
+     #693 already answered on other screens.
+
+     Measured, ground = the cell's own tint over --bg1, at the three alphas
+     this ramp uses:
+
+                     dark                      light
+         a   base -> -fg            base -> -fg
+        0c   5.01    7.69           6.15    8.21     red
+        16   4.80    7.36           5.76    7.68
+        28   4.39    6.73           5.09    6.79     <- dark red failed here
+        0c   6.77    6.77           4.81    6.49     green
+        16   6.37    6.37           4.55    6.15
+        28   5.63    5.63           4.12    5.57     <- light green fails here
+
+     Dark green already passes and --green-fg aliases --green-2 there, so it is
+     unchanged. LIGHT GREEN AT THE STRONGEST TINT IS 4.12 AND FAILS - that is
+     not in QA's reopened count, which is dark only, so this fixes a failure
+     nobody has measured yet rather than waiting for it to be reported. */
+  const fg      = isFlush ? 'var(--red-fg)' : 'var(--green-fg)';
   const alpha   = sig.strength >= 70 ? '28' : sig.strength >= 40 ? '16' : '0c';
   return {
     bg:     withAlpha(base, alpha),
-    text:   base,
+    text:   fg,
     border: withAlpha(base, '33'),
   };
 }


### PR DESCRIPTION
## Summary

#698's remaining 12 — the RSI arrow and value cells, not heatmap tiles, which is why #701 correctly did not touch them.

Both text and tint were `base`, so it is signal colour on a wash of itself: the shape #688 and #693 already answered elsewhere.

## Measured — ground: the cell's own tint over `--bg1`

```
             dark                  light
 a    base -> -fg          base -> -fg
0c    5.01    7.69         6.15    8.21    red
16    4.80    7.36         5.76    7.68
28    4.39    6.73         5.09    6.79    <- dark red failed here
0c    6.77    6.77         4.81    6.49    green
16    6.37    6.37         4.55    6.15
28    5.63    5.63         4.12    5.57    <- light green fails here
```

## Light green at the strongest tint is 4.12

**That is not in your reopened count**, which is dark and red only. So this fixes a failure nobody has measured yet rather than waiting for it to be reported.

Dark green already passes and `--green-fg` aliases `--green-2` there, so dark green is unchanged.

## The tint keeps the base colour

Deliberately — it *is* the signal, and weakening it to match the foreground would trade a contrast fix for a legibility loss on the thing the cell exists to show.

## How to test (QA)

`/scanner?design=terminal`, **both themes**. The multi-timeframe squeeze grid's arrows and RSI numbers on the **most saturated** cells. Dark red and light green are the two that were failing.

## Risk level

**Low.** One helper, text only. Gates: lint 0, `tsc` 0, `npm test` 0 (555), `build` 0. Not verified rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
