### PR TITLE
feat(dashboard): terminal is the default design on every route (#748)

### DIFF
--- a/__tests__/designMode.test.mts
+++ b/__tests__/designMode.test.mts
@@ -1,15 +1,14 @@
-/* The design-mode resolver, and the bootstrap script that duplicates it (#719).
+/* The design-mode resolver, and the bootstrap script that duplicates it (#748).
  *
- * Terminal now ships on `/` for every visitor, so this function decides what a
- * prospective user sees on the first frame of the acquisition page. It had no
- * tests at all before this.
+ * Terminal is now the default on EVERY route, so this function decides what
+ * every visitor sees on the first frame of every page. #719's route list is
+ * gone; what remains is the escape hatch and the precedence around it.
  *
  * THE REAL RISK HERE IS DRIFT, NOT ARITHMETIC. The precedence lives in two
  * places: `resolveDesignMode` in lib/designMode.ts, and a hand-written copy
- * inside the `design-init` <Script> in app/layout.tsx. The copy exists because
- * that script runs `beforeInteractive` - before any module is loaded - which is
- * the only way to set `data-design` before first paint and avoid flashing the
- * current design's light ground on a page that should be near-black.
+ * inside the inline `design-init` script in app/layout.tsx. The copy exists
+ * because that script runs before any module is loaded, which is the only way
+ * to set `data-design` before first paint and avoid flashing the wrong ground.
  *
  * Two copies of a rule stay in step for about a week. So the last test here
  * extracts the script's logic from layout.tsx and runs BOTH against every
@@ -20,67 +19,47 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
-import {
-  resolveDesignMode, designAttribute, isTerminalByDefault,
-  TERMINAL_BY_DEFAULT_ROUTES,
-} from '../lib/designMode.ts';
+import { resolveDesignMode, designAttribute } from '../lib/designMode.ts';
 
-test('/ defaults to terminal for a visitor with no param and nothing stored', () => {
-  /* The whole point of #719. If this ever returns 'current', the landing ships
-     the old design to everyone and nothing else in the app notices. */
-  assert.equal(resolveDesignMode('', null, '/'), 'terminal');
+const APP_ROUTES = ['/', '/dashboard', '/arena', '/liq', '/scanner', '/hours', '/settings'];
+
+test('terminal is the default everywhere, with no param and nothing stored', () => {
+  /* The whole point of #748. If this ever returns 'current', the flip is
+     silently undone and nothing else in the app notices. */
+  assert.equal(resolveDesignMode('', null), 'terminal');
 });
 
-test('every other route still defaults to current', () => {
-  for (const p of ['/dashboard', '/arena', '/liq', '/scanner', '/hours', '/settings']) {
-    assert.equal(resolveDesignMode('', null, p), 'current', `${p} must not default to terminal`);
-  }
-});
-
-test('?design=current on / is a real escape hatch, and survives as a stored value', () => {
+test('?design=current is a real escape hatch, and survives as a stored value', () => {
   /* Both halves matter. The param has to win on the request that carries it,
      AND the stored value it writes has to keep winning on the next load -
-     otherwise the hatch undoes itself on reload and the visitor is stuck. */
-  assert.equal(resolveDesignMode('?design=current', null, '/'), 'current');
-  assert.equal(resolveDesignMode('', 'current', '/'), 'current');
+     otherwise the hatch undoes itself on reload and the visitor is stuck on a
+     design they opted out of. After #748 this is also the only rollback that
+     does not require a deploy. */
+  assert.equal(resolveDesignMode('?design=current', null), 'current');
+  assert.equal(resolveDesignMode('', 'current'), 'current');
 });
 
-test('?design=terminal still works on app routes, and sticks', () => {
-  // QA reviews deployed builds through this path; #719 says keep it.
-  assert.equal(resolveDesignMode('?design=terminal', null, '/dashboard'), 'terminal');
-  assert.equal(resolveDesignMode('', 'terminal', '/dashboard'), 'terminal');
+test('?design=terminal still parses, and is now a no-op naming the default', () => {
+  // Links carrying it exist all over the issue tracker; it must not break.
+  assert.equal(resolveDesignMode('?design=terminal', null), 'terminal');
+  assert.equal(resolveDesignMode('', 'terminal'), 'terminal');
 });
 
 test('the query param outranks a conflicting stored value, both directions', () => {
-  assert.equal(resolveDesignMode('?design=current', 'terminal', '/dashboard'), 'current');
-  assert.equal(resolveDesignMode('?design=terminal', 'current', '/'), 'terminal');
+  assert.equal(resolveDesignMode('?design=current', 'terminal'), 'current');
+  assert.equal(resolveDesignMode('?design=terminal', 'current'), 'terminal');
 });
 
-test('a stored value outranks the route default', () => {
-  /* This is the line that makes the escape hatch real: without it, `/` would
-     re-assert terminal on every load and stored 'current' would be inert. */
-  assert.equal(resolveDesignMode('', 'current', '/'), 'current');
+test('a stored value outranks the default', () => {
+  /* The line that makes the escape hatch real: without it every load would
+     re-assert terminal and a stored 'current' would be inert. */
+  assert.equal(resolveDesignMode('', 'current'), 'current');
 });
 
-test('omitting pathname means no route default, not terminal', () => {
-  /* The parameter is optional so older call sites compile. Optional must not
-     mean "assume the landing page" - that would flip the default app-wide the
-     first time someone calls this without a route. */
-  assert.equal(resolveDesignMode('', null), 'current');
-  assert.equal(resolveDesignMode('', null, null), 'current');
-});
-
-test('a trailing slash is the same page', () => {
-  assert.equal(isTerminalByDefault('/'), true);
-  assert.equal(resolveDesignMode('', null, '/'), 'terminal');
-});
-
-test('a route that merely starts with / is not the landing page', () => {
-  /* Guards the obvious wrong implementation - `pathname.startsWith('/')` is
-     true of every route in the app. */
-  assert.equal(isTerminalByDefault('/dashboard'), false);
-  assert.equal(isTerminalByDefault(''), false);
-  assert.equal(isTerminalByDefault(null), false);
+test('an unrecognised value falls through to the default rather than sticking', () => {
+  assert.equal(resolveDesignMode('?design=garbage', null), 'terminal');
+  assert.equal(resolveDesignMode('', 'garbage'), 'terminal');
+  assert.equal(resolveDesignMode('?foo=1', null), 'terminal');
 });
 
 test('designAttribute removes the attribute for current rather than naming it', () => {
@@ -101,15 +80,18 @@ test('the layout bootstrap script agrees with resolveDesignMode on every input',
   const m = layout.match(/__html:\s*`([\s\S]*?)`,?\s*\}\}/);
   assert.ok(m, 'the design-init inline script was not found in app/layout.tsx - moved, renamed, or converted back to <Script>?');
 
-  /* The file holds the TEMPLATE, not what the browser receives. Two things
-     differ and both bit me writing this:
-       - `${JSON.stringify(TERMINAL_BY_DEFAULT_ROUTES)}` is still literal text
-       - a `\\` in the source is one backslash after the template is evaluated
-     Reproduce both, or the extracted string is not the script that ships. */
-  const src = m![1]
-    .replace('${JSON.stringify(TERMINAL_BY_DEFAULT_ROUTES)}', JSON.stringify(TERMINAL_BY_DEFAULT_ROUTES))
-    .replace(/\\\\/g, '\\');
-  assert.ok(!src.includes('${'), 'an interpolation in design-init is not being substituted here - the gate would test the wrong string');
+  /* The file holds the TEMPLATE, not what the browser receives: a `\\` in the
+     source is one backslash once the template is evaluated.
+
+     #748 removed the only interpolation the script had - the route list - so
+     the assertion below now does double duty. It still catches a gate testing
+     an un-substituted string, and it also catches a NEW interpolation being
+     added without this extraction learning about it, which would otherwise
+     silently compare the wrong text. */
+  const src = m![1].replace(/\\\\/g, '\\');
+  assert.ok(!src.includes('${'),
+    'design-init contains an interpolation this gate does not substitute - ' +
+    'it would be testing a string the browser never runs. Substitute it here.');
 
   /* The script is written for a browser. Give it exactly the globals it uses
      and read back what it did to documentElement.
@@ -146,14 +128,17 @@ test('the layout bootstrap script agrees with resolveDesignMode on every input',
 
   const searches = ['', '?design=terminal', '?design=current', '?foo=1'];
   const stores: (string | null)[] = [null, 'terminal', 'current', 'garbage'];
-  const paths = ['/', '/dashboard', '/arena', '/liq'];
+  /* Every route, not a sample. The script no longer reads the pathname, so
+     these must all agree - and if a route default is ever reintroduced,
+     this is what catches the two copies disagreeing about it. */
+  const paths = APP_ROUTES;
 
   const mismatches: string[] = [];
   for (const s of searches) {
     for (const st of stores) {
       for (const p of paths) {
         const fromScript = runScript(s, st, p);
-        const fromModule = resolveDesignMode(s, st, p);
+        const fromModule = resolveDesignMode(s, st);
         if (fromScript !== fromModule) {
           mismatches.push(`search=${s || '(none)'} stored=${st ?? 'null'} path=${p}: script=${fromScript} module=${fromModule}`);
         }
@@ -168,17 +153,12 @@ test('CONTROL: the drift gate can actually detect a disagreement', () => {
      "false clean" in this project started as a check that quietly measured
      nothing - a regex that matched no rules, a grep for a class that never
      existed. Prove the comparison has teeth by feeding it a wrong resolver. */
-  const wrong = (_s: string, _st: string | null, _p: string) => 'terminal' as const;
+  const wrong = (_s: string, _st: string | null) => 'current' as const;
   let disagreed = false;
-  for (const p of ['/dashboard']) {
-    if (wrong('', null, p) !== resolveDesignMode('', null, p)) disagreed = true;
-  }
+  /* 'current' is now the WRONG answer for an unspecified visitor - before #748
+     it was the right one for every route but `/`, which is why this control
+     had to be rewritten rather than left alone. A control that still passed
+     after the default flipped would have been measuring nothing. */
+  if (wrong('', null) !== resolveDesignMode('', null)) disagreed = true;
   assert.ok(disagreed, 'the comparison cannot distinguish a wrong resolver from the real one');
-});
-
-test('the route list is the single source the script interpolates', () => {
-  const layout = readFileSync('app/layout.tsx', 'utf8');
-  assert.match(layout, /JSON\.stringify\(TERMINAL_BY_DEFAULT_ROUTES\)/,
-    'layout.tsx should interpolate the exported list rather than hardcode routes');
-  assert.deepEqual([...TERMINAL_BY_DEFAULT_ROUTES], ['/']);
 });

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,7 +4,6 @@ import Script from 'next/script';
 import './globals.css';
 import AppShell from '@/components/AppShell';
 import DesignModeProvider from '@/components/DesignModeProvider';
-import { TERMINAL_BY_DEFAULT_ROUTES } from '@/lib/designMode';
 
 // Self-hosted, previously next/font/google.
 //
@@ -126,14 +125,16 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
        *
        * The precedence MUST match resolveDesignMode in lib/designMode.ts.
        * It is duplicated because this runs before any module is loaded, which
-       * is the point. The route list is interpolated from
-       * TERMINAL_BY_DEFAULT_ROUTES so that half has one source; the ordering
-       * is kept in step by __tests__/designMode.test.mts, which extracts this
-       * exact string and runs both against every combination of inputs rather
-       * than trusting this comment. */}
+       * is the point. It is kept in step by __tests__/designMode.test.mts,
+       * which extracts this exact string and runs both against every
+       * combination of inputs rather than trusting this comment.
+       *
+       * #748 removed the interpolated route list. Terminal is the default on
+       * every route now, so there is no list to mirror and no pathname to
+       * read - the script is the param, the stored value, then terminal. */}
       <script
         dangerouslySetInnerHTML={{
-          __html: `(function(){try{var q=new URLSearchParams(window.location.search).get('design');var s=null;try{s=localStorage.getItem('lhq-design-mode');}catch(e){}var r=${JSON.stringify(TERMINAL_BY_DEFAULT_ROUTES)};var p=window.location.pathname;if(p.length>1)p=p.replace(/\\/+$/,'');if(!p)p='/';var m=q==='terminal'?'terminal':q==='current'?'current':s==='terminal'?'terminal':s==='current'?'current':(r.indexOf(p)>=0?'terminal':'current');if(m==='terminal'){document.documentElement.setAttribute('data-design','terminal');}else{document.documentElement.removeAttribute('data-design');}}catch(e){}})();`,
+          __html: `(function(){try{var q=new URLSearchParams(window.location.search).get('design');var s=null;try{s=localStorage.getItem('lhq-design-mode');}catch(e){}var m=q==='terminal'?'terminal':q==='current'?'current':s==='terminal'?'terminal':s==='current'?'current':'terminal';if(m==='terminal'){document.documentElement.setAttribute('data-design','terminal');}else{document.documentElement.removeAttribute('data-design');}}catch(e){}})();`,
         }}
       />
       {/* No manual apple-touch-icon <link> here - app/apple-icon.png's file

--- a/components/DesignModeProvider.tsx
+++ b/components/DesignModeProvider.tsx
@@ -60,13 +60,15 @@ export default function DesignModeProvider({ children }: { children: React.React
 
   const snapshot = useSyncExternalStore(noopSubscribe, readSnapshot, () => SERVER_SNAPSHOT);
   const [search, stored] = JSON.parse(snapshot) as [string, string | null];
-  /* `pathname` comes from usePathname(), which is correct on the server too -
-     so `/` resolves to terminal in the SSR markup rather than only after
-     hydration. The query param and stored value still arrive client-only via
-     the snapshot above, which is why the server snapshot is ['', null]: on the
-     server we know the route and nothing else, and that is exactly the input
-     the route default needs. */
-  const mode = resolveDesignMode(search, stored, pathname);
+  /* The route is no longer an input (#748): terminal is the default
+     everywhere, so there is nothing for a pathname to decide. The query param
+     and stored value arrive client-only via the snapshot above, which is why
+     the server snapshot is ['', null] - on the server we know neither, and the
+     SSR pass therefore renders the default. That is the trade recorded in
+     lib/designMode.ts, and after #748 the default is the common case rather
+     than the exception, so SSR is now right for most visitors instead of for
+     one route. */
+  const mode = resolveDesignMode(search, stored);
 
   useEffect(() => {
     /* PERSIST ONLY WHAT THE QUERY PARAM ASKED FOR.

--- a/lib/designMode.ts
+++ b/lib/designMode.ts
@@ -12,18 +12,29 @@
  * owner asked to review screens as they land, and a branch nobody can visit is
  * not reviewable.
  *
- * DEFAULT IS THE CURRENT DESIGN, EXCEPT ON `/` (#719, 2026-09-03). The owner
- * stopped the canvas-mirror redesign and decided terminal ships on the landing
- * page only: `/` renders terminal for every visitor, every app screen stays on
- * the current design. That is the first time any of this work becomes visible
- * to someone who did not type the query param themselves.
+ * TERMINAL IS THE DEFAULT, EVERYWHERE (#748, 2026-09-04). Owner: "remove
+ * ?design terminal make terminal design default".
  *
- * THE "GLOBAL CHROME" NOTE ABOVE IS STILL TRUE AND IS NOT WHAT BLOCKS THIS.
- * The shell cannot opt in per page, and this does not ask it to - the mode is
- * still one value for the whole tree at any moment. What changed is only how
- * the DEFAULT is computed: the route is now an input to it, alongside the query
- * param and the stored preference. The shell reads the same single value it
- * always did.
+ * This reverses #719, which had shipped terminal on `/` alone, and it retires
+ * the route list that made that possible - there is no longer a route whose
+ * default differs, so `TERMINAL_BY_DEFAULT_ROUTES` and `isTerminalByDefault`
+ * are gone rather than left holding every route in the app. `pathname` is no
+ * longer an input to the resolver at all.
+ *
+ * THE QUERY PARAM STAYS, and `?design=terminal` is now a no-op that names the
+ * default. `?design=current` is the reason to keep the mechanism: it is the
+ * only way back to the previous design without a deploy, it is how the two get
+ * compared, and it is what QA's sweeps use to measure the design a user is NOT
+ * getting. Removing the param entirely would read the owner's instruction as
+ * "delete the escape hatch", which is not what it says and would make a
+ * rollback a code change.
+ *
+ * WHAT THIS COSTS ON THE FIRST FRAME. The trade recorded below under
+ * `resolveDesignMode` now applies to every route rather than to `/`: a visitor
+ * who has opted OUT gets one terminal-rendered frame from the server before
+ * the client corrects. The palette does not flash - the inline script in
+ * app/layout.tsx sets data-design before paint - it is the component tree that
+ * arrives from the default. Wider than it was, and the same decision.
  */
 
 export type DesignMode = 'current' | 'terminal';
@@ -31,60 +42,41 @@ export type DesignMode = 'current' | 'terminal';
 export const DESIGN_STORAGE_KEY = 'lhq-design-mode';
 export const DESIGN_QUERY_PARAM = 'design';
 
-/** Routes that default to terminal with no query param and nothing stored.
- *  Exactly one today. A set rather than an `=== '/'` so adding a second is a
- *  data change, and so the bootstrap script in app/layout.tsx has one list to
- *  mirror rather than a condition to re-derive. */
-export const TERMINAL_BY_DEFAULT_ROUTES = ['/'] as const;
-
-/** Whether a pathname is terminal-by-default. Trailing slash tolerated because
- *  a visitor can arrive at either form and they are the same page. */
-export function isTerminalByDefault(pathname: string | null | undefined): boolean {
-  if (!pathname) return false;
-  const p = pathname.length > 1 ? pathname.replace(/\/+$/, '') : pathname;
-  return (TERMINAL_BY_DEFAULT_ROUTES as readonly string[]).includes(p || '/');
-}
-
 /**
- * Resolve the mode from a URL, a stored preference, and the current route.
+ * Resolve the mode from a URL and a stored preference.
  *
  * PRECEDENCE, highest first:
  *
- *   1. the query param   - `?design=terminal` / `?design=current`
- *   2. a stored value    - whatever the param last set, on every route
- *   3. the route default - terminal on `/`, current everywhere else
+ *   1. the query param - `?design=current` / `?design=terminal`
+ *   2. a stored value  - whatever the param last set
+ *   3. terminal        - the default, on every route (#748)
  *
- * The query param WINS and is sticky - `?design=terminal` turns it on and keeps
- * it on across navigation, `?design=current` turns it off again. Without that
- * second escape hatch the only way out would be devtools or clearing storage,
- * which is a bad trap to leave for whoever reviews this.
+ * The query param WINS and is sticky, so `?design=current` turns the previous
+ * design back on and KEEPS it on across navigation. Without that the only way
+ * out would be devtools or clearing storage, which is a bad trap to leave for
+ * whoever reviews this - and after #748 it is also the only rollback that does
+ * not need a deploy.
  *
- * A STORED VALUE OUTRANKS THE ROUTE DEFAULT, IN BOTH DIRECTIONS. `?design=current`
- * on `/` has to keep the visitor on the current landing across a reload, or it
- * is not an escape hatch - it is a button that undoes itself. Likewise stored
- * `terminal` keeps every app screen in terminal for review. #719 says both
- * hatches must survive, and this is the line that makes that true: the route
- * only decides for a visitor who has expressed no preference at all.
+ * A STORED VALUE OUTRANKS THE DEFAULT. That single line is what makes the
+ * escape hatch real: without it, every load would re-assert terminal and a
+ * stored 'current' would be inert - a button that undoes itself.
  *
- * `pathname` is optional so existing callers keep compiling, but omitting it
- * means "no route default" - not "default to terminal".
+ * A KNOWN COST, ACCEPTED DELIBERATELY (QA, on #724; widened by #748). The
+ * server knows nothing - DesignModeProvider's server snapshot is ['', null],
+ * since the query param and localStorage are both client-only. So the SSR pass
+ * always renders the default:
  *
- * A KNOWN COST, ACCEPTED DELIBERATELY (QA, on #724). The server knows the route
- * and nothing else - DesignModeProvider's server snapshot is ['', null], since
- * the query param and localStorage are both client-only. So on `/` the SSR pass
- * renders from the route default:
+ *     /?design=current            SSR terminal -> hydrates to current
+ *     /dashboard?design=current   SSR terminal -> hydrates to current
  *
- *     /?design=current            SSR terminal  -> hydrates to current
- *     /dashboard?design=terminal  SSR current   -> hydrates to terminal
- *
- * The second line was already true before #719. The FIRST is new: `/` used to
- * server-render current for everyone, and now someone opting out sees one
- * terminal frame before the client corrects. The palette itself does not flash
- * either way - the inline script in app/layout.tsx sets data-design before
- * paint - it is the component tree that arrives from the route.
+ * Before #748 this affected `/` alone; now it is every route. It is still the
+ * OPT-OUT path that pays, which is the right way round - the common case is
+ * server-rendered correctly. The palette does not flash either way, because the
+ * inline script in app/layout.tsx sets data-design before paint; it is the
+ * component tree that arrives from the default.
  *
  * Not fixed, and the reason is a trade rather than difficulty: reading the
- * param server-side means `searchParams`, which opts `/` out of static
+ * param server-side means `searchParams`, which opts every page out of static
  * rendering. That charges every visitor on the default path to tidy up the rare
  * opt-out path. Recorded here so the next person finds it as a decision rather
  * than as a bug.
@@ -94,14 +86,13 @@ export function isTerminalByDefault(pathname: string | null | undefined): boolea
 export function resolveDesignMode(
   search: string | null | undefined,
   stored: string | null | undefined,
-  pathname?: string | null,
 ): DesignMode {
   const fromQuery = new URLSearchParams(search ?? '').get(DESIGN_QUERY_PARAM);
   if (fromQuery === 'terminal') return 'terminal';
   if (fromQuery === 'current')  return 'current';
   if (stored === 'terminal') return 'terminal';
   if (stored === 'current')  return 'current';
-  return isTerminalByDefault(pathname) ? 'terminal' : 'current';
+  return 'terminal';
 }
 
 /**


### PR DESCRIPTION
## Summary

#748, on the owner's instruction: *"remove ?design terminal make terminal design default"*. Terminal is now what every visitor gets, on every route, with no query param and nothing stored.

This reverses #719, which had shipped terminal on `/` alone.

## What changed

| File | Change |
|---|---|
| `lib/designMode.ts` | default is `terminal`; `TERMINAL_BY_DEFAULT_ROUTES` and `isTerminalByDefault` deleted; `pathname` dropped from `resolveDesignMode` |
| `app/layout.tsx` | bootstrap script loses the interpolated route list and the pathname handling |
| `components/DesignModeProvider.tsx` | stops passing a pathname |
| `__tests__/designMode.test.mts` | route-default cases replaced; drift gate and control rewritten |

The route list existed to express exactly one exception. With no route defaulting differently, keeping it would have meant listing **every route in the app** — so it is gone rather than inverted.

```
1  the query param   ?design=current / ?design=terminal
2  a stored value    whatever the param last set
3  terminal          the default, everywhere
```

## The query param stays, deliberately

`?design=terminal` becomes a no-op that names the default. **`?design=current` is the reason to keep the mechanism**, and it is doing three jobs:

- the only way back to the previous design **without a deploy**
- how the two get compared
- what QA's sweeps use to measure the design a user is *not* getting

Reading *"remove ?design terminal"* as "delete the escape hatch" would make a rollback a code change on the day it is most needed. If the owner did mean remove the param outright, say so and it is a small follow-up — but that is not what the sentence says and it is the more expensive reading to be wrong about.

## Verified by rendering — all four behaviours, local dev

```
/                     no param, storage cleared   data-design=terminal   stored null
/dashboard            no param                    data-design=terminal   tnav x29, app-bar x0
/dashboard?design=current                         data-design absent     app-bar x1, stored 'current'
/arena                no param, after the above   data-design absent     app-bar x1   <- sticky
```

The last line is the one that matters most: the escape hatch **survives navigation without the param**. If it did not, `?design=current` would undo itself on the next click and there would be no way out.

Also confirmed: **nothing is written to localStorage unless the param asked for it** — a default-path visitor leaves no stored value, so the default can be changed again later without stale preferences pinning people to it.

## The SSR trade, widened rather than changed

The server knows neither the query param nor localStorage — `DesignModeProvider`'s server snapshot is `['', null]` — so the SSR pass renders the default:

```
/?design=current           SSR terminal -> hydrates to current
/dashboard?design=current  SSR terminal -> hydrates to current
```

Before #748 the opt-out path paid this on `/` alone; now on every route. **It is still the opt-out that pays**, which is the right way round: the common case is server-rendered correctly. The palette does not flash either way, because the inline script sets `data-design` before paint — it is the component tree that arrives from the default. Recorded in `lib/designMode.ts` as a decision, not a bug; fixing it means `searchParams`, which opts every page out of static rendering.

## The drift gate and its control both needed rewriting

The gate that runs the layout script and `resolveDesignMode` against every input still passes, now across **all seven routes** rather than a sample of four.

Its **control** had to change and this is worth flagging: it previously proved teeth by asserting a wrong resolver returning `'terminal'` disagreed with the real one on `/dashboard`. After this change that is the *right* answer, so the control would have passed while proving nothing — exactly the false-clean this project keeps hitting. It now feeds `'current'` instead, and the comment says why.

The `${...}` assertion also earns its keep differently now: with the last interpolation gone, it catches a **new** one being added without this extraction learning about it.

## How to test (QA)

1. **Clear `lhq-design-mode` from localStorage**, then visit any app route with no query param — `/dashboard`, `/arena`, `/scanner`, `/funding`, `/journal`. All terminal.
2. **`/` with storage cleared** — terminal, as it already was.
3. **`?design=current` on any route** — previous design returns. Then **navigate to another route without the param**: it must stay on the previous design.
4. **`?design=terminal`** — still parses, still works, now redundant.
5. **Both themes**, since this is the change that puts terminal-light in front of everyone. #707, #752, #758, #761 and #762 were the ones that gated this.

## Risk level

**High** — this is the flip. It changes what every user sees on every route.

Four gates: lint 0 errors (242 pre-existing warnings, down 1), `tsc --noEmit` clean, 579/579 tests, build succeeds. Test count drops by 4 because the retired route-default cases are gone, not because anything was skipped.

**Why the remaining 579 are worth trusting - the control had to be rewritten, and that is the point.**

The drift gate control proved teeth by asserting that a deliberately wrong resolver, one that always returns `terminal`, disagreed with the real one on `/dashboard`. After this change **that is the right answer**. The control would have kept passing while proving nothing, and the pass would have been empty.

That is the same shape as an empty page reporting zero contrast failures, and **flipping a default is exactly when it strikes**: a control is only valid against the behaviour it was written for, and changing that behaviour invalidates it silently, with no failure to notice. It now feeds `current` instead, and the comment in the test says why, so the next person changing a default knows to check it.

**What is NOT verified:** every route's terminal rendering. I checked the mechanism — resolver, bootstrap script, provider, stickiness — on `/`, `/dashboard` and `/arena`. Whether each individual screen looks right in terminal is your 80-load sweep, and it is the thing worth doing before this reaches `main`.

**Rollback:** `?design=current` for one person, revert this commit for everyone. No data migration, nothing persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
