### PR TITLE
fix(chart): the price-alert line and entry marker take per-theme ink (#752)

### DIFF
--- a/components/KLineProChart.tsx
+++ b/components/KLineProChart.tsx
@@ -265,6 +265,59 @@ const LIGHT: Record<string, unknown> = {
   },
 };
 
+/* ── OVERLAY INK - the colours the custom overlays DRAW with (#752) ────────
+ *
+ * The three palettes above are handed to klinecharts' setStyles and cover
+ * candles, axes, grid and crosshair. They do NOT cover the overlays this file
+ * draws itself, and those carried raw literals outside all three:
+ *
+ *     price-alert line   #f59e0b   9.78 on the dark ground, 1.78 on the light
+ *     entry-marker ring  #f59e0b   same
+ *     chevron            #fde68a   16.86 dark, 1.03 light
+ *
+ * The alert line is not decoration - it is the control the user DRAGS to move
+ * a price alert, and it is the only indication of where that alert sits. At
+ * 1.78 against a 3:1 bar it is close to invisible on a light chart.
+ *
+ * The canvas is transparent, so the ground is .klc-wrap's own `var(--bg)`:
+ * #000000 in both dark themes, #E8EAED in both light ones. That is why this
+ * switches on THEME and not on design - unlike setStyles above.
+ *
+ * The centre diamond was worse than a contrast failure: it was
+ * `color: 'var(--amber-2)'`, and a canvas fillStyle cannot resolve a CSS
+ * custom property at all. That value has never drawn anything. The comment on
+ * TERMINAL.overlay.line says exactly this about its own colour, ten lines up
+ * from a call site doing the thing it warns against.
+ *
+ * Light values are the palette's own light amber (--amber #8F4508,
+ * --amber-2 #92400E) rather than newly invented hues. */
+const OVERLAY_INK = {
+  dark: {
+    alertLine:   '#f59e0b',   // 9.78 on #000000
+    markerRing:  '#f59e0b',   // 9.78
+    markerGlow:  'rgba(251,191,36,0.15)',
+    markerFill:  'rgba(245,158,11,0.1)',
+    markerCore:  '#fcd34d',   // --amber-2, dark
+    chevron:     '#fde68a',   // 16.86
+  },
+  light: {
+    alertLine:   '#8F4508',   // 5.76 on #E8EAED
+    markerRing:  '#8F4508',   // 5.76
+    markerGlow:  'rgba(146,64,14,0.18)',
+    markerFill:  'rgba(124,45,18,0.10)',
+    markerCore:  '#92400E',   // --amber-2, light
+    chevron:     '#7c2d12',   // 7.77
+  },
+} as const;
+
+/* Module scope rather than a ref, because the overlay draw functions below are
+   plain callbacks registered with klinecharts and have no access to component
+   state. Written by the theme-sync effect, read at draw time - so the marker
+   picks up a theme change on its next frame with nothing to re-create. The
+   alert line is different: its colour is baked in at createOverlay, so that
+   effect re-runs on the same signal. */
+let overlayInk: typeof OVERLAY_INK.dark | typeof OVERLAY_INK.light = OVERLAY_INK.dark;
+
 // ── Component ─────────────────────────────────────────────────────────────
 
 export type ChartTf = '1m' | '5m' | '15m' | '30m' | '1h' | '2h' | '4h' | '1d';
@@ -493,6 +546,10 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
   const [wsStatus,     setWsStatus]    = useState<'connecting' | 'live' | 'error'>('connecting');
   const [fullscreen,   setFullscreen]  = useState(false);
   const [chartReady,   setChartReady]  = useState(false);
+  /* Which ink the overlays are drawn with. Only the price-alert line needs it
+     as state - its colour is fixed when the overlay is created, so the effect
+     that creates them has to re-run when the theme flips (#752). */
+  const [themeInk,     setThemeInk]    = useState<'dark' | 'light'>('dark');
   const [countdown,    setCountdown]   = useState('-');
   const [priceLabelY,  setPriceLabelY] = useState<number | null>(null);
   const lastCloseRef   = useRef<number>(0);
@@ -654,6 +711,14 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
       const dark = document.documentElement.getAttribute('data-theme') !== 'light';
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       chartRef.current?.setStyles((mode === 'terminal' ? TERMINAL_DARK : dark ? DARK : LIGHT) as any);
+      /* Overlay ink follows the THEME only - the overlays are drawn on a
+         transparent canvas over .klc-wrap's var(--bg), which is #000000 in
+         both dark themes and #E8EAED in both light ones (#752). Bumping
+         themeInk re-runs the price-alert effect, whose colour is fixed at
+         createOverlay time; the marker reads overlayInk at draw time and
+         needs no re-creation. */
+      overlayInk = dark ? OVERLAY_INK.dark : OVERLAY_INK.light;
+      setThemeInk(dark ? 'dark' : 'light');
     };
     apply();
     // Theme (not design mode) can still change without a re-render of this
@@ -1011,16 +1076,17 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
               : [{ x: cx - 3.5, y: cy + 2.5 }, { x: cx, y: cy - 2.5 }, { x: cx + 3.5, y: cy + 2.5 }];
             return [
               // Outer glow ring
-              { type: 'polygon', attrs: { coordinates: ring(12) }, styles: { style: 'stroke', borderColor: 'rgba(251,191,36,0.15)', borderSize: 5 } },
+              { type: 'polygon', attrs: { coordinates: ring(12) }, styles: { style: 'stroke', borderColor: overlayInk.markerGlow, borderSize: 5 } },
               // Translucent amber fill
-              { type: 'polygon', attrs: { coordinates: ring(9) }, styles: { style: 'fill', color: 'rgba(245,158,11,0.1)' } },
+              { type: 'polygon', attrs: { coordinates: ring(9) }, styles: { style: 'fill', color: overlayInk.markerFill } },
               // Crisp amber ring
-              { type: 'polygon', attrs: { coordinates: ring(9) }, styles: { style: 'stroke', borderColor: '#f59e0b', borderSize: 1.5 } },
-              // Center diamond accent
-              { type: 'polygon', attrs: { coordinates: [{ x: cx, y: cy - 3 }, { x: cx + 3, y: cy }, { x: cx, y: cy + 3 }, { x: cx - 3, y: cy }] }, styles: { style: 'fill', color: 'var(--amber-2)' } },
+              { type: 'polygon', attrs: { coordinates: ring(9) }, styles: { style: 'stroke', borderColor: overlayInk.markerRing, borderSize: 1.5 } },
+              // Center diamond accent. Was 'var(--amber-2)', which a canvas
+              // fillStyle cannot resolve - it never drew (#752).
+              { type: 'polygon', attrs: { coordinates: [{ x: cx, y: cy - 3 }, { x: cx + 3, y: cy }, { x: cx, y: cy + 3 }, { x: cx - 3, y: cy }] }, styles: { style: 'fill', color: overlayInk.markerCore } },
               // Directional chevron (two line segments)
-              { type: 'line', attrs: { coordinates: [v[0], v[1]] }, styles: { color: '#fde68a', size: 1.5 } },
-              { type: 'line', attrs: { coordinates: [v[1], v[2]] }, styles: { color: '#fde68a', size: 1.5 } },
+              { type: 'line', attrs: { coordinates: [v[0], v[1]] }, styles: { color: overlayInk.chevron, size: 1.5 } },
+              { type: 'line', attrs: { coordinates: [v[1], v[2]] }, styles: { color: overlayInk.chevron, size: 1.5 } },
             ];
           },
         });
@@ -1736,7 +1802,10 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
         lock: false,
         points: [{ value: alert.target_price }],
         styles: {
-          line: { style: 'dashed', color: '#f59e0b', size: 1, dashedValue: [5, 3] },
+          // Baked in at creation, which is why themeInk is in this effect's
+          // deps - the line is the control the user drags, and at 1.78:1 on a
+          // light chart it was close to invisible (#752).
+          line: { style: 'dashed', color: overlayInk.alertLine, size: 1, dashedValue: [5, 3] },
         },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         onPressedMoveEnd: ({ overlay }: { overlay: { points: Array<{ value?: number }> } }) => {
@@ -1746,7 +1815,7 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
       } as OverlayCreate);
       if (typeof id === 'string') alertOverlayMap.current.set(alert.id, id);
     });
-  }, [chartAlerts, chartReady]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [chartAlerts, chartReady, themeInk]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // ── Draw / redraw S/R level lines ───────────────────────────────────
   useEffect(() => {


### PR DESCRIPTION
## Summary

Section 2 of #752 — the part I said was ready to build and needed no ruling. The overlays `KLineProChart` draws itself now take per-theme ink instead of raw literals.

**The alert line is a control, not decoration.** It is the dashed line the user drags to move a price alert, and the only indication of where that alert sits. At `#f59e0b` it measured **1.78:1** on a light chart against a 3:1 bar.

## What changed

A single `OVERLAY_INK` table with a `dark` and a `light` half, covering the alert line, the entry marker's ring / glow / fill / centre diamond, and the direction chevron.

```
                        dark              on #000000    light          on #E8EAED
price-alert line        #f59e0b             9.78        #8F4508          5.76
entry-marker ring       #f59e0b             9.78        #8F4508          5.76
chevron                 #fde68a            16.86        #7c2d12          7.77
centre diamond          #fcd34d               -         #92400E            -
```

**The ink follows the THEME, not the design** — unlike `setStyles` above it. The canvas is transparent, so the ground is `.klc-wrap`'s `var(--bg)`, which is `#000000` in both dark themes and `#E8EAED` in both light ones. Verified in the browser rather than assumed: flipping the theme on `/arena` moves `--bg` between exactly those two values.

Light values are the palette's own light amber (`--amber` `#8F4508`, `--amber-2` `#92400E`), not new hues.

## The dead value

The centre diamond was `color: 'var(--amber-2)'`. **A canvas `fillStyle` cannot resolve a CSS custom property**, so it has never drawn anything. The `TERMINAL` palette's own comment says precisely this about its own colour — ten lines above a call site doing the thing it warns against.

That is the same species as #663's collisions: a declaration that reads correctly and does nothing, invisible to lint, `tsc`, tests and build.

## How the two halves update

`overlayInk` is module scope, not a ref, because the marker's draw function is a plain callback registered with klinecharts and has no access to component state. It is written by the theme-sync effect and read at draw time, so the marker picks up a theme change on its next frame.

The **alert line is different** — its colour is baked in at `createOverlay`, so that effect now has `themeInk` in its deps and recreates the overlays when the theme flips.

## How to test (QA)

On `qa`, `/arena`, with the chart loaded.

1. **Dark theme first**, so you know what the marker is meant to look like — the amber ring with the chevron, on the EMA entry signal.
2. **Switch to light with the chart open.** The marker must stay clearly visible — a dark amber ring rather than a washed-out pale one. Before this change it faded to near nothing.
3. **If you have a price alert set on that coin**, its dashed horizontal line is the one that mattered: visible in light, and still draggable.
4. **Switch back to dark.** Everything returns to the previous appearance — the dark half of the table is the values that were already there.
5. The **centre diamond** inside the marker ring is new in the sense that it has never rendered before. If it looks wrong, that is a design call and worth saying so.

## Risk level

**Medium.** Four gates pass: lint 0 errors (9 pre-existing warnings on this file, unchanged), `tsc --noEmit` clean, 583/583 tests, build succeeds.

**Verified by rendering, partially.** `/arena` loads the chart locally with real data — 14 canvases — and I confirmed the theme flip runs clean with no console errors and the ground moving between `#000` and `#e8eaed`.

**What I could NOT verify by rendering:** the alert line itself. It only draws when `chartAlerts` has rows, which needs a signed-in user with an alert set, and I did not have one locally. The colour swap is a value substitution on a property that was already there, but "the effect re-runs and recreates the overlay with the new ink" is reasoning, not a measurement. **Step 3 is the one that matters.**

**Also unverified:** whether the entry marker actually appeared during my check. It depends on the EMA signal, and I did not confirm one was on screen. So the marker path is measured arithmetic plus a clean render, not a seen result.

## One thing found while doing this — filed as #758, NOT fixed here

`setStyles` computes `dark` and then does not use it on the terminal branch: `mode === 'terminal' ? TERMINAL_DARK : dark ? DARK : LIGHT`. **Terminal + light theme paints the dark chart onto a light page.** The last-price readout measures **1.01:1** there, the candles 2.11, the axis text 3.22.

Left alone deliberately — the fix is either a one-line fallback to `LIGHT` or a fourth `TERMINAL_LIGHT` palette, and choosing between them is a ruling, not a mechanical change. It matters for #748: today it needs a query param plus light theme, and after the flip it is every light-theme user's chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
