### PR TITLE
fix(auth): bound the initial session read so /upgrade cannot hang forever

### DIFF
--- a/components/AuthProvider.tsx
+++ b/components/AuthProvider.tsx
@@ -33,6 +33,14 @@ export function useAuth() {
 }
 
 const INACTIVITY_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+/* How long the initial session read may take before the app gives up and
+   renders as signed-out (#727). Generous enough that a slow-but-working
+   network still resolves to the real session - Render's free plan can be slow
+   and QA measured the healthy anonymous path at 2-3s on staging - and short
+   enough that a hang does not read as a broken page. The value is a ceiling on
+   a failure, not a target: the normal path settles long before it. */
+const SESSION_RESOLVE_MS = 8000;
 const LAST_ACTIVE_KEY = 'lhq_last_active';
 // Read by AuthGate - shared here so both sides reference the same literal.
 export const BAN_NOTICE_KEY = 'lhq_ban_notice';
@@ -62,14 +70,48 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
     const sb = getSupabase();
     if (!sb) { setLoading(false); return; }
 
-    // Seed initial session, force sign-out if inactive >7 days
-    sb.auth.getSession().then(async ({ data }) => {
-      const sessionUser = data.session?.user ?? null;
+    /* Seed initial session, force sign-out if inactive >7 days.
+     *
+     * BOUNDED, because `loading` staying true is a page-blocking failure and
+     * this promise does not always settle (#727).
+     *
+     * A browser holding an EXPIRED session made `getSession()` hang: supabase-js
+     * tries to refresh the token on read, and when that refresh neither resolves
+     * nor rejects the `.finally` below never runs, so `loading` stays true
+     * forever. `/upgrade` is the one screen that gates its whole render on
+     * `loading` (page.tsx:105), so it sat on "Loading…" indefinitely while the
+     * rest of the app looked fine - QA measured /dashboard settling in 1ms and
+     * /upgrade stuck past 25s in the same browser, same commit.
+     *
+     * That is the ordinary state of a returning user's browser, since tokens
+     * expire by design, and the wall is exactly where they try to pay.
+     *
+     * The timeout treats "no answer" as "no session" rather than guessing at a
+     * user. That is the safe direction: a real session that merely arrives late
+     * is still delivered by the onAuthStateChange subscription below, which
+     * fires on TOKEN_REFRESHED and SIGNED_IN and sets the user then. The
+     * failure this replaces had no recovery path at all.
+     *
+     * NOT the opposite bug. #377 was a stuck `loading` that GRANTED Pro; this
+     * resolves to signed-out, which grants nothing. */
+    const withTimeout = <T,>(p: PromiseLike<T>, ms: number): Promise<T | null> =>
+      Promise.race([
+        Promise.resolve(p),
+        new Promise<null>(resolve => setTimeout(() => resolve(null), ms)),
+      ]);
+
+    withTimeout(sb.auth.getSession(), SESSION_RESOLVE_MS).then(async (res) => {
+      const data = res?.data;
+      const sessionUser = data?.session?.user ?? null;
       if (sessionUser && isSessionExpired()) {
+        /* Bounded for the same reason as the read above: signOut() is a network
+           call and this branch awaits it, so a hang here would keep `loading`
+           true just as effectively. forceSignOut already clears local storage
+           when the call errors; a timeout is the third case it did not have. */
         // forceSignOut, not sb.auth.signOut: this path exists to END a session
         // that has outlived its window, so it failing quietly would keep the
         // user signed in past the expiry it is enforcing (#304).
-        await forceSignOut(sb);
+        await withTimeout(forceSignOut(sb), SESSION_RESOLVE_MS);
         localStorage.removeItem(LAST_ACTIVE_KEY);
         setUser(null);
       } else {

--- a/qa/e2e/_entitled-session.ts
+++ b/qa/e2e/_entitled-session.ts
@@ -94,7 +94,7 @@ export interface EntitledOptions {
    *  thing being sold. Found by running it: my first #243 check used 'pro',
    *  got redirected, and reported a config disagreement that was really my
    *  own wrong session state. */
-  as?: 'pro' | 'trial' | 'free';
+  as?: 'pro' | 'trial' | 'free' | 'expired';
   supabaseUrl?: string;
 }
 
@@ -130,7 +130,13 @@ export async function useEntitledSession(page: Page, opts: EntitledOptions = {})
   const userId = '00000000-0000-4000-8000-000000000001';
   const email = 'qa-entitled@example.invalid'; // .invalid is reserved (RFC 2606)
   const nowSec = Math.floor(Date.now() / 1000);
-  const accessToken = unsignedJwt(userId, email, nowSec + 3600);
+  /* 'expired' puts the expiry an hour in the PAST. Everything else about the
+     session is identical - this is the state a returning user's browser is in
+     between visits, which is the normal case rather than an edge one, since
+     tokens expire by design. #727. */
+  const expired = as === 'expired';
+  const expSec = expired ? nowSec - 3600 : nowSec + 3600;
+  const accessToken = unsignedJwt(userId, email, expSec);
 
   const user = {
     id: userId, aud: 'authenticated', role: 'authenticated', email,
@@ -143,7 +149,7 @@ export async function useEntitledSession(page: Page, opts: EntitledOptions = {})
     refresh_token: 'test-refresh-token-not-valid',
     token_type: 'bearer',
     expires_in: 3600,
-    expires_at: nowSec + 3600,
+    expires_at: expSec,
     user,
   };
 
@@ -193,6 +199,14 @@ export async function useEntitledSession(page: Page, opts: EntitledOptions = {})
   /* supabase-js calls these when it refreshes or re-validates. Unhandled they
      would hit the real project with an invalid token, and its 401 would sign
      the fixture out mid-test. */
+  /* DELIBERATELY NOT INTERCEPTED FOR 'expired'. The whole point of that state
+     is what supabase-js does when it tries to refresh a dead token and the
+     refresh does not come back - fulfilling /auth/v1/token here with a valid
+     session would paper over exactly the condition under test and the fixture
+     would prove the opposite of what it claims. Left to reach the real
+     endpoint, which rejects the bogus refresh token. */
+  if (expired) return;
+
   await page.route(`${supabaseUrl}/auth/v1/**`, async route => {
     const url = route.request().url();
     if (/\/user\b/.test(url)) {

--- a/qa/e2e/upgrade-expired-session.spec.ts
+++ b/qa/e2e/upgrade-expired-session.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test';
+import { useEntitledSession } from './_entitled-session';
+
+/* /upgrade MUST RESOLVE FOR A BROWSER HOLDING AN EXPIRED SESSION (#727).
+ *
+ * QA found `/upgrade` stuck on "Loading…" indefinitely when the browser holds
+ * an expired Supabase session, on deployed staging, twice, on a warm service.
+ * Removing that one localStorage key made it render instantly.
+ *
+ * WHO THIS HITS: every returning user, eventually. Tokens expire by design, so
+ * an expired token is the ORDINARY state of a browser between visits - not an
+ * edge case. Those users can browse the whole product normally and hit a wall
+ * only when they try to pay, which also makes it hard to notice: nothing else
+ * is broken and they have no reason to suspect their session.
+ *
+ * WHY THE EXISTING SUITE WAS GREEN THROUGHOUT. Playwright starts every test
+ * with a fresh context and empty storage, so every check either of us ran
+ * exercised the ANONYMOUS path - which genuinely resolves in 2-3 seconds. The
+ * four passing runs I reported on #243 were correct and measured the wrong
+ * state. "Suite green, user blocked" is the shape worth naming, and the fix
+ * for it is a fixture that can express the states real browsers are actually
+ * in rather than only the empty one.
+ */
+
+test.describe('#727 /upgrade with an expired session', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('the page resolves instead of hanging on Loading', async ({ page }) => {
+    await useEntitledSession(page, { as: 'expired' });
+    await page.goto('/upgrade');
+
+    /* The failure is a page that never leaves its loading branch, so the
+       assertion is "something other than the spinner arrived", not a specific
+       CTA - whether checkout is CONFIGURED is a separate question this must not
+       be coupled to (it is unset on qa and set on staging, and #727 is true on
+       both). Either the pricing content or a redirect is a pass; only the
+       spinner forever is a failure. */
+    const resolved = await page
+      .locator('[data-testid^="checkout-cta"], [data-testid="locked-feature"], h1, h2')
+      .first()
+      .waitFor({ state: 'attached', timeout: 25_000 })
+      .then(() => true)
+      .catch(() => false);
+
+    const mainText = (await page.locator('main').first().innerText().catch(() => '')).slice(0, 60);
+
+    expect(
+      resolved,
+      `/upgrade never left its loading branch with an expired session in localStorage. ` +
+      `main showed: "${mainText}". This is the state every returning user's browser is in.`,
+    ).toBe(true);
+
+    /* And specifically not the spinner. `resolved` can be true while the
+       loading branch is still what a user sees, since LoadingState renders its
+       own markup - so the text is checked directly rather than inferred. */
+    expect(mainText, 'the page is still showing its loading state after 25s').not.toMatch(/^Loading/i);
+  });
+
+  test('CONTROL: the anonymous path resolves, so a pass above is not vacuous', async ({ page }) => {
+    /* Without this, the test above passing proves only that /upgrade renders
+       SOMETHING - not that the expired session was the variable. This is the
+       path the whole suite was already exercising, and it was always green;
+       it is here to keep the comparison honest rather than to find anything. */
+    await page.goto('/upgrade');
+
+    /* Poll, do not sample. "Loading…" is a REAL transient state on this page
+       for two to three seconds while Supabase resolves the absent session -
+       reading innerText immediately after goto() catches it every time and
+       reports the healthy path as stuck. My first version did exactly that and
+       failed the control while the actual fix was working. */
+    await expect
+      .poll(async () => (await page.locator('main').first().innerText().catch(() => '')).slice(0, 60),
+        { timeout: 25_000, message: 'even the anonymous path is stuck - the finding is wider than #727 describes' })
+      .not.toMatch(/^Loading/i);
+  });
+});


### PR DESCRIPTION
## Summary

`/upgrade` hung on `"Loading…"` forever for any browser holding an **expired** Supabase session. This bounds the initial session read so it cannot. Fixes #727.

Every returning user hits this eventually — tokens expire by design, so an expired token is the *ordinary* state of a browser between visits. Those users browse the product normally and hit the wall only when they try to pay.

## Mechanism

`loading` is cleared in exactly one place: the `.finally()` on `AuthProvider`'s initial promise chain. Both awaits inside it are network calls, and supabase-js attempts a token refresh when it reads an expired session. If that refresh neither resolves nor rejects, `.finally` never runs and `loading` stays true for the life of the page.

`/upgrade` is the one screen gating its entire render on `loading` (`page.tsx:105`) — which is why it alone hung while everything else was fine. QA measured `/dashboard` settling in 1ms and `/upgrade` stuck past 25s, same browser, same commit.

## The fix, and why the direction is safe

Both awaits are wrapped in an 8s timeout; on timeout the app renders as **signed-out**.

That resolves to "no session" rather than guessing at a user, and it is recoverable: a real session arriving late is still delivered by the `onAuthStateChange` subscription, which fires on `TOKEN_REFRESHED` and `SIGNED_IN`. The failure it replaces had no recovery path at all.

**Not #377 inverted.** That was a stuck `loading` that *granted* Pro. This resolves to signed-out, which grants nothing.

## Verification — stated honestly, because a local pass here proves nothing

**The bug reproduces on deployed staging and not on localhost.** `getSession()` settles fine against Supabase from my machine. So:

- the new spec **fails against staging pre-fix** (measured — that is the reproduction)
- it **passes locally whether the fix is present or not**

I confirmed the second half by reverting the fix locally and re-running: still green. So I am not claiming the local run validates anything, and **this needs post-deploy verification on staging** — that is the measurement that settles it.

What *can* be argued without a reproduction is the shape: `loading` is cleared only in that one `.finally()`, and both awaits feeding it are now bounded, so it resolves within 8s regardless of **which** call hangs. That is mechanism-independent within the only chain that can block it.

## Why the whole suite was green through all of this

**Playwright starts every test with a fresh context and empty storage**, so every check either of us ran exercised the anonymous path — which genuinely resolves in 2–3s. My four passing runs on #243 were correct and measured the wrong state.

*Suite green, user blocked.* The fixture now has an `expired` variant so that state is reachable at all; QA's point that this was a small addition to a file that already writes sessions was right.

It deliberately does **not** intercept `/auth/v1` — fulfilling the token refresh with a valid session would paper over the exact condition under test.

## How to test (QA)

```
E2E_BASE_URL=https://liquidity-hq-staging.onrender.com \
  npx playwright test qa/e2e/upgrade-expired-session.spec.ts
```

Or by hand: seed `sb-<ref>-auth-token` with `expires_at` in the past, load `/upgrade`, and confirm the pricing page renders rather than sitting on the spinner. **The pre-fix build fails this and the post-deploy build should pass it** — that comparison is the whole verification.

## Risk level

**Medium.** Touches the auth provider every page depends on, and cannot be verified locally. Mitigated by the timeout resolving to the *less* privileged state and by `onAuthStateChange` remaining the recovery path. Gates: lint 0 errors, `tsc` 0, `npm test` 568/0, `build` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
