### PR TITLE
fix(dashboard): the market-structure age stamp takes a dedicated token, in both designs (#771)

### DIFF
--- a/__tests__/marketStructureStamp.test.mts
+++ b/__tests__/marketStructureStamp.test.mts
@@ -1,0 +1,155 @@
+/* --txt-stamp clears every ground the market-structure age stamp can land on
+ * (#771).
+ *
+ * WHY A TEST AND NOT A MEASUREMENT. `.ms-last-event` takes an inline
+ * `background: evBg(le)` - a 10% tint of the LATEST EVENT's own colour, gold
+ * for a CHoCH, red for bearish, green for bullish. The ground therefore depends
+ * on what the market last did, and a browser can only ever show the one state
+ * that is live. Three separate rendered measurements of this element were taken
+ * on 2026-09-04; each saw a different tint, and two of them were wrong for
+ * unrelated parsing reasons. A test can composite all twelve grounds at once,
+ * which is the only instrument that covers the case.
+ *
+ * WHY 5.0 AND NOT 4.5. The binding ground measured 4.49 with the previous
+ * token. A hundredth of margin on a ground that changes with the market is not
+ * a fix, it is the same defect with better luck.
+ *
+ * WHAT #641 GOT WRONG, since this replaces it. Its rule was scoped
+ * [data-design="terminal"], and its comment quoted "4.78 / 5.07 / 4.87 dark" -
+ * those are TERMINAL dark. The current design's dark figures are 4.65 / 4.56 /
+ * 4.41, it never received the rule at all, and its bull-green ground failed
+ * outright. Measured against one context, applied to another; the same shape as
+ * #750 and #769 on the same day.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseCssColor, compositeOver, contrastRatio, type Rgb } from '../lib/readableOn.ts';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CSS = readFileSync(path.join(ROOT, 'app', 'globals.css'), 'utf8');
+
+const TARGET = 5.0;
+
+function tokens(selector: string): Record<string, string> {
+  const lines = CSS.split('\n');
+  const idx = lines.findIndex(l => l.trim() === selector + ' {');
+  assert.ok(idx >= 0, `token block not found: ${selector}`);
+  const from = lines.slice(0, idx).join('\n').length;
+  let i = CSS.indexOf('{', from), depth = 0, end = i;
+  for (; i < CSS.length; i++) {
+    if (CSS[i] === '{') depth++;
+    else if (CSS[i] === '}') { depth--; if (depth === 0) { end = i; break; } }
+  }
+  const body = CSS.slice(CSS.indexOf('{', from) + 1, end);
+  const out: Record<string, string> = {};
+  for (const m of body.matchAll(/(--[a-z0-9-]+)\s*:\s*([^;\n]+)/g)) {
+    out[m[1]] = m[2].split('/*')[0].trim().replace(/;$/, '');
+  }
+  return out;
+}
+
+function resolve(map: Record<string, string>, value: string, depth = 0): string | null {
+  if (depth > 10) return null;
+  const m = /^var\((--[a-z0-9-]+)(?:\s*,\s*([^)]+))?\)$/.exec(value.trim());
+  if (!m) return value.trim();
+  const next = map[m[1]] ?? m[2];
+  return next === undefined ? null : resolve(map, next, depth + 1);
+}
+
+const root = tokens(':root');
+const light = tokens('[data-theme="light"]');
+const termDark = tokens('[data-design="terminal"]:not([data-theme="light"])');
+const termLight = tokens('[data-design="terminal"][data-theme="light"]');
+
+/* All four, because the rule is unscoped now and the current design is the one
+   that was never covered. */
+const CONTEXTS: Array<[string, Record<string, string>]> = [
+  ['current dark', { ...root }],
+  ['current light', { ...root, ...light }],
+  ['terminal dark', { ...root, ...termDark }],
+  ['terminal light', { ...root, ...light, ...termLight }],
+];
+
+/* MarketStructure.tsx's evBg(): --accent for a CHoCH, --red bearish,
+   --green-2 bullish, all at 10%. --bg1 is .ms-card's declared background;
+   --bg2 is included because the component is not pinned to one surface and a
+   token this narrow should survive being moved one level. */
+const TINTS = ['var(--accent)', 'var(--red)', 'var(--green-2)'];
+const SURFACES = ['--bg1', '--bg2'];
+
+function groundsFor(map: Record<string, string>): Array<{ label: string; rgb: Rgb }> {
+  const out: Array<{ label: string; rgb: Rgb }> = [];
+  for (const tint of TINTS) {
+    const t = parseCssColor(resolve(map, tint) ?? '');
+    assert.ok(t, `tint ${tint} does not resolve to a colour`);
+    for (const surface of SURFACES) {
+      const bg = parseCssColor(resolve(map, `var(${surface})`) ?? '');
+      assert.ok(bg, `${surface} does not resolve to a colour`);
+      out.push({
+        label: `${tint.replace('var(--', '').replace(')', '')} 10% over ${surface}`,
+        rgb: compositeOver(t!.rgb, bg!.rgb, 0.10),
+      });
+    }
+  }
+  return out;
+}
+
+test('the ground set is the size it claims to be', () => {
+  /* Twelve grounds is the whole argument for the token. If this ever counts
+     fewer, the sweep below is passing on a subset and the margin it reports is
+     not the margin that ships. */
+  let total = 0;
+  for (const [, map] of CONTEXTS) total += groundsFor(map).length;
+  assert.equal(total, 24, `expected 6 grounds x 4 contexts = 24, built ${total}`);
+});
+
+test('--txt-stamp clears 5.0 on every event tint, surface and context', () => {
+  const failures: string[] = [];
+  for (const [name, map] of CONTEXTS) {
+    const stamp = parseCssColor(resolve(map, 'var(--txt-stamp)') ?? '');
+    assert.ok(stamp, `--txt-stamp does not resolve in ${name}`);
+    for (const g of groundsFor(map)) {
+      const c = contrastRatio(stamp!.rgb, g.rgb);
+      if (c < TARGET) failures.push(`${name}: ${g.label} -> ${c.toFixed(2)}`);
+    }
+  }
+  assert.deepEqual(failures, [],
+    `${failures.length} ground(s) below ${TARGET}:\n  ${failures.join('\n  ')}`);
+});
+
+test('CONTROL: the tokens this replaced really do fail these grounds', () => {
+  /* Without this, the sweep above proves only that it ran. Both previous
+     answers are checked, because the issue had two halves: terminal was on
+     --txt2 and the current design was left on --txt3. */
+  const failed: string[] = [];
+  for (const [name, map] of CONTEXTS) {
+    for (const tok of ['var(--txt2)', 'var(--txt3)']) {
+      const c0 = parseCssColor(resolve(map, tok) ?? '');
+      if (!c0) continue;
+      for (const g of groundsFor(map)) {
+        if (contrastRatio(c0!.rgb, g.rgb) < TARGET) { failed.push(`${name} ${tok}`); break; }
+      }
+    }
+  }
+  assert.ok(failed.length >= 4,
+    `expected the old tokens to fail in every context; only ${failed.length} did (${failed.join(', ')}). ` +
+    'If they now pass, --txt-stamp is no longer load-bearing and this should be revisited rather than kept as cargo.');
+});
+
+test('the stylesheet actually uses the token, and only where it was measured', () => {
+  /* A token nothing references is a decoration, and a token applied wider than
+     it was measured is a claim nobody checked. Both are failure modes this
+     project has shipped. */
+  assert.match(CSS, /\.ms-ev-ago\s*\{[^}]*color:\s*var\(--txt-stamp\)/,
+    '.ms-ev-ago does not take --txt-stamp');
+  const uses = [...CSS.matchAll(/var\(--txt-stamp\)/g)].length;
+  assert.equal(uses, 1,
+    `--txt-stamp is referenced ${uses} times. It was measured against ONE element's ` +
+    'grounds; every additional use needs its own grounds added to this file first.');
+  assert.doesNotMatch(CSS, /\[data-design="terminal"\][^{]*\.ms-ev-ago/,
+    'the terminal-scoped .ms-ev-ago override is back - the base rule already ' +
+    'covers both designs, and scoping it is what left the current design failing');
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -74,6 +74,19 @@
      empty-cell dash only. Verified: 5.724/5.248/5.312/4.791 across
      --bg0/--bg1/--bg2/#1d1e20. */
   --txt-dash: #848a92;
+  /* --txt-stamp: the market-structure age stamp, and ONLY that (#771).
+     It sits on .ms-last-event, whose background is a 10% tint of whatever the
+     latest event was - gold, red or green - so its ground is DATA-DEPENDENT and
+     there are twelve of them: three tints x --bg1/--bg2 x two themes, in each
+     design. #641 fixed this with --txt2 scoped to terminal; the numbers in that
+     comment were terminal dark written as "dark", the current design never got
+     the rule at all, and --txt2 lands 4.22-4.78 on the worst grounds either way.
+     Target here is 5.0, not 4.5: the binding case was 4.49 and a hundredth of
+     margin on a ground that changes with the market is not a fix.
+     Dark value clears at 6.40 current / 5.90 terminal; the light value below at
+     5.99 / 5.10. Verified over all twelve grounds in
+     __tests__/marketStructureStamp.test.mts rather than asserted here. */
+  --txt-stamp: #9aa0a6;
 
   /* Borders - neutral white hairline, no indigo tint */
   --bdr:  rgba(255,255,255,0.08);
@@ -2553,6 +2566,9 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
      only dark's composited /scanner tile background was. Alias rather
      than invent a second light value nobody measured a failure on. */
   --txt-dash: var(--txt3);
+  /* See --txt-stamp in :root. #4f5257 is the value terminal light already uses
+     for --txt-dash, reached independently for this ground. */
+  --txt-stamp: #4f5257;
   --bdr:  rgba(0,0,0,0.08);
   --bdr2: rgba(0,0,0,0.14);
 
@@ -4551,7 +4567,8 @@ body.consent-pending .gchat-fab { visibility: hidden; }
 }
 .ms-ev-ago {
   font-size: var(--fs-caption);
-  color: var(--txt3);
+  /* --txt-stamp, not --txt3 (#771). See the token's own note in :root. */
+  color: var(--txt-stamp);
   margin-left: auto;
 }
 .ms-levels {
@@ -6682,7 +6699,14 @@ body.nav-drawer-open .mobile-tab-bar { display: none !important; }
    .ms-hist-row, which has no background of its own and composites on plain
    --bg1 at 4.71 - passing. Only the BADGE in a history row is tinted, not
    the row. The first version of this rule targeted the passing element. */
-[data-design="terminal"] .ms-ev-ago,
+/* .ms-ev-ago is NOT here any more (#771). It takes --txt-stamp from its base
+   rule, unscoped, because the defect was never terminal-specific: the current
+   design was left on --txt3 by this very rule's scoping and measures 4.41 on a
+   green last-event in dark. A token that both designs need does not belong
+   behind a design selector.
+   .ms-hist-ago stays: it sits in .ms-hist-row, which has no background of its
+   own, so it composites on plain --bg1 and measures 5.26-8.49 across the four
+   contexts. It passes, so it is not being changed to match a pattern. */
 [data-design="terminal"] .ms-hist-ago { color: var(--txt2); }
 
 /* Footer column links: a 25px hit area with ZERO layout change (#641).


### PR DESCRIPTION
## Summary

#771, on your ruling: a dedicated token. **Your `#4f5257` candidate is confirmed** — 5.10 on the worst terminal-light ground — and it turned out one token with two values covers all four contexts, so the fix is unscoped and the current design gets it too.

```
--txt-stamp    :root              #9aa0a6      [data-theme="light"]   #4f5257

               current dark   6.40      terminal dark   5.90
               current light  5.99      terminal light  5.10
```

Worst of twenty-four grounds: **5.10**.

## Your candidate, verified and then extended

`#4f5257` is the value terminal light already uses for `--txt-dash`, reached independently for this ground. You derived 5.14 against one ground; across all six terminal-light grounds the worst is **5.10**, so the figure holds and the margin is real.

What the sweep added: the dark contexts need to move the **other way**, and the usable bands are wide and non-overlapping.

```
grey values clearing 5.0 on all six grounds of that context
  current dark    140..255
  terminal dark   146..255
  current light     0..93
  terminal light    0..82
```

So one light value in `0..82` and one dark value in `146..255` satisfies **both designs** — no terminal-specific override needed, which is why this lands at `:root` and `[data-theme="light"]`.

## That is what makes it fix the half that is live today

#641's rule was `[data-design="terminal"]`-scoped. The current design was never covered, is still on `--txt3`, and its bull-green ground measures **4.41**. **That is shipping right now and is not behind the flip.** A token both designs need does not belong behind a design selector, so the base rule carries it and the terminal override is reduced to `.ms-hist-ago`.

## Target 5.0, per your reasoning

The binding ground measured 4.49 with the old token. A hundredth of margin on a ground that changes with the market is the same defect with better luck.

## `.ms-hist-ago` deliberately unchanged

It sits in `.ms-hist-row`, which has no background of its own, composites on plain `--bg1`, and measures 5.26–8.49 across the four contexts — matching your re-derived numbers. It passes. Changing it to match the pattern is what took `.scan-badge` from 4.85 to 4.47 on #738.

## The test is the instrument, because a browser cannot be

`__tests__/marketStructureStamp.test.mts` composites **all twenty-four grounds** — 3 tints × 2 surfaces × 4 contexts — and asserts ≥ 5.0.

You put this better than I would have: *"a test can composite twelve grounds; a browser can show me one."* Three rendered measurements of this element were taken today, each saw a different tint, and two were wrong for unrelated parsing reasons. Four tests:

- **the ground set is the size it claims to be** — 24, or the sweep is passing on a subset
- **the sweep itself**
- **CONTROL: both old tokens still fail** — `--txt2` and `--txt3`, in every context, so the change is load-bearing and not cargo
- **the stylesheet uses it exactly once** — a token nothing references is decoration; a token applied wider than it was measured is a claim nobody checked. Also asserts the terminal-scoped `.ms-ev-ago` override does not come back.

## How to test (QA)

1. `/arena`, market structure card, the `~16h ago` stamp beside the last event — readable in **both themes and both designs**.
2. The current design is the interesting one: it never had the #641 fix, so this is a visible change there rather than a margin adjustment.
3. The tint changes with the market. If you catch a red or green last-event, that is a ground neither of us has rendered — worth a number if you do.
4. `npm test` — the control is the one to read.

## Risk level

**Low-Medium.** Four gates via `npm run verify`: lint 0 errors, typecheck clean, 585/585, build succeeds.

**Not rendered.** Deliberately: the ground is data-dependent, so a render confirms one of twelve. The token values come from a sweep of the real palette and the test pins all twenty-four.

**New token in two blocks** — `:root` and `[data-theme="light"]`. The terminal palettes inherit rather than declaring their own, so `__tests__/terminalTokens.test.mts`'s same-token-set assertion is unaffected; it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
