### PR TITLE
fix(arena): the bias badge's bullish text takes --green-fg on its own tint

### DIFF
--- a/components/MultiTFAlignment.tsx
+++ b/components/MultiTFAlignment.tsx
@@ -37,7 +37,31 @@ function BiasBadge({ bias }: { bias: Bias }) {
   const { t } = useLabels();
   const icon = bias === 'bullish' ? '▲' : bias === 'bearish' ? '▼' : '→';
   const label = bias === 'bullish' ? t('MULTI_TF_ALIGNMENT_BIAS_BULLISH') : bias === 'bearish' ? t('MULTI_TF_ALIGNMENT_BIAS_BEARISH') : t('MULTI_TF_ALIGNMENT_BIAS_NEUTRAL');
-  const color = bias === 'bullish' ? 'var(--green-2)' : bias === 'bearish' ? 'var(--red)' : 'var(--txt3)';
+  /* Bullish TEXT takes --green-fg, not --green-2 (#738).
+   *
+   * The badge puts its label on a 12% tint of its own signal colour - the
+   * "signal colour on its own tint" shape --green-fg was created for (#652).
+   * --green-2 aliases to --green under terminal, and terminal-light's --green
+   * was chosen against FLAT grounds: its own comment names 4.752:1 on --bg2 as
+   * the binding figure. On a tint of itself it does not hold.
+   *
+   * Measured on terminal light, --green on a 12% tint of itself:
+   *
+   *     --bg0  4.84      --bg1  4.35      --bg2  4.05
+   *     --green-fg       6.53             5.87        5.47
+   *
+   * 4.35 is exactly what QA measured on /arena, so this is the mechanism
+   * rather than a lookalike.
+   *
+   * BEARISH IS DELIBERATELY UNCHANGED. The symmetric edit would be --red-fg,
+   * and the established pattern uses both - but --red on its own 12% tint
+   * measures 6.06 / 5.43 / 5.06 and passes on every ground. Applying the
+   * pattern for consistency would be a change with no defect behind it, and
+   * it would spend --red-fg's meaning on a case that does not need it.
+   *
+   * bg and border keep the base token: the tint carries state, the foreground
+   * carries legibility. Same split as MultiTFSqueezeView (#708). */
+  const color = bias === 'bullish' ? 'var(--green-fg)' : bias === 'bearish' ? 'var(--red)' : 'var(--txt3)';
   const border = bias === 'bullish' ? 'color-mix(in srgb, var(--green-2) 40%, transparent)' : bias === 'bearish' ? 'color-mix(in srgb, var(--red) 40%, transparent)' : 'var(--border-input)';
   const bg = bias === 'bullish' ? 'color-mix(in srgb, var(--green-2) 12%, transparent)' : bias === 'bearish' ? 'color-mix(in srgb, var(--red) 12%, transparent)' : 'transparent';
   return (


### PR DESCRIPTION
## Summary

`MultiTFAlignment`'s `BiasBadge` renders bullish label text in `--green-fg` instead of `--green-2`. Background and border keep the base token. Partial fix for #738 — `/arena`'s five instances.

## Why

The badge puts its label on a **12% tint of its own signal colour** — the shape `--green-fg` was created for on #652. `--green-2` aliases to `--green` under terminal, and terminal-light's `--green` was chosen against **flat** grounds; its own comment names *"4.752:1 on --bg2, the binding figure"*. On a tint of itself it doesn't hold.

Measured, terminal light, `--green` on a 12% tint of itself:

| ground | base | `--green-fg` |
|---|---|---|
| `--bg0` | 4.84 | 6.53 |
| `--bg1` | **4.35** | 5.87 |
| `--bg2` | **4.05** | 5.47 |

**4.35 is exactly what QA measured**, so this is the mechanism rather than a lookalike.

## Bearish deliberately unchanged

The symmetric edit would be `--red-fg`, and the established pattern uses both. But `--red` on its own 12% tint measures **6.06 / 5.43 / 5.06** and passes on every ground.

Applying the pattern for consistency would be a change with no defect behind it, and would spend `--red-fg`'s meaning on a case that doesn't need it. Measuring first is what decided it.

## The sixth instance is NOT in this PR

QA's sweep names `/scanner`'s `"↑ 47"` with the same token and tint family. **I could not locate it in source with confidence:**

- `MultiTFSqueezeView`'s `cellColors` already takes `--green-fg` (#708)
- `SignalAccuracy`'s `↑` sits on a flat ground, where `--green` passes
- my best remaining candidate (`.scan-badge-bull`) composites to ~`rgb(216,231,222)`, which doesn't match the measured `rgb(214,221,211)`

QA has the rendered element; I have the source. **Asked for the selector rather than editing a file on a guess** — #738 stays open for it.

## How to test (QA)

1. `/arena?design=terminal` toggled to **light**: the `▲ Bullish` badges read darker green on their tint.
2. **Dark unchanged** — `--green-fg` aliases `--green-2` there, so this is a light-only difference by construction.
3. Bearish badges unchanged in both themes.

## Risk level

**Low.** One expression, text colour only; the tint that carries state is untouched. Gates: lint 0 errors, `tsc` 0, `npm test` 571/0, `build` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
