### PR TITLE
fix(upgrade): plan checkmarks take var(--green), not a Tailwind literal

### DIFF
--- a/app/upgrade/page.tsx
+++ b/app/upgrade/page.tsx
@@ -149,7 +149,25 @@ export default function UpgradePage() {
             <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: 9 }}>
               {FREE_FEATURES.map(([k, vars]) => (
                 <li key={k} style={{ fontSize: 'var(--fs-label)', color: 'var(--txt2)', display: 'flex', alignItems: 'flex-start', gap: 8 }}>
-                  <span style={{ color: '#22c55e', fontWeight: 700, flexShrink: 0, marginTop: 1 }}>✓</span> {t(k, vars)}
+                  {/* #705: var(--green), not #22c55e. That literal is Tailwind's green-500 and
+    is in NEITHER palette - not the current design's --green (#4ade80 dark,
+    #046B4E light) nor terminal's (#3fb950 / #14702c) - so it tracked no theme
+    and measured 1.88:1 on terminal light's --bg1. Dark passed at 7.4, which is
+    why it survived: the failure only existed in the theme nobody defaulted to.
+    --green is declared in all four scopes, so this is one token everywhere.
+    Measured, ground stated:
+
+        terminal light  --green #14702c on --bg1 #ebe9e6   5.12   was 1.88
+        terminal dark   --green #3fb950 on --bg1 #141517   7.19   was 8.29
+        current light   --green #046B4E on #E8EAED         5.41   was 1.89
+        current dark    --green #4ade80 on #06070a        11.56   was 8.84
+
+    THE CURRENT DESIGN'S LIGHT THEME WAS ALSO FAILING, at 1.89. #705 measured
+    terminal only, so that half was never counted - the literal tracked no
+    theme, and both light themes land it on a light ground. Dark passed in both
+    designs, which is why seven checkmarks sat at under 2:1 without anyone
+    noticing. */}
+                  <span style={{ color: 'var(--green)', fontWeight: 700, flexShrink: 0, marginTop: 1 }}>✓</span> {t(k, vars)}
                 </li>
               ))}
             </ul>
@@ -203,7 +221,7 @@ export default function UpgradePage() {
               <div style={{ display: 'flex', gap: 20, flexWrap: 'wrap', justifyContent: 'center' }}>
                 {(['UPGRADE_TRUST_CANCEL_ANYTIME', 'UPGRADE_TRUST_BILLED_ANNUALLY', 'UPGRADE_TRUST_INSTANT_ACCESS', 'UPGRADE_TRUST_SECURE_CHECKOUT'] as const).map(label => (
                   <span key={label} style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', display: 'flex', alignItems: 'center', gap: 5 }}>
-                    <span style={{ color: '#22c55e', fontSize: '0.6875rem' }}>✓</span> {t(label)}
+                    <span style={{ color: 'var(--green)', fontSize: '0.6875rem' }}>✓</span> {t(label)}
                   </span>
                 ))}
               </div>
@@ -223,7 +241,7 @@ export default function UpgradePage() {
               <div style={{ display: 'flex', gap: 20, flexWrap: 'wrap', justifyContent: 'center' }}>
                 {(['UPGRADE_TRUST_CANCEL_ANYTIME', 'UPGRADE_TRUST_INSTANT_ACCESS', 'UPGRADE_TRUST_SECURE_CHECKOUT'] as const).map(label => (
                   <span key={label} style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', display: 'flex', alignItems: 'center', gap: 5 }}>
-                    <span style={{ color: '#22c55e', fontSize: '0.6875rem' }}>✓</span> {t(label)}
+                    <span style={{ color: 'var(--green)', fontSize: '0.6875rem' }}>✓</span> {t(label)}
                   </span>
                 ))}
               </div>


### PR DESCRIPTION
## Summary

`/upgrade`'s three `#22c55e` checkmark literals take `var(--green)`.

`#22c55e` is Tailwind's green-500 and is in **neither** palette — not the current design's `--green` (`#4ade80` dark, `#046B4E` light) nor terminal's (`#3fb950` / `#14702c`). It tracked no theme.

## The current design's light theme was also failing

Measured, ground stated:

```
terminal light  --green #14702c on --bg1 #ebe9e6   5.12   was 1.88
terminal dark   --green #3fb950 on --bg1 #141517   7.19   was 8.29
current light   --green #046B4E on #E8EAED         5.41   was 1.89
current dark    --green #4ade80 on #06070a        11.56   was 8.84
```

**#705 measured terminal only, so `1.89` in the current design was never counted.** The literal tracked no theme, and *both* light themes land it on a light ground. Dark passed in both designs — which is why seven checkmarks sat under 2:1 without anyone noticing.

So this is the seven failures on the issue, plus seven more that were not on it.

## Not `--green-fg`

These sit on a plain card, not a tint of themselves, so the composited-ground variant is not what this needs. `--green` is declared in all four scopes and clears everywhere.

`KLineProChart`'s `#22c55e` copies are **untouched** — chart-library config, already allow-listed in `eslint.config.mjs` because KLineCharts cannot read CSS variables.

## How to test (QA)

`/upgrade` in **light**, both designs — the `✓` beside each Pro feature is a readable green rather than a pale wash. Three places: the main plan list and the two comparison blocks. Dark should look near-identical in both designs.

## Risk level

**Low.** Three literals to one existing token, one route. Gates: lint 0, `tsc` 0, `npm test` 0 (555), `build` 0. Not verified rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
