### PR TITLE
fix(chart): light theme wins over terminal when choosing the chart palette (#758)

### DIFF
--- a/components/KLineProChart.tsx
+++ b/components/KLineProChart.tsx
@@ -709,8 +709,25 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
     if (!chartReady) return;
     const apply = () => {
       const dark = document.documentElement.getAttribute('data-theme') !== 'light';
+      /* LIGHT WINS OVER TERMINAL (#758, owner ruling). This read
+         `mode === 'terminal' ? TERMINAL_DARK : dark ? DARK : LIGHT` - `dark`
+         was computed on the line above and then discarded on the terminal
+         branch, so terminal + light theme painted the DARK chart onto a light
+         page. The canvas is transparent, so the ground is .klc-wrap's
+         var(--bg) = #E8EAED there, and against it:
+
+           last-price text  #e8e9ea   1.01     the number the chart exists for
+           candle up        #3fb950   2.11
+           priceMark hi/lo  #8b8f94   2.70
+           axis tickText    #7c828a   3.22
+
+         There is no terminal-light palette. The owner chose this fallback over
+         building one, accepting that in light mode the chart will not match
+         the terminal shell around it - a chart that looks slightly out of
+         place beats one whose price readout is at 1.01. That is the end state,
+         not a stopgap: no fourth palette is booked. */
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      chartRef.current?.setStyles((mode === 'terminal' ? TERMINAL_DARK : dark ? DARK : LIGHT) as any);
+      chartRef.current?.setStyles((!dark ? LIGHT : mode === 'terminal' ? TERMINAL_DARK : DARK) as any);
       /* Overlay ink follows the THEME only - the overlays are drawn on a
          transparent canvas over .klc-wrap's var(--bg), which is #000000 in
          both dark themes and #E8EAED in both light ones (#752). Bumping
@@ -725,7 +742,21 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
     // component - 'theme-change' covers that; `mode` in the dependency
     // array below covers design mode resolving or changing.
     window.addEventListener('theme-change', apply);
-    return () => window.removeEventListener('theme-change', apply);
+    /* And an observer, because this effect READS an attribute rather than
+       being told about it. On #707 that exact shape was wrong: a page effect
+       read --bg3 before DesignModeProvider had set data-design, and the answer
+       was plausible and stale. 'theme-change' only fires from lib/theme.ts's
+       own paths, so a theme set any other way - and the initial resolve
+       ordering - reaches this only by watching the attribute. Cheap, and it
+       removes the assumption rather than betting on it. */
+    const observer = new MutationObserver(apply);
+    observer.observe(document.documentElement, {
+      attributes: true, attributeFilter: ['data-theme', 'data-design'],
+    });
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('theme-change', apply);
+    };
   }, [chartReady, mode]);
 
   // Keep coinRef fresh for the DataLoader closure


### PR DESCRIPTION
## Summary

#758, on the owner's ruling: **option A — light theme wins over terminal when choosing the chart palette.**

One condition changed, plus a `MutationObserver` on the attribute this effect reads.

## What was wrong

```ts
const dark = document.documentElement.getAttribute('data-theme') !== 'light';
chartRef.current?.setStyles((mode === 'terminal' ? TERMINAL_DARK : dark ? DARK : LIGHT) as any);
```

`dark` is computed on the first line and **discarded on the terminal branch**. Terminal + light theme painted the dark chart onto a light page. The canvas is transparent, so the ground is `.klc-wrap`'s `var(--bg)` = `#E8EAED`:

```
last-price text  #e8e9ea   1.01     the number the chart exists to show
candle up        #3fb950   2.11
priceMark hi/lo  #8b8f94   2.70
axis tickText    #7c828a   3.22
```

Now: `!dark ? LIGHT : mode === 'terminal' ? TERMINAL_DARK : DARK`.

## What the ruling accepts, recorded here so it is not re-litigated

**In light mode the chart will not match the terminal shell.** The owner took that knowingly, over building a fourth `TERMINAL_LIGHT` palette. A chart that looks slightly out of place beats one whose price readout is at 1.01.

**This is the end state, not a stopgap.** No fourth palette is booked, and per QA's ruling comment I have deliberately **not** opened a follow-up issue for one — booking design work the owner declined would record a decision they did not make.

## The observer, and why it is not scope creep

This effect **reads** `data-theme` rather than being told about it. That is the exact shape that was wrong on #707: a page effect read `--bg3` before `DesignModeProvider` had set `data-design`, and produced an answer that was plausible and stale.

`theme-change` only fires from `lib/theme.ts`'s own paths, so the initial-resolve ordering and any theme set another way reach this effect only by watching the attribute. `MutationObserver` on `['data-theme', 'data-design']`, disconnected on cleanup.

QA's own note on the ruling made the same point: *"the theme-flip-while-open case matters here for the same reason it did on #753 — this fix reads the same attribute."*

## How to test (QA)

`/arena`, chart open.

1. **Terminal design + light theme.** The chart must be a *light* chart — dark axis labels and dark price text on the light panel. The **last-price label on the right edge** is the one that was invisible at 1.01.
2. **Toggle the theme with the chart open**, both directions, in terminal. It must switch each way, not only on reload.
3. **Dark theme, both designs** — identical to before. Terminal dark still gets `TERMINAL_DARK`; that branch is untouched.
4. **Current design, light** — also unchanged; it was already taking `LIGHT`.

You said you will verify by reading which palette object is applied rather than sampling the canvas, since the canvas resists readback. That is the right check and it is what step 1 actually tests.

## Risk level

**Low-Medium.** Four gates: lint 0 errors (9 pre-existing warnings on this file), `tsc --noEmit` clean, 583/583 tests, build succeeds.

**Not verified by rendering.** I did not have a way to confirm which palette klinecharts ended up holding — that is exactly the readback problem you hit. What I can say is that the branch order is now theme-first and the dark branches are byte-identical to before.

**One consequence worth naming:** `OVERLAY_INK` from #759 already keyed on theme, not design, so the overlays were *already* correct in terminal light while the base chart was not. After this they agree. Nothing changes for the overlays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
