### PR TITLE
fix(dashboard): keep Perps vs Spot on one row at every verdict string

### DIFF
--- a/components/PerpSpotCard.tsx
+++ b/components/PerpSpotCard.tsx
@@ -66,18 +66,53 @@ export default function PerpSpotCard() {
         Perps vs Spot · {coin.toUpperCase()}
       </div>
 
-      {/* #656 item 4: verdict pill and number share one row instead of two
-          stacked blocks. Owner's ruling was "keep the content, restyle to
-          fit" - not a trim, so the verdict text and the number are both
-          still here, unchanged. What moved is the LAYOUT: the canvas draws
-          this as "one 11.5px line and a 1.4x value", i.e. the verdict and
-          the number read as one unit, not two. Two stacked blocks each
-          carrying their own marginBottom (8 + 8 = 16px) is what the canvas
-          does not have; one flex row with a single marginBottom removes
-          that duplicated spacing without cutting either piece of content. */}
+      {/* The verdict pill and the number share one row (#656 item 4), and that
+          row now fits at every verdict string (#723).
+       *
+       * WHAT WENT WRONG THE FIRST TIME. This row was `flexWrap: 'wrap'` with
+       * both children sized to their content, so whether it rendered as one
+       * line depended on how long the verdict happened to be:
+       *
+       *     NORMAL            79 + 10 + 182 = 271   fits in the 330px rail
+       *     CANNOT MEASURE   140 + 10 + 182 = 332   wraps back to a stack
+       *
+       * FUTURES LEADING and SPOT LEADING sit between those, so it was about
+       * half the value set, not an edge case - and it is data-driven, so the
+       * card silently changed shape as the market moved.
+       *
+       * THE FIX IS TO LET THE NUMBER BLOCK SHRINK, not to forbid wrapping.
+       * `flex: 1 1 0` + `minWidth: 0` lets its LABEL wrap inside the row
+       * instead of the whole block dropping below the pill. The value itself
+       * (`1.4x`) is short and never wraps, and it is the part a user actually
+       * reads - forcing one line by squeezing the number would have traded a
+       * cosmetic inconsistency for a legibility one.
+       *
+       * Measured at 330px, all four verdicts on one row:
+       *
+       *     NORMAL           pill  79   row 48
+       *     SPOT LEADING     pill 116   row 48
+       *     FUTURES LEADING  pill 139   row 64   <- label wraps to two lines
+       *     CANNOT MEASURE   pill 142   row 64
+       *
+       * So the long verdicts cost 16px, and the pre-#717 stacked layout was 82
+       * (26 pill + 8 margin + 48 block). Worst case here still beats it by 18px
+       * and the best case by 34. What actually matters is that the row no
+       * longer changes shape with the data - deterministic beats
+       * occasionally-shorter on a card whose job is to be read at a glance.
+       *
+       * NOT restored to the pre-#717 stack, though that was on the table.
+       * #717's justification was canvas conformance, and #718 stopped that
+       * while #656 was closed as superseded - so the original reason for this
+       * layout is gone. It stays because a shorter card is still better on a
+       * crowded rail, which is true independently of the canvas. Recorded
+       * because "the canvas said so" is no longer an argument anyone can
+       * lean on here. */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6, flexWrap: 'wrap' }}>
         <div className="psc-verdict-pill" style={{
           display: 'inline-flex', alignItems: 'center', gap: 5, padding: '3px 10px',
+          /* The verdict must not shrink - it is a fixed set of short strings and
+             hyphenating FUTURES LEADING would be worse than any wrap. */
+          flexShrink: 0,
           background: `color-mix(in srgb, ${tone} 12%, transparent)`,
           border: `0.5px solid color-mix(in srgb, ${tone} 40%, transparent)`,
         }}>
@@ -94,7 +129,14 @@ export default function PerpSpotCard() {
         {/* The number. A dash when it could not be measured - never a 1.0x,
             which would read as "an ordinary day" and be indistinguishable
             from having checked. */}
-        <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <div style={{
+          display: 'flex', flexDirection: 'column',
+          /* Shrink to whatever the pill leaves. minWidth: 0 is the load-bearing
+             half - a flex item's default min-width is `auto`, which floors it at
+             its longest unbreakable content and would keep this block at its
+             full width no matter what `flex` says. */
+          flex: '1 1 0', minWidth: 0,
+        }}>
           <span style={{
             fontSize: 'var(--fs-micro)', color: 'var(--txt3)', textTransform: 'uppercase',
             letterSpacing: '0.05em', marginBottom: 1,

--- a/qa/e2e/entitled-macro-cards.spec.ts
+++ b/qa/e2e/entitled-macro-cards.spec.ts
@@ -99,4 +99,48 @@ test.describe('macro cards, entitled branch', () => {
     expect(shape!.numberIsSibling).toBe(true);
     expect(shape!.rowChildren).toBe(2);
   });
+
+  test('#723: the row holds one line at EVERY verdict, not just the short ones', async ({ page }) => {
+    /* The deterministic version of the assertion I had to remove.
+     *
+     * The original compared the pill's and number's vertical centres against
+     * whatever verdict the live market produced, so it failed once and passed
+     * on a re-measure - the string is data-driven and the long ones wrapped.
+     * Waiting for the market to produce `CANNOT MEASURE` is not a test, it is
+     * a stakeout.
+     *
+     * So the verdict is INJECTED. Every one of the four real strings is written
+     * into the pill and the row re-measured, which tests the CSS at the
+     * boundary that actually matters rather than at whichever point the data
+     * happened to be. Nothing about the layout depends on where the string came
+     * from. */
+    await useEntitledSession(page);
+    await page.goto(DASHBOARD);
+
+    const card = page.getByTestId('perp-spot-card');
+    await expect(card).toBeVisible();
+
+    const VERDICTS = ['NORMAL', 'SPOT LEADING', 'FUTURES LEADING', 'CANNOT MEASURE'];
+    const wrapped: string[] = [];
+
+    for (const verdict of VERDICTS) {
+      const sameRow = await card.evaluate((el: HTMLElement, v: string) => {
+        const pill = el.querySelector('.psc-verdict-pill') as HTMLElement | null;
+        const span = pill?.querySelector('span') as HTMLElement | null;
+        const num = pill?.nextElementSibling as HTMLElement | null;
+        if (!pill || !span || !num) return null;
+        span.textContent = v;
+        const p = pill.getBoundingClientRect();
+        const n = num.getBoundingClientRect();
+        /* Centres within half the taller box = same row. Stacked, they differ
+           by roughly a full box height. */
+        return Math.abs((p.y + p.height / 2) - (n.y + n.height / 2)) < Math.max(p.height, n.height) / 2;
+      }, verdict);
+
+      expect(sameRow, `could not measure the row at "${verdict}"`).not.toBeNull();
+      if (!sameRow) wrapped.push(verdict);
+    }
+
+    expect(wrapped, 'these verdicts push the number onto a second line - the number block is not shrinking, so check flex/minWidth on it').toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

The Perps vs Spot row now holds one line at **every** verdict string, not just the short ones. Closes #723.

## The defect

The row was `flexWrap: 'wrap'` with both children sized to content, so whether it rendered as one line depended on how long the verdict happened to be — and the verdict is data-driven:

```
NORMAL            79 + 10 + 182 = 271   fits the 330px rail
CANNOT MEASURE   140 + 10 + 182 = 332   wraps back to a stack
```

`FUTURES LEADING` and `SPOT LEADING` sit between those, so roughly **half the value set** wrapped. The card changed shape as the market moved.

## The fix is to let the number block shrink, not to forbid wrapping

`flex: 1 1 0` + `minWidth: 0` on the number block lets its **label** wrap inside the row instead of the whole block dropping below the pill. The pill gets `flexShrink: 0`.

**`minWidth: 0` is the load-bearing half.** A flex item's default `min-width` is `auto`, which floors it at its longest unbreakable content — `flex: 1 1 0` alone would have changed nothing.

Forcing one line the other way means squeezing something at 330px with a 142px pill, and the only candidate is the number — the part a user actually reads. QA said the same in triage: *"the number is the thing a user actually reads."*

## Measured, all four verdicts

```
NORMAL           pill  79   row 48
SPOT LEADING     pill 116   row 48
FUTURES LEADING  pill 139   row 64   <- label wraps to two lines
CANNOT MEASURE   pill 142   row 64
```

Long verdicts cost 16px. The pre-#717 stacked layout was 82px (26 pill + 8 margin + 48 block), so the worst case still beats it by 18 and the best by 34.

**The saving isn't the point** — the height no longer depends on the data.

## On QA's question of whether #717's premise was wrong

Partly, and worth stating: **#717's justification was canvas conformance.** #718 stopped that, and #656 was closed as superseded — so the original reason for this layout is gone, and reverting to the stack was genuinely on the table.

It stays because a shorter card is still better on a crowded rail, which is true independently of the canvas. That reasoning is now in the file, because *"the canvas said so"* is no longer an argument anyone here can lean on.

No copy changed, so no design ruling was needed — which is what QA's *"keep it to what the data needs"* pointed at.

## The regression test is deterministic now

The original assertion compared vertical centres against whatever verdict the live market produced. It failed once, passed on re-measure, and I removed it as a coin flip.

The replacement **injects all four verdict strings** and re-measures each. Waiting for the market to produce `CANNOT MEASURE` is a stakeout, not a test — and nothing about the layout depends on where the string came from.

## How to test (QA)

`/dashboard` with an entitled session (`qa/e2e/_entitled-session.ts`), desktop and mobile:

1. The verdict pill and the `1.4x` value sit on **one row**.
2. `npx playwright test qa/e2e/entitled-macro-cards.spec.ts` — 5 assertions, both projects.
3. If the current verdict is short, the injected-string test is the one that covers the long cases.

## Risk level

**Low.** Three flex properties on one card, no copy change, no other surface touched. Gates: lint 0 errors, `tsc` 0, `npm test` 568/0, `build` 0, plus 10 E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
