### PR TITLE
fix(theme): the light root override could never match, on any route

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2603,7 +2603,23 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   --glow-amber:  0 0 16px rgba(180,83,9,0.12);
 }
 
-[data-theme="light"] html { background: #E8EAED; }
+/* #706: `html`, not ` html`. This read `[data-theme="light"] html`, which asks
+   for an <html> that is a DESCENDANT of an element carrying data-theme - and
+   data-theme is set on <html> itself (app/layout.tsx:190 writes it to
+   document.documentElement). A document has one <html> and it is the root, so
+   the selector could never match anything, on any route, in any theme.
+
+   The light root has therefore always rendered :255's `html { background:
+   #06070a }` - the dark pin. It hid because <body> paints over <html> almost
+   everywhere, and the body rules just below are correctly scoped and do match.
+   It shows wherever body does not paint: /learn's headings measured 2.76:1,
+   light --accent on a near-black ground.
+
+   Split the same way as the body rules directly below, and for the same reason
+   given in their comment: --bg0 is not declared in the current design's own
+   light block, so terminal takes it and the current design keeps its literal. */
+html[data-theme="light"]:not([data-design="terminal"]) { background: #E8EAED; }
+html[data-design="terminal"][data-theme="light"] { background: var(--bg0); }
 /* #557 investigation (QA, terminal-light audit): unscoped, so terminal+light
    pages rendered the current design's #E8EAED canvas instead of terminal's
    own --bg0 (#f7f6f3) - close enough in hue that it went unnoticed visually,


### PR DESCRIPTION
## Summary

`[data-theme="light"] html` asks for an `<html>` that is a **descendant** of an element carrying `data-theme` — and `data-theme` is written to `document.documentElement` (`app/layout.tsx:190`), so it is on `<html>` itself. A document has one `<html>` and it is the root.

**The selector matched nothing, on any route, in any theme, since it was written.** Your browser count confirms it: `0` for the written form, `1` for the intended one.

## Your `#E8EAED` question — answered by the split

I did not pick a third value. The html rules now mirror the body rules directly below them:

```
current design light   html #E8EAED      body #E8EAED
terminal light         html var(--bg0)   body var(--bg0)
```

So html matches body in **both** designs, which is what it should always have done. Switching the single rule to `var(--bg0)` would have been wrong for the reason those body rules' own comment already gives: `--bg0` is not declared in the current design's light block, so it falls through to root's dark value and blackens that design.

## Why it hid

`<body>` paints over `<html>` almost everywhere, and the body rules immediately below **are** correctly scoped and do match — they say `… body`, and body genuinely is a descendant. Read together, the html line looks like the same shape and is not.

Your point that the other ten routes are **unexposed rather than safe** is the important one: any layout change would have surfaced it with no commit to blame.

## A class no detector we have would catch

This is #629/#633/#660 and the coin-icon radius again — a declaration that is present, correct-looking and unreachable. But the mechanism is different: **a selector that cannot match**, rather than one that is outranked. `deadRules` and `inertInline` both inspect rules that *do* apply, so neither would ever have seen this.

`:255` is untouched — it clips the nav drawer, and the phantom overflow without it has been measured twice.

## How to test (QA)

1. `/learn` in **light**, both designs — background light, headings readable.
2. Any light route where content does not fill the viewport height; that is where the root shows.
3. **Dark unchanged in both designs**, and the current design's light body still `#E8EAED`.

## Risk level

**Medium.** One selector, but it affects every route in light theme — and it is the first time that rule has ever applied, so this is closer to enabling untested CSS than changing tested CSS.

Gates: lint 0, `tsc` 0, `npm test` 0 (555), `build` 0. **Not verified rendered** — worth a look at a light route with short content specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
