### PR TITLE
fix(a11y): replace the #f59e0b amber literal, which fails both light themes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3037,7 +3037,7 @@ html[data-design="terminal"][data-theme="light"] { background: var(--bg0); }
 .ps-result-profit .ps-rval { color: var(--green); }
 .ps-result-good   .ps-rval { color: var(--green); }
 .ps-result-danger .ps-rval { color: var(--red); }
-.ps-warn { background: rgba(217,119,6,.1); border: 0.5px solid rgba(217,119,6,.3); border-radius: 8px; padding: 8px 12px; font-size: var(--fs-caption); color: #f59e0b; margin-bottom: 8px; }
+.ps-warn { background: rgba(217,119,6,.1); border: 0.5px solid rgba(217,119,6,.3); border-radius: 8px; padding: 8px 12px; font-size: var(--fs-caption); color: var(--amber); margin-bottom: 8px; }
 .ps-log-btn { width: 100%; padding: 13px; border-radius: var(--radius-card); border: 0.5px solid var(--green-bdr); background: var(--green-bg); color: var(--green); font-size: var(--fs-label); font-weight: 700; cursor: pointer; margin-top: 4px; transition: box-shadow .15s; }
 .ps-log-btn:hover { box-shadow: 0 0 16px rgba(52,211,153,.2); }
 /* ── Shared empty state pattern ── */
@@ -3158,7 +3158,7 @@ html[data-design="terminal"][data-theme="light"] { background: var(--bg0); }
 .tj-trade-dir-tag.tj-short { background: var(--red-bg);   color: var(--red);   border: 0.5px solid var(--red-bdr); }
 .tj-trade-setup-tag { font-size: var(--fs-caption); color: var(--txt3); padding: 2px 7px; border-radius: 20px; border: 0.5px solid var(--bdr); }
 .tj-result-badge { font-size: var(--fs-caption); font-weight: 700; padding: 2px 8px; border-radius: 20px; }
-.tj-rb-open { background: rgba(217,119,6,.12); color: #f59e0b; border: 0.5px solid rgba(217,119,6,.3); }
+.tj-rb-open { background: rgba(217,119,6,.12); color: var(--amber); border: 0.5px solid rgba(217,119,6,.3); }
 .tj-rb-win  { background: var(--green-bg); color: var(--green); border: 0.5px solid var(--green-bdr); }
 .tj-rb-loss { background: var(--red-bg);   color: var(--red);   border: 0.5px solid var(--red-bdr); }
 .tj-rb-be   { background: var(--bg3); color: var(--txt3); border: 0.5px solid var(--bdr); }

--- a/app/liq/page.tsx
+++ b/app/liq/page.tsx
@@ -602,16 +602,16 @@ export default function LiqPage() {
                     border: '0.5px solid rgba(245,158,11,0.3)',
                     display: 'flex', gap: 8, alignItems: 'flex-start',
                   }}>
-                    <span style={{ color: '#f59e0b', flexShrink: 0, lineHeight: 0 }}><Warn size={13} /></span>
+                    <span style={{ color: 'var(--amber)', flexShrink: 0, lineHeight: 0 }}><Warn size={13} /></span>
                     <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', lineHeight: 1.6 }}>
                       {longSqueezeRisk ? (
                         <>
-                          <span style={{ color: '#f59e0b', fontWeight: 700 }}>{t('LIQ_WHALE_LONG_SQUEEZE_TITLE')}</span>
+                          <span style={{ color: 'var(--amber)', fontWeight: 700 }}>{t('LIQ_WHALE_LONG_SQUEEZE_TITLE')}</span>
                           {' '}{t('LIQ_WHALE_LONG_SQUEEZE_BODY', { retailPct: (retailLong * 100).toFixed(0), whalePct: (whaleShort * 100).toFixed(0) })}
                         </>
                       ) : (
                         <>
-                          <span style={{ color: '#f59e0b', fontWeight: 700 }}>{t('LIQ_WHALE_SHORT_SQUEEZE_TITLE')}</span>
+                          <span style={{ color: 'var(--amber)', fontWeight: 700 }}>{t('LIQ_WHALE_SHORT_SQUEEZE_TITLE')}</span>
                           {' '}{t('LIQ_WHALE_SHORT_SQUEEZE_BODY', { retailPct: ((1 - retailLong) * 100).toFixed(0), whalePct: (whaleLong * 100).toFixed(0) })}
                         </>
                       )}

--- a/app/markets/page.tsx
+++ b/app/markets/page.tsx
@@ -112,7 +112,7 @@ export default function MarketsPage() {
   const GRADE_STYLE: Record<string, { bg: string; col: string }> = {
     A: { bg: 'rgba(52,211,153,0.15)',  col: 'var(--green-2)' },
     B: { bg: 'rgba(96,165,250,0.15)',  col: 'var(--accent-2)' },
-    C: { bg: 'rgba(245,158,11,0.15)',  col: '#f59e0b' },
+    C: { bg: 'rgba(245,158,11,0.15)',  col: 'var(--amber)' },
     D: { bg: 'rgba(248,113,113,0.15)', col: 'var(--red)' },
     F: { bg: 'rgba(239,68,68,0.15)',   col: 'var(--red)' },
   };

--- a/components/KLineProChart.tsx
+++ b/components/KLineProChart.tsx
@@ -1989,7 +1989,7 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
               <span
                 key={alert.id}
                 className="klc-price-chip"
-                style={{ color: '#f59e0b', background: 'rgba(245,158,11,0.08)', borderColor: 'rgba(245,158,11,0.2)', cursor: 'default' }}
+                style={{ color: 'var(--amber)', background: 'rgba(245,158,11,0.08)', borderColor: 'rgba(245,158,11,0.2)', cursor: 'default' }}
                 title={`Alert: ${alert.direction} $${fmtPx(alert.target_price)}${alert.label ? ` · ${alert.label}` : ''} - drag the dashed line to adjust`}
               >
                 {alert.direction === 'above' ? '↑' : '↓'} ${fmtPx(alert.target_price)}
@@ -2127,7 +2127,7 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
             textTransform: 'none',
             letterSpacing: 'normal',
           }}>
-            <span style={{ color: '#f59e0b', marginRight: 5, lineHeight: 0 }}><Warn size={13} /></span>
+            <span style={{ color: 'var(--amber)', marginRight: 5, lineHeight: 0 }}><Warn size={13} /></span>
             {rwTooltip.dir === 'bearish'
               ? 'Trend reversal - RSI divergence detected'
               : 'Potential bottom - RSI divergence detected'}

--- a/components/LiqTerminal.tsx
+++ b/components/LiqTerminal.tsx
@@ -583,16 +583,16 @@ export default function LiqTerminal() {
                     border: '0.5px solid rgba(245,158,11,0.3)',
                     display: 'flex', gap: 8, alignItems: 'flex-start',
                   }}>
-                    <span style={{ color: '#f59e0b', flexShrink: 0, lineHeight: 0 }}><Warn size={13} /></span>
+                    <span style={{ color: 'var(--amber)', flexShrink: 0, lineHeight: 0 }}><Warn size={13} /></span>
                     <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', lineHeight: 1.6 }}>
                       {longSqueezeRisk ? (
                         <>
-                          <span style={{ color: '#f59e0b', fontWeight: 700 }}>{t('LIQ_WHALE_LONG_SQUEEZE_TITLE')}</span>
+                          <span style={{ color: 'var(--amber)', fontWeight: 700 }}>{t('LIQ_WHALE_LONG_SQUEEZE_TITLE')}</span>
                           {' '}{t('LIQ_WHALE_LONG_SQUEEZE_BODY', { retailPct: (retailLong * 100).toFixed(0), whalePct: (whaleShort * 100).toFixed(0) })}
                         </>
                       ) : (
                         <>
-                          <span style={{ color: '#f59e0b', fontWeight: 700 }}>{t('LIQ_WHALE_SHORT_SQUEEZE_TITLE')}</span>
+                          <span style={{ color: 'var(--amber)', fontWeight: 700 }}>{t('LIQ_WHALE_SHORT_SQUEEZE_TITLE')}</span>
                           {' '}{t('LIQ_WHALE_SHORT_SQUEEZE_BODY', { retailPct: ((1 - retailLong) * 100).toFixed(0), whalePct: (whaleLong * 100).toFixed(0) })}
                         </>
                       )}

--- a/components/MarketsTerminal.tsx
+++ b/components/MarketsTerminal.tsx
@@ -96,7 +96,7 @@ export default function MarketsTerminal() {
   const GRADE_STYLE: Record<string, { bg: string; col: string }> = {
     A: { bg: 'rgba(52,211,153,0.15)',  col: 'var(--green-2)' },
     B: { bg: 'rgba(96,165,250,0.15)',  col: 'var(--accent-2)' },
-    C: { bg: 'rgba(245,158,11,0.15)',  col: '#f59e0b' },
+    C: { bg: 'rgba(245,158,11,0.15)',  col: 'var(--amber)' },
     D: { bg: 'rgba(248,113,113,0.15)', col: 'var(--red)' },
     F: { bg: 'rgba(239,68,68,0.15)',   col: 'var(--red)' },
   };

--- a/components/StopLossZone.tsx
+++ b/components/StopLossZone.tsx
@@ -194,10 +194,10 @@ export default function StopLossZone({ coin, grokSignal }: { coin: CoinId; grokS
                 background: 'rgba(245,158,11,0.07)',
                 border: '0.5px solid rgba(245,158,11,0.22)',
               }}>
-                <span style={{ color: '#f59e0b', flexShrink: 0, lineHeight: 0 }}><Warn size={12} /></span>
+                <span style={{ color: 'var(--amber)', flexShrink: 0, lineHeight: 0 }}><Warn size={12} /></span>
                 <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', lineHeight: 1.5 }}>
                   {t('STOP_LOSS_ZONE_CONFLICT_PREFIX')}{' '}
-                  <span style={{ color: '#f59e0b', fontWeight: 700 }}>{grokSignal}</span>
+                  <span style={{ color: 'var(--amber)', fontWeight: 700 }}>{grokSignal}</span>
                   {' '}{t('STOP_LOSS_ZONE_CONFLICT_SUFFIX')}
                 </span>
               </div>

--- a/components/TradeJournal.tsx
+++ b/components/TradeJournal.tsx
@@ -989,11 +989,11 @@ function Inner() {
               background: 'rgba(217,119,6,0.08)', border: '0.5px solid rgba(217,119,6,0.3)',
               borderRadius: 8, padding: '10px 12px', marginBottom: 12,
             }}>
-              <div style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: '#f59e0b', marginBottom: 6, display: 'flex', alignItems: 'center', gap: 5 }}>
+              <div style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: 'var(--amber)', marginBottom: 6, display: 'flex', alignItems: 'center', gap: 5 }}>
                 <Warn /> {t('TRADE_JOURNAL_LOG_LEVEL_WARNINGS_TITLE')}
               </div>
               {levelWarnings.map((w, i) => (
-                <div key={i} style={{ fontSize: 'var(--fs-caption)', color: '#f59e0b', opacity: 0.85, lineHeight: 1.5 }}>
+                <div key={i} style={{ fontSize: 'var(--fs-caption)', color: 'var(--amber)', opacity: 0.85, lineHeight: 1.5 }}>
                   · {w}
                 </div>
               ))}

--- a/components/UsageRings.tsx
+++ b/components/UsageRings.tsx
@@ -11,7 +11,7 @@ const RINGS = [
   { id: 'deep',     labelKey: 'USAGE_RINGS_DEEP',     color: 'var(--accent-2)', used: 'deep_used',      limit: 'deep_limit'      },
   { id: 'chat',     labelKey: 'USAGE_RINGS_CHAT',     color: 'var(--accent-2)', used: 'chat_used',      limit: 'chat_limit'      },
   { id: 'search',   labelKey: 'USAGE_RINGS_SEARCH',   color: 'var(--accent)', used: 'search_used',    limit: 'search_limit'    },
-  { id: 'briefing', labelKey: 'USAGE_RINGS_BRIEFING', color: '#f59e0b', used: 'briefing_used',  limit: 'briefing_limit'  },
+  { id: 'briefing', labelKey: 'USAGE_RINGS_BRIEFING', color: 'var(--amber)', used: 'briefing_used',  limit: 'briefing_limit'  },
   // Shared budget across all 11 one-shot tools. Pro-only, so this ring is
   // filtered out below when the limit is 0 - free is capped per tool and has
   // no single number to show.


### PR DESCRIPTION
## Summary

**This is a production fix, not a terminal one.** 16 text and icon sites take `var(--amber)` instead of the raw hex `#f59e0b`. Fixes #739.

## `#f59e0b` matches no token in any palette

```
:root            --amber  #fbbf24
[data-theme=light]        #8F4508
terminal dark             #fbbf24
terminal light            #755100
on the page               #f59e0b   <- a fourth value, chosen for no theme
```

Measured on the `rgba(245,158,11,0.15)` tint these elements sit on:

| | literal `#f59e0b` | `var(--amber)` |
|---|---|---|
| app dark | 7.13 | 9.17 |
| **app LIGHT** | **1.92 fails** | 6.20 |
| terminal dark | 7.26 | 9.34 |
| **terminal light** | **1.79 fails** | 5.96 |

**The current design's light theme fails**, and QA measured **1.62 against the real ground in production**. That's the shipping design, one click away on the app bar's theme button — not behind `?design=terminal`, not behind any flag. `/markets` and `/liq` have been showing it to users.

The issue was filed as terminal-light because that's the surface being audited. **The literal never cared which design it was in**, which is the whole reason a raw hex is the defect rather than the ratio.

## No new token needed

QA flagged that no `--amber-fg` exists, so a substitution might not suffice. **It does** — `--amber` already carries per-theme values chosen against light grounds, which is exactly what the literal lacked.

## Appearance changes in dark too, deliberately

`#f59e0b` → `#fbbf24`, a slightly brighter amber, and the token the system already names for *"weak/caution state"*. Flagged on the issue before building rather than left to be discovered in review.

## Not changed, each for a reason

| Site | Why |
|---|---|
| `KLineProChart:1018,1739` | klinecharts **canvas strokes** — graphics at 3:1, not DOM text |
| `news/page.tsx:171-173` | Reuters **source-identity** colours — same class as `coinBadgeColor` on #734; identity, not state, and that question is the owner's |

`UsageRings:14` **is** included though it's a ring rather than text: its three sibling entries already use `var(--green-2)`/`var(--accent-2)`, so the literal was the odd one out in its own array. **Consistency with its neighbours, not a measured failure** — stated rather than folded into the count.

## How to test (QA)

1. **`/markets` and `/liq` in the CURRENT design, theme toggled to light** — the `C` grade chip and the squeeze warnings are readable. This is the half that matters.
2. Same two routes in terminal light.
3. Dark, both designs: amber is marginally brighter than before.
4. The chart's dashed amber line and the Reuters news chips are unchanged.

## Risk level

**Medium.** Touches nine files across both designs and changes a visible colour in dark as well as light. Mitigated by every site being the same one-value substitution to a token the system already owns. Gates: lint 0 errors, `tsc` 0, `npm test` 571/0, `build` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
