### PR TITLE
fix(arena): settle-poll the chart container instead of a single-shot resize

### DIFF
--- a/components/KLineProChart.tsx
+++ b/components/KLineProChart.tsx
@@ -1488,12 +1488,52 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
       setChartSymbolPeriod(chart, coin, tf);
 
       if (!disposed) {
-        setTimeout(() => {
+        /* #712: settle-poll the container instead of a single fixed-delay
+           resize. The one-shot `setTimeout(resize, 100)` this replaces
+           assumed the surrounding layout - the rail, the macro cards, #656's
+           own oversized panels next to this one - finishes reflowing within
+           100ms of chart creation. On a real page with real network-fetched
+           data it does not always: QA measured a live container 800px tall
+           holding a canvas drawn at 614px, on `staging`, not a synthetic
+           timing.
+
+           A `ResizeObserver` already watches this container further down and
+           calls resize() on every change it sees - that is correct and
+           stays. This poll is the backstop for the case the observer cannot
+           cover: the FIRST chart creation is a one-time mount effect
+           (`[]` below), so if the container's height is still climbing
+           when `kc.init()` first measures it, klinecharts' resize() needs to
+           be told again once things stop moving, not just when they change -
+           and "stopped moving" is a state the observer alone does not signal.
+
+           Same shape as #697's contrast settle-gate earlier tonight: poll a
+           cheap proxy (height, not a full relayout) until two consecutive
+           reads agree, rather than guess a duration long enough for every
+           page and network condition. Bounded at 3s so a container that
+           genuinely never stops resizing (unlikely, but not provable from
+           here) cannot poll forever. */
+        let lastH = -1;
+        let stableReads = 0;
+        const settleStart = Date.now();
+        const pollSettle = () => {
+          if (disposed || !containerRef.current) return;
+          const h = containerRef.current.getBoundingClientRect().height;
           chartRef.current?.resize();
-          if (chartRef.current && containerRef.current) {
-            applyProportionalPaneHeights(chartRef.current, containerRef.current.getBoundingClientRect().height);
+          if (chartRef.current) applyProportionalPaneHeights(chartRef.current, h);
+          if (h === lastH) {
+            stableReads++;
+            // Two consecutive matching reads, 150ms apart: not a coincidence
+            // of the container being unchanged for one frame - genuinely
+            // settled, so stop spending timers on it.
+            if (stableReads >= 2) return;
+          } else {
+            stableReads = 0;
+            lastH = h;
           }
-        }, 100);
+          if (Date.now() - settleStart > 3000) return; // bounded, see comment above
+          setTimeout(pollSettle, 150);
+        };
+        setTimeout(pollSettle, 100); // first read at the same delay the old single-shot used
         setChartReady(true);
       }
     })();


### PR DESCRIPTION
## Summary

QA measured `<canvas>` at 812×614 inside an 867×800 `.klc-canvas` container on `staging` — 93% width, 77% height, 186px of dead space below the arena chart.

The chart mount effect settle-polls the container's height until it stops changing, instead of a single fixed 100ms timeout.

## Why a poll, not a guessed duration

Chart creation is a mount-only effect (`[]`). The existing `setTimeout(resize, 100)` assumed 100ms was always enough for the surrounding layout — the rail, the macro cards, any async panel — to finish settling before the chart's first real measurement. QA's number is live-page evidence that it isn't always.

The `ResizeObserver` further down the same effect is unchanged and still correct — it reacts to actual layout changes after mount. This poll only covers the gap it can't: the *first* measurement, if the container is still growing when `kc.init()` reads it.

## Same shape as #697, applied to layout instead of contrast

Poll a cheap proxy — height, not a full relayout — until two consecutive reads agree, rather than guess a duration long enough for every page and network condition. Bounded at 3 seconds so a container that genuinely never stabilizes can't poll forever.

## Not a fix for a confirmed single cause

QA named three candidates and explicitly did not distinguish them. I could not run the live arena page with real market data to test which one applies, so this doesn't pick one — it addresses all three the way QA's own suggestion does: *"a ResizeObserver … or the library's own resize() on container change, would fix all three."* It doesn't matter *why* the container was still settling, only that resize keeps being called until it stops.

## How to test (QA)

`/arena?design=terminal` desktop 1920 — the chart canvas should fill `.klc-canvas` within a pixel or two on both axes, no dead space right or below. Worth checking mobile 390 too, since QA hadn't measured that shape yet.

## Risk level

**Medium.** Touches the chart's mount effect on the app's most complex visualization, though the change is additive (a new poll layered on existing calls, nothing removed).

Gates: lint 0, `tsc` 0, `npm test` 0 (555), `build` 0.

**Not verified rendered.** No local environment with live market data to reproduce QA's staging measurement against — this is reasoned from the code and the existing settle-gate precedent, not confirmed to close the gap QA measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
