### PR TITLE
fix(auth): primary buttons take --on-accent instead of hardcoded white (#775 cause 1)

### DIFF
--- a/__tests__/onAccent.test.mts
+++ b/__tests__/onAccent.test.mts
@@ -1,0 +1,137 @@
+/* Nothing paints hardcoded white on the accent, and --on-accent clears where
+ * it is used (#775).
+ *
+ * THE SHAPE. An accent chosen to be visible against a dark ground is by
+ * construction a light colour. So "primary buttons are white on the accent" is
+ * a convention that fails precisely when the accent is doing its job - and it
+ * did: terminal dark's --accent-solid is #d9a626, where white measures 2.23:1.
+ * Ten rules carried that pairing, and six of the eight routes in #775's count
+ * were the same line showing up on different screens.
+ *
+ * A count grouped by where a failure appears hides that. This file is grouped
+ * by what produces it: one token, one assertion, and a control that the token
+ * is load-bearing.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseCssColor, contrastRatio } from '../lib/readableOn.ts';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CSS = readFileSync(path.join(ROOT, 'app', 'globals.css'), 'utf8');
+
+function tokens(selector: string): Record<string, string> {
+  const lines = CSS.split('\n');
+  const idx = lines.findIndex(l => l.trim() === selector + ' {');
+  assert.ok(idx >= 0, `token block not found: ${selector}`);
+  const from = lines.slice(0, idx).join('\n').length;
+  let i = CSS.indexOf('{', from), depth = 0, end = i;
+  for (; i < CSS.length; i++) {
+    if (CSS[i] === '{') depth++;
+    else if (CSS[i] === '}') { depth--; if (depth === 0) { end = i; break; } }
+  }
+  const body = CSS.slice(CSS.indexOf('{', from) + 1, end);
+  const out: Record<string, string> = {};
+  for (const m of body.matchAll(/(--[a-z0-9-]+)\s*:\s*([^;\n]+)/g)) {
+    out[m[1]] = m[2].split('/*')[0].trim().replace(/;$/, '');
+  }
+  return out;
+}
+function resolve(map: Record<string, string>, value: string, depth = 0): string | null {
+  if (depth > 10) return null;
+  const m = /^var\((--[a-z0-9-]+)(?:\s*,\s*([^)]+))?\)$/.exec(value.trim());
+  if (!m) return value.trim();
+  const next = map[m[1]] ?? m[2];
+  return next === undefined ? null : resolve(map, next, depth + 1);
+}
+
+const root = tokens(':root');
+const light = tokens('[data-theme="light"]');
+const termDark = tokens('[data-design="terminal"]:not([data-theme="light"])');
+const termLight = tokens('[data-design="terminal"][data-theme="light"]');
+const CONTEXTS: Array<[string, Record<string, string>]> = [
+  ['current dark', { ...root }],
+  ['current light', { ...root, ...light }],
+  ['terminal dark', { ...root, ...termDark }],
+  ['terminal light', { ...root, ...light, ...termLight }],
+];
+
+const WHITE = /color:\s*(#fff\b|#ffffff\b|white\b|rgba\(\s*255\s*,\s*255\s*,\s*255\s*,\s*1\s*\))/i;
+
+/** Declaration blocks that paint a background of var(--accent-solid). */
+function accentSolidRules(): Array<{ selector: string; body: string }> {
+  const out: Array<{ selector: string; body: string }> = [];
+  for (const m of CSS.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    if (/background(-color)?:\s*var\(--accent-solid\)/.test(m[2])) {
+      out.push({ selector: m[1].trim().split('\n').pop()!.trim(), body: m[2] });
+    }
+  }
+  return out;
+}
+
+test('the rule set is not empty - this check has something to check', () => {
+  /* A selector that matches nothing returns a clean result. Ten rules were
+     converted; if this ever drops to zero the sweep below is measuring air. */
+  const rules = accentSolidRules();
+  assert.ok(rules.length >= 8,
+    `only ${rules.length} rules paint on --accent-solid; the regex has probably stopped matching`);
+});
+
+test('no rule hardcodes white on --accent-solid', () => {
+  const offenders = accentSolidRules()
+    .filter(r => WHITE.test(r.body))
+    .map(r => r.selector);
+  assert.deepEqual(offenders, [],
+    `${offenders.length} rule(s) paint hardcoded white on --accent-solid: ${offenders.join(', ')}. ` +
+    'Use var(--on-accent) - white measures 2.23:1 on terminal dark\'s #d9a626.');
+});
+
+test('--on-accent clears 4.5:1 on --accent-solid in all four contexts', () => {
+  const failures: string[] = [];
+  for (const [name, map] of CONTEXTS) {
+    const bg = parseCssColor(resolve(map, 'var(--accent-solid)') ?? '');
+    const fg = parseCssColor(resolve(map, 'var(--on-accent)') ?? '');
+    assert.ok(bg && fg, `--accent-solid or --on-accent does not resolve in ${name}`);
+    const c = contrastRatio(fg!.rgb, bg!.rgb);
+    if (c < 4.5) failures.push(`${name}: ${c.toFixed(2)}`);
+  }
+  assert.deepEqual(failures, [], `--on-accent fails on --accent-solid: ${failures.join(', ')}`);
+});
+
+test('CONTROL: white really does fail there, so the token is doing the work', () => {
+  /* Without this, the assertion above passes in every context where
+     --on-accent IS white and proves nothing. Terminal dark is the context
+     where the two differ, and it is the one that failed. */
+  const map = { ...root, ...termDark };
+  const bg = parseCssColor(resolve(map, 'var(--accent-solid)') ?? '')!;
+  const white = contrastRatio([255, 255, 255], bg.rgb);
+  assert.ok(white < 4.5,
+    `white now measures ${white.toFixed(2)} on terminal dark's accent-solid; ` +
+    'if the accent moved, --on-accent may no longer be load-bearing and this should be revisited.');
+});
+
+test('var(--accent) is NOT covered by this token, and nothing relies on it being', () => {
+  /* White on the CURRENT design's --accent (#1a7aff) is 3.98 - so --on-accent,
+     which is white there, does not rescue a rule that paints on --accent
+     itself. Nothing does today. This is the check that notices if one starts,
+     rather than a comment claiming it cannot happen. */
+  const map = { ...root };
+  const accent = parseCssColor(resolve(map, 'var(--accent)') ?? '')!;
+  const on = parseCssColor(resolve(map, 'var(--on-accent)') ?? '')!;
+  assert.ok(contrastRatio(on.rgb, accent.rgb) < 4.5,
+    'current dark --on-accent now clears --accent; the caveat in globals.css can be relaxed');
+
+  const onAccentRules = [...CSS.matchAll(/([^{}]+)\{([^{}]*)\}/g)]
+    .filter(m => /background(-color)?:\s*var\(--accent\)/.test(m[2]) && /color:\s*var\(--on-accent\)/.test(m[2]))
+    .map(m => m[1].trim().split('\n').pop()!.trim())
+    /* Scoped to rules that can reach the CURRENT design. A terminal-scoped rule
+       painting --on-accent on --accent is correct - there the token is #08090a
+       on gold, 8.95 - and flagging it would be the symmetry mistake this
+       project keeps making. `.sshell-cta` is exactly that case. */
+    .filter(sel => !sel.includes('[data-design="terminal"]'));
+  assert.deepEqual(onAccentRules, [],
+    `unscoped rule(s) paint var(--on-accent) on var(--accent): ${onAccentRules.join(', ')}. ` +
+    'That pairing is 3.98 in the current design - measure it and give it its own token.');
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -97,7 +97,23 @@
      terminal mode inherit white-on-gold (2.23:1) unnoticed - terminalTokens.ts
      documents --accent as "ALWAYS with #08090a text", a contract white text
      violates. Declared here too so var(--on-accent) resolves for every design
-     mode/theme, not just terminal's two. */
+     mode/theme, not just terminal's two.
+
+     #775: TEN RULES STILL HARDCODED #fff ON --accent-solid and they are now
+     all on this token. Terminal dark's accent-solid is #d9a626, where white
+     measures 2.23:1 and this token's #08090a measures 8.95. Six of the eight
+     routes in that issue were the same line: a primary CTA or an auth button.
+
+     The general shape, worth having once rather than ten times: an accent
+     chosen to be visible against a dark ground is BY CONSTRUCTION a light
+     colour, so "white on the accent" is the one pairing guaranteed to fail as
+     soon as the accent does its job. The convention is not wrong by accident -
+     it is wrong in exactly the case it was written for.
+
+     Not a blanket rule for var(--accent): white on the CURRENT design's
+     --accent (#1a7aff) is 3.98, so a rule that paints on THAT token needs its
+     own measurement rather than this token. Nothing in the stylesheet does
+     today; __tests__/onAccent.test.mts is what notices if one starts. */
   --on-accent:  #ffffff;
   --accent-2:   #5aa3ff;
   --accent-dim: rgba(26,122,255,0.12);
@@ -1016,7 +1032,7 @@ body[data-rpm-level="high"]::before {
   border: 0.5px solid transparent; white-space: nowrap;
 }
 .desktop-nav-item:hover { color: var(--txt); background: rgba(90,150,255,0.07); }
-.desktop-nav-item.on { color: #ffffff; background: var(--accent-solid); font-weight: 600; }
+.desktop-nav-item.on { color: var(--on-accent); background: var(--accent-solid); font-weight: 600; }
 
 @media (min-width: 768px) {
   .hamburger   { display: none !important; }
@@ -1760,7 +1776,7 @@ body.ticker-on .breaking-alert { top: calc(var(--appbar-h) + var(--strip-h) + 32
   min-height: 30px; letter-spacing: 0; white-space: nowrap;
   transition: background 0.15s, border-color 0.15s, color 0.15s;
 }
-.ncard-ask-btn:hover { background: var(--accent-solid); border-color: var(--accent); color: #fff; box-shadow: none; }
+.ncard-ask-btn:hover { background: var(--accent-solid); border-color: var(--accent); color: var(--on-accent); box-shadow: none; }
 .ncard-ask-spark { font-size: 0.8em; line-height: 1; }
 /* Secondary action - neutral, not accent-colored, so it doesn't compete with
    Ask LiquidityAI for attention as the primary CTA. */
@@ -3544,7 +3560,7 @@ html[data-design="terminal"][data-theme="light"] { background: var(--bg0); }
    this block got rewritten rather than patched. */
 .auth-gate-btn {
   margin-top: 6px; padding: 9px 26px; border-radius: 10px;
-  background: var(--accent-solid); color: #fff;
+  background: var(--accent-solid); color: var(--on-accent);
   font-size: var(--fs-label); font-weight: 600; text-decoration: none; letter-spacing: -0.1px;
   transition: filter 0.15s; display: inline-block;
 }
@@ -3746,7 +3762,7 @@ html[data-design="terminal"][data-theme="light"] { background: var(--bg0); }
    fixing the one element issue #56 named: white text on --purple (= --accent,
    #1a7aff) is 3.98:1. Only on hover, so axe's resting-state sweep never saw it.
    --accent-solid is the filled-surface token: 5.09:1. */
-.st-save-btn:hover { background: var(--accent-solid); color: #fff; }
+.st-save-btn:hover { background: var(--accent-solid); color: var(--on-accent); }
 .st-save-btn:disabled { opacity: 0.5; cursor: default; }
 
 /* Sign out */
@@ -4124,7 +4140,11 @@ html[data-design="terminal"][data-theme="light"] { background: var(--bg0); }
 .login-email-btn {
   width: 100%; padding: 11px 16px; border-radius: 12px;
   background: var(--accent-solid); border: 0.5px solid var(--accent);
-  color: #fff; font-size: var(--fs-label); font-weight: 600; cursor: pointer;
+  /* var(--on-accent), not #fff (#775). This is /login's "Send Magic Link" -
+     2.23:1 in terminal dark, and a line-based sweep missed it because the
+     declaration sits on a different line from the background. The test found
+     it; the grep did not. */
+  color: var(--on-accent); font-size: var(--fs-label); font-weight: 600; cursor: pointer;
   transition: all 0.15s; font-family: inherit; letter-spacing: -0.1px;
   display: flex; align-items: center; justify-content: center; gap: 8px;
 }
@@ -4833,7 +4853,7 @@ body.landing {
 .lp-nav-actions { display: flex; align-items: center; gap: 10px; }
 .lp-btn-ghost  { font-size: var(--fs-label); font-weight: 500; color: var(--txt2); padding: 6px 14px; border-radius: var(--radius-chip); text-decoration: none; transition: color .15s, background .15s; min-height: 36px; display: inline-flex; align-items: center; }
 .lp-btn-ghost:hover { color: var(--txt); background: rgba(255,255,255,.05); }
-.lp-btn-primary { font-size: var(--fs-label); font-weight: 600; color: #fff; background: var(--accent-solid); padding: 7px 16px; border-radius: var(--radius-chip); text-decoration: none; transition: opacity .15s; min-height: 36px; display: inline-flex; align-items: center; }
+.lp-btn-primary { font-size: var(--fs-label); font-weight: 600; color: var(--on-accent); background: var(--accent-solid); padding: 7px 16px; border-radius: var(--radius-chip); text-decoration: none; transition: opacity .15s; min-height: 36px; display: inline-flex; align-items: center; }
 .lp-btn-primary:hover { opacity: .85; }
 .lp-lang-short { display: none; }
 
@@ -4872,7 +4892,7 @@ body.landing {
 .lp-h1-accent   { font-family: Georgia, 'Times New Roman', serif; font-style: italic; font-weight: 400; color: var(--accent-2); }
 .lp-hero-sub    { font-size: var(--fs-caption); color: var(--txt2); line-height: 1.65; max-width: 520px; margin: 0; }
 .lp-hero-ctas   { display: flex; gap: 12px; flex-wrap: wrap; justify-content: center; }
-.lp-cta-primary { font-size: var(--fs-card-title); font-weight: 700; color: #fff; background: var(--accent-solid); padding: 13px 28px; border-radius: var(--radius-card); text-decoration: none; transition: opacity .15s; }
+.lp-cta-primary { font-size: var(--fs-card-title); font-weight: 700; color: var(--on-accent); background: var(--accent-solid); padding: 13px 28px; border-radius: var(--radius-card); text-decoration: none; transition: opacity .15s; }
 .lp-cta-primary:hover { opacity: .88; }
 .lp-cta-ghost   { font-size: var(--fs-card-title); font-weight: 600; color: var(--txt2); background: rgba(255,255,255,.06); border: 1px solid var(--bdr); padding: 13px 28px; border-radius: var(--radius-card); text-decoration: none; transition: background .15s, color .15s; }
 .lp-cta-ghost:hover { background: rgba(255,255,255,.1); color: var(--txt); }
@@ -4913,7 +4933,7 @@ body.landing {
 .lp-step          { flex: 1; padding: 0 28px; text-align: center; }
 .lp-step:first-child { padding-left: 0; }
 .lp-step:last-child  { padding-right: 0; }
-.lp-step-num      { width: 40px; height: 40px; border-radius: 50%; background: var(--accent-solid); color: #fff; font-size: var(--fs-data); font-weight: 800; display: flex; align-items: center; justify-content: center; margin: 0 auto 14px; }
+.lp-step-num      { width: 40px; height: 40px; border-radius: 50%; background: var(--accent-solid); color: var(--on-accent); font-size: var(--fs-data); font-weight: 800; display: flex; align-items: center; justify-content: center; margin: 0 auto 14px; }
 .lp-step h3       { font-size: var(--fs-card-title); font-weight: 700; margin: 0 0 8px; }
 .lp-step p        { font-size: var(--fs-label); color: var(--txt2); line-height: 1.6; margin: 0; }
 .lp-step-arrow    { font-size: 1.25rem; color: var(--txt3); margin-top: 10px; flex-shrink: 0; align-self: center; }
@@ -4922,7 +4942,7 @@ body.landing {
 .lp-pricing         { display: flex; gap: 20px; align-items: flex-start; justify-content: center; flex-wrap: wrap; }
 .lp-plan            { flex: 1; min-width: 280px; max-width: 380px; border-radius: var(--radius-card); padding: 28px; border: 1px solid var(--bdr); background: var(--bg2); position: relative; }
 .lp-plan-pro        { border-color: rgba(26,122,255,.3); background: var(--bg2); }
-.lp-plan-badge      { position: absolute; top: -12px; left: 50%; transform: translateX(-50%); font-size: var(--fs-micro); font-weight: 700; letter-spacing: .08em; text-transform: uppercase; background: var(--accent-solid); color: #fff; padding: 3px 14px; border-radius: var(--radius-chip); white-space: nowrap; }
+.lp-plan-badge      { position: absolute; top: -12px; left: 50%; transform: translateX(-50%); font-size: var(--fs-micro); font-weight: 700; letter-spacing: .08em; text-transform: uppercase; background: var(--accent-solid); color: var(--on-accent); padding: 3px 14px; border-radius: var(--radius-chip); white-space: nowrap; }
 .lp-plan-header     { margin-bottom: 24px; }
 .lp-plan-name       { font-size: var(--fs-label); font-weight: 700; color: var(--txt2); letter-spacing: .06em; text-transform: uppercase; margin-bottom: 6px; }
 .lp-plan-price      { font-size: 3rem; font-weight: 900; letter-spacing: -.04em; line-height: 1; margin-bottom: 6px; }
@@ -4936,7 +4956,7 @@ body.landing {
 .lp-plan-cta        { display: block; text-align: center; padding: 12px; border-radius: var(--radius-card); font-size: var(--fs-label); font-weight: 700; text-decoration: none; transition: opacity .15s; }
 .lp-plan-cta-free   { background: rgba(255,255,255,.07); border: 0.5px solid var(--bdr); color: var(--txt); }
 .lp-plan-cta-free:hover { background: rgba(255,255,255,.12); }
-.lp-plan-cta-pro    { background: var(--accent-solid); color: #fff; }
+.lp-plan-cta-pro    { background: var(--accent-solid); color: var(--on-accent); }
 .lp-plan-cta-pro:hover { opacity: .85; }
 
 /* ── LP FINAL CTA ────────────────────────────────────────────────────── */
@@ -5337,7 +5357,7 @@ html[lang="ar"] .lp-h1-accent {
 }
 .obw-btn-back { flex-shrink: 0; background: transparent; border: 1px solid var(--bdr); color: var(--txt2); }
 .obw-btn-back:hover { border-color: var(--bdr2); color: var(--txt); }
-.obw-btn-next { flex: 1; border: 1px solid var(--accent); background: var(--accent-solid); color: #fff; }
+.obw-btn-next { flex: 1; border: 1px solid var(--accent); background: var(--accent-solid); color: var(--on-accent); }
 .obw-btn-next:hover:not(:disabled) { background: var(--accent-2); border-color: var(--accent-2); }
 .obw-btn-next:disabled { background: var(--bg2); border-color: var(--bdr); color: var(--txt3); cursor: not-allowed; }
 .obw-skip {


### PR DESCRIPTION
## Summary

#775 cause 1 — the six routes that were one line. **Eleven rules** painting `#fff` on `var(--accent-solid)` now take `var(--on-accent)`.

```
terminal dark  --accent-solid #d9a626    white 2.23    --on-accent #08090a  8.95
current dark   --accent-solid #1668e3    white 5.09    --on-accent #ffffff  5.09
current light  --accent-solid #1668e3    white 5.09    --on-accent #ffffff  5.09
terminal light --accent-solid #754e00    white 7.38    --on-accent #ffffff  7.38
```

`--on-accent` already resolved correctly in all four contexts, so this is a substitution, not a new token.

## The shape, recorded once at the token rather than eleven times

**An accent chosen to be visible against a dark ground is by construction a light colour.** So "white on the accent" is the one pairing guaranteed to fail as soon as the accent does its job. The convention is not wrong by accident — it is wrong in exactly the case it was written for.

Your framing of the count was the useful part: eight routes looked like eight problems. Six were this line on different screens.

## The eleventh rule was found by the test, not by the sweep

`.login-email-btn` puts its `background` and its `color` on **different lines**, so my line-based grep missed it. That is `/login`'s "Send Magic Link" — one of the six routes you named, and it would have shipped still failing while the PR claimed the cause was fixed.

Writing the assertion as "no rule whose *block* paints on `--accent-solid` may hardcode white" rather than as a grep is what caught it. The check parses declaration blocks; my sweep read lines.

## Tests

`__tests__/onAccent.test.mts`, five:

- **the rule set is not empty** — a selector that matches nothing returns a clean result; if this drops below 8 the sweep is measuring air
- **no rule hardcodes white on `--accent-solid`** — the one that found `.login-email-btn`
- **`--on-accent` clears 4.5 on `--accent-solid`** in all four contexts
- **CONTROL: white really does fail there** — terminal dark is the only context where the two differ, so without this the main assertion passes on three contexts where `--on-accent` *is* white and proves nothing
- **`var(--accent)` is not covered** — white on the current design's `#1a7aff` is 3.98, so `--on-accent` does not rescue a rule painting on *that* token. Nothing unscoped does today; this notices if one starts.

That last test initially failed on `[data-design="terminal"] .sshell-cta`, which is **correct** code — terminal's `--on-accent` on gold is 8.95. I narrowed the assertion to unscoped rules rather than "fixing" a passing rule. Flagging a correct terminal-scoped pairing would have been the symmetry mistake, same as tokenising red on #770.

## How to test (QA)

1. **Terminal dark**: `/login`, `/upgrade`, `/learn`, `/forgot-password`, and the Sign In buttons on `/journal` and `/alerts`. Button text reads near-black on gold, not white on gold.
2. **Current design**: unchanged — `--on-accent` is `#ffffff` there, so those rules resolve to what they already were.
3. **Terminal light**: also unchanged in appearance (white on `#754e00`, 7.38) — worth confirming it did not flip to black, since that would mean the token is resolving somewhere I did not expect.
4. `npm test` — the control is the one to read.

## Risk level

**Low-Medium.** Four gates via `npm run verify`: lint 0 errors, typecheck clean, 586/586, build succeeds.

**Not rendered.** These are static CSS declarations resolving a token that already existed and already resolved correctly in every context; the measurement is of the token pair, which is exactly what the test asserts. Step 1 is the confirmation.

**Eleven rules is more than the six routes you named** — the extra five are the landing and onboarding buttons carrying the identical pairing. Same defect, same fix, and leaving them would mean the next sweep re-reports it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
