### PR TITLE
test(dashboard): seed an entitled session so the Pro branch is testable

### DIFF
--- a/qa/e2e/_entitled-session.ts
+++ b/qa/e2e/_entitled-session.ts
@@ -1,0 +1,192 @@
+import { readFileSync } from 'node:fs';
+import type { Page } from '@playwright/test';
+
+/* AN ENTITLED SESSION, WITHOUT AUTHENTICATING AS ANYONE.
+ *
+ * QA cannot cover the Pro path. Creating accounts and typing passwords are hard
+ * limits on that session, so "sign up and look" is not available to it — and
+ * `GlobalMacroContext` / `PerpSpotCard` render an entitlement-gated branch that
+ * nothing has ever verified. #717's spacing work sits inside that branch, on
+ * `app/dashboard/page.tsx` — the current-design dashboard, which after #719 is
+ * the screen every user sees. So the uncovered path is the high-traffic one.
+ *
+ * WHAT THIS IS NOT, AND WHY IT MATTERS
+ *
+ * It is NOT an entitlement flag in application code. The obvious version of
+ * this — `NEXT_PUBLIC_TEST_ENTITLED=1` short-circuiting `entitled` in
+ * AuthProvider — ships a paywall bypass in the production bundle, gated on a
+ * variable anyone can set at build time. This codebase already has that
+ * incident on record: #377, where a stuck `loading` state granted Pro access
+ * for free, and the fix commentary at AuthProvider.tsx:89 exists because of
+ * it. A DELIBERATE bypass is strictly worse than the accidental one, so it is
+ * not on the table regardless of how convenient the fixture would be.
+ *
+ * It is also NOT a credential. The token seeded below is a syntactically
+ * well-formed JWT with a deliberately invalid signature. It authenticates
+ * nothing: every request that would carry it to Supabase is intercepted here
+ * and answered locally, and any that escaped would be rejected by the server.
+ * It is a local test double for a client library that reads its session from
+ * localStorage, not a key to anything.
+ *
+ * HOW IT WORKS
+ *
+ * `AuthProvider` resolves the user from `sb.auth.getSession()`
+ * (AuthProvider.tsx:65), which reads localStorage and makes no network call.
+ * It then reads the role from one PostgREST select (AuthProvider.tsx:171).
+ * So an entitled render needs exactly two things faked, both client-side:
+ *
+ *   1. a session in localStorage under supabase-js's key
+ *   2. that one subscription row coming back as `role: 'pro'`
+ *
+ * Everything else — the paywall logic, the gate at each call site, the
+ * components themselves — runs as shipped. That is the point: a fixture that
+ * stubbed `entitled` directly would prove nothing about the code under test.
+ */
+
+/* Next.js loads .env.local for the APP, but Playwright's own process does not
+   inherit it - the spec runs in plain Node. Rather than edit playwright.config.ts
+   (QA's file) to pull in dotenv, this reads the one variable it needs. Falls
+   back to the real process env first so CI, which sets it properly, is
+   unaffected. */
+function envSupabaseUrl(): string | undefined {
+  if (process.env.NEXT_PUBLIC_SUPABASE_URL) return process.env.NEXT_PUBLIC_SUPABASE_URL;
+  for (const f of ['.env.e2e.local', '.env.local', '.env']) {
+    try {
+      const m = readFileSync(f, 'utf8').match(/^\s*NEXT_PUBLIC_SUPABASE_URL\s*=\s*(.+)$/m);
+      if (m) return m[1].trim().replace(/^["']|["']$/g, '');
+    } catch { /* file absent is normal - try the next one */ }
+  }
+  return undefined;
+}
+
+/** supabase-js keys its session `sb-<project-ref>-auth-token`, where the ref is
+ *  the first hostname label of the project URL. Derived rather than hardcoded so
+ *  this keeps working when the harness points at a different project. */
+function storageKey(supabaseUrl: string): string {
+  const ref = new URL(supabaseUrl).hostname.split('.')[0];
+  return `sb-${ref}-auth-token`;
+}
+
+/** A structurally valid JWT whose signature is intentionally not valid.
+ *  supabase-js decodes the payload locally to find `exp` and the user; it does
+ *  not verify the signature client-side, and no request carrying this ever
+ *  reaches a server (see the routes installed below). */
+function unsignedJwt(userId: string, email: string, expSeconds: number): string {
+  const b64 = (o: unknown) =>
+    Buffer.from(JSON.stringify(o)).toString('base64url');
+  const header = b64({ alg: 'HS256', typ: 'JWT' });
+  const payload = b64({
+    sub: userId, email, role: 'authenticated', aud: 'authenticated',
+    exp: expSeconds, iat: Math.floor(Date.now() / 1000),
+  });
+  return `${header}.${payload}.test-signature-not-valid`;
+}
+
+export interface EntitledOptions {
+  /** 'pro' is a paid subscriber; 'trial' exercises the OTHER branch of
+   *  `entitled = isPro || isTrial`, which is the one a real new signup gets. */
+  as?: 'pro' | 'trial';
+  supabaseUrl?: string;
+}
+
+/**
+ * Make the page render as an entitled user.
+ *
+ * MUST be called before the first navigation — it installs an init script and
+ * network routes, neither of which applies retroactively to a loaded page.
+ *
+ * ```ts
+ * test('macro card renders its full breakdown', async ({ page }) => {
+ *   await useEntitledSession(page);
+ *   await page.goto('/dashboard');
+ *   await expect(page.getByTestId('locked-feature')).toHaveCount(0);
+ * });
+ * ```
+ */
+export async function useEntitledSession(page: Page, opts: EntitledOptions = {}): Promise<void> {
+  const as = opts.as ?? 'pro';
+  const supabaseUrl = opts.supabaseUrl ?? envSupabaseUrl();
+  if (!supabaseUrl) {
+    /* Loud, not skipped. A fixture that silently no-ops leaves the test
+       asserting against a SIGNED-OUT page — which renders the locked card, so
+       an entitled-path assertion fails with a message about the wrong thing.
+       Every "false clean" in this project's history started as a check that
+       quietly measured nothing. */
+    throw new Error(
+      'useEntitledSession: NEXT_PUBLIC_SUPABASE_URL is unset, so the session key ' +
+      'cannot be derived. Set it in the harness env, or pass { supabaseUrl }.',
+    );
+  }
+
+  const userId = '00000000-0000-4000-8000-000000000001';
+  const email = 'qa-entitled@example.invalid'; // .invalid is reserved (RFC 2606)
+  const nowSec = Math.floor(Date.now() / 1000);
+  const accessToken = unsignedJwt(userId, email, nowSec + 3600);
+
+  const user = {
+    id: userId, aud: 'authenticated', role: 'authenticated', email,
+    app_metadata: { provider: 'email' }, user_metadata: {},
+    created_at: new Date(0).toISOString(),
+  };
+
+  const session = {
+    access_token: accessToken,
+    refresh_token: 'test-refresh-token-not-valid',
+    token_type: 'bearer',
+    expires_in: 3600,
+    expires_at: nowSec + 3600,
+    user,
+  };
+
+  const key = storageKey(supabaseUrl);
+
+  await page.addInitScript(
+    ({ key, session }) => {
+      window.localStorage.setItem(key, JSON.stringify({
+        currentSession: session, expiresAt: session.expires_at,
+      }));
+      /* AuthProvider force-signs-out a session idle more than 7 days
+         (AuthProvider.tsx:49, #304). Without this the fixture would be
+         torn down by the app's own expiry check and the test would see a
+         signed-out page. */
+      window.localStorage.setItem('lhq_last_active', String(Date.now()));
+    },
+    { key, session },
+  );
+
+  /* The one row that decides `entitled`. A trial is the NON-pro branch:
+     role stays 'free' and the window carries it, exactly as the signup
+     trigger writes it (supabase/migrations/20260804g_trial_email_dedup.sql). */
+  const row = as === 'pro'
+    ? { role: 'pro', trial_ends_at: null }
+    : { role: 'free', trial_ends_at: new Date(Date.now() + 14 * 864e5).toISOString() };
+
+  await page.route(`${supabaseUrl}/rest/v1/**`, async route => {
+    const url = route.request().url();
+    if (!/user_subscriptions/.test(url)) return route.fallback();
+    /* `.maybeSingle()` asks PostgREST for a single object via the Accept
+       header rather than an array. Answering with the wrong shape makes
+       supabase-js return null data and the app reads that as 'free' - a
+       fixture that fails by looking like a correct not-entitled result. */
+    const single = (route.request().headers()['accept'] ?? '').includes('vnd.pgrst.object');
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(single ? row : [row]),
+    });
+  });
+
+  /* supabase-js calls these when it refreshes or re-validates. Unhandled they
+     would hit the real project with an invalid token, and its 401 would sign
+     the fixture out mid-test. */
+  await page.route(`${supabaseUrl}/auth/v1/**`, async route => {
+    const url = route.request().url();
+    if (/\/user\b/.test(url)) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(user) });
+    }
+    if (/token/.test(url)) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(session) });
+    }
+    return route.fallback();
+  });
+}

--- a/qa/e2e/entitled-macro-cards.spec.ts
+++ b/qa/e2e/entitled-macro-cards.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '@playwright/test';
+import { useEntitledSession } from './_entitled-session';
+
+/* THE ENTITLED BRANCH OF THE MACRO CARDS (#717).
+ *
+ * `GlobalMacroContext` gates on `entitled` and renders `LockedFeatureCard` to
+ * everyone else. #717 compressed the spacing INSIDE the entitled branch, and
+ * that branch has never been verified by anyone: QA measured 227px twice,
+ * hours apart, read the stability as confirmation, and was looking at the
+ * static locked card both times. The measurement was of a different component
+ * than the one that changed.
+ *
+ * Why it is worth a spec rather than one manual look: after #719 ships terminal
+ * on landing only, `app/dashboard/page.tsx` is the dashboard every user sees,
+ * and both cards render there (`:579`, `:587`). The gated branch is on the
+ * highest-traffic screen in the app.
+ *
+ * THE CONTROL IS THE POINT. `locked-feature` being absent proves an entitled
+ * render only if it is PRESENT without the fixture. Asserting one without the
+ * other would pass just as happily against a page that failed to load, which is
+ * this project's most repeated failure: a check that measures nothing and
+ * reports clean.
+ */
+
+const DASHBOARD = '/dashboard';
+
+test.describe('macro cards, entitled branch', () => {
+  test('CONTROL: signed out, the dashboard shows the Pro gate', async ({ page }) => {
+    await page.goto(DASHBOARD);
+    /* If this ever reports 0, the fixture below is proving nothing - either the
+       marker was renamed (#441 put it on LockedFeatureCard) or the gate stopped
+       being applied at the call site, which is #442's whole subject. */
+    await expect(page.getByTestId('locked-feature')).not.toHaveCount(0);
+  });
+
+  test('as pro: the gate is gone and the real breakdown renders', async ({ page }) => {
+    await useEntitledSession(page, { as: 'pro' });
+    await page.goto(DASHBOARD);
+
+    await expect(page.getByTestId('locked-feature')).toHaveCount(0);
+    /* PerpSpotCard has no entitlement gate of its own, so it renders either
+       way - it is here because #717 changed its layout, not its visibility. */
+    await expect(page.getByTestId('perp-spot-card')).toBeVisible();
+  });
+
+  test('as trial: entitled too - the OTHER half of isPro || isTrial', async ({ page }) => {
+    /* A real new signup lands here, not on 'pro': the trigger writes
+       role 'free' with a 14-day window. If these two branches ever diverge,
+       every trial user sees a paywall they should not, and no pro-only
+       fixture would notice. */
+    await useEntitledSession(page, { as: 'trial' });
+    await page.goto(DASHBOARD);
+
+    await expect(page.getByTestId('locked-feature')).toHaveCount(0);
+  });
+
+  test('#717: the verdict pill and the number are one flex row, not two blocks', async ({ page }) => {
+    /* The change under test: two stacked blocks, each carrying its own 8px
+       marginBottom, became one flex row.
+     *
+     * THIS ASSERTS THE DOM, NOT THE PIXELS, AND THAT IS DELIBERATE. My first
+     * version compared their vertical centres, and it failed once then passed
+     * on a re-measure. Not flake in the harness - the rail is 330px wide with
+     * `flexWrap: 'wrap'`, and the verdict string is data-driven:
+     *
+     *     NORMAL           pill  79px  + gap 10 + number 182 = 271  fits
+     *     CANNOT MEASURE   pill ~140px + gap 10 + number 182 = 332  wraps
+     *
+     * So whether the two sit on one visual line depends on what the market is
+     * doing when the test runs. A pixel assertion here is a coin flip, and a
+     * coin-flip test gets muted rather than fixed.
+     *
+     * The wrapping is a real limitation of #717 at this width and is filed
+     * separately - it is not this spec's job to fail intermittently as a way
+     * of remembering it. */
+    await useEntitledSession(page);
+    await page.goto(DASHBOARD);
+
+    const card = page.getByTestId('perp-spot-card');
+    await expect(card).toBeVisible();
+    await expect(card.locator('.psc-verdict-pill')).toBeVisible();
+
+    const shape = await card.evaluate((el: HTMLElement) => {
+      const pill = el.querySelector('.psc-verdict-pill');
+      const row = pill?.parentElement;
+      if (!pill || !row) return null;
+      return {
+        display: getComputedStyle(row).display,
+        // The number block must be the pill's SIBLING. Stacked, it was the
+        // pill's parent's sibling instead - a different tree, which is what
+        // regressing this change would restore.
+        numberIsSibling: pill.nextElementSibling !== null,
+        rowChildren: row.children.length,
+      };
+    });
+
+    expect(shape, 'verdict pill or its row did not render').not.toBeNull();
+    expect(shape!.display).toBe('flex');
+    expect(shape!.numberIsSibling).toBe(true);
+    expect(shape!.rowChildren).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a Playwright fixture that renders a page as an **entitled** user, plus a spec covering the branch #717 changed. Closes the coverage gap QA recorded as permanently unreachable from their side.

QA cannot cover the Pro path at all — creating accounts and entering passwords are hard limits on that session. So `GlobalMacroContext`'s entitlement-gated branch has never been verified by anyone, and that is exactly where #717's spacing work lives. After #719 ships terminal on landing only, `app/dashboard/page.tsx` is the dashboard every user sees — **the uncovered branch is the high-traffic one.**

## What this deliberately is not

**An entitlement flag in application code.** The obvious version — `NEXT_PUBLIC_TEST_ENTITLED=1` short-circuiting `entitled` in `AuthProvider` — ships a paywall bypass in the production bundle, gated on a build-time variable. This repo already has that incident on record: **#377**, where a stuck `loading` state granted Pro access for free; the comment at `AuthProvider.tsx:89` exists because of it. A *deliberate* bypass is strictly worse than the accidental one. **No application code changes in this PR.**

**A credential.** The seeded token is a syntactically valid JWT with an intentionally invalid signature (`test-signature-not-valid`). Every request that would carry it to Supabase is intercepted and answered locally; a real server would reject it. It's a test double for a client library that reads its session from `localStorage` — not a key to anything.

## How it works

The fixture fakes exactly two things, both client-side:

1. the session `localStorage` entry `supabase-js` reads in `getSession()` — `AuthProvider.tsx:65`, no network call
2. the single subscription row at `AuthProvider.tsx:171`

The paywall logic, the per-call-site gates and the components themselves all run **as shipped**. A fixture that stubbed `entitled` directly would prove nothing about the code under test.

## Verified by running it

**4 passed** against a local production build — not reasoned about.

The signed-out control asserts `locked-feature` **is** present; the fixture tests assert it is **absent**. The pair is what proves the fixture actually flips the state rather than passing vacuously — the failure mode this project keeps hitting is a check that measures nothing and reports clean.

Both branches of `entitled = isPro || isTrial` are covered. A real signup lands on **trial** (role stays `free` with a 14-day window), not `pro`; if those two ever diverge, every trial user sees a paywall they shouldn't and a pro-only fixture would never notice.

## Found while writing it — reported, not quietly fixed

**#717's verdict pill and number are one flex row in the DOM, but they don't always render on one line.** The rail is 330px with `flexWrap: 'wrap'`, and the verdict string is data-driven:

```
NORMAL           pill  79px + gap 10 + number 182 = 271   fits
CANNOT MEASURE   pill ~140px + gap 10 + number 182 = 332   wraps
```

So whether the compression materialises depends on what the market is doing. My first assertion compared their vertical centres, **failed once, then passed on a re-measure** — a coin-flip test, and coin-flip tests get muted rather than fixed. It now asserts the DOM shape, which is what #717 actually changed. The wrapping is a real limitation of that change at this width; filing it separately rather than letting an intermittent test serve as the reminder.

## How to test (QA)

```
npx playwright test qa/e2e/entitled-macro-cards.spec.ts
```

Needs `NEXT_PUBLIC_SUPABASE_URL`. Read from the process env first, then `.env.e2e.local` / `.env.local` — Playwright's own process doesn't inherit what Next loads for the app. If it's missing the fixture **throws loudly** rather than no-opping into a signed-out page that would then fail against the wrong thing.

`playwright.config.ts` is untouched — it's yours, and the fixture resolves its own env rather than making me edit it.

## Risk level

**Low.** Test-only; no file under `app/`, `components/` or `lib/` changes. Gates: lint 0 errors, `tsc` 0, `npm test` 555/0, and the spec itself 4/4 against a local production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
