### PR TITLE
fix(dashboard): restore the section gap, and give the coin row a ground

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -7181,9 +7181,28 @@ main.app-content[data-chrome="none"] {
    per-band fill. Terminal only - the current design's dashboard keeps its
    spaced cards, and .scc-card/.dash-conditions-row both render there too. */
 [data-design="terminal"] .dash-main { gap: 0; }
+/* The coin row keeps a surface (#744). Owner: "the coin item. Why does it have
+   no background even in dark theme."
+
+   THIS PARTLY REVERSES #607, WHICH IS WHY IT IS SPELLED OUT. That decision made
+   the whole main column banded rather than carded - no per-band fill, hairline
+   separators, column ground throughout - and `background: transparent` here was
+   part of it, not an oversight. The owner is asking for the opposite for this
+   one element, so this is a ruling overriding a ruling rather than a bug fix.
+
+   --bg1, not the base rule's card treatment: it lifts the row off --bg0 enough
+   to read as a surface while staying inside terminal's palette, and the
+   hairline separator and zero radius from #607 are kept. So the row gains a
+   ground without becoming a floating card again, which is the half of #607
+   the owner did not object to.
+
+   The sibling bands (.dash-conditions-row below) are deliberately NOT given a
+   fill - the owner named this element specifically, and changing the others to
+   match would be me deciding how far the reversal goes. If the column should
+   be carded again throughout, that is a bigger call and theirs. */
 [data-design="terminal"] .dash-main > .scc-card {
   border: 0; border-bottom: 1px solid var(--bdr);
-  background: transparent; border-radius: 0;
+  background: var(--bg1); border-radius: 0;
 }
 [data-design="terminal"] .dash-main > .dash-conditions-row {
   gap: 0; border-bottom: 1px solid var(--bdr);

--- a/components/DashboardTerminal.tsx
+++ b/components/DashboardTerminal.tsx
@@ -512,7 +512,15 @@ export default function DashboardTerminal() {
         <MarketRead />
 
         <TPanel id="tour-best-setup">
-          <div className="dash-section dash-section-hot" style={{ marginTop: 0 }}>{t('DASH_BEST_SETUP_TODAY_HEADER')}</div>
+          {/* No marginTop override (#743). Owner: "I want to add spacing
+              between the market read and best setup today."
+              .dash-section already declares `margin: 20px 0 10px`; this inline
+              `marginTop: 0` outranked it and closed the gap, so the panel
+              above and this label sat flush. Deleting the override restores
+              the 20px the rule already intended - same shape as #681 and #660,
+              where an inline value silently owned a property the stylesheet
+              was written to own. */}
+          <div className="dash-section dash-section-hot">{t('DASH_BEST_SETUP_TODAY_HEADER')}</div>
           <SOTD />
         </TPanel>
 


### PR DESCRIPTION
## Summary

Two owner-reported items on the terminal dashboard. Fixes #743, addresses #744.

## #743 — the section gap

`.dash-section` already declares `margin: 20px 0 10px`. An inline `marginTop: 0` on the BEST SETUP TODAY label outranked it and closed the gap, so the market-read panel and the label sat flush.

**Deleting the override restores the 20px the rule already intended** — the same inline-owns-a-property-the-stylesheet-owns shape as #681 and #660.

## #744 — the coin row's ground, and this one is a proposal

`.scc-card` takes `background: var(--bg1)` under terminal instead of `transparent`.

**This partly reverses #607, and I haven't hidden that.** That decision made the whole main column *banded rather than carded* — no per-band fill, hairline separators, column ground throughout — and `background: transparent` was part of it, not an oversight. So this is a ruling overriding a ruling, not a bug fix. QA asked me to propose rather than pick; here's what I picked and what I deliberately left.

**What I changed:** `--bg1` lifts the row off `--bg0` enough to read as a surface while staying inside terminal's palette. #607's hairline separator and zero radius are **kept** — so the row gains a ground without becoming a floating card again, which is the half of #607 the owner didn't object to.

**What I left:** the sibling band (`.dash-conditions-row`) gets no fill. The owner named this element specifically, and changing the others to match would be me deciding how far the reversal goes. **If the column should be carded throughout, that's a bigger call and it's theirs.**

Hover still reads: resting `--bg1`, hover `--bg2` from the base rule, distinct in both themes.

## How to test (QA)

1. `/dashboard?design=terminal`: a 20px gap above BEST SETUP TODAY.
2. The BTC coin row below it has a visible surface in **both** themes rather than sitting flush on the body.
3. Hovering the row still changes its ground.
4. The neighbouring conditions row is unchanged — **that's the open question, not an omission.**

## Risk level

**Low** for #743, **Low but visible** for #744 — one background value on one element, reversing part of a documented decision. Gates: lint 0 errors, `tsc` 0, `npm test` 571/0, `build` 0.

Per your reordering these are items 5 and 6, behind the four that block #748 — no rush on the review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
