### PR TITLE
fix(briefing): the SHORT direction badge takes --red-fg (#775 cause 3)

### DIFF
--- a/components/BriefingTerminal.tsx
+++ b/components/BriefingTerminal.tsx
@@ -373,7 +373,28 @@ export default function BriefingTerminal() {
         ) : (
           top3Setups.map(({ id, c, sq }, i) => {
             const isLong   = sq.dir === 'SHORT_SQ';
-            const dirColor = isLong ? 'var(--green-2)' : 'var(--red)';
+            /* --red-fg for SHORT, --green-2 for LONG, and the asymmetry is
+               the measurement rather than an oversight (#775 cause 3).
+               The badge is a signal colour on a FIXED literal wash - the two
+               rgba() values below are the current design's red and green and
+               do not move with the theme - so the ground changes only with
+               --bg1 while the text changes with the palette. Measured on that
+               ground, all four contexts:
+
+                 SHORT  --red     6.43 / 5.76 / 4.45 / 6.01   terminal dark FAILS
+                        --red-fg  6.43 / 5.76 / 6.82 / 8.02
+                 LONG   --green-2 8.87 / 6.00 / 5.80 / 4.80   passes everywhere
+                        --green-fg                     6.48
+
+               So red takes the -fg token and green does not. On #738 it was the
+               other way round - green needed it, red passed - which is the
+               point: the -fg pattern belongs to a GROUND, not to a colour, and
+               applying it by symmetry is what took .scan-badge from 4.85 to
+               4.47. Green at 4.80 is thin but passing, and changing a passing
+               colour to tidy the expression is the same mistake.
+               The washes are left alone deliberately: tokenising them would
+               move the ground these numbers were measured against. */
+            const dirColor = isLong ? 'var(--green-2)' : 'var(--red-fg)';
             const dirLabel = isLong ? t('BRIEFING_DIR_LONG') : t('BRIEFING_DIR_SHORT');
             const tags     = c ? getSignalTags(c, sq.dir as 'LONG_LIQ' | 'SHORT_SQ', t) : [];
             const isLast   = i === top3Setups.length - 1;


### PR DESCRIPTION
## Summary

#775 cause 3. You said the `--red-fg` decision was mine on evidence rather than pattern — here is the evidence, and the answer is yes for red and **no for green on the same element**.

```
                current dark  current light  terminal dark  terminal light
SHORT  --red        6.43          5.76           4.45  FAIL      6.01
       --red-fg     6.43          5.76           6.82            8.02
LONG   --green-2    8.87          6.00           5.80            4.80
       --green-fg    "             "              "              6.48
```

Your rendered 4.46 against my 4.45. Red takes the token; green does not.

## One correction: `--red-fg` already exists

> *"`--red-fg` does not exist yet"*

It does, from #684:

```
globals.css:156    --red-fg: var(--red);   :root, aliased
globals.css:5718   --red-fg: #ff8a85;      terminal dark
globals.css:5892   --red-fg: #7d0f18;      terminal light
lib/terminalTokens.ts:71, :118
```

So this is a substitution, not a new token — which also means the three passing contexts are byte-identical, because the alias makes `--red-fg` *be* `--red` outside the terminal palettes.

## The asymmetry is the finding

On #738 it was **the other way round**: green needed the `-fg` token and red passed everywhere. Here red needs it and green passes. Same pattern, opposite colours, and the reason is that the `-fg` treatment belongs to a **ground**, not to a colour.

This badge makes that unusually visible, because its ground is a **fixed literal**:

```jsx
background: isLong ? 'rgba(52,211,153,0.12)' : 'rgba(248,113,113,0.12)'
```

Those are the *current design's* red and green, hardcoded — they do not move with the theme. So the ground changes only with `--bg1` while the text changes with the whole palette, and the pairing goes out of step in exactly one context.

Green at **4.80** is thin but passing. Changing it to `--green-fg` for symmetry would be the `.scan-badge` mistake again — 4.85 to 4.47 by applying a pattern instead of a measurement.

## What I deliberately did not do

**Tokenise the washes.** They are the obvious next target and they would move the ground these numbers were measured against, invalidating both your rendered figure and mine in the same edit. If the washes should be tokens that is a separate change with its own before-and-after.

## How to test (QA)

1. `/briefing`, top setups list, **terminal dark** — the SHORT badge text against its red tint. That is the only context that changes.
2. **LONG in all four** — unchanged. If green moved, the alias assumption is wrong and that is worth catching.
3. Current design, both themes — unchanged, since `--red-fg` aliases `--red` at `:root`.

## Risk level

**Low.** Four gates via `npm run verify`: lint 0 errors, typecheck clean, 595/595, build succeeds.

**Not rendered** — `/briefing` needs live setup data. The arithmetic reproduced your staging figure to 0.01 on the one ground you measured, which is the corroboration available.

That closes cause 3. Cause 1 is merged; cause 2 is `/`'s route string and is the owner's screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
