### PR TITLE
fix(hours): band labels take --txt, and the prime pill takes --green-fg

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1402,6 +1402,21 @@ body.ticker-on .breaking-alert { top: calc(var(--appbar-h) + var(--strip-h) + 32
 .wp-prime  { background: var(--green-bg);  color: var(--green);  border: 0.5px solid var(--green-bdr);  box-shadow: var(--glow-green); }
 .wp-london { background: var(--blue-bg);   color: var(--blue);   border: 0.5px solid var(--blue-bdr); }
 .wp-dead   { background: var(--red-bg);    color: var(--red);    border: 0.5px solid var(--red-bdr); }
+/* .wp-prime's text takes --green-fg under terminal (#707). --green on
+   rgb(210,216,207) - the pill's own green tint over the light ground -
+   measures 4.28, short of 4.5 by 0.22. --green-fg is 5.6 there and is the
+   treatment already shipped for this exact shape on #688 and #693.
+
+   TERMINAL-SCOPED RATHER THAN CHANGING THE BASE RULE, deliberately. At :root
+   --green-fg aliases --green-2, which is a different colour from --green - so
+   editing the base rule would repaint the pill on the CURRENT design, where
+   nothing has been measured failing. The defect was measured in terminal
+   light; the fix goes where the measurement was.
+
+   The other three pills are untouched: only .wp-prime was measured short, and
+   applying the -fg treatment to all four for symmetry would be four changes
+   with one defect behind them. */
+[data-design="terminal"] .wp-prime { color: var(--green-fg); }
 .wp-other  { background: var(--bg2);       color: var(--txt2);   border: 0.5px solid var(--bdr); }
 .nw-row       { display: flex; align-items: center; justify-content: space-between; padding: 8px 10px; border-radius: 10px; background: var(--bg2); border: 0.5px solid var(--bdr); }
 .nw-name      { font-size: var(--fs-label); font-weight: 600; }

--- a/app/hours/page.tsx
+++ b/app/hours/page.tsx
@@ -157,8 +157,27 @@ export default function BestHours() {
                   background: seg.bg,
                   display: 'flex', alignItems: 'center', justifyContent: 'center',
                 }}>
+                  {/* --txt, not '#fff' (#707). The band is pastel in light
+                      theme - rgb(156,224,181), rgb(240,206,119) - while the
+                      label stayed pure white, giving 1.46-1.78:1. The label
+                      colour never changed with the theme; only the band did.
+
+                      --txt is near-white in dark and near-black in light, so
+                      one token covers both: dark keeps the appearance it had,
+                      light becomes legible. Same answer /correlation (#570)
+                      and the scanner heatmap (#701) landed on - let the tint
+                      carry the meaning, put the text in the theme's own
+                      foreground - rather than saturating the bands, which
+                      would change the screen's whole character to keep a
+                      colour nothing requires.
+
+                      opacity 0.9 is KEPT and measured rather than assumed:
+                      --txt at 0.9 gives 9.39 PRIME, 9.44 ASIA, 7.93 DEAD,
+                      7.82 NY, 8.53 LONDON. Every band clears 4.5 with the
+                      existing fade, so removing it would have been a second
+                      change with nothing behind it. */}
                   {width > 7 && (
-                    <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: '#fff', letterSpacing: '.04em', opacity: 0.9 }}>
+                    <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: 'var(--txt)', letterSpacing: '.04em', opacity: 0.9 }}>
                       {t(seg.labelKey)}
                     </span>
                   )}


### PR DESCRIPTION
## Summary

Both causes on `/hours`. Fixes #707 — **item 1 of the four blocking #748.**

Reopened because it was closed on reachability (*"terminal is opt-in twice, nobody reaches it"*), and #748 makes terminal the default — which voids that reasoning without touching the measurements.

## Cause 1 — six labels at 1.46–1.78

The bands are **pastel in light theme** — `rgb(156,224,181)`, `rgb(240,206,119)` — while the label stayed pure white. **The label colour never changed with the theme; only the band did.**

`var(--txt)` is near-white in dark and near-black in light, so one token covers both: dark keeps the appearance it had, light becomes legible.

Same answer `/correlation` (#570) and the scanner heatmap (#701) both landed on — let the tint carry the meaning, put the text in the theme's own foreground — rather than saturating the bands, which would change the screen's whole character to keep a colour nothing requires.

**`opacity: 0.9` is kept, and measured rather than assumed:**

| band | white @0.9 | `--txt` @0.9 |
|---|---|---|
| PRIME | 1.47 | **9.39** |
| ASIA | 1.46 | **9.44** |
| DEAD | 1.76 | **7.93** |
| NY | 1.78 | **7.82** |
| LONDON | 1.62 | **8.53** |

Every band clears 4.5 with the existing fade, so removing it would have been a second change with nothing behind it.

## Cause 2 — two pills at 4.28

`--green` on `rgb(210,216,207)` is short by 0.22. `--green-fg` measures **5.6** there and is the treatment already shipped for this shape on #688 and #693.

**Terminal-scoped rather than editing the base rule.** At `:root`, `--green-fg` aliases `--green-2` — a *different* colour from `--green` — so changing `.wp-prime`'s base rule would repaint the pill on the **current design**, where nothing was measured failing. The defect was measured in terminal light; the fix goes where the measurement was.

The other three pills are untouched: only `.wp-prime` was measured short, and applying the `-fg` treatment to all four for symmetry would be four changes with one defect behind them.

## How to test (QA)

1. `/hours?design=terminal` toggled to **light**: PRIME, ASIA, DEAD, NY and LONDON labels read dark on their pastel bands.
2. The PRIME window pill is a darker green.
3. **Dark**: both unchanged.
4. **`/hours` on the current design**: unchanged — the pill fix is terminal-scoped and `--txt` was already the right colour there.

## Risk level

**Low.** One inline colour and one scoped rule; no layout, no new token. Gates: lint 0 errors, `tsc` 0, `npm test` 571/0, `build` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
