### PR TITLE
fix(upgrade): the remaining white-on-accent pairings are inline styles, not CSS (#775)

### DIFF
--- a/__tests__/onAccent.test.mts
+++ b/__tests__/onAccent.test.mts
@@ -14,7 +14,7 @@
  */
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseCssColor, contrastRatio } from '../lib/readableOn.ts';
@@ -58,6 +58,16 @@ const CONTEXTS: Array<[string, Record<string, string>]> = [
   ['terminal light', { ...root, ...light, ...termLight }],
 ];
 
+/** A white COLOUR VALUE anywhere in a style object. No `color:` prefix: in
+ *  JSX the declaration is comma-separated and the colour can sit either side
+ *  of the background it pairs with.
+ *
+ *  The first version of this line went through a heredoc and a python -c and
+ *  arrived with a literal BACKSPACE where each \\b was meant. It matched
+ *  nothing, the JSX sweep reported clean, and only the control below caught
+ *  it - a test that could never fail, which is the exact defect this suite
+ *  keeps finding elsewhere. */
+const WHITE_VALUE = /(#fff\b|#ffffff\b|'white'|"white")/i;
 const WHITE = /color:\s*(#fff\b|#ffffff\b|white\b|rgba\(\s*255\s*,\s*255\s*,\s*255\s*,\s*1\s*\))/i;
 
 /** Declaration blocks that paint a background of var(--accent-solid). */
@@ -134,4 +144,85 @@ test('var(--accent) is NOT covered by this token, and nothing relies on it being
   assert.deepEqual(onAccentRules, [],
     `unscoped rule(s) paint var(--on-accent) on var(--accent): ${onAccentRules.join(', ')}. ` +
     'That pairing is 3.98 in the current design - measure it and give it its own token.');
+});
+
+/* ── AND THE SAME PAIRING IN JSX, WHICH THE STYLESHEET CHECK CANNOT SEE ────
+ *
+ * The assertion above reads globals.css and is TRUE. It stayed true while two
+ * inline `style={{ background: 'var(--accent-solid)', color: '#fff' }}` props
+ * on /upgrade kept failing at 2.23:1 - QA caught them on the post-deploy
+ * sweep, after the fix, after the approval, with the suite green.
+ *
+ * That is a coverage boundary rather than a broken test, and it is the
+ * sharpest instance of the day's pattern: THE TEST PASSING IS WHAT MADE THE
+ * GAP INVISIBLE. Eleven rules were converted, the assertion covered exactly
+ * those eleven, and nobody looked at the twelfth because the check that would
+ * have looked was already green.
+ *
+ * So the boundary moves to where the pattern can occur, not to where it
+ * happened to be found. */
+const SRC_DIRS = ['app', 'components'];
+
+/** Every .tsx under app/ and components/. */
+function tsxFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap(name => {
+    const full = path.join(dir, name);
+    if (name === 'node_modules' || name === '.next') return [];
+    return statSync(full).isDirectory()
+      ? tsxFiles(full)
+      : name.endsWith('.tsx') ? [full] : [];
+  });
+}
+
+/* THE ONE EXEMPTION, BY NAME. app/global-error.tsx renders when the root
+   layout has already failed, so no stylesheet is guaranteed. There
+   var(--accent-solid) may resolve to nothing and the button falls back to
+   transparent on that file's own #0d0d0d body - where white is the readable
+   answer and var(--on-accent) would resolve to nothing at all. The fallback
+   behaviour is the point, which is why eslint.config.mjs allow-lists the same
+   file. Listed rather than filtered by a rule, so removing the exemption is a
+   deliberate edit. */
+const JSX_EXEMPT = new Set(['app/global-error.tsx']);
+
+test('no JSX inline style pairs white with --accent-solid', () => {
+  const offenders: string[] = [];
+  for (const dir of SRC_DIRS) {
+    for (const file of tsxFiles(path.join(ROOT, dir))) {
+      const rel = path.relative(ROOT, file).split(path.sep).join('/');
+      if (JSX_EXEMPT.has(rel)) continue;
+      const src = readFileSync(file, 'utf8');
+      /* Brace-depth capture, not a regex over the whole file: a style object
+         can contain a ternary, a template literal or a nested object, and
+         `[^}]*` stops at the first one. Same lesson as #681. */
+      for (const m of src.matchAll(/style=\{\{/g)) {
+        const open = src.indexOf('{', m.index! + 6);
+        let depth = 0, end = open;
+        for (let i = open; i < src.length && i < open + 4000; i++) {
+          if (src[i] === '{') depth++;
+          else if (src[i] === '}') { depth--; if (depth === 0) { end = i; break; } }
+        }
+        const obj = src.slice(open, end + 1);
+        if (/var\(--accent-solid\)/.test(obj) && WHITE_VALUE.test(obj)) {
+          offenders.push(`${rel} (offset ${m.index})`);
+        }
+      }
+    }
+  }
+  assert.deepEqual(offenders, [],
+    `${offenders.length} inline style(s) pair white with --accent-solid: ${offenders.join(', ')}. ` +
+    "Use 'var(--on-accent)' - white is 2.23:1 on terminal dark's #d9a626. " +
+    'If this is genuinely a no-stylesheet context, add the file to JSX_EXEMPT with the reason.');
+});
+
+test('CONTROL: the JSX scan can actually see the shape it looks for', () => {
+  /* The stylesheet assertion was true and useless for two lines of JSX. This
+     control exists so the JSX one cannot become the same thing: it feeds the
+     scanner the exact source that shipped the defect and requires a hit. */
+  const shipped = `<div style={{ position: 'absolute', top: -11, fontSize: 'var(--fs-micro)', fontWeight: 700, color: '#fff', background: 'var(--accent-solid)', padding: '3px 12px' }}>`;
+  assert.ok(/var\(--accent-solid\)/.test(shipped) && WHITE_VALUE.test(shipped),
+    'the scan predicate no longer matches the /upgrade "Recommended" badge as it was written');
+
+  /* And that a nested brace does not truncate the object before the colour. */
+  const nested = `<div style={{ transform: \`translate(\${x}px)\`, background: 'var(--accent-solid)', color: '#fff' }}>`;
+  assert.ok(WHITE_VALUE.test(nested), 'a template literal in the object breaks the predicate');
 });

--- a/__tests__/onAccent.test.mts
+++ b/__tests__/onAccent.test.mts
@@ -214,7 +214,13 @@ const ACCENT_TOKENS = /var\(--accent(-solid)?\)/;
  *  Funnier and worse: a scanner that reads comments can be silenced by
  *  deleting one. The code is the subject; the prose about it is not. */
 function stripComments(src: string): string {
-  return src.replace(/\/\*[\s\S]*?\*\//g, m => ' '.repeat(m.length));
+  /* Newlines survive. `' '.repeat(m.length)` preserves the character count but
+     flattens a multi-line comment onto one line, so any offset-to-line mapping
+     computed afterwards is silently wrong - I hit that comparing this scan's
+     output against QA's and got line numbers 100+ short. Offsets are unaffected
+     either way; line numbers are not, and the next person to make this report
+     lines rather than offsets should not have to rediscover it. */
+  return src.replace(/\/\*[\s\S]*?\*\//g, m => m.replace(/[^\n]/g, ' '));
 }
 
 /** A style object literal, captured by brace depth from a starting index. */

--- a/__tests__/onAccent.test.mts
+++ b/__tests__/onAccent.test.mts
@@ -184,33 +184,94 @@ function tsxFiles(dir: string): string[] {
    deliberate edit. */
 const JSX_EXEMPT = new Set(['app/global-error.tsx']);
 
-test('no JSX inline style pairs white with --accent-solid', () => {
+/* WHICH ACCENT TOKENS ARE IN SCOPE, AND WHY --accent IS ONE OF THEM.
+ *
+ * The first version of this scan looked only for `--accent-solid`, on the
+ * reasoning that `--accent` is a different colour and white passes on it. True
+ * in the CURRENT design - #1a7aff against #1668e3 - and false in terminal,
+ * where globals.css:5676 and :5875 alias `--accent-solid: var(--accent)`. So
+ * white on `var(--accent)` in terminal dark is white on #d9a626: 2.23:1, the
+ * identical defect, and the scan was scoped to walk past it.
+ *
+ * That is the one-ground family again, in a TEST's scope rather than in a
+ * stylesheet: a boundary measured in one design and applied in all four. #768
+ * turned the aliased design into the default, so the edge case became the
+ * normal path.
+ *
+ * The exclusion assertion below is kept - it is still true that --on-accent
+ * does not rescue --accent in the current design, which is exactly why a
+ * filled control belongs on --accent-solid. */
+const ACCENT_TOKENS = /var\(--accent(-solid)?\)/;
+
+/** Block comments blanked, length preserved so offsets still point at the
+ *  source a reader will open.
+ *
+ *  WITHOUT THIS THE SCAN READS ITS OWN EXPLANATIONS. The comments written for
+ *  #775 quote the value they replaced - "var(--on-accent), not '#fff'" beside
+ *  a `background: 'var(--accent-solid)'` - so the first widened run reported
+ *  three offenders that were the FIXES, not defects.
+ *
+ *  Funnier and worse: a scanner that reads comments can be silenced by
+ *  deleting one. The code is the subject; the prose about it is not. */
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, m => ' '.repeat(m.length));
+}
+
+/** A style object literal, captured by brace depth from a starting index. */
+function objectAt(src: string, from: number): string {
+  const open = src.indexOf('{', from);
+  if (open < 0) return '';
+  let depth = 0;
+  for (let i = open; i < src.length && i < open + 4000; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') { depth--; if (depth === 0) return src.slice(open, i + 1); }
+  }
+  return '';
+}
+
+test('no JSX style object pairs white with an accent token', () => {
+  /* TWO ENTRY POINTS, because QA found the second by reading the file after
+     this test passed on the first:
+
+       style={{ … }}                       a prop
+       const x: React.CSSProperties = { … } a named constant, spread later
+
+     The brace-depth capture is shared. A regex like `[^}]*` stops at the first
+     nested brace, so a ternary, template literal or nested object truncates the
+     object before the colour - the #681 lesson.
+
+     Widening from "where the defect was found" to "where the shape can occur"
+     is the whole point: three separate instruments have now missed an instance
+     each by being scoped to the last place one was seen. */
   const offenders: string[] = [];
   for (const dir of SRC_DIRS) {
     for (const file of tsxFiles(path.join(ROOT, dir))) {
       const rel = path.relative(ROOT, file).split(path.sep).join('/');
       if (JSX_EXEMPT.has(rel)) continue;
-      const src = readFileSync(file, 'utf8');
-      /* Brace-depth capture, not a regex over the whole file: a style object
-         can contain a ternary, a template literal or a nested object, and
-         `[^}]*` stops at the first one. Same lesson as #681. */
-      for (const m of src.matchAll(/style=\{\{/g)) {
-        const open = src.indexOf('{', m.index! + 6);
-        let depth = 0, end = open;
-        for (let i = open; i < src.length && i < open + 4000; i++) {
-          if (src[i] === '{') depth++;
-          else if (src[i] === '}') { depth--; if (depth === 0) { end = i; break; } }
-        }
-        const obj = src.slice(open, end + 1);
-        if (/var\(--accent-solid\)/.test(obj) && WHITE_VALUE.test(obj)) {
-          offenders.push(`${rel} (offset ${m.index})`);
+      const src = stripComments(readFileSync(file, 'utf8'));
+
+      const starts: number[] = [];
+      for (const m of src.matchAll(/style=\{\{/g)) starts.push(m.index! + 6);
+      for (const m of src.matchAll(/:\s*React\.CSSProperties\s*=\s*\{/g)) starts.push(m.index!);
+      /* Any object literal that sets a background at all. Catches the shapes
+         above and anything else assigned to a variable, at the cost of some
+         non-style objects - which cannot contain both an accent var and a
+         white literal, so they cost nothing. */
+      for (const m of src.matchAll(/\{[^{}]{0,80}background(Color)?:/g)) starts.push(m.index!);
+
+      for (const start of [...new Set(starts)]) {
+        const obj = objectAt(src, start);
+        if (ACCENT_TOKENS.test(obj) && WHITE_VALUE.test(obj)) {
+          offenders.push(`${rel} (offset ${start})`);
         }
       }
     }
   }
-  assert.deepEqual(offenders, [],
-    `${offenders.length} inline style(s) pair white with --accent-solid: ${offenders.join(', ')}. ` +
-    "Use 'var(--on-accent)' - white is 2.23:1 on terminal dark's #d9a626. " +
+  assert.deepEqual([...new Set(offenders)], [],
+    `${offenders.length} style object(s) pair white with an accent token: ${[...new Set(offenders)].join(', ')}. ` +
+    "On --accent-solid use 'var(--on-accent)'. On --accent, --on-accent is NOT enough - " +
+    'it is white in the current design and 3.98 there - so move a FILLED control to ' +
+    "'var(--accent-solid)' as well. " +
     'If this is genuinely a no-stylesheet context, add the file to JSX_EXEMPT with the reason.');
 });
 

--- a/app/alerts/page.tsx
+++ b/app/alerts/page.tsx
@@ -520,7 +520,12 @@ export default function AlertsPage() {
   const numStyle: React.CSSProperties = {
     width: 24, height: 24, borderRadius: '50%', background: 'var(--accent-solid)',
     display: 'flex', alignItems: 'center', justifyContent: 'center',
-    fontSize: 'var(--fs-caption)', fontWeight: 700, color: '#fff', flexShrink: 0, marginTop: 1,
+    /* var(--on-accent), not '#fff' (#775). White on terminal dark's
+       --accent-solid (#d9a626) is 2.23:1. Found by QA reading the file, not by
+       the JSX scan: this is a named React.CSSProperties constant rather than a
+       `style={{ }}` prop, so the scan walked past it. The scan is widened in
+       this same change. */
+    fontSize: 'var(--fs-caption)', fontWeight: 700, color: 'var(--on-accent)', flexShrink: 0, marginTop: 1,
   };
 
   return (

--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -1770,7 +1770,7 @@ function ArenaContent() {
                 onClick={saveArenaAlert}
                 disabled={alertSaving || !alertPrice}
                 style={{
-                  width: '100%', fontSize: 'var(--fs-body)', fontWeight: 700, color: '#fff',
+                  width: '100%', fontSize: 'var(--fs-body)', fontWeight: 700, color: 'var(--on-accent)',
                   background: 'var(--accent-solid)', border: 'none', borderRadius: 10, padding: '12px 18px',
                   cursor: alertSaving || !alertPrice ? 'default' : 'pointer',
                   opacity: alertSaving || !alertPrice ? 0.5 : 1, transition: 'opacity .15s',

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -20,6 +20,17 @@ export default function GlobalError({
         <div style={{ textAlign: 'center', padding: '2rem' }}>
           <h2 style={{ fontSize: 'var(--fs-section)', marginBottom: '0.5rem' }}>Something went wrong</h2>
           <p style={{ color: '#9ca3af', marginBottom: '1.5rem' }}>An unexpected error occurred.</p>
+          {/* #fff STAYS HERE, and it is the one exemption from #775.
+              This screen renders when the root layout has already failed, so
+              no stylesheet is guaranteed. If the tokens are missing,
+              `var(--accent-solid)` resolves to nothing and the button falls
+              back to transparent - on this file's own #0d0d0d body, where
+              white text is the readable answer and var(--on-accent) would
+              resolve to nothing at all, leaving the inherited colour.
+              Everywhere else the token is strictly better; here the fallback
+              behaviour is the whole point, which is also why eslint.config.mjs
+              already allow-lists this file. Exempted by name in
+              __tests__/onAccent.test.mts rather than silently skipped. */}
           <button
             onClick={reset}
             style={{ padding: '0.5rem 1.5rem', background: 'var(--accent-solid)', color: '#fff', border: 'none', borderRadius: '0.5rem', cursor: 'pointer', fontSize: 'var(--fs-card-title)' }}

--- a/app/markets/page.tsx
+++ b/app/markets/page.tsx
@@ -357,8 +357,14 @@ export default function MarketsPage() {
                   style={{
                     width: 26, height: 26, fontSize: 'var(--fs-caption)', fontWeight: 700, borderRadius: 6,
                     border: `0.5px solid ${i === pageSafe ? 'var(--accent-bdr)' : 'var(--bdr)'}`,
-                    background: i === pageSafe ? 'var(--accent)' : 'transparent',
-                    color: i === pageSafe ? '#fff' : 'var(--txt3)',
+                    /* --accent-solid and --on-accent, not --accent and '#fff' (#775).
+                         A filled control belongs on --accent-solid, and the
+                         pairing matters: --on-accent alone does not rescue
+                         --accent, because it IS white in the current design
+                         where --accent measures 3.98. Same change as
+                         TradeJournal's history pagination. */
+                      background: i === pageSafe ? 'var(--accent-solid)' : 'transparent',
+                    color: i === pageSafe ? 'var(--on-accent)' : 'var(--txt3)',
                     cursor: 'pointer',
                   }}
                 >

--- a/app/upgrade/page.tsx
+++ b/app/upgrade/page.tsx
@@ -175,7 +175,7 @@ export default function UpgradePage() {
 
           {/* Pro card */}
           <div style={{ borderRadius: 16, padding: '24px 28px', border: '0.5px solid var(--accent-bdr)', background: 'linear-gradient(160deg, var(--accent-bg) 0%, var(--bg1) 60%)', position: 'relative' }}>
-            <div style={{ position: 'absolute', top: -11, left: '50%', transform: 'translateX(-50%)', fontSize: 'var(--fs-micro)', fontWeight: 700, letterSpacing: '.08em', textTransform: 'uppercase', background: 'var(--accent-solid)', color: '#fff', padding: '3px 14px', borderRadius: 20, whiteSpace: 'nowrap' }}>
+            <div style={{ position: 'absolute', top: -11, left: '50%', transform: 'translateX(-50%)', fontSize: 'var(--fs-micro)', fontWeight: 700, letterSpacing: '.08em', textTransform: 'uppercase', background: 'var(--accent-solid)', color: 'var(--on-accent)', padding: '3px 14px', borderRadius: 20, whiteSpace: 'nowrap' }}>
               {t('UPGRADE_PRO_CARD_BADGE')}
             </div>
             <div style={{ fontSize: 'var(--fs-micro)', fontWeight: 700, letterSpacing: '.08em', textTransform: 'uppercase', color: 'var(--accent)', marginBottom: 6 }}>{t('UPGRADE_PRO_CARD_EYEBROW')}</div>
@@ -235,7 +235,7 @@ export default function UpgradePage() {
                 data-testid="checkout-cta-monthly"
                 onClick={handleCheckout}
                 disabled={redirecting}
-                style={{ fontSize: 'var(--fs-data)', fontWeight: 700, color: '#fff', background: 'var(--accent-solid)', padding: '14px 40px', borderRadius: 12, border: 'none', cursor: redirecting ? 'default' : 'pointer', opacity: redirecting ? 0.7 : 1, transition: 'opacity .15s, transform .15s', transform: 'translateY(0)' }}
+                style={{ fontSize: 'var(--fs-data)', fontWeight: 700, color: 'var(--on-accent)', background: 'var(--accent-solid)', padding: '14px 40px', borderRadius: 12, border: 'none', cursor: redirecting ? 'default' : 'pointer', opacity: redirecting ? 0.7 : 1, transition: 'opacity .15s, transform .15s', transform: 'translateY(0)' }}
                 onMouseEnter={e => { if (!redirecting) (e.currentTarget as HTMLButtonElement).style.transform = 'translateY(-1px)'; }}
                 onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.transform = 'translateY(0)'; }}
               >

--- a/components/MarketsTerminal.tsx
+++ b/components/MarketsTerminal.tsx
@@ -341,8 +341,14 @@ export default function MarketsTerminal() {
                   style={{
                     width: 26, height: 26, fontSize: 'var(--fs-caption)', fontWeight: 700, borderRadius: 0,
                     border: `0.5px solid ${i === pageSafe ? 'var(--accent-bdr)' : 'var(--bdr)'}`,
-                    background: i === pageSafe ? 'var(--accent)' : 'transparent',
-                    color: i === pageSafe ? '#fff' : 'var(--txt3)',
+                    /* --accent-solid and --on-accent, not --accent and '#fff' (#775).
+                         A filled control belongs on --accent-solid, and the
+                         pairing matters: --on-accent alone does not rescue
+                         --accent, because it IS white in the current design
+                         where --accent measures 3.98. Same change as
+                         TradeJournal's history pagination. */
+                      background: i === pageSafe ? 'var(--accent-solid)' : 'transparent',
+                    color: i === pageSafe ? 'var(--on-accent)' : 'var(--txt3)',
                     cursor: 'pointer',
                   }}
                 >

--- a/components/PWAInstallPrompt.tsx
+++ b/components/PWAInstallPrompt.tsx
@@ -97,7 +97,7 @@ export default function PWAInstallPrompt() {
             padding: '5px 11px',
             fontSize: 'var(--fs-caption)',
             fontWeight: 700,
-            color: '#fff',
+            color: 'var(--on-accent)',
             cursor: 'pointer',
             whiteSpace: 'nowrap',
           }}

--- a/components/TradeJournal.tsx
+++ b/components/TradeJournal.tsx
@@ -1273,8 +1273,23 @@ function Inner() {
                     style={{
                       width: 26, height: 26, fontSize: 'var(--fs-caption)', fontWeight: 700, borderRadius: 6,
                       border: `0.5px solid ${i === historyPageSafe ? 'var(--accent-bdr)' : 'var(--bdr)'}`,
-                      background: i === historyPageSafe ? 'var(--accent)' : 'transparent',
-                      color: i === historyPageSafe ? '#fff' : 'var(--txt3)',
+                      /* --accent-solid, not --accent, and --on-accent, not
+                         '#fff' (#775). This is a FILLED control, which is what
+                         --accent-solid exists for. The pairing matters because
+                         --on-accent alone does not rescue --accent here:
+
+                           on --accent        3.98 / 6.82 / 8.95 / 7.38
+                           on --accent-solid  5.09 / 5.09 / 8.95 / 7.38
+
+                         Current dark stays below the bar on --accent whatever
+                         the foreground, because #1a7aff is simply too light for
+                         white and --on-accent IS white in that context. Moving
+                         the background is what fixes it, and it also moves this
+                         button onto the token every other filled control uses.
+                         White here was 2.23 in terminal dark, where
+                         --accent-solid is aliased to --accent. */
+                      background: i === historyPageSafe ? 'var(--accent-solid)' : 'transparent',
+                      color: i === historyPageSafe ? 'var(--on-accent)' : 'var(--txt3)',
                       cursor: 'pointer',
                     }}
                   >

--- a/components/TradeJournal.tsx
+++ b/components/TradeJournal.tsx
@@ -820,7 +820,7 @@ function Inner() {
           {t('TRADE_JOURNAL_TAB_RULES')}{rules.filter(r => r.enabled).length > 0 && (
             <span style={{
               marginLeft: 5, fontSize: 'var(--fs-caption)', fontWeight: 700,
-              background: 'var(--accent-solid)', color: '#fff',
+              background: 'var(--accent-solid)', color: 'var(--on-accent)',
               borderRadius: 10, padding: '1px 5px',
             }}>{rules.filter(r => r.enabled).length}</span>
           )}
@@ -829,7 +829,7 @@ function Inner() {
         <button data-testid="journal-tab" className={`tj-tab${tab === 'bias' ? ' on' : ''}`} onClick={() => setTab('bias')}>{t('TRADE_JOURNAL_TAB_BIAS')}</button>
         <button data-testid="journal-tab" className={`tj-tab${tab === 'thesis' ? ' on' : ''}`} onClick={() => setTab('thesis')} style={{ position: 'relative' }}>
           {t('TRADE_JOURNAL_TAB_THESIS')}{theses.length > 0 && (
-            <span style={{ marginLeft: 5, fontSize: 'var(--fs-caption)', fontWeight: 700, background: 'var(--accent-solid)', color: '#fff', borderRadius: 10, padding: '1px 5px' }}>{theses.length}</span>
+            <span style={{ marginLeft: 5, fontSize: 'var(--fs-caption)', fontWeight: 700, background: 'var(--accent-solid)', color: 'var(--on-accent)', borderRadius: 10, padding: '1px 5px' }}>{theses.length}</span>
           )}
         </button>
       </div>


### PR DESCRIPTION
## Summary

**Your list of eleven, and this now covers all of it.** Ten converted, one exempt by name, and the scan widened twice so the boundary sits where the shape can occur rather than where it was last found.

```
--accent-solid
  app/upgrade/page.tsx:178, :238         converted   <- your original two, 2.23:1
  app/arena/page.tsx                     converted
  components/PWAInstallPrompt.tsx        converted
  components/TradeJournal.tsx x2         converted
  app/alerts/page.tsx:520                converted   <- named React.CSSProperties
  app/global-error.tsx:12, :25           EXEMPT, by name
--accent
  app/markets/page.tsx                   converted   <- also moved to --accent-solid
  components/MarketsTerminal.tsx         converted   <- ditto
  components/TradeJournal.tsx:1273       converted   <- ditto
```

Our two scans agree on all eleven, written independently.

## The `--accent` three needed the background moved, not just the foreground

`--on-accent` alone does not rescue `--accent`:

```
on --accent        3.98 / 6.82 / 8.95 / 7.38    current dark still fails
on --accent-solid  5.09 / 5.09 / 8.95 / 7.38
```

`--on-accent` **is white** in the current design, so no foreground change fixes `#1a7aff` there. All three are filled controls, which is what `--accent-solid` exists for, so they take both tokens.

## The scan, widened twice and then corrected once

**Past `style={{ }}`** — to any object literal that sets a `background`, which is what catches `app/alerts/page.tsx:520`'s `React.CSSProperties` constant.

**Past `--accent-solid`** — to `--accent` too. The exclusion was reasoned from the current design, where the two tokens are different colours and white passes on `#1a7aff`. `globals.css:5676` and `:5875` alias `--accent-solid: var(--accent)` in both terminal palettes, so in terminal dark they are the same colour and the exclusion walked past three real instances. **That is the one-ground family inside a test's scope** — a boundary measured in one design, applied in all four — and #768 made the aliased design the default.

The `var(--accent) is NOT covered by this token` assertion stays. It is still true, and it is now the thing that explains why a filled control has to move its background rather than only its text.

**Then the correction.** The first widened run reported three offenders that were the **fixes**: the comments written for this issue quote the value they replaced — `var(--on-accent), not '#fff'` sitting beside `background: 'var(--accent-solid)'`. The scan was reading its own explanations.

Worse than noisy: **a scanner that reads comments can be silenced by deleting one.** It now blanks block comments before reading, preserving length so offsets still point at real source.

## Reachability — your framing, kept

You measured `.mkt-page-btn` at **zero elements** on staging and correctly refused to call that zero failures. Trap 3, in the tool that documents trap 3.

So of the ten converted, six are on surfaces you measured failing and four are source-level: pagination that needs more rows than the data currently produces, and step numbers below a signed-out gate. **Neither of us is claiming those four render today.** The claim is that the pairing is in the tree and that no test could fail on it — which outlives whether it renders this week.

## How to test (QA)

1. **`/upgrade`, terminal dark** — "Recommended" and "Get Pro". The re-sweep you are waiting on.
2. `/arena` save-alert button, `/journal` tab badges, PWA install prompt — same substitution.
3. The four unreachable ones are source-level; `npm test` is the check that they stay fixed.
4. **Current design unchanged** on the seven `--accent-solid` conversions. The three `--accent` ones **do** change there — `#1a7aff` to `#1668e3` background — which is the visible part of this PR and worth an eye.

## Risk level

**Medium**, up from Low: the three pagination buttons change colour in the current design, not only in terminal.

Four gates via `npm run verify`: lint 0 errors (232 warnings, down 10), typecheck clean, 597/597, build succeeds.

**Not rendered** — six of ten are on surfaces you measured; four cannot be rendered by either of us today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
