### PR TITLE
fix(hours): derive each session-band label from the band's own luminance (#707)

### DIFF
--- a/__tests__/readableOn.test.mts
+++ b/__tests__/readableOn.test.mts
@@ -1,0 +1,212 @@
+/* The /hours session-band labels, measured against the real palette (#707).
+ *
+ * Two fixes shipped here and each one fixed a theme and broke the other:
+ * `'#fff'` fails all six bands in light, `var(--txt)` fails three in dark.
+ * Both were reasoned about correctly and measured on one axis. This is the
+ * test that makes the second axis non-optional.
+ *
+ * It reads the band colours from app/hours/page.tsx and the grounds from
+ * app/globals.css - not from constants restated here - so a palette change
+ * moves the assertion with it. Restating either would be the two-sources bug
+ * that #736 and #663 are both about, in the file meant to prevent it.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  readableOn, parseCssColor, compositeOver, contrastRatio, relativeLuminance,
+  BLACK, WHITE, type Rgb,
+} from '../lib/readableOn.ts';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CSS = readFileSync(path.join(ROOT, 'app', 'globals.css'), 'utf8');
+const PAGE = readFileSync(path.join(ROOT, 'app', 'hours', 'page.tsx'), 'utf8');
+
+const BAR = 4.5;
+
+/** Custom-property declarations inside one top-level rule. */
+function tokens(selector: string): Record<string, string> {
+  const lines = CSS.split('\n');
+  const idx = lines.findIndex(l => l.trim() === selector + ' {');
+  assert.ok(idx >= 0, `token block not found in globals.css: ${selector}`);
+  const from = lines.slice(0, idx).join('\n').length;
+  let i = CSS.indexOf('{', from), depth = 0, end = i;
+  for (; i < CSS.length; i++) {
+    if (CSS[i] === '{') depth++;
+    else if (CSS[i] === '}') { depth--; if (depth === 0) { end = i; break; } }
+  }
+  const body = CSS.slice(CSS.indexOf('{', from) + 1, end);
+  const out: Record<string, string> = {};
+  for (const m of body.matchAll(/(--[a-z0-9-]+)\s*:\s*([^;]+);/g)) out[m[1]] = m[2].trim();
+  return out;
+}
+
+function resolve(map: Record<string, string>, value: string, depth = 0): string | null {
+  if (depth > 10) return null;
+  const m = /^var\((--[a-z0-9-]+)(?:\s*,\s*([^)]+))?\)$/.exec(value.trim());
+  if (!m) return value.trim();
+  const next = map[m[1]] ?? m[2];
+  return next === undefined ? null : resolve(map, next, depth + 1);
+}
+
+const root = tokens(':root');
+const light = tokens('[data-theme="light"]');
+const termDark = tokens('[data-design="terminal"]:not([data-theme="light"])');
+const termLight = tokens('[data-design="terminal"][data-theme="light"]');
+
+/* The four contexts the page can actually render in. Terminal light layers on
+   the light block because that is the cascade order in globals.css. */
+const CONTEXTS: Array<[string, Record<string, string>]> = [
+  ['current dark', { ...root }],
+  ['current light', { ...root, ...light }],
+  ['terminal dark', { ...root, ...termDark }],
+  ['terminal light', { ...root, ...light, ...termLight }],
+];
+
+/** The band colours, read out of the page rather than copied.
+ *  `{ start: 4, end: 7, bg: 'rgba(248,113,113,0.45)', labelKey: 'HOURS_SEG_DEAD' … }` */
+function bandsFromPage(): Array<{ label: string; bg: string }> {
+  const out: Array<{ label: string; bg: string }> = [];
+  for (const m of PAGE.matchAll(/bg:\s*'([^']+)',\s*labelKey:\s*'([A-Z_]+)'/g)) {
+    out.push({ label: m[2].replace('HOURS_SEG_', ''), bg: m[1] });
+  }
+  return out;
+}
+
+test('the band list parsed out of the page is plausible', () => {
+  const bands = bandsFromPage();
+  assert.equal(bands.length, 6,
+    `expected 6 session bands in app/hours/page.tsx, parsed ${bands.length} ` +
+    `(${bands.map(b => b.label).join(', ')}). If a band was added or the literal ` +
+    'was reformatted, fix the parser - do not relax this number, or the sweep ' +
+    'below silently stops covering a band.');
+  for (const b of bands) {
+    assert.ok(parseCssColor(b.bg), `band ${b.label} has an unparseable colour: ${b.bg}`);
+  }
+});
+
+test('every band label clears 4.5:1 in all four theme x design contexts', () => {
+  /* HONEST NOTE ON WHAT THIS CAN AND CANNOT FAIL.
+   *
+   * I wrote this expecting it to be the main guard, then control-tested it by
+   * swapping a band for a mid-grey - and it still passed. It cannot fail on a
+   * band colour, and the reason is the point of the whole ruling:
+   *
+   *   contrast(white, L) = 1.05 / (L + 0.05)
+   *   contrast(black, L) = (L + 0.05) / 0.05
+   *
+   * The two are equal at L = 0.1791, where both are 4.58. So max(black, white)
+   * has a FLOOR of 4.58 for every opaque colour that exists, and compositing a
+   * translucent band onto an opaque ground always produces an opaque colour.
+   * There is no band this can fail on - which is exactly why deriving per band
+   * is guaranteed to work where a single token could not.
+   *
+   * What it does still catch: an unresolvable --bg3, a band literal that stops
+   * parsing, and any future change to the candidate set (a token instead of
+   * black/white has no such floor). Kept for those, with its ceiling stated
+   * rather than left to be discovered by whoever trusts it next. The assertion
+   * that carries real weight here is the opacity one below. */
+  const bands = bandsFromPage();
+  const failures: string[] = [];
+  for (const [name, map] of CONTEXTS) {
+    const ground = resolve(map, 'var(--bg3)');
+    assert.ok(ground, `--bg3 does not resolve in ${name}`);
+    for (const band of bands) {
+      const pick = readableOn(band.bg, ground!);
+      assert.ok(pick, `readableOn returned null for ${band.label} on ${ground}`);
+      if (pick!.ratio < BAR) {
+        failures.push(`${name} / ${band.label}: best is ${pick!.color} at ${pick!.ratio.toFixed(2)}`);
+      }
+    }
+  }
+  assert.deepEqual(failures, [],
+    'a session band cannot carry a legible label:\n  ' + failures.join('\n  ') +
+    '\nBlack and white are the only candidates, so this means the BAND colour ' +
+    'has to move - no text colour rescues a band that lands mid-tone.');
+});
+
+test('the 4.58 floor is real, not an assumption - swept', () => {
+  /* The claim above, measured rather than derived on paper: across a dense
+     sweep of the sRGB cube, the better of black and white never drops below
+     4.5. If this ever fails, the guarantee the #707 ruling rests on is wrong
+     and the per-band derivation needs a third candidate. */
+  let worst = Infinity, worstAt: Rgb = [0, 0, 0];
+  for (let r = 0; r <= 255; r += 5) {
+    for (let g = 0; g <= 255; g += 5) {
+      for (let b = 0; b <= 255; b += 5) {
+        const c: Rgb = [r, g, b];
+        const best = Math.max(contrastRatio(BLACK, c), contrastRatio(WHITE, c));
+        if (best < worst) { worst = best; worstAt = c; }
+      }
+    }
+  }
+  assert.ok(worst >= BAR,
+    `black-or-white bottoms out at ${worst.toFixed(3)} on rgb(${worstAt.join(',')}), below the 4.5 bar`);
+  assert.ok(Math.abs(worst - 4.58) < 0.02,
+    `expected the floor near 4.58, swept ${worst.toFixed(3)} - the maths in ` +
+    'relativeLuminance or contrastRatio has changed');
+});
+
+test('the label carries no opacity - the fade is what made ASIA unfixable', () => {
+  /* With opacity 0.9 ASIA in dark measures 4.27 black / 4.07 white: both
+     below the bar, so no colour choice can fix it while the fade is there.
+     This is the assertion that stops the fade coming back as a "restore the
+     original look" change - it would silently re-break one band. */
+  const seg = PAGE.slice(PAGE.indexOf('{width > 7 && ('), PAGE.indexOf('{width > 7 && (') + 400);
+  assert.ok(!/opacity/.test(seg),
+    'the session-band label has an opacity again. Any fade multiplies through ' +
+    'the contrast: ASIA in dark falls to 4.27 (black) / 4.07 (white) at 0.9, ' +
+    'and no colour clears it. Remove the opacity or move the band colour.');
+});
+
+test('a translucent surface is measured against the ground, not against white', () => {
+  /* The bug this whole file exists for, in one assertion: the SAME band gets
+     opposite answers on the two grounds, so any code path that forgets the
+     ground gets the light answer in dark. */
+  const prime = 'rgba(125,224,164,0.70)';
+  const onDark = readableOn(prime, '#0f1115');
+  const onLight = readableOn(prime, '#E4E6E9');
+  assert.equal(onDark?.color, '#000');
+  assert.equal(onLight?.color, '#000');
+
+  const london = 'rgba(122,184,245,0.55)';
+  assert.equal(readableOn(london, '#0f1115')?.color, '#fff');
+  assert.equal(readableOn(london, '#E4E6E9')?.color, '#000');
+});
+
+test('an unparseable ground returns null rather than guessing', () => {
+  assert.equal(readableOn('rgba(125,224,164,0.70)', 'var(--bg3)'), null);
+  assert.equal(readableOn('rgba(125,224,164,0.70)', 'chartreuse'), null);
+  assert.equal(readableOn('not a colour', '#000000'), null);
+});
+
+test('the primitives agree with the WCAG reference values', () => {
+  // Anchors, so a refactor of the maths cannot drift unnoticed.
+  assert.equal(relativeLuminance(WHITE), 1);
+  assert.equal(relativeLuminance(BLACK), 0);
+  assert.equal(contrastRatio(BLACK, WHITE), 21);
+  assert.equal(contrastRatio(WHITE, WHITE), 1);
+
+  // #767676 on white is the canonical 4.54:1 "smallest passing grey".
+  const grey = parseCssColor('#767676')!.rgb;
+  assert.ok(Math.abs(contrastRatio(grey, WHITE) - 4.54) < 0.01,
+    `#767676 on white measured ${contrastRatio(grey, WHITE).toFixed(2)}, expected 4.54`);
+});
+
+test('parseCssColor handles the three shapes this codebase writes', () => {
+  assert.deepEqual(parseCssColor('#fff'), { rgb: [255, 255, 255], alpha: 1 });
+  assert.deepEqual(parseCssColor('#0f1115'), { rgb: [15, 17, 21], alpha: 1 });
+  assert.deepEqual(parseCssColor('rgb(1, 2, 3)'), { rgb: [1, 2, 3], alpha: 1 });
+  assert.deepEqual(parseCssColor('rgba(125,224,164,0.7)'), { rgb: [125, 224, 164], alpha: 0.7 });
+  assert.equal(parseCssColor('#ff'), null);
+  assert.equal(parseCssColor(''), null);
+});
+
+test('compositeOver flattens toward the ground as alpha falls', () => {
+  const white: Rgb = [255, 255, 255];
+  assert.deepEqual(compositeOver(white, BLACK, 1), [255, 255, 255]);
+  assert.deepEqual(compositeOver(white, BLACK, 0), [0, 0, 0]);
+  assert.deepEqual(compositeOver(white, BLACK, 0.5), [127.5, 127.5, 127.5]);
+});

--- a/app/hours/page.tsx
+++ b/app/hours/page.tsx
@@ -7,6 +7,7 @@ import Tip from '@/components/Tip';
 import { useLabels } from '@/lib/labels';
 import type { LabelKey } from '@/lib/labelKeys';
 import { useDesignMode } from '@/components/DesignModeProvider';
+import { readableOn } from '@/lib/readableOn';
 
 /* Typical-weekday session blocks, as UTC hour ranges - the same windows
    lib/session.ts enforces. These used to be PHT hours on a fixed PHT axis
@@ -76,6 +77,47 @@ export default function BestHours() {
     setMounted(true);
     const timer = setInterval(() => setTick(v => v + 1), 1000);
     return () => clearInterval(timer);
+  }, []);
+
+  /* THE GROUND THE BANDS SIT ON, READ FROM THE LIVE STYLESHEET (#707).
+     The band colours are translucent, so what the label has to contrast
+     against is the band flattened onto the strip's own background - which is
+     `--bg3`, and which has four different values across theme x design.
+
+     Read rather than restated. Hardcoding those four values here would put the
+     same fact in globals.css and in this file, and the two would part company
+     the first time a palette moved - which is #736 and #663, both of which
+     cost a public retraction this week. getComputedStyle sees whatever the
+     cascade actually resolved, including any design mode added later.
+
+     WATCHED, NOT SAMPLED ONCE. The first version read on mount and re-ran on
+     `mode`, and it was WRONG in terminal - measured live, ASIA rendered white
+     where the palette says black. React runs child effects before parent
+     effects, so this page's effect fires BEFORE DesignModeProvider has put
+     `data-design` on <html>: the read happens while the document is still
+     current-design and returns #0f1115 instead of #111416. Close enough that
+     it renders plausibly, wrong enough to pick the other colour on a band
+     that is a 0.12 tie.
+
+     So watch the attributes rather than guess when they settle - the same
+     MutationObserver pattern GrokSignalChart uses, plus the `theme-change`
+     event lib/theme.ts dispatches on an explicit toggle or a system change. */
+  const [ground, setGround] = useState<string | null>(null);
+  useEffect(() => {
+    const read = () => {
+      const v = getComputedStyle(document.documentElement).getPropertyValue('--bg3').trim();
+      setGround(prev => (v && v !== prev ? v : prev));
+    };
+    read();
+    const observer = new MutationObserver(read);
+    observer.observe(document.documentElement, {
+      attributes: true, attributeFilter: ['data-theme', 'data-design'],
+    });
+    window.addEventListener('theme-change', read);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('theme-change', read);
+    };
   }, []);
 
   const now = new Date();
@@ -150,6 +192,12 @@ export default function BestHours() {
             {mounted && localSegments(-new Date().getTimezoneOffset() / 60).map((seg, i) => {
               const left  = (seg.start / 24) * 100;
               const width = ((seg.end - seg.start) / 24) * 100;
+              /* Derived, never tabulated - see lib/readableOn.ts. `ground` is
+                 null only on the first client frame, before the effect has
+                 read it; --txt for that one frame is the pre-#707 behaviour,
+                 which is legible in light and imperfect in dark rather than
+                 wrong in both. */
+              const pick = ground ? readableOn(seg.bg, ground) : null;
               return (
                 <div key={i} style={{
                   position: 'absolute', top: 0, bottom: 0,
@@ -157,27 +205,44 @@ export default function BestHours() {
                   background: seg.bg,
                   display: 'flex', alignItems: 'center', justifyContent: 'center',
                 }}>
-                  {/* --txt, not '#fff' (#707). The band is pastel in light
-                      theme - rgb(156,224,181), rgb(240,206,119) - while the
-                      label stayed pure white, giving 1.46-1.78:1. The label
-                      colour never changed with the theme; only the band did.
+                  {/* PER BAND, DERIVED (#707, owner ruling). Two single-colour
+                      answers were tried here and both failed on one theme:
 
-                      --txt is near-white in dark and near-black in light, so
-                      one token covers both: dark keeps the appearance it had,
-                      light becomes legible. Same answer /correlation (#570)
-                      and the scanner heatmap (#701) landed on - let the tint
-                      carry the meaning, put the text in the theme's own
-                      foreground - rather than saturating the bands, which
-                      would change the screen's whole character to keep a
-                      colour nothing requires.
+                        '#fff'      fails all six bands in light  1.43 - 1.78
+                        var(--txt)  fails three bands in dark     2.33 - 4.42
 
-                      opacity 0.9 is KEPT and measured rather than assumed:
-                      --txt at 0.9 gives 9.39 PRIME, 9.44 ASIA, 7.93 DEAD,
-                      7.82 NY, 8.53 LONDON. Every band clears 4.5 with the
-                      existing fade, so removing it would have been a second
-                      change with nothing behind it. */}
+                      My own note in this spot claimed --txt was "measured" -
+                      the five numbers it quoted were light theme only, and it
+                      read as covering both. That is what shipped the dark
+                      regression, so the numbers below name their ground.
+
+                      Black or white, whichever wins on the flattened band.
+                      Every band clears 4.5 in all four theme x design
+                      combinations:
+
+                        band     cur dark      cur light   term dark     term light
+                        DEAD     white 8.34    black 11.57 white 8.17    black 11.28
+                        LONDON   white 5.42    black 12.66 white 5.33    black 12.37
+                        PRE_NY   white 7.81    black 12.43 white 7.63    black 12.10
+                        NY       white 6.23    black 11.43 white 6.12    black 11.15
+                        PRIME    black 6.89    black 13.97 black 6.96    black 13.77
+                        ASIA     white 4.60    black 14.10 black 4.64    black 13.84
+
+                      ASIA is a near-tie in dark - 4.57 black against 4.60
+                      white in the current design, and the other way round in
+                      terminal - so the derived answer differs by design on
+                      that one band. Both clear, and forcing agreement would
+                      mean a tiebreak rule that is a table by another name.
+
+                      THE 0.9 FADE IS GONE, and that is required rather than
+                      tidying: with it, ASIA in dark fails BOTH ways (black
+                      4.27, white 4.07). No colour clears that band through
+                      the fade, so the fade had to be the thing that moved. */}
                   {width > 7 && (
-                    <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, color: 'var(--txt)', letterSpacing: '.04em', opacity: 0.9 }}>
+                    <span style={{
+                      fontSize: 'var(--fs-caption)', fontWeight: 700, letterSpacing: '.04em',
+                      color: pick ? pick.color : 'var(--txt)',
+                    }}>
                       {t(seg.labelKey)}
                     </span>
                   )}

--- a/lib/readableOn.ts
+++ b/lib/readableOn.ts
@@ -1,0 +1,108 @@
+/* Pick black or white for text sitting on an arbitrary background, by
+ * measuring rather than by remembering (#707).
+ *
+ * WHY THIS EXISTS RATHER THAN A LOOKUP TABLE. /hours paints six session bands
+ * as translucent colours over the page ground. Two fixes were tried and both
+ * failed, because both assumed one text colour could serve every band:
+ *
+ *     '#fff'        fails all six bands in light   (1.43 - 1.78)
+ *     var(--txt)    fails three bands in dark      (2.33 - 4.42)
+ *
+ * There is no third token that clears all six in both themes - the bands land
+ * light in light mode and mid-tone in dark, and a mid-tone band is equidistant
+ * from both ends. The colour has to be chosen per band, and once it is chosen
+ * per band it must not be WRITTEN per band: a six-entry map goes stale the
+ * moment a band colour moves, and nothing fails when it does. That is #736's
+ * and #663's shape, twice over.
+ *
+ * So the rule is the source of truth. Give it the band and the ground and it
+ * computes the answer, which stays correct through any palette change without
+ * anyone remembering this file exists.
+ *
+ * SCOPE: sRGB relative luminance per WCAG 2.x. Deliberately not APCA - the
+ * project's bar is 4.5:1 and every measurement on every issue in this area is
+ * a WCAG ratio, so introducing a second scale here would make two numbers that
+ * cannot be compared. */
+
+export type Rgb = [number, number, number];
+
+/** `#rgb`, `#rrggbb`, `rgb()` and `rgba()`. Returns the colour and its alpha
+ *  separately, because a band's alpha is the whole reason it needs
+ *  compositing before it can be measured. */
+export function parseCssColor(input: string): { rgb: Rgb; alpha: number } | null {
+  const s = input.trim();
+
+  const hex6 = /^#([0-9a-fA-F]{6})$/.exec(s);
+  if (hex6) {
+    return { rgb: [0, 2, 4].map(i => parseInt(hex6[1].slice(i, i + 2), 16)) as Rgb, alpha: 1 };
+  }
+  const hex3 = /^#([0-9a-fA-F]{3})$/.exec(s);
+  if (hex3) {
+    return { rgb: [0, 1, 2].map(i => parseInt(hex3[1][i] + hex3[1][i], 16)) as Rgb, alpha: 1 };
+  }
+  const fn = /^rgba?\(([^)]+)\)$/i.exec(s);
+  if (fn) {
+    const parts = fn[1].split(/[,\s/]+/).filter(Boolean).map(Number);
+    if (parts.length < 3 || parts.slice(0, 3).some(Number.isNaN)) return null;
+    const alpha = parts.length > 3 && !Number.isNaN(parts[3]) ? parts[3] : 1;
+    return { rgb: [parts[0], parts[1], parts[2]], alpha };
+  }
+  return null;
+}
+
+/** Flatten a translucent colour onto an opaque one. */
+export function compositeOver(fg: Rgb, bg: Rgb, alpha: number): Rgb {
+  return [0, 1, 2].map(i => fg[i] * alpha + bg[i] * (1 - alpha)) as Rgb;
+}
+
+export function relativeLuminance(rgb: Rgb): number {
+  const chan = (v: number) => {
+    const c = v / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * chan(rgb[0]) + 0.7152 * chan(rgb[1]) + 0.0722 * chan(rgb[2]);
+}
+
+export function contrastRatio(a: Rgb, b: Rgb): number {
+  const la = relativeLuminance(a), lb = relativeLuminance(b);
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+
+export const BLACK: Rgb = [0, 0, 0];
+export const WHITE: Rgb = [255, 255, 255];
+
+/** Whichever of black or white reads better on `surface` once `surface` has
+ *  been flattened onto `ground`.
+ *
+ *  `ground` is required and not defaulted. A translucent surface measured
+ *  against nothing is measured against white, which is the answer for exactly
+ *  one theme - and silently having the light-theme answer in dark is the bug
+ *  this function replaces. Callers read the real ground from the live
+ *  stylesheet so there is no second copy of it. */
+export function readableOn(
+  surface: string,
+  ground: Rgb | string,
+): { color: '#000' | '#fff'; ratio: number } | null {
+  const parsed = parseCssColor(surface);
+  if (!parsed) return null;
+  /* A ground that will not parse returns null rather than falling back to
+     white. Guessing here would reproduce the exact defect: an answer computed
+     against a background that is not the one on screen. */
+  const groundRgb = typeof ground === 'string' ? parseCssColor(ground)?.rgb : ground;
+  if (!groundRgb) return null;
+  const flat = compositeOver(parsed.rgb, groundRgb, parsed.alpha);
+  const onBlack = contrastRatio(BLACK, flat);
+  const onWhite = contrastRatio(WHITE, flat);
+  /* local/no-bare-hex-colour disabled, with the reason it asks for: these two
+     literals are the OUTPUT of a contrast measurement against the live ground,
+     not a colour someone picked and hoped about. The rule exists because a
+     hardcoded colour does not adapt to theme - this one adapts to the theme by
+     construction, since the ground it is measured against came from
+     getComputedStyle. Tokenising it would break it: --txt is near-white in
+     dark, and "near-white" is what fails on the light bands. */
+  return onBlack >= onWhite
+    // eslint-disable-next-line local/no-bare-hex-colour
+    ? { color: '#000', ratio: onBlack }
+    // eslint-disable-next-line local/no-bare-hex-colour
+    : { color: '#fff', ratio: onWhite };
+}


### PR DESCRIPTION
## Summary

Closes #707, third attempt, on the owner's ruling: **the label colour is derived per band from that band's own luminance**, black or white, and never written down.

Verified by rendering in all four theme × design combinations, not only by arithmetic — and the rendered check caught a real bug the arithmetic could not see. Details under "What the rendered check found".

## What changed

**`lib/readableOn.ts`** (new) — `parseCssColor`, `compositeOver`, `relativeLuminance`, `contrastRatio`, and `readableOn(surface, ground)` returning whichever of black/white measures higher once `surface` is flattened onto `ground`. `ground` is required: a translucent band measured against nothing is measured against white, which is the light-theme answer, which is the bug.

**`app/hours/page.tsx`** — the strip's real ground (`--bg3`) is read from the live stylesheet with `getComputedStyle`, watched with a `MutationObserver` on `data-theme` / `data-design` plus the existing `theme-change` event. Each band label takes `readableOn(seg.bg, ground)`. **The `opacity: 0.9` is removed.**

**`__tests__/readableOn.test.mts`** (new) — 9 tests. Band colours are parsed out of `page.tsx` and grounds resolved out of `globals.css`, so neither is restated here.

## Why one colour could never work

```
              six bands, four contexts
'#fff'        fails all six in light          1.43 - 1.78
var(--txt)    fails three in dark             2.33 - 4.42   ← what I shipped in #750
```

The bands are translucent, so they land **light in light mode and mid-tone in dark**. A mid-tone band is equidistant from both ends of the scale — no single token reaches it from either side.

## The measured result

Every band, every context, opacity removed:

```
band     current dark    current light   terminal dark   terminal light
DEAD     white  8.34     black 11.57     white  8.17     black 11.28
LONDON   white  5.42     black 12.66     white  5.33     black 12.37
PRE_NY   white  7.81     black 12.43     white  7.63     black 12.10
NY       white  6.23     black 11.43     white  6.12     black 11.15
PRIME    black  6.89     black 13.97     black  6.96     black 13.77
ASIA     white  4.60     black 14.10     black  4.64     black 13.84
```

**ASIA is a 0.12 tie in dark** — 4.57 black against 4.60 white in the current design, and the other way round in terminal — so the derived answer differs by design on that one band. Both clear. Forcing them to agree would need a tiebreak rule, which is a table wearing a different hat.

**The fade had to go, and that is not tidying.** At `opacity: 0.9`, ASIA in dark fails *both* ways: 4.27 black, 4.07 white. No colour clears that band through the fade, so the fade was the thing that had to move. There is a test asserting the label carries no opacity, so it cannot come back as a "restore the original look" change.

## What the rendered check found

The arithmetic said terminal dark ASIA should be **black**. Rendered, it came out **white**.

Cause: React runs child effects before parent effects, so this page's effect fired **before `DesignModeProvider` had put `data-design` on `<html>`**. The read returned `#0f1115` (current design) instead of `#111416` (terminal). Two grounds four RGB steps apart — invisible on every band except the one that is a 0.12 tie, where it picks the other colour.

Fixed by watching the attributes with a `MutationObserver` instead of assuming when they settle — the pattern `GrokSignalChart` already uses. Re-verified: terminal dark ASIA now renders `rgb(0,0,0)`.

**This is the argument for QA's guardrail, made against my own work.** Token arithmetic predicted #752's production numbers to two decimal places, and it still could not see this, because the defect was not in the colour maths — it was in *which ground the maths was handed*.

## Honest note on one of the tests

`every band label clears 4.5:1 in all four contexts` **cannot fail on a band colour**, and I found that by control-testing it rather than by trusting it. `contrast(white,L) = 1.05/(L+0.05)` and `contrast(black,L) = (L+0.05)/0.05` cross at L = 0.1791, where both are **4.58** — so `max(black, white)` has a floor of 4.58 for every opaque colour that exists.

That is the guarantee the ruling rests on, so it is now asserted directly: a dense sweep of the sRGB cube confirms the floor at 4.58. The original test is kept for what it *does* catch (an unresolvable `--bg3`, a band literal that stops parsing, a future change to the candidate set) with its ceiling written into the test rather than left for the next reader to discover.

## How to test (QA)

On `qa`, `/hours`, the 24-hour session bar at the top.

1. **Dark, current design.** Every band label legible. PRIME reads **black** where the others read white — that is correct, not a bug.
2. **Light, current design.** Every label black and legible. The two that failed at 1.46–1.78 (PRIME, ASIA) are the ones to look at.
3. **Terminal, dark** (`?design=terminal`). Same as 1, except **ASIA is also black**. The 0.12 tie flips with the ground.
4. **Terminal, light.** All black.
5. **Toggle the theme with the page open**, in both designs. Labels must re-derive immediately — this is the `MutationObserver`, and it is the part that was broken until the rendered check.
6. **Hard-reload directly on `?design=terminal`** and check ASIA without touching the toggle. That is the exact case the effect-ordering bug got wrong; on a stale ground ASIA renders white.

## Risk level

**Medium.** Four gates pass: lint 0 errors, `tsc --noEmit` clean, 583/583 tests, build succeeds. Verified by rendering in all four contexts on a local dev server, reading computed `color` off each label rather than eyeballing.

**What is still unverified:** not measured on a deployed environment — I am under a standing instruction not to deploy, so the rendered check is localhost against this branch. `--bg3` reads `#0f1115` / `#e4e6e9` / `#111416` / `#e3e1dd` there, matching the stylesheet, so I do not expect a deployed difference; that is an expectation, not a measurement.

**Thinnest margin:** ASIA in dark at 4.57 / 4.64, about 0.1 above the bar. If a band colour is ever adjusted, that is the one that crosses first.

**Third attempt on this issue.** The first two each passed review and each broke the theme nobody checked, so the useful question on this one is not "does light work" but "was every ground measured" — steps 3, 5 and 6 are where the previous two would have failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
