### PR TITLE
refactor(chart): one expression decides the chart palette, not two (#763 follow-up)

### DIFF
--- a/components/KLineProChart.tsx
+++ b/components/KLineProChart.tsx
@@ -318,6 +318,29 @@ const OVERLAY_INK = {
    effect re-runs on the same signal. */
 let overlayInk: typeof OVERLAY_INK.dark | typeof OVERLAY_INK.light = OVERLAY_INK.dark;
 
+/** Which of the three palettes a given theme and design gets.
+ *
+ *  ONE EXPRESSION, TWO CALL SITES. It was two expressions: the theme-sync
+ *  effect knew about terminal and the init call did not
+ *  (`setStyles(dark ? DARK : LIGHT)`), so at creation terminal dark was painted
+ *  with DARK and corrected a moment later. QA raised it on #763 as "probably
+ *  one frame, your call".
+ *
+ *  It is not reliably one frame. The correcting effect depends on `mode` from
+ *  useDesignMode(), and #753's bug was exactly that value arriving LATE - a
+ *  read that fired before DesignModeProvider had set its attribute. If `mode`
+ *  resolves after the effect's first run, the wrong dark palette persists
+ *  until it does rather than flashing.
+ *
+ *  The deeper reason is the one this codebase keeps paying for: two
+ *  expressions encoding one rule is the two-sources shape from #736 and #663,
+ *  and here the two had already drifted - the init site never learned about
+ *  terminal at all. Light-wins-over-terminal (#758) now lives in one place. */
+function paletteFor(dark: boolean, terminal: boolean): Record<string, unknown> {
+  if (!dark) return LIGHT;
+  return terminal ? TERMINAL_DARK : DARK;
+}
+
 // ── Component ─────────────────────────────────────────────────────────────
 
 export type ChartTf = '1m' | '5m' | '15m' | '30m' | '1h' | '2h' | '4h' | '1d';
@@ -502,6 +525,14 @@ function computeSRLevels(
 
 export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal, chartAlerts, onAlertMove, gexLevels, onStructure }: Props) {
   const mode = useDesignMode();
+  /* The init effect below runs once and must not re-run when the design mode
+     resolves - re-creating the chart would throw away its data. So it reads
+     the mode through a ref rather than closing over the value it happened to
+     have at mount. The theme-sync effect still corrects a late resolve; this
+     only means the FIRST paint is already right when the mode is known by
+     then, which it usually is. */
+  const modeRef = useRef(mode);
+  useEffect(() => { modeRef.current = mode; }, [mode]);
   const containerRef   = useRef<HTMLDivElement>(null);
   const wrapRef        = useRef<HTMLDivElement>(null);
   const canvasFadeRef  = useRef<HTMLDivElement>(null);
@@ -727,7 +758,7 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
          place beats one whose price readout is at 1.01. That is the end state,
          not a stopgap: no fourth palette is booked. */
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      chartRef.current?.setStyles((!dark ? LIGHT : mode === 'terminal' ? TERMINAL_DARK : DARK) as any);
+      chartRef.current?.setStyles(paletteFor(dark, mode === 'terminal') as any);
       /* Overlay ink follows the THEME only - the overlays are drawn on a
          transparent canvas over .klc-wrap's var(--bg), which is #000000 in
          both dark themes and #E8EAED in both light ones (#752). Bumping
@@ -842,7 +873,7 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
       // Apply current theme via setStyles (avoids DeepPartial type gymnastics)
       const dark = document.documentElement.getAttribute('data-theme') !== 'light';
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      chart.setStyles((dark ? DARK : LIGHT) as any);
+      chart.setStyles(paletteFor(dark, modeRef.current === 'terminal') as any);
 
       // EMA 9/20/50/200 ribbon - drawn as 4 emaRibbonLine overlays (registered
       // below, synced via syncEmaRibbon), not a klinecharts built-in indicator.


### PR DESCRIPTION
## Summary

Your #763 observation, taken. You asked for my judgement on whether the init call needs anything — **it does**, and for a slightly different reason than the one frame.

## What changed

```
:753   setStyles(paletteFor(dark, mode === 'terminal'))            theme-sync effect
:868   setStyles(paletteFor(dark, modeRef.current === 'terminal')) chart init
```

One function decides it:

```ts
function paletteFor(dark: boolean, terminal: boolean) {
  if (!dark) return LIGHT;
  return terminal ? TERMINAL_DARK : DARK;
}
```

The init effect reads the mode through a **ref** so it stays mount-only — putting `mode` in its deps would re-create the chart and throw away its data.

## Why it is not reliably one frame

The correcting effect depends on `mode` from `useDesignMode()`. **#753's bug was exactly that value arriving late** — a read that fired before `DesignModeProvider` had set its attribute. If `mode` resolves *after* the sync effect's first run, the wrong dark palette does not flash, it persists until the resolve.

You spotted the same shape and said so: *"if the sync effect can be late, it is the same bug you already fixed once tonight."* It can.

## The stronger reason

**Two expressions encoding one rule, and they had already drifted.** The init site never learned about terminal at all — and it would not have learned about #758's light-wins rule either, so it was one release away from being wrong in a second way.

That is #736 and #663's shape, on a rule we changed twice tonight.

## How to test (QA)

`/arena`, chart open.

1. **Terminal dark, watch the chart appear** (hard reload). It should be `TERMINAL_DARK` from the first paint — previously `DARK` briefly, or longer if the mode resolved late.
2. **Current dark** — unchanged, `DARK` at both sites.
3. **Light, both designs** — unchanged from #758; `LIGHT` wins regardless.
4. **Toggle the theme with the chart open**, both designs, both directions.

Your palette-object check is the right instrument here, same as on #758.

## Risk level

**Low.** Four gates: lint 0 errors (9 pre-existing warnings), `tsc --noEmit` clean, 583/583 tests, build succeeds.

**Verified by rendering, partially.** `/arena?design=terminal` locally: chart loads with 14 canvases, and toggling `data-theme` in both directions keeps it alive with **zero console errors**.

Worth noting how I flipped it: a bare `setAttribute` with **no `theme-change` event dispatched**. The chart still tracked it — so that exercises the `MutationObserver` from #763 specifically, not the event path.

**Not verified:** which palette object klinecharts ends up holding. `chartRef` is component-internal and the canvas resists readback, which is the same wall you hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
