### PR TITLE
fix(settings): the terminal nav avatar is gone when there is no identity to show (#747)

### DIFF
--- a/components/TerminalNav.tsx
+++ b/components/TerminalNav.tsx
@@ -193,7 +193,11 @@ export default function TerminalNav({ onOpenDrawer }: TerminalNavProps) {
     return () => clearInterval(id);
   }, []);
 
-  const initials = user?.email?.[0]?.toUpperCase() ?? '?';
+  /* null, not '?' (#747). The fallback was a placeholder for initials that do
+     not exist, and it rendered a bordered box containing a question mark next
+     to the real SIGN IN control. Returning null lets the render gate below
+     drop the element entirely rather than draw an empty identity. */
+  const initials = user?.email?.[0]?.toUpperCase() ?? null;
 
   const tabs = (
     <nav className="tnav-tabs" aria-label={t('TNAV_ARIA_LABEL')}>
@@ -371,8 +375,24 @@ export default function TerminalNav({ onOpenDrawer }: TerminalNavProps) {
               Back to what the frames draw: an identity box with no behaviour.
               A <span>, not a disabled <button>, because a button that does
               nothing still takes focus and still announces itself as
-              actionable. Mobile keeps .tnav-mmore as its opener. */}
-          <span className="tnav-avatar" aria-hidden="true">{initials}</span>
+              actionable. Mobile keeps .tnav-mmore as its opener.
+
+              SIGNED OUT IT IS GONE ENTIRELY (#747). Owner: "wtf is this? pls
+              remove if not needed." A dead <span> was the right answer to the
+              question #731 asked - should this still be a control - but nobody
+              asked the wider one, whether it should be here at all. Signed out
+              there is no identity to show, SIGN IN is already beside it, and
+              aria-hidden means it was not even announced: a box with a
+              question mark in it.
+
+              Signed in it stays, because a real initial IS an identity
+              affordance and is presumably why the element exists. The gate is
+              on `initials` rather than on `user` alone, so a signed-in account
+              with no email address drops it too rather than reintroducing the
+              same empty box by another route. */}
+          {!authLoading && initials && (
+            <span className="tnav-avatar" aria-hidden="true">{initials}</span>
+          )}
         </div>
       </header>
 


### PR DESCRIPTION
## Summary

Closes #747. The `?` box after `SIGN IN` in the terminal nav renders only when there is a real initial to put in it.

Owner: *"wtf is this? pls remove if not needed."*

## What changed

```
- const initials = user?.email?.[0]?.toUpperCase() ?? '?';
+ const initials = user?.email?.[0]?.toUpperCase() ?? null;

- <span className="tnav-avatar" aria-hidden="true">{initials}</span>
+ {!authLoading && initials && (
+   <span className="tnav-avatar" aria-hidden="true">{initials}</span>
+ )}
```

**The gate is on `initials`, not on `user`.** A signed-in account with no email address would otherwise reintroduce the same empty box by a different route.

`!authLoading` keeps it from flashing in during the resolve, matching how `SIGN IN` beside it is already gated.

## Why the `<span>` was not enough

#731 turned this from a `<button>` into a `<span>`, and that was right — a button that does nothing still takes focus and still announces itself as a control. But that answered "should this be a control", not "should this be here". Signed out there is no identity to show, `SIGN IN` is already adjacent, and `aria-hidden="true"` means it was not even announced. A bordered box with a question mark in it.

## Verified by rendering — the signed-out half

`/dashboard?design=terminal`, local dev, signed out:

```
before        .tnav-avatar x1   text "?"     .tnav-signin x1
after         .tnav-avatar x0                .tnav-signin x1
```

## The signed-in half is still unobserved, by both of us

QA said on the issue: *"I cannot sign in, so I have only ever observed the signed-out case."* **I tried to close that gap and could not.**

I seeded a session into `localStorage` under supabase-js's key — the same shape `qa/e2e/_entitled-session.ts` uses — and reloaded. The app **cleared the key** and rendered signed out. That fixture works under Playwright because it also intercepts the network; in a plain browser, supabase-js attempts a token refresh with the fixture's deliberately-invalid refresh token, the request actually reaches Supabase, fails, and the client discards the session.

So: **the fixture is not usable outside Playwright**, which is worth knowing on its own, and I did not run Playwright — E2E runs are owner-gated and I am not treating a localhost target as an exemption.

**What that leaves unverified:** that a signed-in user sees a single-letter box, and that it looks right. The code path is `initials` being non-null, which is the same expression that produced `"?"` before, so the render is not conditional on anything new — but nobody has seen it. Step 2 below needs someone who can sign in.

## How to test (QA)

1. **Signed out**, `/dashboard?design=terminal`, desktop width. No box between `SIGN IN` and the right edge. Check a couple of terminal routes — the bar is shared.
2. **Signed in** — the one neither of us has seen. Expect a single-letter box showing the first letter of the account email, in the position the `?` used to occupy.
3. **Mobile width** — the mobile header uses `.tnav-mmore` as its opener and is untouched; confirm it still opens.

## Risk level

**Low.** Four gates: lint 0 errors, `tsc --noEmit` clean, 583/583 tests, build succeeds. Signed-out state verified by reading the DOM rather than by eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
