### PR TITLE
fix(nav): the right-side drawer is mobile and tablet only

### DIFF
--- a/components/NavDrawer.tsx
+++ b/components/NavDrawer.tsx
@@ -518,6 +518,16 @@ export default function NavDrawer() {
       <div
         id="nav-drawer"
         className={`nav-drawer${drawerOpen ? ' open' : ''}`}
+        /* inert while closed - the same fix as GrokChat. The drawer is hidden
+           with a transform and pointer-events:none, so its 23 focusable
+           controls otherwise stayed in the tab order behind an invisible panel.
+           STILL LOAD-BEARING, on mobile. The render gate above removes those
+           controls from the document entirely on desktop, which solves it there
+           outright - but below 768 the drawer exists and spends most of its
+           life closed, so this is what keeps it out of the tab order. Restored
+           after QA noticed I had dropped the explanation with the comment block
+           the #731 note replaced; a future reader seeing a bare `inert` and the
+           new gate could reasonably conclude the gate had made it redundant. */
         inert={!drawerOpen}
         aria-hidden={!drawerOpen}
       >

--- a/components/NavDrawer.tsx
+++ b/components/NavDrawer.tsx
@@ -22,6 +22,7 @@ import {
 } from './icons';
 import type { ComponentType } from 'react';
 import { useLabels } from '@/lib/labels';
+import { useIsDesktop } from '@/lib/useIsDesktop';
 /* Shared with TerminalNav so both designs reach the same routes (#714). */
 import { PRIMARY, SCANNERS, TOOLS, TAIL } from '@/lib/navRoutes';
 import type { LabelKey } from '@/lib/labelKeys';
@@ -228,6 +229,8 @@ export default function NavDrawer() {
   const [authOpen, setAuthOpen]         = useState(false);
   const [usageOpen, setUsageOpen] = useState(false);
   const { theme, toggleTheme }          = useTheme();
+  /* 768px, the same breakpoint .hamburger and .tnav-mmore already use (#731). */
+  const isDesktop = useIsDesktop();
   const pathname = usePathname();
   const dot      = useStatusDot();
   const mode     = useDesignMode();
@@ -485,9 +488,33 @@ export default function NavDrawer() {
       </nav>
       )}
 
-      {/* inert while closed - see the same fix in GrokChat. The drawer is
-          hidden with a transform and pointer-events:none, so its 23 focusable
-          controls stayed in the tab order behind an invisible panel. */}
+      {/* MOBILE AND TABLET ONLY (#731). Owner: "the side menu on the right
+          side, it should be only available on mobile view or tablet."
+
+          `.nav-menu` is 360px wide and slid off-canvas by a transform that
+          left 8px of its near-black ground inside the right edge on desktop -
+          a visible strip on every route, in BOTH designs, scaling with the
+          window (14px at 2818px). `pointer-events: none` is why it intercepted
+          nothing and every click test passed, and why platform-audit reported
+          `overflow 0`: 8px of a fixed element INSIDE the viewport is neither an
+          overflow nor a page wider than the screen. Nothing in the suite asked
+          whether an off-canvas panel is actually off canvas.
+
+          A RENDER GATE, NOT `display: none`, per #728 - a CSS hide applied
+          after hydration paints first.
+
+          768px because that is the breakpoint the drawer's own openers already
+          use: `.hamburger` is hidden at `min-width: 768px` (globals.css:1022)
+          and `.tnav-mmore` lives in `@media (max-width: 767px)`. So on desktop
+          the drawer already had no opener in either design - it was unreachable
+          chrome bleeding 8px. No new number invented.
+
+          SAFE ONLY BECAUSE #732 LANDED FIRST. Until then `.tnav-avatar` was
+          terminal's DESKTOP drawer opener and the sole path to ~15 routes;
+          gating here would have stranded them. The bar now reaches those routes
+          directly, which is what makes this a removal rather than a
+          regression. */}
+      {!isDesktop && (
       <div
         id="nav-drawer"
         className={`nav-drawer${drawerOpen ? ' open' : ''}`}
@@ -595,6 +622,7 @@ export default function NavDrawer() {
           )}
         </div>
       </div>
+      )}
     </>
   );
 }

--- a/components/TerminalNav.tsx
+++ b/components/TerminalNav.tsx
@@ -361,22 +361,18 @@ export default function TerminalNav({ onOpenDrawer }: TerminalNavProps) {
           {!authLoading && !user && (
             <Link href="/login" className="tnav-signin">{t('NAV_SIGN_IN')}</Link>
           )}
-          {/* The avatar is the DESKTOP drawer opener. Hiding .app-bar for
-              terminal takes the hamburger with it, and with it every route
-              outside the five plus sign-out - so the bar needs an opener the
-              same way the mobile header does. The frames draw this box but
-              give it no behaviour at all, so attaching one adds nothing they
-              specify and removes nothing either. */}
-          <button
-            type="button"
-            className="tnav-avatar"
-            onClick={onOpenDrawer}
-            aria-haspopup="menu"
-            aria-controls="nav-drawer"
-            aria-label={t('TNAV_MORE_ARIA')}
-          >
-            {initials}
-          </button>
+          {/* The avatar carries no behaviour again (#731).
+              It was wired to open the drawer because hiding .app-bar for
+              terminal took the hamburger with it, leaving no desktop route to
+              anything outside the five tabs. #732 gave the bar those routes
+              directly and #731 gates the drawer to mobile, so on desktop this
+              click would now open nothing - a dead control on the most-used
+              chrome in the app.
+              Back to what the frames draw: an identity box with no behaviour.
+              A <span>, not a disabled <button>, because a button that does
+              nothing still takes focus and still announces itself as
+              actionable. Mobile keeps .tnav-mmore as its opener. */}
+          <span className="tnav-avatar" aria-hidden="true">{initials}</span>
         </div>
       </header>
 


### PR DESCRIPTION
## Summary

The right-side drawer no longer renders at 768px and above, and the terminal avatar goes back to a plain identity box. Closes #731.

```
desktop 1440        drawerInDom   menuInDom   strip on screen
terminal            false         false       0px
current             false         false       0px
```

## The bug

`.nav-menu` is 360px wide and slid off-canvas by a transform that left **8px of its near-black ground inside the right edge on desktop** — every route, both designs, scaling with the window (14px at 2818px).

**Why nothing caught it:** `pointer-events: none`, so it intercepted no clicks and every click test passed. `platform-audit` reported `overflow 0` — correctly, because 8px of a fixed element *inside* the viewport is neither an overflow nor a page wider than the screen. Nothing in the suite asked whether an off-canvas panel is actually off canvas.

## 768px is not a new number

`.hamburger` is hidden at `min-width: 768px` (`globals.css:1022`) and `.tnav-mmore` lives in `@media (max-width: 767px)`. **On desktop the drawer already had no opener in either design** — it was unreachable chrome bleeding 8px.

Render gate rather than `display: none`, per #728: a CSS hide applied after hydration paints first.

## This would have been a regression before #732

`.tnav-avatar` was terminal's **desktop** drawer opener and the sole path to ~15 routes. Gating the drawer before the bar reached those routes would have stranded them behind a button that opened nothing — a worse defect than the strip, shipped in the PR claiming to fix it.

#732 gave the bar those routes, so the avatar loses its job here rather than becoming dead. A `<span>`, not a disabled `<button>` — a button that does nothing still takes focus and still announces itself as actionable.

## Mobile, which is the risk this carries

Verified at 390, not assumed:

```
drawer present · .tnav-mmore present · opens on click
panel at left 39 of a 390 viewport · 20 nav items
```

The drawer is the primary navigation on small screens, so the gate catching it would have been the serious failure. It doesn't.

## How to test (QA)

1. Desktop ≥1200, `/dashboard`, **both designs**: no dark strip at the right edge, `.nav-drawer` absent from the DOM rather than hidden.
2. Mobile 390 and tablet: drawer opens and closes normally with MAIN / ANALYSIS / RESEARCH.
3. No flash of the drawer on desktop first paint.
4. `document.querySelector('.nav-menu')` at 1503px finds nothing.
5. Terminal desktop: the avatar is still visible but no longer clickable — and everything it used to reach is in the bar from #732.

## Risk level

**Medium.** Shared app chrome on every route in both designs, and the mobile drawer is primary navigation. Mitigated by the 390 verification above and by the breakpoint already being the one both openers use. Gates: lint 0 errors, `tsc` 0, `npm test` 569/0, `build` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
