### PR TITLE
fix(scanner): green signal text on a green wash takes --green-fg (#738)

### DIFF
--- a/components/CoinHeatmap.tsx
+++ b/components/CoinHeatmap.tsx
@@ -148,8 +148,26 @@ export default function CoinHeatmap() {
         <span style={{ fontSize: 'var(--fs-micro)', fontWeight: 700, color: 'var(--txt3)', letterSpacing: '.07em', textTransform: 'uppercase', flex: 1 }}>
           <Tip text={t('COIN_HEATMAP_TOOLTIP')}>{t('COIN_HEATMAP_TITLE')}</Tip>
         </span>
+        {/* --green-fg on the TEXT, --green-2 still on the tint and border
+            (#738). This is the pattern the token exists for: a signal colour
+            printed on a wash of itself. In terminal light --green is #14702c,
+            and on its own 10% wash that measures 4.47 by token arithmetic and
+            4.11 rendered - QA's number, three runs, same ratio each time.
+            --green-fg is 6.03 there and is ALIASED to --green everywhere else,
+            so the other three contexts are byte-identical. The tint keeps
+            --green-2 deliberately: changing the wash would move the ground
+            this was just measured against.
+
+            The comment sits ABOVE the conditional, not inside it. A
+            short-circuit render takes exactly one child, and a JSX comment in
+            that slot is a second one - it compiles to an object where JSX
+            expects an element. Third time in this session; tests pass every
+            time, because nothing typechecks a .tsx, and only tsc says so.
+            Braces are spelled out in words here for the same reason: this
+            comment lives inside a JSX expression container, so a stray brace
+            in the prose closes it early. */}
         {positiveCount > 0 && (
-          <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, padding: '2px 7px', borderRadius: 20, color: 'var(--green-2)', background: 'color-mix(in srgb, var(--green-2) 10%, transparent)', border: '0.5px solid color-mix(in srgb, var(--green-2) 25%, transparent)' }}>
+          <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 700, padding: '2px 7px', borderRadius: 20, color: 'var(--green-fg)', background: 'color-mix(in srgb, var(--green-2) 10%, transparent)', border: '0.5px solid color-mix(in srgb, var(--green-2) 25%, transparent)' }}>
             ↑ {positiveCount}
           </span>
         )}

--- a/components/EMASignal.tsx
+++ b/components/EMASignal.tsx
@@ -169,7 +169,23 @@ export default function EMASignal({ signal, tf = '4h', coin }: Props) {
         }}>
           {signal.conditions.map((c, i) => {
             const pass = c.pass;
-            const col  = pass === true ? 'var(--green-2)' : pass === false ? 'var(--red)' : 'var(--txt-dim)';
+            /* --green-fg for the PASS text, not --green-2 (#738). The row is a
+               7% wash of its own signal colour, and in terminal light --green
+               (#14702c) on that wash measures 4.66 by token arithmetic, 4.41
+               rendered - QA's figure, seven of these on /arena. --green-fg is
+               6.29 there and aliases --green in the other three contexts, so
+               nothing else moves.
+               `col` also feeds the row's border via withAlpha(col,'22'), which
+               is a 13% line rather than text, so it is unaffected by the swap
+               in every practical sense.
+               RED IS LEFT ALONE, and measured rather than assumed: --red on
+               its 7% wash is 6.84 / 5.75 / 4.89 / 5.92 across the four
+               contexts. It passes. --red-fg would raise the worst to 7.50,
+               but tokenising a passing colour to match a pattern is exactly
+               what dropped .scan-badge from 4.85 to 4.47 on this issue's
+               sibling - so it needs its own measurement and its own decision,
+               not this commit. */
+            const col  = pass === true ? 'var(--green-fg)' : pass === false ? 'var(--red)' : 'var(--txt-dim)';
             const bg   = pass === true ? 'color-mix(in srgb, var(--green-2) 7%, transparent)' : pass === false ? 'color-mix(in srgb, var(--red) 7%, transparent)' : 'rgba(255,255,255,0.02)';
             const icon = pass === true ? '✓' : pass === false ? '✗' : '-';
             return (


### PR DESCRIPTION
## Summary

#738's green rows, using the token that already exists for them. Two elements, text only.

```
                          --green-2 (was)          --green-fg (now)
                    arithmetic   QA rendered
/scanner  up-count     4.47          4.11              6.03
/arena    check x7     4.66          4.41              6.29
```

Terminal light only. `--green-fg` is **aliased to `--green` in the other three contexts**, so current dark, current light and terminal dark are byte-identical.

## What changed

`components/CoinHeatmap.tsx` — the `↑ N` badge's `color`.
`components/EMASignal.tsx` — `col` for the passing condition rows.

**The tint and border keep `--green-2` deliberately.** Changing the wash would move the ground these numbers were measured against, and the wash is not what fails.

## Red is left alone, and was measured rather than assumed

```
--red on its own 7% wash    6.84  /  5.75  /  4.89  /  5.92
--red-fg would give                                    7.50 worst
```

**It passes.** `--red-fg` would raise the margin, and the symmetry is tempting — but tokenising a passing colour to match a pattern is exactly what dropped `.scan-badge` from 4.85 to **4.47** on this issue's sibling. It gets its own measurement and its own decision, not this commit.

## The third row is NOT in here, and the reason is a finding

Your `~16h ago` at 4.46, `div.ms-last-event`. **That element already has a terminal fix and it is not enough.**

`globals.css:6685` sets `.ms-ev-ago` to `--txt2` under `[data-design="terminal"]`, from #641. Measured against the three tinted grounds `.ms-last-event` actually takes:

```
                CHoCH gold   bear red   bull green
current dark      4.65         4.56        4.41   <- fails, and this is --txt3 territory today
current light     7.78         7.73        7.88
terminal dark     4.77         5.07        4.87
terminal light    4.80         4.70        4.85   <- you rendered 4.46
```

Two things fall out of that table:

1. **#641's comment quotes `4.78 / 5.07 / 4.87` as its "dark" figures.** Those are my **terminal dark** row. The current-design dark numbers are `4.65 / 4.56 / 4.41`, and the bull-green one **fails**. So #641 measured terminal, wrote "dark", and left the current design on `--txt3` — which its own note measured at 4.02–4.08. Same shape as #750 and #769: verified against one ground, applied to another.

2. **Even in terminal light `--txt2` is marginal** — my 4.70–4.85 against your rendered 4.46. Where we disagree I trust yours.

So this is a token decision, not a substitution: `--txt` clears everything at 12.4–15.9 but makes a timestamp as loud as primary text, and the tint is data-dependent so there is no single ground to tune against. **Filed as its own thing rather than guessed at here** — and worth noting it reaches the current design, so it is not gated behind #768.

## How to test (QA)

1. **`/scanner`, light theme** — the `↑ N` badge beside MARKET HEATMAP. Readable. It is live market data, so the digits will differ from your run; the colour is the thing.
2. **`/arena`, light theme** — the seven check rows under the EMA signal. Green ticks and labels readable.
3. **Dark theme, both screens** — unchanged. If anything moved in dark, the alias assumption is wrong and that is the thing to catch.
4. **The `✗` rows stay the red they were.** Deliberate, measured above.

## Risk level

**Low.** Four gates: lint 0 errors, `tsc --noEmit` clean, 583/583 tests, build succeeds.

**Not verified by rendering** — both screens need live market data I do not have locally. The arithmetic reproduced your rendered figures within 0.2–0.3 on the two rows you measured, which is the corroboration available.

**One process note, since it cost two cycles here.** I put the explanatory comment inside `positiveCount > 0 && ( … )`, which takes exactly one child, and then used braces in the prose of a JSX comment. `npm test` passed both times — nothing typechecks a `.tsx` — and only `tsc` caught it. Third time this session for the first mistake, so the fixed version says so in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
