### PR TITLE
fix(arena): the anti-chop Tip icon takes the theme token, not a white literal

### DIFF
--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -2087,9 +2087,23 @@ function ArenaContent() {
             constraint that component carries: Tip must never be rendered inside
             a <button>, <a>, or anything with an interactive role.
             The label stays inside the button so clicking it still toggles. */}
+        {/* No iconColor override (#734). This passed
+            `rgba(255,255,255,0.6)` - white at 60% alpha, a dark-theme literal
+            that cannot work on a light ground. QA measured the glyph at 1.05:1
+            in terminal light: effectively invisible, and the worst ratio in
+            the whole light audit.
+
+            Tip already defaults to `var(--txt3)` (Tip.tsx:18), which is what
+            the literal was approximating by hand - a muted foreground - except
+            the token flips with the theme and the literal could not. Every
+            other Tip in the codebase passes a token or nothing; this was the
+            only caller hand-rolling a colour.
+
+            So the fix is to delete the prop rather than replace the value.
+            Dark keeps the muted appearance it already had, light gets a
+            readable one, and there is no new number to govern. */}
         <Tip
           width={260}
-          iconColor="rgba(255,255,255,0.6)"
           text={t('ARENA_ANTICHOP_TIP')}
         />
         {/* opacity 0.35 computed to #55565b = 2.75:1. This hint explains what


### PR DESCRIPTION
## Summary

Removes `iconColor="rgba(255,255,255,0.6)"` from the anti-chop `Tip` on `/arena`. **No replacement value** — deleting the prop is the fix.

Part of #734, and the only part needing no ruling.

## The defect

QA's terminal-light audit measured that glyph at **1.05:1** — the worst ratio in the entire light sweep. White at 60% alpha on a light ground isn't a colour that reads poorly; it's a dark-theme literal that cannot work on light at all. A token would have flipped with the theme.

## Why deleting rather than replacing

`Tip` already defaults to `var(--txt3)` (`Tip.tsx:18`) — which is exactly what the literal was approximating by hand, a muted foreground. The token flips with the theme; the literal couldn't.

So dark keeps the appearance it already had, light gets a readable one, and **no new value enters the system to govern.**

Every other `Tip` caller passes a token or nothing — `var(--red)`, `var(--green-2)`, `var(--accent)`. This was the only one hand-rolling a colour, and a grep for a literal `iconColor` now returns none.

`--txt3` cleared 4.5:1 on all three grounds in **both** terminal palettes in the static token sweep, so this is governed rather than hand-checked.

## What is NOT in this PR

**The `coinBadgeColor`-as-text half** — with the owner, since it changes what the app looks like.

**The two unscoped white CSS rules** (`.gex-insight`, `.frh-sig-hint`) — I checked before changing them and **both already have `[data-theme="light"]` overrides on the following line**, at `(0,2,0)` against the base `(0,1,0)`, with no terminal-scoped rule to outrank them and no inline colour on either element. They should already render `var(--txt2)`. Reported on the issue rather than "fixed".

The better candidate there is `.frh-sig-crowd`, which sets its colour **inline** from tokens — four of which (`--orange`, `--txt-dim`, `--green-soft`, `--green-2`) exist in **neither** terminal palette and fall through to app-root values tuned for dark. That's the documented #542 class, and it's invisible to `terminalTokens.test.mts` because that guard only inspects terminal-*scoped selectors*, not inline styles.

## How to test (QA)

1. `/arena?design=terminal`, toggle to light: the ⓘ beside the anti-chop label is legible.
2. Dark: unchanged from before.
3. Current design: untouched.

## Risk level

**Low.** One prop removed on one element; the component's own default takes over. Gates: lint 0 errors, `tsc` 0, `npm test` 569/0, `build` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
