### PR TITLE
test(tokens): name the second source, and assert the two palettes stay in step

### DIFF
--- a/__tests__/terminalTokens.test.mts
+++ b/__tests__/terminalTokens.test.mts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
-import { TERMINAL_COLORS, TERMINAL_FLAT_CELL } from '../lib/terminalTokens.ts';
+import { TERMINAL_ALIASES, TERMINAL_COLORS, TERMINAL_FLAT_CELL } from '../lib/terminalTokens.ts';
 
 /* Makes lib/terminalTokens.ts's claim true: that it is the single source of
    truth both app/globals.css and this test read from, and that the two
@@ -86,6 +86,79 @@ test('terminal design tokens', async (t) => {
     assert.deepEqual(undocumented, [],
       'hex-valued custom properties in the terminal block not listed in TERMINAL_COLORS - ' +
       'add them there (or to the radius/other exception if they are not a colour)');
+  });
+
+  await t.test('the CSS terminal blocks declare exactly the documented tokens plus the named aliases (#736)', () => {
+    /* THE TWO-SOURCES BUG, GUARDED.
+     *
+     * The terminal CSS blocks declare 48 properties; this file's TERMINAL_COLORS
+     * documents 18. Nothing recorded that the other 28 existed, so "is
+     * --green-2 terminal-aware?" had two answers depending on which file you
+     * opened - and on #734 two of us independently grepped the SAME file,
+     * agreed, and were both wrong. Agreement between two readings of one half
+     * is not corroboration.
+     *
+     * This asserts in both directions, so neither source can gain a token the
+     * other does not know about. */
+    const declared = new Set(
+      [...block.matchAll(/^\s*(--[a-z][a-z0-9-]*)\s*:/gm)].map(m => m[1])
+    );
+    const known = new Set<string>([
+      ...Object.keys(TERMINAL_COLORS),
+      ...TERMINAL_ALIASES,
+      '--flat-cell',   // documented above; dark-only and currently unreferenced
+    ]);
+
+    const undocumented = [...declared].filter(n => !known.has(n)).sort();
+    assert.deepEqual(undocumented, [],
+      `declared in the terminal CSS block but named in neither TERMINAL_COLORS nor ` +
+      `TERMINAL_ALIASES: ${undocumented.join(', ')}. Add it to TERMINAL_ALIASES ` +
+      `(names only - the value stays in globals.css) or to TERMINAL_COLORS if it is a palette token.`);
+
+    const orphaned = [...TERMINAL_ALIASES].filter(n => !declared.has(n)).sort();
+    assert.deepEqual(orphaned, [],
+      `named in TERMINAL_ALIASES but no longer declared in the terminal CSS block: ` +
+      `${orphaned.join(', ')}. Remove it here, or it claims governance that does not exist.`);
+  });
+
+  await t.test('the terminal dark and light blocks declare the SAME token set (#561)', () => {
+    /* One palette gaining a token the other lacks is how #561's light
+     * fall-through happened: the dark block was updated, light was not, and
+     * terminal+light silently resolved to the app-root value. The values
+     * differ by design - the NAMES must not. */
+    /* Anchored to a line start. A bare indexOf matches
+       `html[data-design="terminal"][data-theme="light"] {` at globals.css:2625
+       first - a different, single-declaration rule - and the block comes back
+       empty, which reports every dark token as missing from light. The test
+       failed that way on its first run, which is the correct behaviour for a
+       guard whose block extraction has gone wrong, but the message pointed at
+       the palette rather than at itself. */
+    const lightSel = CSS.match(/^\[data-design="terminal"\]\[data-theme="light"\] \{/m);
+    assert.ok(lightSel?.index !== undefined, 'terminal light token block not found in globals.css');
+    const lightStart = lightSel!.index!;
+    let depth = 0, lightEnd = lightStart;
+    for (let i = lightStart; i < CSS.length; i++) {
+      if (CSS[i] === '{') depth++;
+      else if (CSS[i] === '}') { depth--; if (depth === 0) { lightEnd = i; break; } }
+    }
+    const lightBlock = CSS.slice(lightStart, lightEnd);
+
+    const namesIn = (b: string) =>
+      new Set([...b.matchAll(/^\s*(--[a-z][a-z0-9-]*)\s*:/gm)].map(m => m[1]));
+    const dark = namesIn(block);
+    const light = namesIn(lightBlock);
+
+    /* --flat-cell is the one known asymmetry and it is documented in
+       lib/terminalTokens.ts with its reason - absent from light deliberately,
+       raised on #602 for design, and currently referenced nowhere. Listed
+       rather than silently filtered so removing it from dark fails here. */
+    const KNOWN_DARK_ONLY = new Set(['--flat-cell']);
+
+    const darkOnly = [...dark].filter(n => !light.has(n) && !KNOWN_DARK_ONLY.has(n)).sort();
+    const lightOnly = [...light].filter(n => !dark.has(n)).sort();
+
+    assert.deepEqual(darkOnly, [], `declared in terminal DARK but not LIGHT: ${darkOnly.join(', ')} - terminal light will fall through to the app-root value`);
+    assert.deepEqual(lightOnly, [], `declared in terminal LIGHT but not DARK: ${lightOnly.join(', ')}`);
   });
 
   await t.test('every custom property USED under [data-design="terminal"] is DECLARED in the terminal block', () => {

--- a/lib/terminalTokens.ts
+++ b/lib/terminalTokens.ts
@@ -132,6 +132,45 @@ export const TERMINAL_COLORS_LIGHT = {
  * behind it rather than an archaeology exercise. */
 export const TERMINAL_FLAT_CELL = '#1c1f22';
 
+/* ── THE SECOND SOURCE, NAMED (#736) ─────────────────────────────────────
+ *
+ * The terminal CSS blocks declare 48 custom properties. This file documents
+ * 18 of them. The other 28 are ALIASES - tokens the current design owns that
+ * terminal re-points at its own palette (`--green-2: var(--green)`), plus the
+ * radius and surface overrides that make terminal square and flat.
+ *
+ * WHY THIS LIST EXISTS. Nothing recorded that the second set was governed at
+ * all, so the honest answer to "is --green-2 terminal-aware?" depended on
+ * which file you opened: `terminalTokens.ts` said no, `globals.css` said yes.
+ * On #734 I grepped this file, concluded four tokens were ungoverned, and QA
+ * verified by grepping the same file. Two people agreed and both were wrong,
+ * because agreement between two readings of the same half is not
+ * corroboration. Resolving the enclosing selector in globals.css took one
+ * command and gave the opposite answer.
+ *
+ * So this is not a second copy of the values - it deliberately holds NAMES
+ * only. The values stay in globals.css, which remains where they are read
+ * from; duplicating them here would recreate exactly the drift the file
+ * header warns about. What this fixes is the question "which file is
+ * authoritative", by making this one say out loud that the CSS blocks carry
+ * more than it does and listing what.
+ *
+ * __tests__/terminalTokens.test.mts asserts the two agree in both directions,
+ * so a token added to the CSS blocks and not named here fails, and vice
+ * versa. */
+export const TERMINAL_ALIASES = [
+  '--accent-2', '--accent-bdr', '--accent-bg', '--accent-dim', '--accent-solid',
+  '--amber-bdr', '--amber-bg',
+  '--bg3', '--bg4',
+  '--blue', '--blue-bdr', '--blue-bg',
+  '--font-sans',
+  '--green-2', '--green-bdr', '--green-bg', '--green-soft',
+  '--on-accent',
+  '--radius-card', '--radius-chip', '--radius-data', '--radius-pill', '--radius-sharp',
+  '--red-bdr', '--red-bg', '--red-soft',
+  '--txt-dim',
+] as const;
+
 /* Liquidation map only. The one place the design permits a multi-hue ramp,
    because a heatmap's whole content is magnitude. Four palettes are selectable;
    magma is the default and the only one specified in the README.


### PR DESCRIPTION
## Summary

Names the second source of terminal token truth, and guards both directions. Addresses #736's guard half.

`TERMINAL_ALIASES` in `lib/terminalTokens.ts` — **names only, no values** — plus two assertions.

## The problem this actually fixes

The terminal CSS blocks declare **48** custom properties. `terminalTokens.ts` documented **18**. Nothing recorded that the other 28 existed, so *"is `--green-2` terminal-aware?"* had two answers depending on which file you opened.

On #734 I grepped `terminalTokens.ts`, concluded four tokens were ungoverned, and QA "verified independently" — by grepping the same file. **Two people agreed and both were wrong.** Resolving the enclosing selector in `globals.css` took one command and gave the opposite answer: `--green-2`, `--green-soft` and `--txt-dim` are aliased in *both* terminal palettes and flip correctly.

## Not a second copy of the values

`TERMINAL_ALIASES` holds **names only**. The values stay in `globals.css` where they're read from — duplicating them here would recreate exactly the drift this file's header warns about.

What it fixes is *which file is authoritative*, by making this one say out loud that the CSS blocks carry more than it does, and listing what.

## Assertion 1 — the two sources agree, both directions

The CSS block must declare exactly `TERMINAL_COLORS` + `TERMINAL_ALIASES` + `--flat-cell`. A token added to the CSS and not named here fails; a name here the CSS no longer declares also fails, since it would claim governance that doesn't exist.

## Assertion 2 — dark and light declare the same token set

One palette gaining a token the other lacks is how **#561**'s light fall-through happened: dark updated, light not, `terminal+light` silently resolving to the app-root value. Values differ by design; **names must not**.

`--flat-cell` is the one known asymmetry — already documented in this file as dark-only and raised on #602 — so it's a *named exception* rather than silently filtered.

## The justification is the weaker, true one

QA first framed this as stopping the next four tokens landing the same way. **They didn't land that way** — three of the four were governed all along — so that isn't what it does. It makes terminal's ownership explicit, so the answer is recorded rather than inferred by whoever next greps one of two sources.

## Both assertions verified against a planted defect

| Planted | Result |
|---|---|
| Remove `--txt-dim` from `TERMINAL_ALIASES` | assertion 1 fails, names it |
| Remove `--green-soft` from the **light** block only | assertion 2 fails: *"terminal light will fall through to the app-root value"* |

Both restored; 27 assertions green.

**My first control was itself wrong**, which is worth recording: it used `indexOf('[data-design="terminal"][data-theme="light"] {')`, which matches `html[data-design=…]` at `globals.css:2625` first — a different single-declaration rule — so it edited the *dark* block and the test passed. The same bug was in the test's own block extraction and made it report every dark token as missing from light. Both now anchor to a line start.

## How to test (QA)

```
node --test --experimental-strip-types __tests__/terminalTokens.test.mts
```

27 assertions. **No runtime code changes** — `TERMINAL_ALIASES` is not imported by the app, so nothing ships differently.

## Risk level

**Low.** Test and a names-only export. Gates: lint 0 errors, `tsc` 0, `npm test` 571/0, `build` 0.

**Not in scope:** `--orange`'s ownership decision, and the inline-usage half. The latter would need a per-token call on ~24 tokens, most legitimately exempt (typography, spacing, locally-defined properties, and `--purple` which aliases `--accent` and flips correctly) — I'd be inventing exemptions rather than recording decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
