### PR TITLE
fix(arena): 16px coin marks went square when .coin-icon left the exemption list

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -7685,7 +7685,14 @@ main.app-content[data-chrome="none"] {
    on inherently circular glyphs at 24px or under, and a selector cannot
    tell a 16px icon from a 26px one. The component can. */
 [data-design="terminal"] .tj-lev-slider::-webkit-slider-thumb,
-[data-design="terminal"] .tj-lev-slider::-moz-range-thumb {
+[data-design="terminal"] .tj-lev-slider::-moz-range-thumb,
+/* #703: back on the list, but as .coin-icon-round - a class CoinIcon only emits
+   at 24px or under, which is the ruling's own threshold. The note above is right
+   that a selector cannot tell a 16px icon from a 32px one; the component can, so
+   it decides and the class carries that decision somewhere that outranks the
+   blanket `* { border-radius: 0 !important }` shells. The inline radius alone
+   never could. */
+[data-design="terminal"] .coin-icon-round {
   border-radius: 50% !important;
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -7691,8 +7691,20 @@ main.app-content[data-chrome="none"] {
    that a selector cannot tell a 16px icon from a 32px one; the component can, so
    it decides and the class carries that decision somewhere that outranks the
    blanket `* { border-radius: 0 !important }` shells. The inline radius alone
-   never could. */
-[data-design="terminal"] .coin-icon-round {
+   never could.
+
+   BOTH CLASSES IN THE SELECTOR, deliberately. `.coin-icon-round` alone is
+   (0,2,0) with the attribute - exactly equal to `[data-design="terminal"]
+   .at-root *` - so it would win only by sitting later in the file. That holds
+   against the thirteen page-root blankets at :6219-:7340, and fails against the
+   twenty `!important` radius rules after it at :7742 (`.app-bar *`,
+   `.nav-menu *`, `.mobile-tab-bar *` and friends): a coin icon rendered inside
+   any of those would go square again.
+
+   Adding `.coin-icon` makes it (0,3,0), which beats every `.<x> *` blanket on
+   SPECIFICITY rather than position - so it survives a future rule being appended
+   below, which source order does not. QA caught this on the #709 review. */
+[data-design="terminal"] .coin-icon.coin-icon-round {
   border-radius: 50% !important;
 }
 

--- a/components/CoinIcon.tsx
+++ b/components/CoinIcon.tsx
@@ -16,7 +16,24 @@ import { withAlpha } from '@/lib/color';
  * only that call site is being corrected here. The frames keep their 16px
  * rail marks round, so this is not "squares everywhere". */
 export default function CoinIcon({ coin, size = 22, color, bg, square = false }: { coin: CoinId; size?: number; color?: string; bg?: string; square?: boolean }) {
+  /* #703: a CLASS, not just the inline radius. The inline value cannot win -
+     terminal's shells carry blanket `.<page>-root * { border-radius: 0
+     !important }` rules, and no inline declaration beats !important. Removing
+     .coin-icon from the 50%-exemption list in #630/#631 was done on the
+     reasoning that "CoinIcon sets border-radius inline on every render path, so
+     its default already keeps the rail's 16px marks round without a rule". That
+     reasoning is wrong in exactly the way #633 was: it holds against ordinary
+     rules and not against !important, so the 16px marks went square everywhere a
+     blanket rule applies. Nobody saw it because the icons are small and the
+     inline declaration still reads `50%` in source.
+
+     The size test lives here because the ruling is about size and a selector
+     cannot measure one - which is what that same comment correctly said. The
+     class carries the component's decision to a place that can outrank the
+     blanket. */
   const radius = square ? 0 : '50%';
+  const round = !square && size <= 24;   // radius-ruling.md: 50% only at 24px or under
+  const cls = round ? 'coin-icon coin-icon-round' : 'coin-icon';
   const [failed, setFailed] = useState(false);
   const src = `/coin-icons/${coin}.png`;
   // Every supported coin has a bundled icon file, so this should never trigger. If a file is
@@ -24,7 +41,7 @@ export default function CoinIcon({ coin, size = 22, color, bg, square = false }:
   // the icon it replaces - never a letter/text abbreviation.
   if (failed) {
     return (
-      <span className="coin-icon" style={{
+      <span className={cls} style={{
         width: size, height: size, borderRadius: radius, flexShrink: 0,
         background: bg ?? 'rgba(255,255,255,0.07)',
         border: `0.5px solid ${color ? withAlpha(color, '44') : 'rgba(255,255,255,0.1)'}`,
@@ -40,7 +57,7 @@ export default function CoinIcon({ coin, size = 22, color, bg, square = false }:
     // arguing about a cost this particular image does not have.
     // eslint-disable-next-line @next/next/no-img-element
     <img
-      className="coin-icon"
+      className={cls}
       src={src}
       alt={coin}
       width={size}


### PR DESCRIPTION
## Summary

#703's dead `border-radius: 50%` is the visible half. The real defect underneath is that **16px coin marks went square** when `.coin-icon` left the exemption list.

## The reasoning in #630/#631 was wrong the same way #633 was

> *"CoinIcon sets border-radius inline on every render path, so its default already keeps the rail's 16px marks round without a rule."*

That holds against ordinary rules and **not against `!important`**. Terminal's shells carry blanket `.<page>-root * { border-radius: 0 !important }` at `globals.css:6219`, `:6643` and nine more — so every 16px mark under one went square, against `radius-ruling.md`, and nobody saw it because the icons are small and the inline declaration still reads `50%` in source.

## The fix keeps the size test where it belongs

The component emits `coin-icon-round` at **24px or under** — the ruling's own threshold — and that class is back on the exemption list.

That comment was right that a selector cannot tell a 16px icon from a 32px one. What it got wrong was the mechanism: the component's decision has to reach the cascade somewhere that outranks a blanket `!important`, and an inline style is not that place.

## #703's dead declaration is not dead code

The 32px icon's inline `border-radius: 50%` **applies in the current design**, which has no blanket rule. Terminal overrides it deliberately because 32px is over the threshold.

`inertInline` sees it as inert because it only runs in terminal. **An inline value overridden by a design-scoped `!important` is design-specific rather than inert**, and those are worth distinguishing — otherwise every deliberate terminal override reads as dead code.

## How to test (QA)

`/arena?design=terminal` — the 16px mark beside the AI read is **round again**; the 32px header icon stays square, which the ruling wants. `/dashboard`'s rail marks are 16px and unaffected. No design flag: every icon round at every size, unchanged.

## Risk level

**Low.** One class, one selector. Gates: lint 0, `tsc` 0, `npm test` 0 (555), `build` 0. Not verified rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
