### PR TITLE
fix(news): the coin-buzz separator inherits the chip colour instead of white (#752)

### DIFF
--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -155,7 +155,24 @@ function CoinBuzzBar({ mentions }: { mentions: { symbol: string; total: number; 
             letterSpacing: '.03em', whiteSpace: 'nowrap', flexShrink: 0,
           }}>
             {m.symbol}
-            <span style={{ color: 'rgba(255,255,255,0.3)', fontWeight: 400, fontSize: '0.625rem' }}>·</span>
+            {/* Inherits the chip's own signal colour (#752). It was
+                rgba(255,255,255,0.3), which measured 1.09-2.64 against the
+                chip in every theme - worst 1.09 in light, so the divider
+                simply was not there and the chip read "BTC 12".
+
+                Measured three ways before picking. The chip is its signal
+                colour at 8% over the page ground, and against that:
+
+                  rgba(255,255,255,0.3)   1.09 - 2.64   fails all four
+                  var(--txt3)             4.46          fails terminal light
+                  var(--txt2)             4.81 - 6.68   passes
+                  inherited (no colour)   4.62 - 10.02  passes
+
+                Inheriting wins on being a deletion rather than a new
+                declaration, and the symbol beside it already proves that
+                colour is legible on this chip - it is the same measurement.
+                fontWeight 400 against the symbol's 700 still separates them. */}
+            <span style={{ fontWeight: 400, fontSize: '0.625rem' }}>·</span>
             <span style={{ fontWeight: 500, fontSize: 'var(--fs-caption)' }}>{m.total}{arrow}</span>
           </span>
         );


### PR DESCRIPTION
## Summary

Closes the last open piece of #752 — the `CoinBuzzBar` separator I deliberately left rather than half-measure. Measured now, and it fails in **all four** contexts, not just light.

## What changed

One line. The `·` between a coin symbol and its mention count stops setting its own colour and inherits the chip's signal colour.

## The measurement

The chip is its own signal colour at **8%** (`withAlpha(col, '14')` → `color-mix(… 8%, transparent)`) over the page ground. Against that:

```
                          worst   contexts failing
rgba(255,255,255,0.3)      1.09    all four   (1.09-1.11 in both light themes)
var(--txt3)                4.46    terminal light only
var(--txt2)                4.81    none
inherited (no colour)      4.62    none
```

**Inheriting wins on being a deletion rather than a new declaration**, and it needs no new argument: the symbol sitting next to the dot is already that colour on that chip, so "is this legible here" is a question already answered by the chip itself. `fontWeight: 400` against the symbol's `700` still separates them visually.

At 1.09 the divider was not dim — it was **absent**. The chip read `BTC 12` with a gap where the dot should be.

## Measured and deliberately NOT changed

**The chip's own symbol text passes everywhere:** 4.62 worst (terminal light, bullish), up to 10.02.

That is the useful negative result here. This looked like a `-fg` case — signal colour on a tint of itself, which is #738's whole family — and it is not. **An 8% tint barely moves the ground**, so the signal colour keeps essentially its contrast against the page. The `-fg` treatment is for the heavier tints; applying it here would be the pattern-matching that #738 showed can go the wrong way (tokenising `.scan-badge` dropped bull from 4.85 to 4.47).

So: one line changed, three colours measured and left alone.

## How to test (QA)

`/news`, the coin buzz row above the article grid — the small pills reading `BTC · 12`.

1. **Light theme, either design.** The dot between symbol and count is visible. Before this it was not there at all.
2. **Dark theme.** The dot is now the chip's colour rather than a dim white. It should read as slightly more present than before; that is the change, not a bug.
3. Both designs — nothing here is design-scoped.

The row only renders with **two or more** coin mentions in the feed (`mentions.length < 2` returns null), so an empty or thin feed shows nothing.

## Risk level

**Low.** Four gates pass: lint 0 errors, `tsc --noEmit` clean, 583/583 tests, build succeeds. Lint warnings on this file drop 7 → 6 — the bare-white-literal warning is gone, which is an independent confirmation the literal is actually removed rather than moved.

**Not verified by rendering**, for the same reason as #754: `/news` has no articles outside production (#757), so the buzz row cannot render locally. This is a one-line deletion of a `color` property on a `<span>` whose parent sets `color`, which is about the least surprising change shape available — but that is reasoning, and step 1 is the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
