### PR TITLE
fix(correlations): share the tested tint ramp and stop using --txt3 on tinted cells (#774)

### DIFF
--- a/__tests__/correlationRamp.test.mts
+++ b/__tests__/correlationRamp.test.mts
@@ -17,6 +17,7 @@
  */
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 
 import { tintPct, GREEN_CAP_PCT, RED_CAP_PCT } from '../lib/correlationRamp.ts';
 import { TERMINAL_COLORS, TERMINAL_COLORS_LIGHT } from '../lib/terminalTokens.ts';
@@ -126,4 +127,104 @@ test('--txt3 would still fail there, so the swap is doing the work', () => {
   const T = TERMINAL_COLORS as Record<string, string>;
   const c = ratio(hex(T['--txt3']), over('#ffffff', T['--bg1'], 3));
   assert.ok(c < 4.5, `--txt3 now measures ${c.toFixed(2)} on the null ground; --txt-dash may be unnecessary`);
+});
+
+/* ── THE CURRENT DESIGN USES THE SAME RAMP NOW (#774) ──────────────────────
+ *
+ * app/correlation/page.tsx carried its own copy of this curve - same rescale,
+ * same exponents, same floors, caps of 96% and 92% against this file's 50% and
+ * 56%. Only the caps differed, and that was 1332 failing cells on production,
+ * worst 1.79, concentrated in the strongly-correlated cells the screen exists
+ * to highlight.
+ *
+ * It now imports tintPct(). These assertions are what make that safe, because
+ * the caps above were derived against TERMINAL's tokens and the current design
+ * has different ones:
+ *
+ *     terminal --green  #3fb950        current  rgba(52,211,153)
+ *     terminal --red    (token)        current  rgba(248,113,113)
+ *
+ * The cell colours here are hardcoded literals rather than tokens, so they do
+ * NOT change with the theme - only the ground and the text do. That is why a
+ * cap verified in one theme cannot be assumed in the other, which is the
+ * mistake this whole file exists to prevent, and which #641, #750 and #769 all
+ * repeated on other surfaces the same day this was written.
+ *
+ * THE CAP WAS ONLY HALF THE DEFECT. The current design also used --txt3 for
+ * every cell below |r| = 0.8. Against its own green that fails from 9% alpha
+ * in dark, red from 12% - so most of the grid was failing as soon as it
+ * carried any tint. With the terminal caps and --txt3 it still measures 1.57
+ * at full strength: a smaller failure, not a fix. Text is --txt now, which is
+ * the conclusion CorrelationTerminal.tsx:77 reached in #570. */
+const CURRENT_GREEN = '#34d399';   // rgba(52,211,153,a)
+const CURRENT_RED   = '#f87171';   // rgba(248,113,113,a)
+
+/* Read from globals.css rather than restated: the current design has no
+   TERMINAL_COLORS equivalent, and a hand-copied palette in a test is the
+   two-sources bug this file's own header is about. */
+const GLOBALS = readFileSync('app/globals.css', 'utf8');
+function currentTokens(selector: string): Record<string, string> {
+  const lines = GLOBALS.split('\n');
+  const idx = lines.findIndex(l => l.trim() === selector + ' {');
+  assert.ok(idx >= 0, `token block not found: ${selector}`);
+  const from = lines.slice(0, idx).join('\n').length;
+  let i = GLOBALS.indexOf('{', from), depth = 0, end = i;
+  for (; i < GLOBALS.length; i++) {
+    if (GLOBALS[i] === '{') depth++;
+    else if (GLOBALS[i] === '}') { depth--; if (depth === 0) { end = i; break; } }
+  }
+  const body = GLOBALS.slice(GLOBALS.indexOf('{', from) + 1, end);
+  const out: Record<string, string> = {};
+  for (const m of body.matchAll(/(--[a-z0-9-]+)\s*:\s*(#[0-9a-fA-F]{6})/g)) out[m[1]] = m[2];
+  return out;
+}
+const CURRENT_ROOT  = currentTokens(':root');
+const CURRENT_LIGHT = { ...CURRENT_ROOT, ...currentTokens('[data-theme="light"]') };
+
+/* .card's background is var(--bg2) (globals.css:728) and the grid renders
+   inside one. NOT a sweep of --bg0/--bg1/--bg2 like the terminal tests above:
+   --bg0 is undefined in the light block, so it falls through to :root's
+   near-black, and including it reports a 1.00 in light that no element on this
+   page ever renders. That wrong number appeared in my first run of this
+   measurement. */
+const CURRENT_THEMES = [
+  { name: 'current dark',  T: CURRENT_ROOT },
+  { name: 'current light', T: CURRENT_LIGHT },
+];
+
+test('the shared ramp clears 4.5:1 on the CURRENT design\'s cell colours too', () => {
+  const failures: string[] = [];
+  for (const { name, T } of CURRENT_THEMES) {
+    for (let i = -100; i <= 100; i++) {
+      const r = i / 100;
+      const pct = tintPct(r);
+      const tint = r > 0 ? CURRENT_GREEN : CURRENT_RED;
+      const c = ratio(hex(T['--txt']), over(tint, T['--bg2'], pct));
+      if (c < 4.5) failures.push(`${name} r=${r.toFixed(2)} alpha=${pct.toFixed(1)}% -> ${c.toFixed(2)}`);
+    }
+  }
+  assert.deepEqual(failures.slice(0, 5), [],
+    `${failures.length} current-design cell states below 4.5:1. The caps in ` +
+    'lib/correlationRamp.ts were derived against the TERMINAL palette; if this ' +
+    'fails they no longer cover both designs and the binding one has to be re-derived.');
+});
+
+test('CONTROL: the caps this replaced really did fail, and --txt3 fails even with them', () => {
+  /* Two positive controls, because #774 had two halves and either alone would
+     have looked like a fix.
+
+     Without these, the assertion above passing proves only that it ran - and a
+     check that cannot fail is the defect this project hit five separate ways in
+     one session. */
+  const T = CURRENT_ROOT;
+
+  // 1. The old 96% green cap, which is what shipped.
+  const oldCap = ratio(hex(T['--txt']), over(CURRENT_GREEN, T['--bg2'], 96));
+  assert.ok(oldCap < 4.5, `expected the old 96% cap to fail, measured ${oldCap.toFixed(2)}`);
+
+  // 2. --txt3 at the NEW cap - the half a cap change alone would have missed.
+  const withTxt3 = ratio(hex(T['--txt3']), over(CURRENT_GREEN, T['--bg2'], GREEN_CAP_PCT));
+  assert.ok(withTxt3 < 4.5,
+    `--txt3 now measures ${withTxt3.toFixed(2)} at the capped alpha; if it passes, ` +
+    'the always---txt change is no longer load-bearing and this should be revisited.');
 });

--- a/app/correlation/page.tsx
+++ b/app/correlation/page.tsx
@@ -5,6 +5,7 @@ import LoadingState from '@/components/LoadingState';
 import Tip from '@/components/Tip';
 import { COINS, BINANCE_SYMS, BYBIT_SYMS, COIN_LABELS, type CoinId } from '@/lib/marketStore';
 import { withAlpha } from '@/lib/color';
+import { tintPct } from '@/lib/correlationRamp';
 import { useLabels } from '@/lib/labels';
 import type { LabelKey } from '@/lib/labelKeys';
 import { useDesignMode } from '@/components/DesignModeProvider';
@@ -83,23 +84,64 @@ function pearson(a: number[], b: number[]): number | null {
 /* ── colors ── */
 /* Crypto correlations cluster in 0.5–1.0, so a linear alpha map renders a wall of
    identical green. Rescale 0.35→1.0 onto the full range with a power curve so
-   0.6 reads faint and 0.95+ pops. */
+   0.6 reads faint and 0.95+ pops.
+ *
+ * THE CURVE IS NOW SHARED WITH TERMINAL (#774). This function used to carry its
+ * own copy - same rescale, same exponents, same floors, and caps of 92% and 96%
+ * against lib/correlationRamp.ts's 56% and 50%. Only the caps differed, and
+ * they are the whole defect: 1332 cells below 4.5:1 on production, worst 1.79,
+ * and the failures were concentrated in the STRONGLY correlated cells, which
+ * are the ones the screen exists to draw attention to.
+ *
+ * correlationRamp.ts exists because #570's caps were argued in prose and the
+ * prose was wrong. Importing it rather than re-deriving a second set means the
+ * tested constants govern both designs. */
 function cellBg(r: number | null, diag: boolean): string {
   if (diag)    return 'var(--accent-bdr)';
   if (r == null) return 'rgba(255,255,255,0.03)';
-  if (r > 0) {
-    const t = Math.max(0, (r - 0.35) / 0.65);
-    const a = 0.04 + Math.pow(t, 2.2) * 0.92;
-    return `rgba(52,211,153,${a.toFixed(2)})`;
-  }
-  const a = 0.06 + Math.pow(Math.abs(r), 1.5) * 0.86;
-  return `rgba(248,113,113,${a.toFixed(2)})`;
+  const a = tintPct(r) / 100;
+  return r > 0
+    ? `rgba(52,211,153,${a.toFixed(2)})`
+    : `rgba(248,113,113,${a.toFixed(2)})`;
 }
 
+/* ALWAYS --txt ON A TINTED CELL (#774), never --txt3.
+ *
+ * The cap was only half of it, and this was the larger half. --txt3 on the
+ * current design's green fails from 9% alpha in dark and red from 12% - so
+ * every cell below |r| = 0.8 was failing almost as soon as it carried any tint
+ * at all, which is most of the grid. Lowering the cap alone leaves --txt3 at
+ * 1.57 at full strength; it is not a fix, it is a smaller failure.
+ *
+ * Terminal already reached this conclusion: CorrelationTerminal.tsx:77 says
+ * "Text is always --txt now", from #570. The current design kept the shape
+ * that issue removed - which is why terminal measures 0 failures on this route
+ * and the design shipping today measures 1332.
+ *
+ * Measured with both changes, worst over the whole ramp on .card's --bg2:
+ * dark 5.01, light 9.95.
+ *
+ * The null cell keeps --txt3 deliberately: it paints rgba(255,255,255,0.03),
+ * essentially the bare card, and measures 4.84 dark / 7.67 light. It is not
+ * part of this defect and #679's --txt-dash is a terminal-only concern. */
 function cellColor(r: number | null, diag: boolean): string {
-  if (diag) return 'var(--accent)';
+  /* THE DIAGONAL TOO, and it was found by rendering rather than by arithmetic
+     (#774). After the two changes above, a 2500-cell sweep of the live grid
+     put the worst cell at 3.88 in dark and 4.34 in light - and it was not a
+     data cell at all. It was the diagonal: var(--accent) printed on
+     var(--accent-bdr), which is #1a7aff at 22%. A signal colour on a wash of
+     itself, the same shape as #738, and there is no --accent-fg token to
+     reach for.
+
+     50 cells, one per coin, and they were the ONLY cells still failing after
+     the ramp fix - so claiming this route was fixed while leaving them would
+     have been the "found a second defect after saying done" failure. --txt
+     measures 12.87 on that ground in dark. The cell shows "-", so it loses
+     nothing by not being blue; the accent-tinted background still marks the
+     diagonal. */
+  if (diag) return 'var(--txt)';
   if (r == null) return 'var(--txt3)';
-  return Math.abs(r) >= 0.8 ? 'var(--txt)' : 'var(--txt3)';
+  return 'var(--txt)';
 }
 
 /* ── alt season signal ── */


### PR DESCRIPTION
## Summary

#774. The production defect: **1332 cells below 4.5:1**, worst 1.79, concentrated in the strongly-correlated cells the screen exists to highlight.

Measured on the rendered grid after the fix: **2500 cells, 0 below 4.5:1** — worst 7.35 dark, 11.81 light.

## Three changes, and only the first was the one in the issue

**1. The shared ramp.** `page.tsx` imports `tintPct()` and deletes its own copy. The two curves were identical — same rescale, same exponents, same floors — except the caps: 96%/92% against 50%/56%.

**2. Text is always `--txt`, and this was the bigger half.** `--txt3` on the current design's green fails from **9% alpha** in dark and red from **12%**, so most of the grid was failing as soon as it carried any tint at all. The terminal caps alone still leave `--txt3` at **1.57** at full strength — a smaller failure, not a fix.

Terminal reached this conclusion in #570 (`CorrelationTerminal.tsx:77`, *"Text is always --txt now"*). **The current design kept the exact shape that issue removed** — which is why terminal measures 0 on this route and the design shipping today measured 1332.

**3. The diagonal, found by rendering rather than by arithmetic.** With the first two changes done, a 2500-cell sweep of the live grid put the worst cell at **3.88 dark / 4.34 light** — and it was not a data cell. It was `var(--accent)` on `var(--accent-bdr)`, `#1a7aff` at 22%: a signal colour on a wash of itself, the #738 shape, with no `--accent-fg` token to reach for.

50 cells, one per coin, and **the only ones still failing** after the ramp fix. Shipping without them would have been the "found a second defect after saying done" failure. `--txt` measures 12.87 there; the cell shows `-`, so it loses nothing by not being blue, and the accent-tinted background still marks the diagonal.

## Your caveat was right and it is now a test

> *"the 50% cap was verified against terminal's `#3fb950`. The current design's is `#34d399`."*

`__tests__/correlationRamp.test.mts` now composites the shared ramp against the **current design's own colours and tokens**, both themes, reading them out of `globals.css` rather than restating them.

**Two positive controls**, because #774 had two halves and either alone would have looked like a fix:

```
the old 96% green cap          fails   -> the cap change is load-bearing
--txt3 at the NEW capped alpha fails   -> the always---txt change is too
```

## One instrument note

My first measurement swept `--bg0/--bg1/--bg2` as candidate grounds, copying the terminal test's approach, and reported **current light failing at 0% alpha**. That was wrong: `--bg0` is not defined in the light block, so it falls through to `:root`'s near-black. The grid renders inside `.card`, whose background is `var(--bg2)` — one ground, not three. Caught it before it became a claim; the test comment records why the sweep is not copied.

(Separately: `--bg0` being undefined in `[data-theme="light"]` is real. Every current-design usage I checked is terminal-gated, so it looks latent — not chased here.)

## How to test (QA)

`/correlation?design=current`, both themes.

1. **Weakly correlated cells** — the 0.4–0.7 band, most of the grid. Readable. These were the bulk of the 1332.
2. **Strongly correlated cells** — 0.9+. These were the worst and are now the deepest tint.
3. **The diagonal** — reads as normal text on the accent tint, not blue on blue.
4. **`?design=terminal`** — unchanged. It already imported this ramp; nothing in `CorrelationTerminal.tsx` was touched.
5. Worth a rendered count rather than an eyeball, since the defect was 1332 cells and the fix is a colour.

## Risk level

**Medium.** Four gates via `npm run verify` — lint 0 errors, typecheck clean, 581/581, build succeeds.

**Verified by rendering**, which is how the third defect was found: 2500 cells sampled with their real composited grounds, both themes, 0 failures.

**Visual change beyond contrast, worth a look:** the diagonal is no longer accent-blue, and weak cells are now `--txt` rather than `--txt3`, so the grid reads with less tonal variation between weak and strong cells. That is the contrast fix doing its job, but it is a look change and you may disagree with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
