### PR TITLE
test(qa): split the audit summary by design (#776 review follow-up)

### DIFF
--- a/qa/platform-audit.mjs
+++ b/qa/platform-audit.mjs
@@ -369,7 +369,19 @@ if (JSON_OUT) { console.log(JSON.stringify(rows, null, 2)); process.exit(0); }
    report came to look clean while measuring nothing. */
 const measured = rows.filter(r => !r.error);
 const errored  = rows.filter(r => r.error);
-const sum = k => measured.reduce((a, r) => a + (r[k] || 0), 0);
+/* Scoped to a design when more than one was swept (#776 review, dev's finding).
+   A `--design terminal,current` run used to total BOTH designs into one number,
+   and the per-row `design` column was the only thing saying otherwise. A reader
+   who scrolls to the summary - which is what a summary is for - got a figure
+   belonging to neither design.
+
+   That is the same shape as the finding this flag was built to catch: on
+   2026-09-04 `current desktop-dark contrast 1330` was 1322 of /correlation and
+   8 of everything else, and the fix was looking at what the total contained.
+   An aggregate that spans the axis under test cannot be read, and this one was
+   latent in precisely the capability the flag adds. */
+const sumOf = (rowset, k) => rowset.reduce((a, r) => a + (r[k] || 0), 0);
+const sum = k => sumOf(measured, k);
 console.log('\n' + '='.repeat(78));
 console.log(`designs ${DESIGNS.join('+')} x routes ${ROUTES.length} x viewports ${VIEWPORTS.length} x themes ${THEMES.length} = ${rows.length} page loads`);
 console.log(`measured ${measured.length} of ${rows.length}   errors ${errored.length}`);
@@ -390,7 +402,23 @@ console.log(`with contrast failures ${measured.filter(r => r.contrastFails > 0).
 console.log(`with off-palette       ${measured.filter(r => r.offDistinct > 0).length}   (total distinct-instances ${sum('offDistinct')})`);
 console.log(`with radius violations ${measured.filter(r => r.radiusTotal > 0).length}   (total ${sum('radiusTotal')}, circular <=24px exempt per radius-ruling.md)`);
 console.log(`with sub-24px targets  ${measured.filter(r => r.subMin > 0).length}   (total ${sum('subMin')})`);
+
 console.log(`with empty fields      ${measured.filter(r => r.empties > 0).length}   (total ${sum('empties')})`);
+
+/* The per-design split. Printed only for a multi-design run, because for a
+   single design it would restate the block above verbatim. */
+if (DESIGNS.length > 1) {
+  console.log('\nBY DESIGN - the totals above span both and belong to neither:');
+  for (const d of DESIGNS) {
+    const rs = measured.filter(r => r.design === d);
+    if (!rs.length) { console.log(`  ${d.padEnd(9)} nothing measured`); continue; }
+    console.log(`  ${d.padEnd(9)} loads ${String(rs.length).padStart(3)}` +
+      `  contrast ${String(sumOf(rs, 'contrastFails')).padStart(5)}` +
+      `  off-palette ${String(sumOf(rs, 'offDistinct')).padStart(4)}` +
+      `  radius ${String(sumOf(rs, 'radiusTotal')).padStart(5)}` +
+      `  <24px ${String(sumOf(rs, 'subMin')).padStart(4)}`);
+  }
+}
 
 /* A run that never settled is not a clean run, and a flag nobody prints is
    the same defect one level up. */


### PR DESCRIPTION
## Summary

Follow-up to #776, from dev's review of it. QA-owned tooling, PR into `dev`.

The `--design` flag #776 added lets a run sweep both designs. The summary block at the bottom then **totalled both into one number**, and the per-row `design` column was the only thing that said otherwise.

## What changed

`qa/platform-audit.mjs` prints a `BY DESIGN` breakdown after the aggregate whenever `--design` names more than one — contrast, off-palette, radius and sub-24px counts per design. Single-design runs print nothing new; the split would restate the block above it verbatim.

## Why

**The defect was latent in exactly the capability #776 added**, so it would have surfaced the first time anyone used the flag for the thing it was built for.

It is also the same failure it was built to catch, one level up. Earlier the same day, `current desktop-dark contrast 1330` looked like a catastrophic result until someone looked at what the total contained: 1322 of `/correlation` and 8 across the other 29 routes. An aggregate that spans the axis under test cannot be read, and a summary is precisely the line someone quotes without reading the rows.

Live output on staging `affe326`:

```
with contrast failures 1   (total 1328)
...
BY DESIGN - the totals above span both and belong to neither:
  terminal  loads   1  contrast     0  off-palette    2  radius     5  <24px    1
  current   loads   1  contrast  1328  off-palette   12  radius  2531  <24px    1
```

The `1328` above the split is the number that describes nothing.

## Credit

Found by dev reviewing #776 **after approving it** — the finding was raised as non-blocking and the PR merged on its own merits. Worth naming, because a review that stops at "approved" would not have produced this.

## How to test (QA)

Reviewer is dev, so these are for you.

1. ```
   MSYS_NO_PATHCONV=1 node qa/platform-audit.mjs --design terminal,current \
     --themes dark --viewports desktop --routes /correlation \
     --base https://liquidity-hq-staging.onrender.com
   ```
   Expect a `BY DESIGN` block reporting terminal contrast `0` and current contrast `~1328`. The exact current figure moves with the live grid; the terminal `0` should not.
2. Run the same command **without** `--design` and confirm no `BY DESIGN` block appears and the output is otherwise identical to before this PR.
3. `MSYS_NO_PATHCONV=1` matters on Windows Git Bash only — without it the leading `/` in `--routes` is rewritten and every load errors. The tool prints `NOTHING WAS MEASURED` and exits non-zero rather than reporting a clean zero; that behaviour is unchanged and worth not breaking.

## Risk level

**Low.** One print block in test tooling, guarded behind `DESIGNS.length > 1`. No application code, no CI, no change to any measurement — only to how measurements are displayed. Default single-design output is byte-identical.

Nothing unverified: both steps above were run against staging before opening this.

— QA Team

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
