### PR TITLE
fix(funding): the coin ticker takes --txt, the badge hue stays on the mark (#734)

### DIFF
--- a/app/funding/page.tsx
+++ b/app/funding/page.tsx
@@ -460,7 +460,14 @@ export default function FundingHistory() {
             <div style={{ maxHeight: 220, overflowY: 'auto' }}>
               {liveCoins.map(({ id, fr, sig, carryArb, contraShort, contraLong }) => (
                 <div key={id} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '3px 0', borderTop: '0.5px solid var(--bdr)' }}>
-                  <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 800, color: coinBadgeColor(id), minWidth: 32, flexShrink: 0, fontFamily: 'var(--font-mono), monospace' }}>
+                  {/* PLAIN TEXT, NOT THE BADGE COLOUR (#734, owner ruling).
+                      coinBadgeColor returns a per-coin identity hue written
+                      for a DOT - a 16-18px filled circle on a tint of itself,
+                      where the 3:1 graphics bar applies. Used as 12px text it
+                      was measured at 1.38:1 at worst. The ruling: keep the
+                      coloured dot, make the ticker plain. The dot is the
+                      CoinIcon further down this file and is untouched. */}
+                  <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 800, color: 'var(--txt)', minWidth: 32, flexShrink: 0, fontFamily: 'var(--font-mono), monospace' }}>
                     {id.toUpperCase()}
                   </span>
                   <span style={{ fontSize: 'var(--fs-caption)', color: frColor(fr), fontFamily: 'var(--font-mono), monospace', minWidth: 64, flexShrink: 0 }}>

--- a/components/FundingTerminal.tsx
+++ b/components/FundingTerminal.tsx
@@ -447,7 +447,12 @@ export default function FundingTerminal() {
             <div style={{ maxHeight: 220, overflowY: 'auto' }}>
               {liveCoins.map(({ id, fr, sig, carryArb, contraShort, contraLong }) => (
                 <div key={id} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '3px 0', borderTop: '0.5px solid var(--bdr)' }}>
-                  <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 800, color: coinBadgeColor(id), minWidth: 32, flexShrink: 0, fontFamily: 'var(--font-mono), monospace' }}>
+                  {/* PLAIN TEXT, NOT THE BADGE COLOUR (#734, owner ruling).
+                      Same change as app/funding/page.tsx and for the same
+                      reason - the badge hue is written for a dot at the 3:1
+                      graphics bar, and reached 1.38:1 as 12px text. The dot
+                      itself, the CoinIcon below, keeps its colour. */}
+                  <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 800, color: 'var(--txt)', minWidth: 32, flexShrink: 0, fontFamily: 'var(--font-mono), monospace' }}>
                     {id.toUpperCase()}
                   </span>
                   <span style={{ fontSize: 'var(--fs-caption)', color: frColor(fr), fontFamily: 'var(--font-mono), monospace', minWidth: 64, flexShrink: 0 }}>


### PR DESCRIPTION
## Summary

Closes #734 on the owner's ruling — **keep the coloured mark, make the ticker plain**. Two call sites, one per design.

Plus the sweep QA explicitly declined to scope for me. The result is smaller than the route list suggested, and one part of it is worth reading before this merges.

## What changed

`app/funding/page.tsx:463` and `components/FundingTerminal.tsx:450` — the coin symbol in the funding regime rows takes `var(--txt)` instead of `coinBadgeColor(id)`. The `CoinIcon` further down each file is untouched.

`coinBadgeColor` returns a per-coin identity hue chosen for a **filled mark**, where the 3:1 graphics bar applies. As 12px text it measured **1.38:1** at worst.

## The sweep — 11 call sites, not 6 routes

> *"Six routes call `coinBadgeColor` and I have not established which colour text versus a dot. Sweep it yourself rather than taking my route list."*

Done. `git grep coinBadgeColor` gives 11 usages across 8 files:

| Use | Count | Where |
|---|---|---|
| **Text** | 2 | `app/funding/page.tsx:463`, `components/FundingTerminal.tsx:450` — **fixed here** |
| **Real dot** | 2 | `components/TradeJournal.tsx:851` and `:1070` — 5px and 6px filled circles |
| **Neither, in practice** | 7 | passed to `CoinIcon` on dashboard ×2, DashboardTerminal ×2, markets, MarketsTerminal, funding, FundingTerminal |

**The 7 are the interesting ones.** `CoinIcon` renders a bundled PNG logo from `public/coin-icons/{coin}.png`. The `color` and `bg` props are used **only on the missing-file fallback path**, which the component's own comment says should never trigger. So on those seven, the badge hue is passed in and then not drawn.

That is not a defect and I have changed nothing there — but it means "six routes use this colour" was true of the source and false of the screen, and it is the reason the sweep was worth doing rather than inferring.

## Measured, and worth a decision that is not mine

The badge palette against the card ground, at the **3:1 graphics** bar:

```
                 glyph vs its own tint      glyph vs card
current dark        4.02  (#9945ff)           4.46
terminal dark       3.56  (#9945ff)           4.05
current light       1.55  (#fbbf24)  FAIL     1.67  FAIL
terminal light      1.31  (#fbbf24)  FAIL     1.38  FAIL
```

**The marks themselves fail 3:1 in both light themes.** That reaches TradeJournal's two real dots, which are the only place the palette is drawn as a shape.

I have **not** touched them, for two reasons. First, they are arguably exempt — SC 1.4.11 covers graphics *required to understand the content*, and the coin is named in text beside every one of these dots, so the colour is redundant encoding. Second, the owner's ruling was "keep the dot", and a mark that fails on light is exactly what that ruling chose to keep; changing it here would be reading past the ruling.

Worth knowing rather than assumed: on light themes the coin rows now have a plain ticker **and** a mark at 1.31–1.67. The identity cue is effectively gone there. If that is not what "keep the dot" meant, the fix is a per-theme badge palette and it is a separate issue.

## How to test (QA)

On `qa`, `/funding`, the coin regime rows (the scrolling list under the funding header).

1. The ticker — BTC, ETH, SOL — reads in **normal text colour**, not a per-coin colour, in dark and light.
2. Both designs: `?design=current` and `?design=terminal`. Two separate call sites, so a fix in one does not imply the other.
3. The round coin **logos** elsewhere on the page are unchanged — if any of those went plain, that is a regression.
4. `/dashboard`, `/markets`, `/journal` should look **identical to before**. Nothing changed there; that is the check that the sweep did not spill.

## Risk level

**Low.** Four gates pass: lint 0 errors (28 warnings on these two files, all pre-existing), `tsc --noEmit` clean, 583/583 tests, build succeeds.

**Not verified by rendering.** `/funding` needs live funding data and I did not have a populated local instance; the change is a token substitution on a `color:` property with no conditional, which is the shape least likely to surprise, but that is reasoning rather than a measurement. Step 1 above is the check.

**Unverified claim I am flagging rather than burying:** that `CoinIcon`'s fallback never triggers comes from the component's own comment plus the presence of the PNG files, not from watching it fail to fire. If a coin icon is ever missing, those 7 sites do draw the badge colour — as a border and background on a plain shape, at the ratios in the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
