### PR TITLE
fix(upgrade): the checkout URL never reached the browser, so Pro was unbuyable

### DIFF
--- a/__tests__/checkoutUrl.test.mts
+++ b/__tests__/checkoutUrl.test.mts
@@ -26,18 +26,31 @@ import assert from 'node:assert/strict';
 
 const KEY = 'NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL';
 
-/** Import fresh each time: the module reads process.env at call time, but a
- *  cached module would hide it if that ever changed to read-at-import. */
-async function checkout() {
-  const mod = await import(`../lib/checkout.ts?t=${Date.now()}`);
-  return mod.getCheckoutUrl as (u: { id: string; email?: string } | null) => string;
-}
+type GetCheckoutUrl = (u: { id: string; email?: string } | null) => string;
 
-async function withEnv<T>(value: string | undefined, fn: () => Promise<T>): Promise<T> {
+/** Import fresh each time, AFTER the environment is set.
+ *
+ *  The comment here used to say the module "reads process.env at call time,
+ *  but a cached module would hide it if that ever changed to read-at-import".
+ *  It changed (#243): lib/checkout.ts now captures the value at module scope,
+ *  because Next.js inlines ONLY a literal `process.env.NEXT_PUBLIC_X` member
+ *  access into the client bundle - reading it off an object at call time
+ *  resolved to nothing in the browser and left the upgrade page with no
+ *  checkout button in every environment.
+ *
+ *  Read-at-import is therefore required, not incidental, and these tests have
+ *  to import after setting the variable rather than before. The ordering now
+ *  lives INSIDE this helper and the module is handed to the callback, so a
+ *  future test cannot get it wrong by writing the two lines in the old order -
+ *  which is exactly how these five started failing. */
+async function withEnv<T>(value: string | undefined, fn: (getCheckoutUrl: GetCheckoutUrl) => Promise<T>): Promise<T> {
   const saved = process.env[KEY];
   if (value === undefined) delete process.env[KEY];
   else process.env[KEY] = value;
-  try { return await fn(); } finally {
+  try {
+    const mod = await import(`../lib/checkout.ts?t=${Date.now()}`);
+    return await fn(mod.getCheckoutUrl as GetCheckoutUrl);
+  } finally {
     if (saved === undefined) delete process.env[KEY];
     else process.env[KEY] = saved;
   }
@@ -47,20 +60,18 @@ const USER = { id: '11111111-2222-4333-8444-555555555555', email: 'payer@example
 
 test('the checkout URL carries the identity the webhook must not trust', async (t) => {
   await t.test('unconfigured checkout sends the user to signup, not to a broken URL', async () => {
-    const getCheckoutUrl = await checkout();
-    await withEnv(undefined, async () => {
+    await withEnv(undefined, async (getCheckoutUrl) => {
       assert.equal(getCheckoutUrl(USER), '/login?signup=1');
     });
     /* '#' is what the env file ships as a placeholder. Treating it as
      * "configured" would produce a checkout link that goes nowhere. */
-    await withEnv('#', async () => {
+    await withEnv('#', async (getCheckoutUrl) => {
       assert.equal(getCheckoutUrl(USER), '/login?signup=1');
     });
   });
 
   await t.test('a signed-in user gets their OWN id and email in the URL', async () => {
-    const getCheckoutUrl = await checkout();
-    await withEnv('https://example.lemonsqueezy.com/checkout/buy/abc', async () => {
+    await withEnv('https://example.lemonsqueezy.com/checkout/buy/abc', async (getCheckoutUrl) => {
       const url = new URL(getCheckoutUrl(USER));
       assert.equal(url.searchParams.get('checkout[custom][user_id]'), USER.id);
       assert.equal(url.searchParams.get('checkout[email]'), USER.email);
@@ -78,8 +89,7 @@ test('the checkout URL carries the identity the webhook must not trust', async (
    * server-side, that is an improvement - and the ownership check should still
    * stay, because defence in depth is the whole argument. */
   await t.test('the id is client-editable, which is WHY the webhook verifies ownership', async () => {
-    const getCheckoutUrl = await checkout();
-    await withEnv('https://example.lemonsqueezy.com/checkout/buy/abc', async () => {
+    await withEnv('https://example.lemonsqueezy.com/checkout/buy/abc', async (getCheckoutUrl) => {
       const mine = new URL(getCheckoutUrl(USER));
 
       // Anyone can do this in the address bar before paying.
@@ -95,8 +105,7 @@ test('the checkout URL carries the identity the webhook must not trust', async (
   });
 
   await t.test('a signed-out visitor leaks no checkout parameters', async () => {
-    const getCheckoutUrl = await checkout();
-    await withEnv('https://example.lemonsqueezy.com/checkout/buy/abc', async () => {
+    await withEnv('https://example.lemonsqueezy.com/checkout/buy/abc', async (getCheckoutUrl) => {
       const url = new URL(getCheckoutUrl(null));
       assert.equal(url.searchParams.get('checkout[custom][user_id]'), null);
       assert.equal(url.searchParams.get('checkout[email]'), null);
@@ -107,8 +116,7 @@ test('the checkout URL carries the identity the webhook must not trust', async (
    * /upgrade and inside UpgradeGateModal; an exception there blanks the page a
    * user reached in order to give us money. */
   await t.test('a malformed checkout URL degrades instead of throwing', async () => {
-    const getCheckoutUrl = await checkout();
-    await withEnv('not a url', async () => {
+    await withEnv('not a url', async (getCheckoutUrl) => {
       assert.doesNotThrow(() => getCheckoutUrl(USER));
       assert.equal(getCheckoutUrl(USER), 'not a url');
     });

--- a/app/upgrade/page.tsx
+++ b/app/upgrade/page.tsx
@@ -198,6 +198,7 @@ export default function UpgradePage() {
             <>
               <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', justifyContent: 'center' }}>
                 <button
+                  data-testid="checkout-cta-monthly"
                   onClick={handleCheckout}
                   disabled={redirecting}
                   style={{ fontSize: 'var(--fs-data)', fontWeight: 700, color: 'var(--on-accent)', background: 'var(--accent-solid)', padding: '14px 32px', borderRadius: 12, border: 'none', cursor: redirecting ? 'default' : 'pointer', opacity: redirecting ? 0.7 : 1, transition: 'opacity .15s, transform .15s', transform: 'translateY(0)' }}
@@ -207,6 +208,7 @@ export default function UpgradePage() {
                   {redirecting ? t('UPGRADE_CHECKOUT_BUTTON_REDIRECTING') : t('UPGRADE_MONTHLY_CHECKOUT_BUTTON_CTA')}
                 </button>
                 <button
+                  data-testid="checkout-cta-annual"
                   onClick={handleCheckoutAnnual}
                   disabled={redirecting}
                   style={{ fontSize: 'var(--fs-data)', fontWeight: 700, color: 'var(--on-accent)', background: 'var(--accent-solid)', padding: '14px 32px', borderRadius: 12, border: 'none', cursor: redirecting ? 'default' : 'pointer', opacity: redirecting ? 0.7 : 1, transition: 'opacity .15s, transform .15s', transform: 'translateY(0)', position: 'relative' }}
@@ -230,6 +232,7 @@ export default function UpgradePage() {
             /* State 2: monthly only — pixel-identical to today */
             <>
               <button
+                data-testid="checkout-cta-monthly"
                 onClick={handleCheckout}
                 disabled={redirecting}
                 style={{ fontSize: 'var(--fs-data)', fontWeight: 700, color: '#fff', background: 'var(--accent-solid)', padding: '14px 40px', borderRadius: 12, border: 'none', cursor: redirecting ? 'default' : 'pointer', opacity: redirecting ? 0.7 : 1, transition: 'opacity .15s, transform .15s', transform: 'translateY(0)' }}

--- a/lib/checkout.ts
+++ b/lib/checkout.ts
@@ -14,15 +14,54 @@
  *  Exported so /api/version can report `configured.checkout` from the SAME read
  *  the app gates on (#282). A boolean computed differently from the thing it
  *  describes is worse than no boolean. */
-export function checkoutBase(env: Record<string, string | undefined> = process.env): string | null {
-  const base = env.NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL;
+
+/* THE VALUES ARE READ HERE, AS LITERAL `process.env.NEXT_PUBLIC_*` MEMBER
+ * ACCESSES AT MODULE SCOPE, AND THAT IS THE WHOLE FIX (#243).
+ *
+ * These functions took `env: Record<…> = process.env` and read
+ * `env.NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL` off it. Next.js inlines ONLY the
+ * literal `process.env.NEXT_PUBLIC_X` form into the client bundle; reading a
+ * property off a `process.env` object passed in as a whole resolves to nothing
+ * in the browser. So `isCheckoutConfigured()` - called with no argument at
+ * module scope in app/upgrade/page.tsx:13 - was permanently false on the
+ * client, and the upgrade page rendered its "no store yet" branch with NO
+ * CHECKOUT BUTTON regardless of how the environment was configured.
+ *
+ * Measured before changing anything: with the variable set in .env.local AND
+ * present at runtime, `/api/version` reported `configured.checkout: true`
+ * (server-side, live process.env - that path always worked) while the built
+ * client chunks contained the URL nowhere, the served HTML contained no CTA,
+ * and the rendered page showed no checkout button. Pro was not buyable through
+ * the UI in any environment.
+ *
+ * lib/analytics.ts:26 already documents this exact hazard, in these words:
+ *
+ *     "Next.js inlines only that literal form into the client bundle, so
+ *      reading properties off a `process.env` object passed in as a whole
+ *      resolves to nothing in the browser ... A default parameter here made
+ *      that mistake easy and invisible, so it is gone."
+ *
+ * That lesson was learned, written down, and applied to analytics - and left
+ * in place on the payment path, where the failure is silent in exactly the same
+ * way and costs money instead of telemetry.
+ *
+ * The optional `env` parameter STAYS, because /api/version and lib/email.ts
+ * legitimately read server-side values, and #282 requires them to use the same
+ * predicate the UI gates on. What changed is the default: an explicit argument
+ * still wins, and omitting it now falls back to a value that was inlined at
+ * build time rather than to an object that is empty in the browser. */
+const INLINED_MONTHLY = process.env.NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL;
+const INLINED_ANNUAL  = process.env.NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL_ANNUAL;
+
+export function checkoutBase(env?: Record<string, string | undefined>): string | null {
+  const base = env ? env.NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL : INLINED_MONTHLY;
   return base && base !== '#' ? base : null;
 }
 
 /** Boolean form of the same read. Returns the URL rather than a boolean above so
  *  callers that need the value get type narrowing from the one check, instead of
  *  testing a helper and then re-testing the variable to satisfy the compiler. */
-export function isCheckoutConfigured(env: Record<string, string | undefined> = process.env): boolean {
+export function isCheckoutConfigured(env?: Record<string, string | undefined>): boolean {
   return checkoutBase(env) !== null;
 }
 
@@ -41,12 +80,14 @@ export function getCheckoutUrl(user: { id: string; email?: string } | null): str
   }
 }
 
-export function checkoutBaseAnnual(env: Record<string, string | undefined> = process.env): string | null {
-  const base = env.NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL_ANNUAL;
+/* Same fix as checkoutBase above - see its header for why the default is a
+   build-time constant rather than `= process.env`. */
+export function checkoutBaseAnnual(env?: Record<string, string | undefined>): string | null {
+  const base = env ? env.NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL_ANNUAL : INLINED_ANNUAL;
   return base && base !== '#' ? base : null;
 }
 
-export function isCheckoutConfiguredAnnual(env: Record<string, string | undefined> = process.env): boolean {
+export function isCheckoutConfiguredAnnual(env?: Record<string, string | undefined>): boolean {
   return checkoutBaseAnnual(env) !== null;
 }
 

--- a/qa/e2e/_entitled-session.ts
+++ b/qa/e2e/_entitled-session.ts
@@ -84,8 +84,17 @@ function unsignedJwt(userId: string, email: string, expSeconds: number): string 
 
 export interface EntitledOptions {
   /** 'pro' is a paid subscriber; 'trial' exercises the OTHER branch of
-   *  `entitled = isPro || isTrial`, which is the one a real new signup gets. */
-  as?: 'pro' | 'trial';
+   *  `entitled = isPro || isTrial`, which is the one a real new signup gets.
+   *
+   *  'free' is SIGNED IN BUT NOT ENTITLED, and it is not a contradiction of
+   *  this file's name - it is the state `/upgrade` needs. That page redirects
+   *  Pro users straight to /arena (app/upgrade/page.tsx:84), so a 'pro'
+   *  session cannot see the checkout button at all, and a signed-OUT session
+   *  renders no CTA either. Only a signed-in non-subscriber is shown the
+   *  thing being sold. Found by running it: my first #243 check used 'pro',
+   *  got redirected, and reported a config disagreement that was really my
+   *  own wrong session state. */
+  as?: 'pro' | 'trial' | 'free';
   supabaseUrl?: string;
 }
 
@@ -159,7 +168,12 @@ export async function useEntitledSession(page: Page, opts: EntitledOptions = {})
      trigger writes it (supabase/migrations/20260804g_trial_email_dedup.sql). */
   const row = as === 'pro'
     ? { role: 'pro', trial_ends_at: null }
-    : { role: 'free', trial_ends_at: new Date(Date.now() + 14 * 864e5).toISOString() };
+    : as === 'trial'
+      ? { role: 'free', trial_ends_at: new Date(Date.now() + 14 * 864e5).toISOString() }
+      /* 'free': a PAST trial end, not null. Both read as not-entitled, but an
+         expired window also exercises the `trialEndsAt > clock` comparison
+         rather than short-circuiting on null - closer to a real lapsed user. */
+      : { role: 'free', trial_ends_at: new Date(Date.now() - 864e5).toISOString() };
 
   await page.route(`${supabaseUrl}/rest/v1/**`, async route => {
     const url = route.request().url();

--- a/qa/e2e/checkout-config-agrees.spec.ts
+++ b/qa/e2e/checkout-config-agrees.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect } from '@playwright/test';
+
+/* DOES THE UPGRADE BUTTON ACTUALLY HAVE A CHECKOUT URL? (#243)
+ *
+ * `/api/version` cannot answer this, and it is the natural place to look:
+ *
+ *   /api/version   lib/configured.ts, runs SERVER-side per request,
+ *                  reads live process.env
+ *
+ *   /upgrade       'use client', and isCheckoutConfigured() is called at
+ *                  MODULE SCOPE (app/upgrade/page.tsx:13), so
+ *                  NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL is baked into the
+ *                  client bundle at BUILD time
+ *
+ * Set the variable after a build and the two disagree: `/api/version` reports
+ * `configured.checkout: true` while the shipped bundle still holds `'#'` and
+ * the button is dead. #243 names that as the most likely way the task fails
+ * quietly - and the check meant to rule it out would confirm the wrong thing.
+ *
+ * SO THIS COMPARES THE TWO SOURCES rather than trusting either. It is a
+ * config-agreement check, not a UI test.
+ *
+ * NO SESSION NEEDED, contrary to where this started. `/upgrade` gates only on
+ * `loading || isPro` (page.tsx:105) and deliberately shows pricing to anonymous
+ * visitors - login is required at the click, not to see the price. So an
+ * unauthenticated check is sufficient AND is the cleaner instrument: it removes
+ * the fixture, the fake session and the Supabase interception from a test whose
+ * subject is a build-time constant.
+ *
+ * QA loaded /upgrade on staging signed out, found no CTA, and concluded an
+ * authenticated session was required. It was not - the CTA was missing because
+ * of the #243 inlining defect this spec now guards. Worth recording: "the
+ * button is absent" and "I am not allowed to see the button" looked identical
+ * from outside.
+ *
+ * RUN IT AGAINST A DEPLOYED HOST:
+ *
+ *   E2E_BASE_URL=https://liquidity-hq-staging.onrender.com \
+ *     npx playwright test qa/e2e/checkout-config-agrees.spec.ts --project=desktop
+ *
+ * The fixture routes Supabase by absolute URL, so it works on any app origin
+ * pointing at the same Supabase project.
+ */
+
+interface VersionPayload {
+  commit?: string;
+  configured?: { checkout?: boolean };
+}
+
+test.describe('#243 checkout config', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('the server and the shipped bundle agree about whether checkout is configured', async ({ page, baseURL }) => {
+    /* The server's claim, from the same read the app gates on (#282). */
+    const res = await page.request.get('/api/version');
+    expect(res.ok(), `/api/version returned ${res.status()}`).toBe(true);
+    const version = (await res.json()) as VersionPayload;
+    const serverSaysConfigured = version.configured?.checkout === true;
+
+    /* Anonymous. A 'pro' session would be REDIRECTED to /arena
+       (page.tsx:84) - my first version used one and reported a config
+       disagreement that was really the wrong session state. */
+    await page.goto('/upgrade');
+
+    /* THE CTA IS A <button>, NOT AN <a>. It navigates via
+       `window.location.href = getCheckoutUrl(user)` in an onClick
+       (page.tsx:96), so there is no href to read - which is also why QA's
+       sweep for anchors matching `lemon` or `href="#"` found neither and
+       could not settle this.
+       Matched on a testid rather than text or styling: the labels are
+       DB-driven through useLabels(), so matching copy binds this to whatever
+       the labels table says today, in one locale. Same reasoning as #441's
+       `locked-feature` marker. */
+    const cta = page.getByTestId('checkout-cta-monthly');
+    const appeared = await cta.waitFor({ state: 'attached', timeout: 20_000 })
+      .then(() => true).catch(() => false);
+
+    /* The button's PRESENCE is the bundle's `CHECKOUT_CONFIGURED`, evaluated at
+       module scope from the inlined build-time value. That is exactly the
+       reading `/api/version` cannot give. */
+    const bundleHasUrl = appeared;
+
+    /* Report both readings whichever way this goes - a bare pass/fail here
+       tells whoever runs it nothing about which side was wrong. */
+    const readings = `/api/version commit=${version.commit ?? 'unknown'} configured.checkout=${serverSaysConfigured} | checkout CTA rendered=${appeared} | base=${baseURL}`;
+
+    if (serverSaysConfigured) {
+      expect(
+        bundleHasUrl,
+        `THE SERVER AND THE BUNDLE DISAGREE. ${readings}\n` +
+        'The environment has NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL set, but the ' +
+        'shipped client bundle does not carry it - so the button is dead while ' +
+        '/api/version reports it configured. The variable was almost certainly ' +
+        'set after this build: redeploy so it is inlined, then re-run. This is ' +
+        'the exact silent failure #243 warns about.',
+      ).toBe(true);
+    } else {
+      /* Not configured is a legitimate state - most environments have never had
+         a store. What must NOT happen is the bundle carrying a live URL the
+         server does not know about, which would mean buyers reaching a checkout
+         nothing else in the app believes exists. */
+      expect(
+        bundleHasUrl,
+        `The bundle carries a checkout URL but the server reports none. ${readings}\n` +
+        'Inverted form of the same drift - the build has a URL the current ' +
+        'environment does not.',
+      ).toBe(false);
+    }
+
+    /* Not an assertion - the run's own record, so a green result still says
+       WHICH state was verified. "Agrees" is meaningless without it. */
+    console.log(`[#243] ${readings} | verdict=${serverSaysConfigured ? 'configured, bundle agrees' : 'not configured, bundle agrees'}`);
+  });
+});


### PR DESCRIPTION
## Summary

**The checkout URL was never reaching the browser, so the Get Pro button did not exist in any environment. Pro was unbuyable through the UI.** Launch blocker, found while working #243. Fixed and measured.

## The defect

`lib/checkout.ts` took `env: Record<…> = process.env` and read `env.NEXT_PUBLIC_LEMONSQUEEZY_CHECKOUT_URL` off it.

**Next.js inlines only the literal `process.env.NEXT_PUBLIC_X` member access into the client bundle.** Reading a property off a `process.env` object passed in as a whole resolves to nothing in the browser.

`app/upgrade/page.tsx:13` calls `isCheckoutConfigured()` with no argument at module scope — so `CHECKOUT_CONFIGURED` was permanently `false` on the client, and `/upgrade` rendered its "no store yet" branch with no checkout button, regardless of configuration.

## Measured, before and after

With the variable set in `.env.local` and present at runtime:

| | before | after |
|---|---|---|
| URL in client chunks | **0 files** | **7 files** |
| checkout CTA rendered | **no** | **yes** |
| `/api/version` `configured.checkout` | true | true |

**`/api/version` was `true` the whole time** — it reads live `process.env` *server*-side, so that path always worked. That is the trap I flagged earlier on #243, and it is worse than a staleness risk: the natural pre-flight check reports "checkout configured" while there is nothing on the page to click.

## The project already knew this

`lib/analytics.ts:26`, verbatim:

> *"Next.js inlines only that literal form into the client bundle, so reading properties off a `process.env` object passed in as a whole resolves to nothing in the browser … A default parameter here made that mistake easy and invisible, so it is gone."*

The lesson was learned, written down, and applied to analytics — and left in place on the payment path, where it fails silently in the same way and costs money rather than telemetry.

## What did not change

The optional `env` parameter stays. `/api/version` and `lib/email.ts` legitimately read server-side values, and #282 requires them to use the same predicate the UI gates on. An explicit argument still wins; only the default changed.

## The test file predicted this

`__tests__/checkoutUrl.test.mts` said the module *"reads process.env at call time, but a cached module would hide it if that ever changed to read-at-import."* It has now changed, necessarily — build-time inlining and runtime-mutable client reads cannot both exist.

Five tests failed on the ordering: they imported the module *before* `withEnv` set the variable. The fresh import now happens **inside** `withEnv`, after the variable is set, and the module is handed to the callback so a future test cannot reintroduce the old ordering. **Assertions are unchanged.**

## Also in this PR

**`data-testid` on the three checkout buttons.** The CTA is a `<button>` navigating via `window.location.href` in an `onClick` — not an `<a href>` — so there is no link to match, and the labels are DB-driven. Same reasoning as #441's `locked-feature` marker.

**`qa/e2e/checkout-config-agrees.spec.ts`** — compares the two sources instead of trusting either. Fails if `/api/version` claims configured while no CTA renders, and inversely. Verified against both a broken build and a fixed one.

## A correction for QA's #243 pre-flight

**No authenticated session is needed.** `/upgrade` gates only on `loading || isPro` and deliberately shows pricing to anonymous visitors — login is required at the click, not to see the price.

QA loaded `/upgrade` signed out, found no CTA, and concluded an authenticated session was required. It was not: **the button was missing because of this defect.** "The button is absent" and "I am not allowed to see the button" looked identical from outside. That unblocks step 3 without a credential.

## How to test (QA)

1. On an environment with the checkout URL set: `/upgrade` renders a Get Pro button, and its click target is a real LemonSqueezy URL carrying `checkout[email]` and `checkout[custom][user_id]`.
2. Unset: the page shows its no-store branch as before.
3. `npx playwright test qa/e2e/checkout-config-agrees.spec.ts`, optionally `E2E_BASE_URL=https://liquidity-hq-staging.onrender.com` against a deployed host.
4. **This needs a redeploy to take effect anywhere** — the value is inlined at build time, which is the whole subject of the PR.

## Risk level

**Medium.** Small change on the payment path, which is the highest-consequence surface in the app; but it moves that path from *provably non-functional* to functional, and the before/after is measured rather than argued. Gates: lint 0 errors, `tsc` 0, `npm test` 568/0, `build` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
