### PR TITLE
fix(scanner): the heatmap legend and the funding separators stop borrowing the wrong ground (#761)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3450,7 +3450,15 @@ html[data-design="terminal"][data-theme="light"] { background: var(--bg0); }
 .frh-summary-heading { font-size: var(--fs-micro); font-weight: 600; color: var(--txt3); text-transform: uppercase; letter-spacing: 0.06em; margin-right: 2px; }
 .frh-summary-item    { font-size: var(--fs-caption); font-weight: 500; display: flex; align-items: center; gap: 4px; }
 .frh-summary-count   { font-size: var(--fs-data); font-weight: 800; font-variant-numeric: tabular-nums; }
-.frh-summary-sep     { color: var(--bdr2); font-size: var(--fs-caption); }
+/* --txt2, not --bdr2 (#761). A BORDER token as a text colour is a category
+   error: --bdr2 is a hairline, so it is defined to sit about a shade from its
+   own ground. Against .frh-summary-bar it measures 1.07 in terminal dark and
+   1.14 in terminal light - the separator was absent, not dim. It passed in
+   the current design (19.24 / 21.00) only because --bdr2 takes a wildly
+   different value there, which is what let it survive this long.
+   --txt2 clears all four (4.80 / 9.15 / 5.24 / 5.59) and stays subordinate to
+   the counts either side, which --txt at 14-18 would not. */
+.frh-summary-sep     { color: var(--txt2); font-size: var(--fs-caption); }
 
 .frh-chart-card     { overflow: hidden; }
 .frh-chart-header   { display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 6px; margin-bottom: 10px; }

--- a/components/CoinHeatmap.tsx
+++ b/components/CoinHeatmap.tsx
@@ -261,7 +261,23 @@ export default function CoinHeatmap() {
           { label: '>+10%', c: 'var(--green-2)' }, { label: '+5%', c: 'var(--green-soft)' },
           { label: '+2%', c: 'var(--green-soft)' },   { label: '0', c: 'var(--txt-dim)' },
           { label: '-2%', c: 'var(--red-soft)' },   { label: '-5%', c: 'var(--red-soft)' },
-          { label: '<-10%', c: '#fee2e2' },
+          /* NOT '#fee2e2' (#761). That is the TILE's text colour, and it is
+             correct there - the worst bucket's tile is var(--red) at 38%, and
+             pale text on a saturated tile measures 8.6-9.6, which is the rule
+             the comment at the top of this file sets out.
+
+             The legend has no tile. It is text on the panel, var(--bg1), and
+             the same value measures 1.22 in current light and 1.01 in terminal
+             light. Dark hid it completely (16.49 / 14.96) because there the
+             panel is dark and pale text is exactly right.
+
+             Same fact, two grounds, and the copy took the value without the
+             surface it depended on. var(--red) clears all four (7.28 / 6.47 /
+             5.24 / 6.65) and reads as the strongest step of the ramp, which is
+             what the legend is for. In terminal dark it coincides with
+             --red-soft, so the last two steps look identical there; that is
+             the palette's own doing, not this substitution's. */
+          { label: '<-10%', c: 'var(--red)' },
         ].map(({ label, c }) => (
           <span key={label} style={{ fontSize: 'var(--fs-caption)', color: c, fontWeight: 600 }}>{label}</span>
         ))}


### PR DESCRIPTION
## Summary

Both findings from QA's final audit (#761). Two lines, two different mistakes, one shared shape: **a colour that is correct on one ground, copied to another.**

## 1. `/scanner` — the heatmap legend's `<-10%` entry

`#fee2e2` is the worst bucket's **tile** text colour, and it is right there. That tile is `var(--red)` at 38%, and this component's own header documents the rule: *text lightens as the tile saturates, severity is carried by the tile*, measuring 8.6–9.6 across the ramp.

**The legend has no tile.** It is text on the panel, `var(--bg1)`:

```
                #fee2e2 on --bg1     var(--red)
current dark      16.49                7.28
current light      1.22   FAIL         6.47
terminal dark     14.96                5.24
terminal light     1.01   FAIL         6.65
```

Matches QA's rendered 1.01 / 1.22 exactly.

**Dark is why this survived.** On a dark panel, pale text is correct, so the legend looked right in the two contexts anyone checks first — and the value that made it right there is the same one that makes it invisible on a light panel.

`var(--red)` reads as the strongest step of the ramp, which is what the legend is for. **One caveat:** in terminal dark, `--red` and `--red-soft` resolve to the same value, so the last two legend steps look identical there. That is the palette's doing rather than this substitution's, but it is a visible consequence and worth a look.

## 2. `/funding` — the summary-bar separators

`.frh-summary-sep { color: var(--bdr2) }`. **A border token used as a text colour is a category error** — `--bdr2` is a hairline, so it is *defined* to sit about a shade from its own ground.

```
                --bdr2 (was)    --txt3    --txt2 (now)    inherit --txt
current dark      19.24          5.02       4.80            16.00
current light     21.00          8.49       9.15            18.58
terminal dark      1.07  FAIL    4.40 FAIL  5.24            14.02
terminal light     1.14  FAIL    5.10       5.59            14.80
```

It passed in the current design only because `--bdr2` takes a very different value there — 19.24 against 1.07 is the same token, same rule, two designs.

`--txt2` clears all four **and stays subordinate** to the counts either side. Inheriting (which is what #760 did for the CoinBuzzBar dot) would land at 14–18 here, making the divider as loud as the data. `--txt3` fails terminal dark at 4.40.

**So the two separators get different answers, and that is deliberate** — #760's chip is small and its dot inherits a signal colour already proven on that chip; this one sits between two bold counts on a neutral bar.

## Neither is design-scoped

Both reach the current design. `#fee2e2` fails in **current** light at 1.22, and the separator rule has no terminal override — one rule, both designs.

## How to test (QA)

1. **`/scanner`**, the colour scale under the coin heatmap. The `<-10%` label at the right-hand end must be readable in **light** theme, both designs. It was invisible.
2. **`/funding`**, the summary bar at the top — the `·` between the counts. Must be visible in **terminal** design, both themes. Current design was already fine, so it is the one to compare against.
3. Dark theme on `/scanner`: the legend's last two steps may now look identical in terminal dark (`--red` and `--red-soft` resolve to the same value). Expected, flagged above — say if it reads wrong.

## Risk level

**Low.** Four gates: lint 0 errors, `tsc --noEmit` clean, 583/583 tests, build succeeds.

**Not verified by rendering.** Both are token substitutions on `color:` with no conditional. The arithmetic reproduces QA's rendered figures to two decimal places on the finding it could be checked against (1.01 / 1.22), which is corroboration of the instrument, not of the fix.

**One thing I did not do:** the legend still shows the ramp as coloured *text* rather than as swatches of the actual tiles. Making each legend entry a mini tile would be truer to what it documents and would remove this class of mismatch entirely — but that is a design change, not a contrast fix, so it is not in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
