### PR TITLE
test(qa): name the rule that won, and flag when it is design-scoped

### DIFF
--- a/qa/fixtures/inert-inline-control.html
+++ b/qa/fixtures/inert-inline-control.html
@@ -15,7 +15,13 @@
   Expect inertInline to contain ONLY .control-important.
 
   All three cases below are exercised and each must land differently:
-    .control-important  reported     a rule outranks inline unconditionally
+    .control-important  reported     a rule outranks inline unconditionally,
+                                     and designScoped is FALSE
+    .control-scoped     reported     same, but the winning rule is scoped to a
+                                     design - designScoped is TRUE. That is the
+                                     difference between a dead declaration and a
+                                     deliberate override, and #703 was filed as
+                                     the former when it was the latter.
     .control-redundant  NOT reported inline matches the rule, so it changes
                                      nothing - but it would win if it differed
     .control-effective  NOT reported inline correctly beats an ordinary rule
@@ -39,6 +45,11 @@
   /* 3. a normal rule the inline value correctly outranks - MUST NOT be flagged,
         or the check reports ordinary cascade use as a defect. */
   .control-effective { color: #ff0000; }
+
+  /* 4. inert for a DESIGN-SCOPED reason. Reported like case 1, but the label
+        must say designScoped so a reader can tell a deliberate override from a
+        dead declaration without opening the stylesheet. */
+  [data-design="terminal"] .control-scoped { letter-spacing: 9px !important; }
 </style>
 
 <p class="control-important" style="font-size: 11px">
@@ -52,3 +63,9 @@
 <p class="control-effective" style="color: #3fb950">
   inline green beats the rule's red - inline IS doing the work
 </p>
+
+<div data-design="terminal">
+  <p class="control-scoped" style="letter-spacing: 2px">
+    inline 2px, design-scoped rule 9px !important - inert, but deliberately
+  </p>
+</div>

--- a/qa/mobile-audit.mjs
+++ b/qa/mobile-audit.mjs
@@ -294,6 +294,47 @@ const result = await page.evaluate(TOKENS => {
             inline: inline.slice(0, 40),
             computed: before.slice(0, 40),
             el: (el.className || el.tagName).toString().slice(0, 40),
+            /* WHICH rule won, and whether it is design-scoped.
+
+               This check runs in ONE design, so a declaration that terminal
+               deliberately overrides looks identical to one that is simply
+               dead. #703 was filed as dead code on exactly that confusion:
+               /arena's 32px coin icon carries `border-radius: 50%` inline, which
+               APPLIES in the current design and which terminal overrides on
+               purpose because 32px is over the ruling's threshold.
+
+               Without this label every deliberate terminal override reads as a
+               defect, and there are hundreds - globals.css carries 45
+               `border-radius: 0 !important` declarations alone. A check that
+               reports intent as error is worse than no check.
+
+               So name the winning selectors and flag the ones scoped to a
+               design. It does not decide - a design-scoped override can still
+               be wrong, as #709 showed when 16px marks were being squared
+               against the ruling - but the reader can now tell the two apart
+               without opening the stylesheet. */
+            ...(() => {
+              const winners = [];
+              for (const sheet of document.styleSheets) {
+                let rules;
+                try { rules = sheet.cssRules; } catch { continue; }
+                const walk = (list) => {
+                  for (const r of list) {
+                    if (r.selectorText && r.style && r.style.getPropertyPriority(p) === 'important') {
+                      let hit = false;
+                      try { hit = el.matches(r.selectorText); } catch { hit = false; }
+                      if (hit) winners.push(r.selectorText);
+                    }
+                    if (r.cssRules && r.cssRules.length) walk(r.cssRules);
+                  }
+                };
+                walk(rules);
+              }
+              return {
+                wonBy: winners.slice(-2).map((w) => w.slice(0, 60)),
+                designScoped: winners.length > 0 && winners.every((w) => w.includes('[data-design=')),
+              };
+            })(),
           });
         }
       }


### PR DESCRIPTION
## Summary

Dev found the flaw on #709: **`inertInline` runs in one design, so a declaration terminal deliberately overrides is indistinguishable from one that is dead.** I filed #703 on exactly that confusion, within an hour of writing the check.

## What changed

Each row now carries:

```
wonBy          the !important selectors that actually matched this element
designScoped   true when every winner is scoped to [data-design=...]
```

Plus a fourth fixture case so the flag is validated rather than assumed.

## Why this is serious rather than untidy

`/arena`'s 32px coin icon carries `border-radius: 50%` inline. That **applies in the current design**, which has no blanket rule, and terminal overrides it on purpose because 32px is over `radius-ruling.md`'s threshold. The check reported it as inert; I reported it as dead code.

**`globals.css` carries 45 `border-radius: 0 !important` declarations.** Without this label, every element under one reads as a defect.

**A check that reports intent as error is worse than no check** — the mistake #666's first version nearly made by flagging `button, input`, and the one #703 actually made.

## The flag does not decide, and #709 is why

A design-scoped override **can** be wrong. #709 is one: blanket `.<root> * { border-radius: 0 !important }` rules were squaring 16px coin marks against a ruling that exempts them. Design-scoped, deliberate-looking, and a real defect.

So this labels rather than filters. It lets a reader tell intent from accident **without reading 7700 lines of CSS**, which is the actual cost it removes.

## How to test (QA)

```
node qa/mobile-audit.mjs "file:///<abs path>/qa/fixtures/inert-inline-control.html"
```

`inertInline` must contain exactly two rows:

```
control-important   designScoped false   wonBy  .control-important
control-scoped      designScoped true    wonBy  [data-design="terminal"] .control-scoped
```

- **if both read the same**, the flag is not discriminating
- **if either is missing**, the check has regressed
- `control-redundant` and `control-effective` must still be absent

## Risk level

**Low.** QA tooling only, and additive — two fields on rows the check already produced.

The stylesheet walk reuses `deadRules`' pattern **including its guard**: collect before recursing, and recurse only into a non-empty list. A `CSSStyleRule` has a truthy-but-empty `cssRules` in modern Chrome, and the naive shape silently collects nothing — that bug returned `[]` against a page built to contain one known dead rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
