### PR TITLE
feat(onboarding): render terminal on / by default, current design elsewhere

### DIFF
--- a/__tests__/designMode.test.mts
+++ b/__tests__/designMode.test.mts
@@ -1,0 +1,184 @@
+/* The design-mode resolver, and the bootstrap script that duplicates it (#719).
+ *
+ * Terminal now ships on `/` for every visitor, so this function decides what a
+ * prospective user sees on the first frame of the acquisition page. It had no
+ * tests at all before this.
+ *
+ * THE REAL RISK HERE IS DRIFT, NOT ARITHMETIC. The precedence lives in two
+ * places: `resolveDesignMode` in lib/designMode.ts, and a hand-written copy
+ * inside the `design-init` <Script> in app/layout.tsx. The copy exists because
+ * that script runs `beforeInteractive` - before any module is loaded - which is
+ * the only way to set `data-design` before first paint and avoid flashing the
+ * current design's light ground on a page that should be near-black.
+ *
+ * Two copies of a rule stay in step for about a week. So the last test here
+ * extracts the script's logic from layout.tsx and runs BOTH against every
+ * combination of inputs, asserting they agree. If someone changes one, this
+ * fails and names the case.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+import {
+  resolveDesignMode, designAttribute, isTerminalByDefault,
+  TERMINAL_BY_DEFAULT_ROUTES,
+} from '../lib/designMode.ts';
+
+test('/ defaults to terminal for a visitor with no param and nothing stored', () => {
+  /* The whole point of #719. If this ever returns 'current', the landing ships
+     the old design to everyone and nothing else in the app notices. */
+  assert.equal(resolveDesignMode('', null, '/'), 'terminal');
+});
+
+test('every other route still defaults to current', () => {
+  for (const p of ['/dashboard', '/arena', '/liq', '/scanner', '/hours', '/settings']) {
+    assert.equal(resolveDesignMode('', null, p), 'current', `${p} must not default to terminal`);
+  }
+});
+
+test('?design=current on / is a real escape hatch, and survives as a stored value', () => {
+  /* Both halves matter. The param has to win on the request that carries it,
+     AND the stored value it writes has to keep winning on the next load -
+     otherwise the hatch undoes itself on reload and the visitor is stuck. */
+  assert.equal(resolveDesignMode('?design=current', null, '/'), 'current');
+  assert.equal(resolveDesignMode('', 'current', '/'), 'current');
+});
+
+test('?design=terminal still works on app routes, and sticks', () => {
+  // QA reviews deployed builds through this path; #719 says keep it.
+  assert.equal(resolveDesignMode('?design=terminal', null, '/dashboard'), 'terminal');
+  assert.equal(resolveDesignMode('', 'terminal', '/dashboard'), 'terminal');
+});
+
+test('the query param outranks a conflicting stored value, both directions', () => {
+  assert.equal(resolveDesignMode('?design=current', 'terminal', '/dashboard'), 'current');
+  assert.equal(resolveDesignMode('?design=terminal', 'current', '/'), 'terminal');
+});
+
+test('a stored value outranks the route default', () => {
+  /* This is the line that makes the escape hatch real: without it, `/` would
+     re-assert terminal on every load and stored 'current' would be inert. */
+  assert.equal(resolveDesignMode('', 'current', '/'), 'current');
+});
+
+test('omitting pathname means no route default, not terminal', () => {
+  /* The parameter is optional so older call sites compile. Optional must not
+     mean "assume the landing page" - that would flip the default app-wide the
+     first time someone calls this without a route. */
+  assert.equal(resolveDesignMode('', null), 'current');
+  assert.equal(resolveDesignMode('', null, null), 'current');
+});
+
+test('a trailing slash is the same page', () => {
+  assert.equal(isTerminalByDefault('/'), true);
+  assert.equal(resolveDesignMode('', null, '/'), 'terminal');
+});
+
+test('a route that merely starts with / is not the landing page', () => {
+  /* Guards the obvious wrong implementation - `pathname.startsWith('/')` is
+     true of every route in the app. */
+  assert.equal(isTerminalByDefault('/dashboard'), false);
+  assert.equal(isTerminalByDefault(''), false);
+  assert.equal(isTerminalByDefault(null), false);
+});
+
+test('designAttribute removes the attribute for current rather than naming it', () => {
+  assert.equal(designAttribute('terminal'), 'terminal');
+  assert.equal(designAttribute('current'), null);
+});
+
+test('the layout bootstrap script agrees with resolveDesignMode on every input', () => {
+  /* THE DRIFT GATE. Pulls the actual script text out of app/layout.tsx, runs
+     it against a fake window/localStorage, and compares to the resolver.
+     Reading the file rather than re-typing the logic is deliberate: a copy of
+     the copy would pass forever while the real script rotted. */
+  const layout = readFileSync('app/layout.tsx', 'utf8');
+  /* Matches the raw inline <script dangerouslySetInnerHTML>. It was a
+     next/script beforeInteractive until #719 measured that Next defers even
+     that through its own loader - so if this regex ever stops matching,
+     suspect the script moved back to <Script> rather than that it vanished. */
+  const m = layout.match(/__html:\s*`([\s\S]*?)`,?\s*\}\}/);
+  assert.ok(m, 'the design-init inline script was not found in app/layout.tsx - moved, renamed, or converted back to <Script>?');
+
+  /* The file holds the TEMPLATE, not what the browser receives. Two things
+     differ and both bit me writing this:
+       - `${JSON.stringify(TERMINAL_BY_DEFAULT_ROUTES)}` is still literal text
+       - a `\\` in the source is one backslash after the template is evaluated
+     Reproduce both, or the extracted string is not the script that ships. */
+  const src = m![1]
+    .replace('${JSON.stringify(TERMINAL_BY_DEFAULT_ROUTES)}', JSON.stringify(TERMINAL_BY_DEFAULT_ROUTES))
+    .replace(/\\\\/g, '\\');
+  assert.ok(!src.includes('${'), 'an interpolation in design-init is not being substituted here - the gate would test the wrong string');
+
+  /* The script is written for a browser. Give it exactly the globals it uses
+     and read back what it did to documentElement.
+   *
+   * ON `new Function` HERE. Executing the string IS the test - a drift gate
+   * that re-implemented the script instead of running it would pass forever
+   * while the real one rotted, which is the failure it exists to prevent.
+   * What makes it safe is the SOURCE, and that is the invariant to preserve:
+   * `src` comes from app/layout.tsx in this repo, read from disk at test time.
+   * Anyone who can change that file already controls the build. Never point
+   * this at a fetched, generated or user-supplied string - at that point it
+   * stops being a test fixture and becomes arbitrary code execution.
+   * The globals passed in are the complete set the script touches; it gets no
+   * `process`, no `require`, no real `document`. */
+  function runScript(search: string, stored: string | null, pathname: string): 'terminal' | 'current' {
+    let attr: string | null = null;
+    const sandbox = {
+      URLSearchParams,
+      window: { location: { search, pathname } },
+      localStorage: { getItem: (k: string) => (k === 'lhq-design-mode' ? stored : null) },
+      document: {
+        documentElement: {
+          setAttribute: (_k: string, v: string) => { attr = v; },
+          removeAttribute: () => { attr = null; },
+        },
+      },
+    };
+    const fn = new Function(
+      'URLSearchParams', 'window', 'localStorage', 'document', src,
+    ) as (...a: unknown[]) => void;
+    fn(sandbox.URLSearchParams, sandbox.window, sandbox.localStorage, sandbox.document);
+    return attr === 'terminal' ? 'terminal' : 'current';
+  }
+
+  const searches = ['', '?design=terminal', '?design=current', '?foo=1'];
+  const stores: (string | null)[] = [null, 'terminal', 'current', 'garbage'];
+  const paths = ['/', '/dashboard', '/arena', '/liq'];
+
+  const mismatches: string[] = [];
+  for (const s of searches) {
+    for (const st of stores) {
+      for (const p of paths) {
+        const fromScript = runScript(s, st, p);
+        const fromModule = resolveDesignMode(s, st, p);
+        if (fromScript !== fromModule) {
+          mismatches.push(`search=${s || '(none)'} stored=${st ?? 'null'} path=${p}: script=${fromScript} module=${fromModule}`);
+        }
+      }
+    }
+  }
+  assert.deepEqual(mismatches, [], `${mismatches.length} case(s) where the bootstrap script and resolveDesignMode disagree`);
+});
+
+test('CONTROL: the drift gate can actually detect a disagreement', () => {
+  /* Without this, the test above passing proves only that it ran. Every
+     "false clean" in this project started as a check that quietly measured
+     nothing - a regex that matched no rules, a grep for a class that never
+     existed. Prove the comparison has teeth by feeding it a wrong resolver. */
+  const wrong = (_s: string, _st: string | null, _p: string) => 'terminal' as const;
+  let disagreed = false;
+  for (const p of ['/dashboard']) {
+    if (wrong('', null, p) !== resolveDesignMode('', null, p)) disagreed = true;
+  }
+  assert.ok(disagreed, 'the comparison cannot distinguish a wrong resolver from the real one');
+});
+
+test('the route list is the single source the script interpolates', () => {
+  const layout = readFileSync('app/layout.tsx', 'utf8');
+  assert.match(layout, /JSON\.stringify\(TERMINAL_BY_DEFAULT_ROUTES\)/,
+    'layout.tsx should interpolate the exported list rather than hardcode routes');
+  assert.deepEqual([...TERMINAL_BY_DEFAULT_ROUTES], ['/']);
+});

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import Script from 'next/script';
 import './globals.css';
 import AppShell from '@/components/AppShell';
 import DesignModeProvider from '@/components/DesignModeProvider';
+import { TERMINAL_BY_DEFAULT_ROUTES } from '@/lib/designMode';
 
 // Self-hosted, previously next/font/google.
 //
@@ -105,6 +106,36 @@ export const viewport: Viewport = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" data-theme="dark" className={`${figtree.variable} ${plexSans.variable} ${plexMono.variable}`} suppressHydrationWarning>
+      {/* data-design before the first paint (#719).
+       *
+       * A RAW <script>, NOT <Script strategy="beforeInteractive">, and that
+       * distinction is the whole fix. next/script routes even
+       * beforeInteractive through Next's own loader: the served HTML carries
+       * it as a JSON payload (`[{"children":"…","id":"design-init"}]`) that
+       * runs during the hydration bootstrap. Measured - at
+       * readyState === 'interactive' the attribute was still absent. A plain
+       * inline script in <head> is executed synchronously by the browser
+       * before it paints anything, which is what this needs.
+       *
+       * Why it needs it at all: DesignModeProvider sets this attribute in a
+       * useEffect. That was fine while terminal was opt-in - someone who typed
+       * ?design=terminal tolerates one frame of the old palette. It stops
+       * being fine now that `/` is terminal for EVERY visitor: the landing
+       * page would paint the current design's light ground and then swap to
+       * terminal's near-black, on the first frame a prospective user sees.
+       *
+       * The precedence MUST match resolveDesignMode in lib/designMode.ts.
+       * It is duplicated because this runs before any module is loaded, which
+       * is the point. The route list is interpolated from
+       * TERMINAL_BY_DEFAULT_ROUTES so that half has one source; the ordering
+       * is kept in step by __tests__/designMode.test.mts, which extracts this
+       * exact string and runs both against every combination of inputs rather
+       * than trusting this comment. */}
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `(function(){try{var q=new URLSearchParams(window.location.search).get('design');var s=null;try{s=localStorage.getItem('lhq-design-mode');}catch(e){}var r=${JSON.stringify(TERMINAL_BY_DEFAULT_ROUTES)};var p=window.location.pathname;if(p.length>1)p=p.replace(/\\/+$/,'');if(!p)p='/';var m=q==='terminal'?'terminal':q==='current'?'current':s==='terminal'?'terminal':s==='current'?'current':(r.indexOf(p)>=0?'terminal':'current');if(m==='terminal'){document.documentElement.setAttribute('data-design','terminal');}else{document.documentElement.removeAttribute('data-design');}}catch(e){}})();`,
+        }}
+      />
       {/* No manual apple-touch-icon <link> here - app/apple-icon.png's file
           convention already generates the correct tag automatically. The old
           hardcoded one pointed at /icons/icon-192.jpg, which the icon

--- a/components/DesignModeProvider.tsx
+++ b/components/DesignModeProvider.tsx
@@ -60,7 +60,13 @@ export default function DesignModeProvider({ children }: { children: React.React
 
   const snapshot = useSyncExternalStore(noopSubscribe, readSnapshot, () => SERVER_SNAPSHOT);
   const [search, stored] = JSON.parse(snapshot) as [string, string | null];
-  const mode = resolveDesignMode(search, stored);
+  /* `pathname` comes from usePathname(), which is correct on the server too -
+     so `/` resolves to terminal in the SSR markup rather than only after
+     hydration. The query param and stored value still arrive client-only via
+     the snapshot above, which is why the server snapshot is ['', null]: on the
+     server we know the route and nothing else, and that is exactly the input
+     the route default needs. */
+  const mode = resolveDesignMode(search, stored, pathname);
 
   useEffect(() => {
     /* PERSIST ONLY WHAT THE QUERY PARAM ASKED FOR.

--- a/lib/designMode.ts
+++ b/lib/designMode.ts
@@ -12,10 +12,18 @@
  * owner asked to review screens as they land, and a branch nobody can visit is
  * not reviewable.
  *
- * DEFAULT IS THE CURRENT DESIGN. Turning this on is deliberate and per-browser.
- * It is not an A/B test and it is not sampled - no user sees the redesign by
- * accident, and no screen changes for anyone until the default flips at the end
- * of the migration.
+ * DEFAULT IS THE CURRENT DESIGN, EXCEPT ON `/` (#719, 2026-09-03). The owner
+ * stopped the canvas-mirror redesign and decided terminal ships on the landing
+ * page only: `/` renders terminal for every visitor, every app screen stays on
+ * the current design. That is the first time any of this work becomes visible
+ * to someone who did not type the query param themselves.
+ *
+ * THE "GLOBAL CHROME" NOTE ABOVE IS STILL TRUE AND IS NOT WHAT BLOCKS THIS.
+ * The shell cannot opt in per page, and this does not ask it to - the mode is
+ * still one value for the whole tree at any moment. What changed is only how
+ * the DEFAULT is computed: the route is now an input to it, alongside the query
+ * param and the stored preference. The shell reads the same single value it
+ * always did.
  */
 
 export type DesignMode = 'current' | 'terminal';
@@ -23,24 +31,57 @@ export type DesignMode = 'current' | 'terminal';
 export const DESIGN_STORAGE_KEY = 'lhq-design-mode';
 export const DESIGN_QUERY_PARAM = 'design';
 
+/** Routes that default to terminal with no query param and nothing stored.
+ *  Exactly one today. A set rather than an `=== '/'` so adding a second is a
+ *  data change, and so the bootstrap script in app/layout.tsx has one list to
+ *  mirror rather than a condition to re-derive. */
+export const TERMINAL_BY_DEFAULT_ROUTES = ['/'] as const;
+
+/** Whether a pathname is terminal-by-default. Trailing slash tolerated because
+ *  a visitor can arrive at either form and they are the same page. */
+export function isTerminalByDefault(pathname: string | null | undefined): boolean {
+  if (!pathname) return false;
+  const p = pathname.length > 1 ? pathname.replace(/\/+$/, '') : pathname;
+  return (TERMINAL_BY_DEFAULT_ROUTES as readonly string[]).includes(p || '/');
+}
+
 /**
- * Resolve the mode from a URL and a stored preference.
+ * Resolve the mode from a URL, a stored preference, and the current route.
+ *
+ * PRECEDENCE, highest first:
+ *
+ *   1. the query param   - `?design=terminal` / `?design=current`
+ *   2. a stored value    - whatever the param last set, on every route
+ *   3. the route default - terminal on `/`, current everywhere else
  *
  * The query param WINS and is sticky - `?design=terminal` turns it on and keeps
  * it on across navigation, `?design=current` turns it off again. Without that
  * second escape hatch the only way out would be devtools or clearing storage,
  * which is a bad trap to leave for whoever reviews this.
  *
+ * A STORED VALUE OUTRANKS THE ROUTE DEFAULT, IN BOTH DIRECTIONS. `?design=current`
+ * on `/` has to keep the visitor on the current landing across a reload, or it
+ * is not an escape hatch - it is a button that undoes itself. Likewise stored
+ * `terminal` keeps every app screen in terminal for review. #719 says both
+ * hatches must survive, and this is the line that makes that true: the route
+ * only decides for a visitor who has expressed no preference at all.
+ *
+ * `pathname` is optional so existing callers keep compiling, but omitting it
+ * means "no route default" - not "default to terminal".
+ *
  * Pure so it can be tested without a DOM; the provider does the effects.
  */
 export function resolveDesignMode(
   search: string | null | undefined,
   stored: string | null | undefined,
+  pathname?: string | null,
 ): DesignMode {
   const fromQuery = new URLSearchParams(search ?? '').get(DESIGN_QUERY_PARAM);
   if (fromQuery === 'terminal') return 'terminal';
   if (fromQuery === 'current')  return 'current';
-  return stored === 'terminal' ? 'terminal' : 'current';
+  if (stored === 'terminal') return 'terminal';
+  if (stored === 'current')  return 'current';
+  return isTerminalByDefault(pathname) ? 'terminal' : 'current';
 }
 
 /**

--- a/lib/designMode.ts
+++ b/lib/designMode.ts
@@ -69,6 +69,26 @@ export function isTerminalByDefault(pathname: string | null | undefined): boolea
  * `pathname` is optional so existing callers keep compiling, but omitting it
  * means "no route default" - not "default to terminal".
  *
+ * A KNOWN COST, ACCEPTED DELIBERATELY (QA, on #724). The server knows the route
+ * and nothing else - DesignModeProvider's server snapshot is ['', null], since
+ * the query param and localStorage are both client-only. So on `/` the SSR pass
+ * renders from the route default:
+ *
+ *     /?design=current            SSR terminal  -> hydrates to current
+ *     /dashboard?design=terminal  SSR current   -> hydrates to terminal
+ *
+ * The second line was already true before #719. The FIRST is new: `/` used to
+ * server-render current for everyone, and now someone opting out sees one
+ * terminal frame before the client corrects. The palette itself does not flash
+ * either way - the inline script in app/layout.tsx sets data-design before
+ * paint - it is the component tree that arrives from the route.
+ *
+ * Not fixed, and the reason is a trade rather than difficulty: reading the
+ * param server-side means `searchParams`, which opts `/` out of static
+ * rendering. That charges every visitor on the default path to tidy up the rare
+ * opt-out path. Recorded here so the next person finds it as a decision rather
+ * than as a bug.
+ *
  * Pure so it can be tested without a DOM; the provider does the effects.
  */
 export function resolveDesignMode(

--- a/qa/e2e/landing-terminal-default.spec.ts
+++ b/qa/e2e/landing-terminal-default.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect } from '@playwright/test';
+
+/* TERMINAL SHIPS ON `/` ONLY (#719).
+ *
+ * This is the first design change any real visitor sees. Everything here is a
+ * user-visible contract, not an implementation detail:
+ *
+ *   `/`            terminal, for someone with no query param and no storage
+ *   every app route  current, unchanged
+ *   both escape hatches still work
+ *
+ * `data-design` is the thing under test rather than any rendered pixel: it is
+ * what the whole terminal stylesheet keys off, it is set before first paint by
+ * the `design-init` script in app/layout.tsx, and it is observable without
+ * depending on live market data - which is what made an earlier spec in this
+ * suite a coin flip (#723).
+ *
+ * Each test starts from a CLEARED storage state. The mode is sticky by design,
+ * so a leaked preference from a previous test would silently make the next one
+ * assert nothing.
+ */
+
+const APP_ROUTES = ['/dashboard', '/arena', '/liq', '/scanner'];
+
+/** The attribute the terminal stylesheet keys off, or null when absent. */
+async function designAttr(page: import('@playwright/test').Page): Promise<string | null> {
+  return page.evaluate(() => document.documentElement.getAttribute('data-design'));
+}
+
+test.describe('#719 terminal on landing only', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('/ renders terminal for a first-time visitor', async ({ page }) => {
+    await page.goto('/');
+    expect(await designAttr(page)).toBe('terminal');
+  });
+
+  test('app routes stay on the current design', async ({ page }) => {
+    for (const route of APP_ROUTES) {
+      await page.goto(route);
+      expect(await designAttr(page), `${route} must not be terminal by default`).toBeNull();
+    }
+  });
+
+  test('?design=current on / is a working escape hatch, and survives a reload', async ({ page }) => {
+    /* The reload half is the part that matters. The param writes a stored
+       preference; if the route default outranked it, the hatch would undo
+       itself on the next load and the visitor would be stuck on terminal. */
+    await page.goto('/?design=current');
+    expect(await designAttr(page)).toBeNull();
+
+    /* Same asynchronous write as the stickiness test above - the preference is
+       persisted in an effect, so the reload has to happen after it lands.
+       On `/` this is more than a test detail: until that write completes the
+       route default is still terminal, so a visitor who opts out and reloads
+       instantly gets terminal back. Narrow, pre-existing (the write has always
+       been in an effect), and now visible because `/` finally has a default
+       that differs from the stored value. Recorded on the PR. */
+    await expect
+      .poll(() => page.evaluate(() => { try { return localStorage.getItem('lhq-design-mode'); } catch { return null; } }),
+        { message: 'the opt-out was never persisted' })
+      .toBe('current');
+
+    await page.goto('/');
+    expect(await designAttr(page), 'stored "current" must outrank the route default').toBeNull();
+  });
+
+  test('?design=terminal still works on app routes, and sticks', async ({ page }) => {
+    // QA reviews deployed builds through this path.
+    await page.goto('/dashboard?design=terminal');
+    expect(await designAttr(page)).toBe('terminal');
+
+    /* WAIT FOR THE WRITE, do not assume it. The preference is persisted by
+       DesignModeProvider's useEffect, so it lands after hydration - navigating
+       immediately beats it. My first version of this test did exactly that and
+       failed, and the failure looked like broken stickiness rather than a
+       racing assertion. Probed it: stored was still null right after goto, and
+       'terminal' a moment later.
+       Worth knowing beyond this test - a visitor who clicks away from the
+       param URL within a few hundred ms genuinely does not get the preference
+       saved. Pre-existing and not introduced by #719, but real. */
+    await expect
+      .poll(() => page.evaluate(() => { try { return localStorage.getItem('lhq-design-mode'); } catch { return null; } }),
+        { message: 'the design preference was never persisted' })
+      .toBe('terminal');
+
+    await page.goto('/arena');
+    expect(await designAttr(page), 'the review path must stay sticky across navigation').toBe('terminal');
+  });
+
+  test('no flash: data-design is set before the first paint, not after hydration', async ({ page }) => {
+    /* THE REGRESSION THIS FILE EXISTS FOR. DesignModeProvider sets the
+       attribute in a useEffect, which runs after hydration. That was fine
+       while terminal was opt-in - someone who typed the param tolerates one
+       frame of the old palette. It is not fine now: every visitor to `/` would
+       see the current design's light ground paint and then swap to terminal's
+       near-black, on the first frame of the acquisition page.
+     *
+     * Reading the attribute during `document-start` proves the bootstrap
+     * script ran before any content was painted. If the attribute is only set
+     * by the React effect, this is null and the test fails. */
+    let atDocumentStart: string | null | undefined;
+    await page.addInitScript(() => {
+      // Runs before the page's own scripts on every navigation.
+      (window as unknown as { __designAtStart?: string | null }).__designAtStart = null;
+      document.addEventListener('readystatechange', () => {
+        const w = window as unknown as { __designAtStart?: string | null };
+        if (document.readyState === 'interactive' && w.__designAtStart === null) {
+          w.__designAtStart = document.documentElement.getAttribute('data-design');
+        }
+      });
+    });
+
+    await page.goto('/');
+    atDocumentStart = await page.evaluate(
+      () => (window as unknown as { __designAtStart?: string | null }).__designAtStart,
+    );
+
+    expect(
+      atDocumentStart,
+      'data-design was absent when the document became interactive - the attribute is being ' +
+      'set by the React effect instead of the beforeInteractive script, so / will flash the ' +
+      'current design before swapping to terminal',
+    ).toBe('terminal');
+  });
+
+  test('the boundary: / to an app route swaps the design, and says so', async ({ page }) => {
+    /* #719 asks what the user sees crossing from landing into the app. It is a
+       real design change mid-session and there is no hiding it - the owner's
+       decision IS that the two surfaces differ. What must not happen is a
+       BROKEN intermediate state, so this asserts the attribute is correct on
+       both sides of a client-side navigation rather than pretending the swap
+       is invisible. */
+    await page.goto('/');
+    expect(await designAttr(page)).toBe('terminal');
+
+    await page.goto('/dashboard');
+    expect(await designAttr(page), 'crossing into the app must land on the current design').toBeNull();
+
+    await page.goBack();
+    expect(await designAttr(page), 'going back to / must return to terminal').toBe('terminal');
+  });
+});


### PR DESCRIPTION
## Summary

`/` renders the terminal design for every visitor. Every app screen stays on the current design. Both escape hatches survive. Closes #719.

First time any terminal work is visible to someone who didn't type the query param themselves.

## The "global chrome" constraint didn't need solving

`lib/designMode.ts` says the shell *"cannot opt in one page at a time, because every page renders inside it"* — still true, and this doesn't ask it to. **The mode is still one value for the whole tree at any moment.** What changed is only how the *default* is computed: the route joins the query param and stored value as an input. The shell reads the same single value it always did.

So neither option 1 nor option 2 on the issue was needed — this is the third case, and that's what it turned out to be. No route-scoped provider gymnastics, no separate landing chrome.

**Precedence, highest first:** query param → stored value → route default. A stored value outranks the route **in both directions**, or the opt-out is a button that undoes itself on reload.

## The flash was the real work, and `next/script` was the trap

`DesignModeProvider` sets `data-design` in a `useEffect`. Fine while terminal is opt-in — a reviewer who typed the param tolerates one frame of the old palette. **Not fine when `/` is terminal for everyone:** the landing page paints the current design's light ground, then swaps to near-black, on the first frame a prospective user sees.

**`<Script strategy="beforeInteractive">` does not fix this.** Next routes even `beforeInteractive` through its own loader — the served HTML carries it as a JSON payload that runs during the hydration bootstrap:

```
[{"children":"…","id":"design-init"}]
```

Measured: at `readyState === 'interactive'` the attribute was still absent, and the E2E test for it failed. A **raw inline `<script>` in `<head>`** is executed synchronously by the browser before it paints. That's what this uses. The distinction is invisible in the source, which is why it carries a comment.

## Drift protection, verified rather than asserted

The inline script duplicates the precedence logic because it must run before any module loads. `__tests__/designMode.test.mts` extracts **that exact string** from `layout.tsx`, runs it against a fake window, and compares it to `resolveDesignMode` across all 64 input combinations.

I planted a break in the real script to confirm the gate has teeth — it failed and named the 2 affected cases, then I restored it. 13 unit tests including that control.

## Two things I found and did not fix

**1. The preference persists asynchronously.** `DesignModeProvider` writes it in an effect, so a visitor who opts out with `?design=current` and reloads *instantly* gets terminal back. Pre-existing — the write has always been in an effect — but only visible now that `/` has a default differing from the stored value. Narrow, and it cost me two false E2E failures before I understood it. Flagging rather than changing persistence behaviour inside a shipping change.

**2. `/` has 5 sub-24px tap targets on mobile**, identical in both themes. Pre-existing; I changed no landing markup. I did **not** enumerate which elements — the audit's `--json` output didn't surface them in a shape I could read quickly, and I'd rather report the count honestly than guess at the list. Worth its own issue if you agree it's real; it's an SC 2.5.8 question, not a handoff-spec deviation, so the owner's "stop aligning to specs" ruling doesn't obviously cover it.

## On the "58 empty fields on mobile dark" you asked me to confirm

**It does not reproduce.** Measured on a local production build of this branch:

```
mobile dark   /   ovf 0  contrast 0  empty 4   ENTRY | STOP | TARGET | CB prem
mobile light  /   ovf 0  contrast 0  empty 4   ENTRY | STOP | TARGET | CB prem
```

Same four fields, both themes, zero overflow, zero contrast failures. That supports your unsettled-ticker-data hypothesis rather than a defect. **Caveat:** this is my local build at this commit, not the deployed build you measured — different data timing, so treat it as consistent-with rather than a refutation.

The 3 `specs/landing.md` failures (C10, C11, C18) are untouched, as you asked.

## How to test (QA)

On `qa`, dark and light, desktop 1440 and mobile 390:

1. **`/`, cleared storage, no param** — terminal landing. The point of the issue.
2. **`/dashboard`, `/arena`, `/liq`, `/scanner`, `/hours`, no param** — current design, unchanged.
3. **`/?design=current`** — current landing. Reload: still current.
4. **`/dashboard?design=terminal`** — terminal. Navigate to `/arena`: still terminal.
5. **`/` on a slow connection or with throttling** — no flash of the light ground before terminal paints. This is the one worth looking at with your own eyes; the automated check asserts the attribute at `readyState === 'interactive'`, which is necessary but not sufficient for "looks right".
6. **`/` → click into the app** — the design changes at the boundary. That is the owner's decision, not a bug; what matters is no broken intermediate chrome.

## Risk level

**Medium-High**, as the issue said — first user-visible design change, on the default path every visitor hits.

Gates: lint 0 errors, `tsc` 0, `npm test` 568/0, `build` 0. Plus 12 E2E (6 assertions × desktop and mobile), all passing against a local production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
