### PR TITLE
chore(api): name the typecheck gate and give all four one command (#772)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -953,8 +953,17 @@ looks.
 
 Before opening a PR, dev has:
 
-- **Run the gates.** `npm run lint` (0 errors), `npx tsc --noEmit`, `npm test`,
-  `npm run build`. All four, not the fast one.
+- **Run the gates.** `npm run verify` runs all four in order — lint (0 errors),
+  typecheck, test, build — and stops at the first failure. Individually they are
+  `npm run lint`, `npm run typecheck`, `npm test`, `npm run build`.
+
+  **All four, not the fast one.** `npm test` is `node --test __tests__/*.test.mts`:
+  it typechecks nothing outside `__tests__`, so a `.tsx` can be syntactically
+  broken while all 583 tests pass. That happened three times in one session
+  before `typecheck` existed as a named script — the output was not wrong, it
+  answered a narrower question than the one being asked. CI has always run all
+  four (`.github/workflows/ci.yml:191-209`), so this is about the local loop,
+  not about what can reach `main`.
 - **Exercised the change**, not reasoned about it. Load the page. Call the
   route. If it is a fix, reproduce the original failure first and then confirm
   it is gone — a fix that was never seen failing is a guess.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:report": "playwright show-report qa/e2e-report",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "verify": "npm run lint && npm run typecheck && npm test && npm run build",
     "labels:regen": "node scripts/regen-label-defaults.mjs"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

#772. Two scripts, one doc paragraph, no new tooling.

```json
"typecheck": "tsc --noEmit",
"verify":    "npm run lint && npm run typecheck && npm test && npm run build"
```

`tsc` was the only one of the four gates with **no name** — it lived in CI and in whatever the person at the keyboard remembered to type.

## Control-tested, because a gate that cannot fail is this session's recurring defect

```
clean tree              npm run verify   exit 0
deliberate type error   npm run verify   exit 2, prints the TS error, runs ZERO tests
```

The second line is the one worth having: it stops **at** the failing gate rather than continuing to test and build, so the first thing you read is the thing that broke.

## Why it was needed

`npm test` is `node --test __tests__/*.test.mts`. It typechecks nothing outside `__tests__`, so a `.tsx` can be syntactically broken while all 583 tests pass — which happened three times in one session. The output was never wrong; **it answered a narrower question than the one I was asking.**

That is the same shape as the other instrument failures this session: an empty `/news` reporting zero contrast fails, a transparent canvas reading `rgb(0,0,0)` in both themes, a control that could not fail, and a probe that composited 0–1 channels as 0–255. Every one produced a clean, confidently-formatted number.

## CI was never the gap, and the issue says so

`.github/workflows/ci.yml:191-209` has always run lint → `tsc --noEmit` → test → build, in that order. **None of those breakages could have reached `main`.** QA's first framing was "a real gap in our gates" and it was corrected on the issue before this was built — the accurate version is narrower and justifies exactly this much fix.

CI is left on its four separate steps rather than calling `verify`. Separate steps give a readable failure; one opaque step does not.

## What was deliberately not done

**No `pretest` hook running `tsc` before every `npm test`.** It would have caught my exact mistake. It also turns a ~6s inner loop into a multi-second one, and a gate people route around by typing `node --test` directly is worse than one they invoke on purpose.

**It shortens the loop; it does not prevent the mistake.** I would still have written the broken JSX. What changes is that "did I check?" has one answer instead of four, and the gate that catches it can be named.

## How to test (QA)

1. `npm run typecheck` on a clean tree — exits 0, prints nothing but the banner.
2. `npm run verify` — runs all four in order, exits 0.
3. Break something on purpose (e.g. `const x: number = 'nope';` in any `.ts`) and re-run `npm run verify`: exit 2, the TS error, and **no test output at all**.
4. `CONTRIBUTING.md`'s pre-PR checklist now names `npm run verify` and explains why `npm test` alone is not enough.

## Risk level

**Low.** No application code. Four gates pass — via `npm run verify` itself, which is the first thing it was used for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
