### PR TITLE
feat(nav): give the terminal top bar the current design's layout and controls

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5963,6 +5963,122 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
 }
 [data-design="terminal"] .tnav-item:hover { color: var(--txt2); }
 
+/* ── Terminal nav dropdowns (#714) ──────────────────────────────────────
+   The owner reported this bar twice: it carried five tabs where the nav it
+   replaced carried eight items and two grouping dropdowns, so everything
+   else was reachable only through the drawer.
+
+   Shaped from .tnav-item rather than from the current design's
+   .nav-more-dropdown: that shell is 12px-radius on --bg2 with a soft shadow,
+   which is the other design's language. Terminal is square, hairline, flat -
+   reusing the current-design shell here would have put a rounded card under a
+   monochrome bar. Same STRUCTURE and same disclosure behaviour, terminal's
+   surface treatment.
+
+   The button inherits .tnav-item, so it is one declaration for type and
+   colour and cannot drift from the tabs beside it - a nav where one item is
+   half a pixel off the rest is exactly what "it got down" describes. */
+[data-design="terminal"] .tnav-drop-wrap { position: relative; }
+[data-design="terminal"] .tnav-drop-btn {
+  background: none; border: 0; cursor: pointer;
+  /* Matches the Link siblings: a <button> inherits none of this. */
+  font-family: var(--font-mono), monospace;
+  font-size: 11px; font-weight: 500; letter-spacing: .1em; text-transform: uppercase;
+}
+[data-design="terminal"] .tnav-item.on,
+[data-design="terminal"] .tnav-drop-btn.on { color: var(--txt); }
+
+[data-design="terminal"] .tnav-dropdown {
+  position: absolute; top: calc(100% + 6px); left: 0; z-index: 300;
+  min-width: 180px; padding: 4px;
+  background: var(--bg1);
+  border: 1px solid var(--bdr2);
+  border-radius: 0;                     /* C17: no radius anywhere in terminal */
+  box-shadow: 0 8px 24px rgba(0,0,0,0.45);
+}
+[data-design="terminal"] .tnav-drop-item {
+  display: block; padding: 7px 10px;
+  font-family: var(--font-mono), monospace;
+  font-size: 11px; letter-spacing: .08em; text-transform: uppercase;
+  color: var(--txt3); text-decoration: none; white-space: nowrap;
+  transition: color .12s, background .12s;
+}
+[data-design="terminal"] .tnav-drop-item:hover {
+  color: var(--txt);
+  /* color-mix on a token, not an rgba() literal - a hardcoded white wash is
+     the cross-palette bug that kept reappearing through the redesign work. */
+  background: color-mix(in srgb, var(--txt) 8%, transparent);
+}
+[data-design="terminal"] .tnav-drop-item.on { color: var(--txt); }
+
+/* Below 768 the drawer is the navigation and these would compete with it -
+   the same breakpoint .hamburger and .tnav-mmore already use, not a new one. */
+@media (max-width: 767px) {
+  [data-design="terminal"] .tnav-drop-wrap { display: none; }
+}
+
+/* Theme toggle, language and Sign In (#714). The owner asked for these by
+   name: "on terminal top app bar There are missing buttons. like switching
+   dark theme and light theme and sign in".
+
+   The theme button is the one that mattered most. Terminal ships a full light
+   palette ([data-design="terminal"][data-theme="light"], #563) and nothing in
+   the terminal UI could reach it - the palette existed and was unreachable
+   without editing localStorage by hand.
+
+   Terminal's treatment, not the current design's: no radius, no accent fill,
+   monochrome, and sized against .tnav-item's 11px so the right cluster reads
+   as one bar rather than two. 28px box for a 16px glyph clears SC 2.5.8's
+   24px minimum without the padded-hit-area trick .tnav-avatar needed. */
+[data-design="terminal"] .tnav-icon-btn {
+  display: flex; align-items: center; justify-content: center;
+  width: 28px; height: 28px; flex-shrink: 0;
+  background: none; border: 0; padding: 0; cursor: pointer;
+  color: var(--txt3);
+  transition: color .12s;
+}
+[data-design="terminal"] .tnav-icon-btn:hover { color: var(--txt); }
+
+[data-design="terminal"] .tnav-signin {
+  font-family: var(--font-mono), monospace;
+  font-size: 11px; font-weight: 500; letter-spacing: .1em; text-transform: uppercase;
+  padding: 6px 12px; white-space: nowrap; text-decoration: none;
+  color: var(--txt);
+  border: 1px solid var(--bdr2);
+  border-radius: 0;
+  transition: border-color .12s, color .12s;
+}
+[data-design="terminal"] .tnav-signin:hover { border-color: var(--txt3); }
+
+/* The language switcher is a shared component carrying the current design's
+   own classes. Only its surface is restated here - structure, dropdown
+   behaviour and the switching itself are untouched. */
+[data-design="terminal"] .lang-nav-btn {
+  font-family: var(--font-mono), monospace;
+  font-size: 11px; letter-spacing: .08em;
+  border-radius: 0; color: var(--txt3);
+}
+[data-design="terminal"] .lang-nav-btn:hover { color: var(--txt); }
+/* Its panel too - verified against the component's own class names rather than
+   assumed. Left rounded it would be the one curved surface in the bar, which
+   is the "two design languages on one screen" failure the redesign notes warn
+   about repeatedly. */
+[data-design="terminal"] .lang-nav-dropdown {
+  background: var(--bg1);
+  border: 1px solid var(--bdr2);
+  border-radius: 0;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.45);
+}
+[data-design="terminal"] .lang-nav-item {
+  font-family: var(--font-mono), monospace;
+  font-size: 11px; letter-spacing: .08em; border-radius: 0; color: var(--txt3);
+}
+[data-design="terminal"] .lang-nav-item:hover {
+  color: var(--txt);
+  background: color-mix(in srgb, var(--txt) 8%, transparent);
+}
+[data-design="terminal"] .lang-nav-item.on { color: var(--txt); }
+
 /* The nav's right-hand cluster (#599). Dashboard 2a.dc.html:49-53 draws
    three elements after a flex spacer at gap:14px - a session indicator, a
    ⌘K hint and an avatar. None of them had ANY rule before this: wiring the

--- a/components/NavDrawer.tsx
+++ b/components/NavDrawer.tsx
@@ -22,6 +22,8 @@ import {
 } from './icons';
 import type { ComponentType } from 'react';
 import { useLabels } from '@/lib/labels';
+/* Shared with TerminalNav so both designs reach the same routes (#714). */
+import { PRIMARY, SCANNERS, TOOLS, TAIL } from '@/lib/navRoutes';
 import type { LabelKey } from '@/lib/labelKeys';
 
 /* ── Mobile tab bar icons - plain SVGs, not emoji. Emoji glyphs like ⚡ render
@@ -122,33 +124,6 @@ function SessionPill() {
 }
 
 /* ── Nav data ──────────────────────────────────────────────────────────────── */
-const PRIMARY = [
-  { path: '/dashboard', labelKey: 'NAV_DASHBOARD' as const },
-  { path: '/arena',     labelKey: 'NAV_ARENA'     as const },
-  { path: '/briefing',  labelKey: 'NAV_BRIEFING'  as const },
-];
-
-const SCANNERS = [
-  { path: '/markets',       labelKey: 'NAV_MARKETS'        as const },
-  { path: '/scanner',       labelKey: 'NAV_SETUP_SCANNER'  as const },
-  { path: '/liq',           labelKey: 'NAV_LIQUIDATION_MAP' as const },
-  { path: '/funding',       labelKey: 'NAV_FR_HISTORY'     as const },
-  { path: '/correlation',   labelKey: 'NAV_CORRELATION'    as const },
-];
-
-const TOOLS = [
-  { path: '/journal',       labelKey: 'NAV_JOURNAL'       as const },
-  { path: '/research',      labelKey: 'NAV_RESEARCH'      as const },
-  { path: '/calc',          labelKey: 'NAV_CALCULATORS'   as const },
-  { path: '/econ-calendar', labelKey: 'NAV_ECON_CALENDAR' as const },
-  { path: '/alerts',        labelKey: 'NAV_ALERTS'        as const },
-  { path: '/hours',         labelKey: 'NAV_BEST_HOURS'    as const },
-  { path: '/playbook',      labelKey: 'NAV_PLAYBOOK'      as const },
-];
-
-const TAIL = [
-  { path: '/news', labelKey: 'NAV_NEWS' as const },
-];
 
 type NavIcon = ComponentType<{ size?: number }>;
 type NavDest = { path: string; labelKey: LabelKey; Icon: NavIcon };

--- a/components/TerminalNav.tsx
+++ b/components/TerminalNav.tsx
@@ -40,8 +40,16 @@ import Link from 'next/link';
 import { useState, useEffect } from 'react';
 import BrandMark from './BrandMark';
 import { useAuth } from './AuthProvider';
+import { useTheme } from '@/lib/theme';
+import { IconSun, IconMoon } from './icons';
+import LanguageNavSwitcher from './LanguageNavSwitcher';
 import { useLabels } from '@/lib/labels';
 import type { LabelKey } from '@/lib/labelKeys';
+/* The SAME arrays the current design's nav renders, imported rather than
+   copied (#714). The owner's complaint was that this bar reaches less than the
+   nav it replaced; two lists that must agree and nothing making them agree is
+   how that gap reappears a month from now. */
+import { SCANNERS, TOOLS, PRIMARY, TAIL } from '@/lib/navRoutes';
 import { getCurrentWindow, getLocalNow } from '@/lib/session';
 
 /* Icon paths transcribed from the frames' own ICON map (Dashboard
@@ -117,6 +125,21 @@ function screenNameFor(pathname: string, t: (k: LabelKey) => string): string {
   return seg ? seg.replace(/-/g, ' ') : '';
 }
 
+/* The two groups the current design's nav discloses, same names and same
+   contents (#714). NAV_* label keys, not TNAV_*: these are the words the other
+   nav already uses for these destinations, and inventing terminal-specific
+   ones would let the two drift into calling the same page different things.
+
+   `as const`, NOT `as LabelKey`. My first version cast to LabelKey and tsc
+   passed while both keys - NAV_SECTION_SCANNERS, NAV_SECTION_TOOLS - did not
+   exist anywhere: the cast asserts the type instead of checking it, so the
+   labels would have rendered as raw key strings in the bar. A cast that
+   silences the compiler is not a type. */
+const DROPDOWNS = [
+  { key: 'scanners' as const, labelKey: 'NAV_DROPDOWN_SCANNERS' as const, items: SCANNERS },
+  { key: 'tools'    as const, labelKey: 'NAV_DROPDOWN_TOOLS'    as const, items: TOOLS },
+];
+
 function isActive(pathname: string, href: string): boolean {
   return pathname === href || pathname.startsWith(href + '/');
 }
@@ -130,8 +153,28 @@ interface TerminalNavProps {
 export default function TerminalNav({ onOpenDrawer }: TerminalNavProps) {
   const pathname = usePathname();
   const { t } = useLabels();
-  const { user } = useAuth();
+  const { user, loading: authLoading } = useAuth();
+  const { theme, toggleTheme } = useTheme();
   const [session, setSession] = useState<{ name: string; left: number | null } | null>(null);
+
+  /* #714. The owner reported this bar twice: "the top navigation bar. It got
+     down. I need you to put it back." It carried five tabs against the current
+     design's eight items and two dropdowns, so everything else was reachable
+     only through the drawer - and on desktop that is one unlabelled avatar.
+     Same grouping, same route lists, same disclosure shape as the nav it
+     replaced; the labels stay TNAV_* because renaming the five is the owner's
+     call and not part of this. */
+  const [openDrop, setOpenDrop] = useState<'scanners' | 'tools' | null>(null);
+  useEffect(() => {
+    if (!openDrop) return;
+    /* Close on any click that is not inside the open menu. The current
+       design's nav does this with the same listener and a stopPropagation on
+       the wrapper - matched deliberately rather than reinvented, so the two
+       behave identically for someone moving between designs. */
+    const close = () => setOpenDrop(null);
+    document.addEventListener('click', close);
+    return () => document.removeEventListener('click', close);
+  }, [openDrop]);
 
   /* Resolved after mount, never during render: getLocalNow() reads the
      viewer's clock, so computing this on the server and again on the client
@@ -193,16 +236,82 @@ export default function TerminalNav({ onOpenDrawer }: TerminalNavProps) {
         </Link>
 
         <nav className="tnav-items" aria-label={t('TNAV_ARIA_LABEL')}>
-          {ITEMS.map(item => {
-            const on = isActive(pathname, item.href);
+          {/* THE CURRENT DESIGN'S ITEM SET, rendered in terminal (#714).
+              Owner: "the layout should be like the current design, but the
+              design is on terminal theme."
+
+              This bar used to carry five flat destinations - Overview, Scan,
+              Flow, Book - where .app-bar carries three destinations and two
+              groups. Those are not different LABELS for the same items, they
+              are a different arrangement, so there is no coherent "same
+              layout, terminal names": the names belong to the layout being
+              replaced. Same items, same order, same grouping as .app-bar.
+
+              What does NOT carry over is the visual language - no blue active
+              pill, no radius, no shadow. That is the "but on terminal theme"
+              half, and it lives in the CSS rather than here.
+
+              ITEMS still exists and still drives the MOBILE tab bar above:
+              the current design has a tab bar on small screens too, so the
+              five-tab arrangement is correct there and only the desktop bar
+              was wrong. */}
+          {PRIMARY.map(item => {
+            const on = isActive(pathname, item.path);
             return (
               <Link
-                key={item.key}
-                href={item.href}
+                key={item.path}
+                href={item.path}
                 className={`tnav-item${on ? ' on' : ''}`}
                 aria-current={on ? 'page' : undefined}
               >
                 {t(item.labelKey)}
+              </Link>
+            );
+          })}
+
+          {DROPDOWNS.map(d => {
+            const open = openDrop === d.key;
+            const groupActive = d.items.some(i => isActive(pathname, i.path));
+            return (
+              <div key={d.key} className="tnav-drop-wrap" onClick={e => e.stopPropagation()}>
+                <button
+                  type="button"
+                  className={`tnav-item tnav-drop-btn${open || groupActive ? ' on' : ''}`}
+                  onClick={() => setOpenDrop(v => (v === d.key ? null : d.key))}
+                  aria-haspopup="menu"
+                  aria-expanded={open}
+                >
+                  {t(d.labelKey)} {open ? '▴' : '▾'}
+                </button>
+                {open && (
+                  <div className="tnav-dropdown" role="menu">
+                    {d.items.map(i => (
+                      <Link
+                        key={i.path}
+                        href={i.path}
+                        role="menuitem"
+                        className={`tnav-drop-item${isActive(pathname, i.path) ? ' on' : ''}`}
+                        onClick={() => setOpenDrop(null)}
+                      >
+                        {t(i.labelKey)}
+                      </Link>
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+
+          {TAIL.map(l => {
+            const on = isActive(pathname, l.path);
+            return (
+              <Link
+                key={l.path}
+                href={l.path}
+                className={`tnav-item${on ? ' on' : ''}`}
+                aria-current={on ? 'page' : undefined}
+              >
+                {t(l.labelKey)}
               </Link>
             );
           })}
@@ -223,6 +332,35 @@ export default function TerminalNav({ onOpenDrawer }: TerminalNavProps) {
             </span>
           )}
           {/* No ⌘K chip - see the file header. */}
+
+          {/* THEME TOGGLE (#714). The owner asked for it by name and it is the
+              most consequential of the three: terminal has a full light palette
+              - [data-design="terminal"][data-theme="light"], shipped in #563 -
+              and until now NOTHING in the terminal UI could reach it. The
+              palette existed and was unreachable without hand-editing
+              localStorage. Same hook and same icons as the current bar, so the
+              two cannot disagree about which way the switch points. */}
+          <button
+            type="button"
+            className="tnav-icon-btn"
+            onClick={toggleTheme}
+            title={theme === 'dark' ? t('NAV_THEME_TO_LIGHT') : t('NAV_THEME_TO_DARK')}
+            aria-label={theme === 'dark' ? t('NAV_THEME_TO_LIGHT') : t('NAV_THEME_TO_DARK')}
+          >
+            {theme === 'dark' ? <IconSun /> : <IconMoon />}
+          </button>
+
+          <LanguageNavSwitcher />
+
+          {/* Sign In. Absent until now, so a signed-out visitor on a terminal
+              app screen had no way to authenticate from the bar - the avatar
+              opens the drawer, which is navigation, not auth. Gated on
+              authLoading for the reason the current bar is: rendering "Sign In"
+              to someone already signed in, for the frame before auth resolves,
+              is worse than rendering nothing. */}
+          {!authLoading && !user && (
+            <Link href="/login" className="tnav-signin">{t('NAV_SIGN_IN')}</Link>
+          )}
           {/* The avatar is the DESKTOP drawer opener. Hiding .app-bar for
               terminal takes the hamburger with it, and with it every route
               outside the five plus sign-out - so the bar needs an opener the

--- a/lib/labelDefaults.en.json
+++ b/lib/labelDefaults.en.json
@@ -83,6 +83,8 @@
   "NAV_SECTION_MY_TOOLS": "My Tools",
   "NAV_SECTION_ACCOUNT": "Account",
   "NAV_SIGN_IN": "Sign In",
+  "NAV_THEME_TO_LIGHT": "Switch to light mode",
+  "NAV_THEME_TO_DARK": "Switch to dark mode",
   "NAV_SIGN_OUT_MENU": "Sign out",
   "NAV_SIGN_OUT_DRAWER": "Sign Out",
   "NAV_SEARCH_PLACEHOLDER": "Search pages",

--- a/lib/labelKeys.ts
+++ b/lib/labelKeys.ts
@@ -69,6 +69,10 @@ export const LABEL_KEYS = [
   'NAV_NEWS', 'NAV_GLOSSARY', 'NAV_SETTINGS_LABEL', 'NAV_ABOUT', 'NAV_HOME', 'NAV_MORE',
   'NAV_DROPDOWN_SCANNERS', 'NAV_DROPDOWN_TOOLS', 'NAV_SECTION_MAIN', 'NAV_SECTION_ANALYSIS',
   'NAV_SECTION_RESEARCH', 'NAV_SECTION_MY_TOOLS', 'NAV_SECTION_ACCOUNT', 'NAV_SIGN_IN',
+  /* Theme-toggle tooltips (#714). The current design's app bar hardcodes these
+     two strings in English; the terminal bar takes keys instead rather than
+     copying that gap into a second place. */
+  'NAV_THEME_TO_LIGHT', 'NAV_THEME_TO_DARK',
   'NAV_SIGN_OUT_MENU', 'NAV_SIGN_OUT_DRAWER', 'NAV_SEARCH_PLACEHOLDER', 'NAV_NO_MATCHES',
   'NAV_VIEW_USAGE', 'USAGE_MODAL_TITLE', 'ALERTS_PRICE_LOCKED_DESC', 'SETTINGS_TF_PRO_ONLY',
 

--- a/lib/navRoutes.ts
+++ b/lib/navRoutes.ts
@@ -1,0 +1,50 @@
+/* The nav's route groups, shared by both designs (#714).
+ *
+ * These lived in components/NavDrawer.tsx and were rendered only by the current
+ * design's app bar. The terminal nav had its own five hardcoded tabs and
+ * reached nothing else, which is the gap the owner reported twice: *"the top
+ * navigation bar. It got down. I need you to put it back."*
+ *
+ * MOVED HERE RATHER THAN IMPORTED ACROSS. NavDrawer already imports
+ * TerminalNav, so having TerminalNav import back from NavDrawer makes a cycle -
+ * ES modules tolerate it, but the constants would be read at module-init time
+ * in one direction and the failure mode is an empty dropdown rather than an
+ * error. A third module both sides import has no such edge.
+ *
+ * ONE LIST, NOT TWO THAT MUST AGREE. The bar that "got down" got that way by
+ * being maintained separately from the one it replaced; two copies of an IA
+ * with nothing binding them is how that returns. A route added here appears in
+ * both navs or neither.
+ *
+ * The labelKeys are the existing NAV_* set - no new keys, so both designs draw
+ * the same words for the same destination and neither can drift into renaming
+ * a page the other calls something else.
+ */
+
+export const PRIMARY = [
+  { path: '/dashboard', labelKey: 'NAV_DASHBOARD' as const },
+  { path: '/arena',     labelKey: 'NAV_ARENA'     as const },
+  { path: '/briefing',  labelKey: 'NAV_BRIEFING'  as const },
+];
+
+export const SCANNERS = [
+  { path: '/markets',       labelKey: 'NAV_MARKETS'        as const },
+  { path: '/scanner',       labelKey: 'NAV_SETUP_SCANNER'  as const },
+  { path: '/liq',           labelKey: 'NAV_LIQUIDATION_MAP' as const },
+  { path: '/funding',       labelKey: 'NAV_FR_HISTORY'     as const },
+  { path: '/correlation',   labelKey: 'NAV_CORRELATION'    as const },
+];
+
+export const TOOLS = [
+  { path: '/journal',       labelKey: 'NAV_JOURNAL'       as const },
+  { path: '/research',      labelKey: 'NAV_RESEARCH'      as const },
+  { path: '/calc',          labelKey: 'NAV_CALCULATORS'   as const },
+  { path: '/econ-calendar', labelKey: 'NAV_ECON_CALENDAR' as const },
+  { path: '/alerts',        labelKey: 'NAV_ALERTS'        as const },
+  { path: '/hours',         labelKey: 'NAV_BEST_HOURS'    as const },
+  { path: '/playbook',      labelKey: 'NAV_PLAYBOOK'      as const },
+];
+
+export const TAIL = [
+  { path: '/news', labelKey: 'NAV_NEWS' as const },
+];


### PR DESCRIPTION
## Summary

The terminal desktop nav now renders the **same item set and the same controls as `.app-bar`**, in terminal's own visual language. Closes #714.

```
before   LIQUIDITYHQ  Overview  Arena  Scan  Flow  Book                                    [badge] avatar
after    LIQUIDITYHQ  Dashboard Arena  Briefing  Scanners ▾  Tools ▾  News   [badge] theme  EN  Sign In  avatar
```

Measured at desktop 1503px, `?design=terminal`; dropdown opens with the full group (`Markets, Setup Scanner, Liquidation Map, FR History, Correlation`).

## The theme toggle is the consequential one

Terminal ships a **full light palette** — `[data-design="terminal"][data-theme="light"]`, from #563 — and **nothing in the terminal UI could reach it**. A large share of the contrast work on this redesign went into terminal light, and it was unreachable without editing `localStorage` by hand. Shipped work nobody could see.

**Sign In** absent meant a signed-out visitor on a terminal app screen couldn't authenticate from the bar — the avatar opens the drawer, which is navigation, not auth.

## Naming: it follows from the layout, it isn't a separate decision

`Overview`/`Scan`/`Flow`/`Book` are gone from the desktop bar. They are **not renames** of `Scanners ▾`/`Tools ▾`/`News` — they are five flat destinations where `.app-bar` has three destinations and two groups. Match the layout and the item set comes with it.

QA first said keep terminal's naming, then withdrew it against the owner's *"the layout should be like the current design"*. The withdrawal is right and the reasoning is on the issue.

## Mobile is unchanged

`ITEMS` still drives the tab bar, which keeps its five. The current design has a tab bar on small screens too, so that arrangement was correct and only the desktop bar was wrong.

Verified at 390: `itemsVisible false`, `dropVisible false`, `tabsVisible true` with `Desk/Arena/Scan/Flow/Book`, mobile drawer opener intact.

## One route list, not two that must agree

`PRIMARY`/`SCANNERS`/`TOOLS`/`TAIL` moved to `lib/navRoutes.ts`; both navs import them. They were `NavDrawer`'s private constants, and a second nav copying them is exactly how the two drifted apart in the first place — which is the shape of this whole issue.

A third module rather than importing across: `NavDrawer` already imports `TerminalNav`, so importing back makes a cycle whose failure mode is an *empty dropdown* rather than an error.

## Terminal styling, not the other design's

No blue active pill, no radius, no soft shadow. The dropdown is built from `.tnav-item` rather than reusing `.nav-more-dropdown`, whose 12px radius and `--bg2` card belong to the current design's language. The language switcher's panel is restated too — left alone it would have been the one rounded surface in a squared bar.

Two label keys added (`NAV_THEME_TO_LIGHT`, `NAV_THEME_TO_DARK`). The current bar hardcodes those strings in English; this takes keys rather than copying that gap.

## One thing I caught mid-build

My first version used `NAV_SECTION_SCANNERS` / `NAV_SECTION_TOOLS` with an `as LabelKey` cast. **Neither key exists**, and `tsc` passed — a cast asserts the type instead of checking it, so the labels would have rendered as raw key strings in the bar. Now `as const` against the real `NAV_DROPDOWN_*` keys, so the compiler actually checks.

## How to test (QA)

1. `/dashboard?design=terminal`, desktop: bar reads Dashboard, Arena, Briefing, Scanners ▾, Tools ▾, News.
2. Both dropdowns open, close on outside click, and mark the active group.
3. **Theme toggle reaches terminal light** — this is the one worth looking at, since that palette has never been reachable.
4. Language switcher opens; its panel should be squared, not rounded.
5. Signed out: Sign In present and goes to `/login`. Signed in: absent.
6. 390: unchanged five-tab arrangement, drawer opener intact.
7. Current design untouched on every route.

## Risk level

**Medium.** Shared app chrome on every terminal route, and it moves route constants out of `NavDrawer`. Mitigated by both navs now reading one list. Gates: lint 0 errors, `tsc` 0, `npm test` 569/0, `build` 0.

**Next:** #731 unblocks on this — once the bar reaches these routes directly, the avatar's drawer-opener role is redundant on desktop and the drawer can be gated without stranding anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
