### PR TITLE
docs(qa): record the redesign reversal and the landing-only ship decision

### DIFF
--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -269,7 +269,31 @@ android/      Capacitor Android shell
   body explaining the real cause and why the fix is shaped that way. Look at recent commits
   before writing one. Trailer: `Co-Authored-By: Claude <model> <noreply@anthropic.com>`.
 
-### Branch & deploy state as of 2026-09-02
+### Branch & deploy state as of 2026-09-03
+
+| Branch | Commit | Note |
+|---|---|---|
+| `origin/dev` | `06c647e` | PR #720 merged — the canvas-mirror revert (#718) |
+| `origin/qa` | `06c647e` | promoted and **deployed** — `/api/version` confirmed `06c647e` |
+| `origin/staging` | `06c647e` | promoted and **deployed** — `/api/version` confirmed `06c647e` |
+| `origin/main` | `1ee554e` | production — **64 commits behind `staging`**, no release PR open. Shipping is the owner's call and they have not given it. |
+
+**READ THIS BEFORE ANY DESIGN WORK — the redesign direction reversed on 2026-09-03.**
+
+The owner stopped the canvas-mirror initiative. Their words: *"we are repackaging the platform without users feedback... we are wasting time, money, and resources, and also tokens."* Two decisions came out of it, and both are now the standing rule:
+
+1. **Terminal styling goes over the existing production layout.** Same button positions, same text positions, same structure. Do **not** restructure a screen to match a `design-handoff-dir/design_files/*.dc.html` canvas. The `#413` batch — closed by `895f116` — is the reference state for what "right" looks like; `/scanner`, `/hours`, `/funding` and `/journal` are still in it.
+2. **Terminal ships on the landing page only** (#719, not yet built). `/` renders terminal by default; every app screen stays on the current design. Until this ships, `lib/designMode.ts` defaults everyone to `current` and **no user has ever seen any of the terminal work.**
+
+The sorting rule that follows from #2, and it governs triage: **after #719, a terminal-mode defect on any route except `/` is invisible to users and does not earn dev time.** A defect on the current design, or on landing, is real. #707, #698 and #663 were parked under exactly this rule with their measurements intact; #656 and #652 were closed as superseded; #620, #622 and #712 are parked.
+
+**The one exception is landing.** The owner likes the canvas-mirrored landing (`ad6b08c`, #592) and it was deliberately excluded from the revert. Never revert it, and treat "landing renders identically" as a hard gate on any work touching `app/globals.css`, `lib/labelKeys.ts`, `lib/labelDefaults.en.json` or `components/AppShell.tsx` — all four are shared between landing and the reverted screens, and `AppShell.tsx` is the one that bit us (it rendered `PriceTickerStrip` on `/` gated on design mode rather than pathname).
+
+**Known and deliberately not filed**, so nobody re-derives them: `/dashboard` shows 10 terminal radius violations, all `MarketRead` (`.mr`, `.mr-factor`, `.mr-track`, unscoped in `app/globals.css` around lines 776-812, outside `.dashboard-term-wrap` so the blanket radius rule misses them). That is `#413`-era, restored correctly by the revert, and invisible after #719. Landing also fails 3 of 21 `specs/landing.md` criteria (C10 hero-glow, C11 nav 44 vs 56, C18 mobile nav 38 vs 52) — pre-existing, and the owner has stopped aligning to the handoff specs.
+
+**Superseded history below.** The 2026-09-02 entry that follows described the redesign as "back and active" and drove the canvas-mirror work. It is kept because the token-governance work in it is still live and correct — only the direction changed.
+
+#### Superseded: branch state as of 2026-09-02
 
 | Branch | Commit | Note |
 |---|---|---|
@@ -278,7 +302,7 @@ android/      Capacitor Android shell
 | `origin/staging` | `507c080` | not yet re-promoted with the terminal work below — check `/api/version` on `liquidity-hq-staging` before assuming |
 | `origin/main` | `b9795ee` | production — not yet touched by the terminal redesign batch |
 
-**Monochrome Terminal redesign (#413) is back and active, unlike the 2026-08-27 revert noted below.** Session 2026-09-01/02 shipped, in order: #558 (Dashboard C8 radius), #560 (platform conformance batch — terminal token governance for `--accent-solid`/`--accent-dim`/`--blue` family/`--bg3`/`--bg4`/`--on-accent`, `/funding`+`/correlation` light-theme contrast, a platform-wide radius carve-out for circular markers, footer link touch targets), #562 (QA's `qa/contrast-diff.mjs` + `qa/platform-audit.mjs` tooling), #563 (the terminal design now has an actual `[data-design="terminal"][data-theme="light"]` token block — it didn't before, terminal+light silently fell back to the current design and QA's #559 audit's light-theme rows were measuring two unrelated systems against each other; see issue #561). A new conformance test direction was added in `__tests__/terminalTokens.test.mts` (2026-09-01): asserts every `var()` a terminal-scoped selector references is actually declared in the terminal token block, not just that the block declares nothing undocumented — the asymmetry that let five different tokens (`--amber`, `--accent-2`, `--accent-bg`/`--accent-bdr`, `--fr-slight-long`, `--on-accent`) fall through ungoverned over the course of the session before being caught by manual sweep or QA's audit.
+**(SUPERSEDED 2026-09-03 — see the reversal above. Token-governance content still accurate.)** Monochrome Terminal redesign (#413) is back and active, unlike the 2026-08-27 revert noted below. Session 2026-09-01/02 shipped, in order: #558 (Dashboard C8 radius), #560 (platform conformance batch — terminal token governance for `--accent-solid`/`--accent-dim`/`--blue` family/`--bg3`/`--bg4`/`--on-accent`, `/funding`+`/correlation` light-theme contrast, a platform-wide radius carve-out for circular markers, footer link touch targets), #562 (QA's `qa/contrast-diff.mjs` + `qa/platform-audit.mjs` tooling), #563 (the terminal design now has an actual `[data-design="terminal"][data-theme="light"]` token block — it didn't before, terminal+light silently fell back to the current design and QA's #559 audit's light-theme rows were measuring two unrelated systems against each other; see issue #561). A new conformance test direction was added in `__tests__/terminalTokens.test.mts` (2026-09-01): asserts every `var()` a terminal-scoped selector references is actually declared in the terminal token block, not just that the block declares nothing undocumented — the asymmetry that let five different tokens (`--amber`, `--accent-2`, `--accent-bg`/`--accent-bdr`, `--fr-slight-long`, `--on-accent`) fall through ungoverned over the course of the session before being caught by manual sweep or QA's audit.
 
 **What changed since 2026-08-01 (older entries, still accurate):**
 - #481: Monochrome Terminal redesign reverted from qa/staging. Preserved on `feature/monochrome-terminal`. `CONVERTED_ROUTES = []` — palette specs paused.


### PR DESCRIPTION
## Summary

`docs/HANDOVER.md` was pointing a fresh session at work the owner cancelled. This corrects it.

## What changed

- **Branch table rewritten** for 2026-09-03. It said `dev`/`qa` were at `7f0178d` and `staging` at `507c080`; all three are now `06c647e` and deployed. `main` is `1ee554e`, **64 commits behind `staging`**, with no release PR open.
- **Added the two standing decisions above the old content**, since they govern everything below it: terminal styling goes over the existing production layout (never restructure a screen to a canvas), and terminal ships on the landing page only (#719).
- **Marked the 2026-09-02 entry superseded rather than deleting it.** It described the redesign as "back and active" and drove the canvas-mirror work, but its token-governance content is still live and correct. Only the direction changed.
- **Recorded the triage rule** that follows from landing-only: after #719, a terminal-mode defect on any route except `/` is invisible to users and does not earn dev time. That is why #707, #698 and #663 are parked with measurements intact, #656 and #652 closed as superseded, and #620/#622/#712 parked.
- **Named the four shared files** that make landing a hard gate — `app/globals.css`, `lib/labelKeys.ts`, `lib/labelDefaults.en.json`, `components/AppShell.tsx`. The last one is called out specifically because it is the one that bit us on #720: it rendered `PriceTickerStrip` on `/` gated on design mode rather than pathname, and my own #718 handoff omitted it from the shared-file list.
- **Recorded two findings deliberately not filed**, so nobody spends a session re-deriving them: `/dashboard`'s 10 `MarketRead` radius violations (`#413`-era, restored correctly by the revert, invisible after #719) and landing's 3 of 21 `specs/landing.md` failures (pre-existing; the owner has stopped aligning to the handoff specs).

## Why

`HANDOVER.md` is the first thing a session with no prior context reads — CLAUDE.md sends people there by name. It was telling that reader the canvas-mirror redesign was active and giving them a branch state that no longer existed. Both would have cost a session before anyone noticed.

## How to test (QA)

Docs only — no build impact, nothing to exercise in a browser.

1. Read `docs/HANDOVER.md`, section **"Branch & deploy state as of 2026-09-03"**.
2. Branch table should read `dev`/`qa`/`staging` all at `06c647e`, `main` at `1ee554e` and 64 behind.
3. The paragraph below it should state the canvas-mirror initiative is stopped and terminal ships on landing only.
4. The 2026-09-02 paragraph further down should still be present, prefixed **(SUPERSEDED 2026-09-03 …)**.
5. Confirm no other section still describes canvas-mirror work as active.

## Risk level

**Low.** Documentation only. No application code, no test changes, no build or deploy impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
