### PR TITLE
fix(nav): the desktop drawer opener grows to a 24px tap target

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5965,12 +5965,29 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
    only the element type moved. background/padding/font are resets: a button
    does not inherit them the way the span did. */
 [data-design="terminal"] .tnav-avatar {
+  /* #714: 22x22 painted, 24x24 tappable. QA measured 22x22 against SC 2.5.8's
+     24px minimum - 2px short on each axis, correctly labelled so this is size
+     only. The frame draws this box at 22px deliberately (it matches
+     .tnav-session-dot's row and the kbd chip's proportions), so growing the
+     visible box would be a design change this fix has no standing to make.
+
+     Same padded-hit-area shape as #652's liq-heat-swatch, and box-sizing:
+     content-box is why it will not repeat that fix's first miss: this project
+     sets `* { box-sizing: border-box }` globally (globals.css:213), so height
+     ALREADY includes padding under the default box model - the swatch's first
+     version added padding under border-box and the hit area never grew. Set
+     explicitly here rather than relying on it being noticed again. */
+  box-sizing: content-box;
   width: 22px; height: 22px;
+  padding: 1px;
+  margin: -1px;
+  background: none;
+  background-clip: content-box;
   border: 1px solid var(--border-input);
   display: flex; align-items: center; justify-content: center;
   color: var(--txt2); font-size: 10px; font-weight: 700;
   flex-shrink: 0;
-  background: none; padding: 0; cursor: pointer;
+  cursor: pointer;
   font-family: var(--font-mono), monospace;
 }
 [data-design="terminal"] .tnav-avatar:hover { color: var(--txt); }


### PR DESCRIPTION
## Summary

`.tnav-avatar` — the desktop drawer opener — gets a padded hit area. Painted box unchanged, tappable area grows to 24px.

QA measured **22×22 against SC 2.5.8's 24px minimum**, correctly labelled so this is size only, not a labelling gap.

## Why the painted box does not grow

The frame draws it at 22px deliberately — it matches `.tnav-session-dot`'s row and the kbd chip's proportions. Growing the visible box would be a design change this has no standing to make, so only the tappable area grows: `padding: 1px` + `margin: -1px`, `box-sizing: content-box`, `background-clip: content-box`.

## The `box-sizing` line is there on purpose, not decoration

Same padded-hit-area shape as #652's `liq-heat-swatch`. That fix's **first version** added padding without setting `box-sizing`, and this project sets `* { box-sizing: border-box }` globally — so the height *already included* the padding and the hit area never grew, silently, for however long it sat unreviewed.

Setting it explicitly here is not relying on the same thing being noticed a second time.

## Verified in Chromium, not by arithmetic

```
hit area 26 x 26
background rgba(0, 0, 0, 0)
```

**26×26**, transparent — no button chrome leaking through the padding, which a naive version of this fix could produce if `background: none` were dropped in the edit (it briefly was, caught before commit).

## How to test (QA)

`/dashboard?design=terminal` desktop — the avatar box top-right is **visually unchanged** (22×22, same border, same initials), but its click area extends slightly past the border. Mobile unaffected — `.tnav-mmore` is a different element and already clears 24px.

## Risk level

**Low.** One rule, six new declarations, no markup change. Gates: lint 0, `tsc` 0, `npm test` 0 (555), `build` 0.

**Verified in a standalone harness**, not the live page — I have not clicked the real button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
