### PR TITLE
fix(scanner): the accumulation score ramp's middle band takes a token (#787)

### DIFF
--- a/__tests__/scoreMidBand.test.mts
+++ b/__tests__/scoreMidBand.test.mts
@@ -1,0 +1,159 @@
+/* The accumulation score ramp's three bands are all readable, in all four
+ * contexts (#787).
+ *
+ * WHAT HAPPENED. `scoreCol` read:
+ *
+ *     s >= 75 ? 'var(--green)' : s >= 60 ? '#a3e635' : 'var(--amber)'
+ *
+ * Two tokens and a literal, in one ternary, reading as one ramp. The tokens
+ * followed the theme and the literal did not: 1.15:1 on this card in terminal
+ * light, the worst text contrast measured on this project, against 12.98 in
+ * the dark it was chosen for. No error, no failing test, and invisible to a
+ * token sweep because a token sweep looks at tokens.
+ *
+ * It also only fails for scores 60-74. A board showing 80s and 50s renders
+ * correctly, so whether the defect is on screen depends on live market data.
+ * That is precisely the case a test can hold and a rendered check cannot.
+ *
+ * THE GROUND. AccumulationTracker's card is
+ * `linear-gradient(180deg, var(--bg2) 0%, var(--bg1) 100%)`, so a row can sit
+ * anywhere between the two stops. Both are checked and the worse one has to
+ * pass; QA measured against --bg0 (the page behind the card) and got 1.40
+ * where the card's own stops give 1.15, which is the same defect read against
+ * a neighbouring surface.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseCssColor, contrastRatio } from '../lib/readableOn.ts';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CSS = readFileSync(path.join(ROOT, 'app', 'globals.css'), 'utf8');
+const SRC = readFileSync(path.join(ROOT, 'components', 'AccumulationTracker.tsx'), 'utf8');
+
+function tokens(selector: string): Record<string, string> {
+  const lines = CSS.split('\n');
+  const idx = lines.findIndex(l => l.trim() === selector + ' {');
+  assert.ok(idx >= 0, `token block not found: ${selector}`);
+  const from = lines.slice(0, idx).join('\n').length;
+  let i = CSS.indexOf('{', from), depth = 0, end = i;
+  for (; i < CSS.length; i++) {
+    if (CSS[i] === '{') depth++;
+    else if (CSS[i] === '}') { depth--; if (depth === 0) { end = i; break; } }
+  }
+  const body = CSS.slice(CSS.indexOf('{', from) + 1, end);
+  const out: Record<string, string> = {};
+  for (const m of body.matchAll(/(--[a-z0-9-]+)\s*:\s*([^;\n]+)/g)) {
+    out[m[1]] = m[2].split('/*')[0].trim().replace(/;$/, '');
+  }
+  return out;
+}
+function resolve(map: Record<string, string>, value: string, depth = 0): string | null {
+  if (depth > 10) return null;
+  const m = /^var\((--[a-z0-9-]+)(?:\s*,\s*([^)]+))?\)$/.exec(value.trim());
+  if (!m) return value.trim();
+  const next = map[m[1]] ?? m[2];
+  return next === undefined ? null : resolve(map, next, depth + 1);
+}
+
+const root = tokens(':root');
+const light = tokens('[data-theme="light"]');
+const termDark = tokens('[data-design="terminal"]:not([data-theme="light"])');
+const termLight = tokens('[data-design="terminal"][data-theme="light"]');
+const CONTEXTS: Array<[string, Record<string, string>]> = [
+  ['current dark', { ...root }],
+  ['current light', { ...root, ...light }],
+  ['terminal dark', { ...root, ...termDark }],
+  ['terminal light', { ...root, ...light, ...termLight }],
+];
+
+/* The card's gradient stops. NOT --bg0: that is the page behind the card, and
+   it is also undefined in [data-theme="light"] (#783), so including it reports
+   a near-black ground the widget never renders on. */
+const GROUNDS = ['--bg1', '--bg2'];
+const BANDS = ['var(--green)', 'var(--score-mid)', 'var(--amber)'];
+
+test('every score band clears 4.5:1 on both gradient stops, all four contexts', () => {
+  const failures: string[] = [];
+  for (const [name, map] of CONTEXTS) {
+    for (const band of BANDS) {
+      const fg = parseCssColor(resolve(map, band) ?? '');
+      assert.ok(fg, `${band} does not resolve in ${name}`);
+      for (const g of GROUNDS) {
+        const bg = parseCssColor(resolve(map, `var(${g})`) ?? '');
+        assert.ok(bg, `${g} does not resolve in ${name}`);
+        const c = contrastRatio(fg!.rgb, bg!.rgb);
+        if (c < 4.5) failures.push(`${name} ${band} on ${g} -> ${c.toFixed(2)}`);
+      }
+    }
+  }
+  assert.deepEqual(failures, [],
+    `${failures.length} band/ground pair(s) below 4.5:\n  ${failures.join('\n  ')}`);
+});
+
+/** Hue angle in degrees. */
+function hue([r, g, b]: [number, number, number]): number {
+  const R = r / 255, G = g / 255, B = b / 255;
+  const max = Math.max(R, G, B), min = Math.min(R, G, B), d = max - min;
+  if (d === 0) return 0;
+  const h = max === R ? ((G - B) / d) % 6 : max === G ? (B - R) / d + 2 : (R - G) / d + 4;
+  return (h * 60 + 360) % 360;
+}
+
+test('the three bands stay visually distinct in every context', () => {
+  /* MEASURED BY HUE, NOT BY CONTRAST, and the first version of this test got
+     that wrong in the way this whole session has been about.
+     I wrote it with contrastRatio and it failed on every context - including
+     `green vs amber -> 1.04` in the CURRENT design, which has shipped for
+     months and is obviously two different colours. Contrast ratio measures
+     LUMINANCE. These bands are deliberately similar in brightness and
+     different in hue, so a contrast floor answers a question nobody asked and
+     answers it wrongly. A check that fails on the untouched baseline is
+     measuring the wrong property, not finding a defect.
+     Hue separation is what "distinct band" means here. 25 degrees is a floor
+     chosen so the three read apart in a screenshot, not a standards figure. */
+  const failures: string[] = [];
+  for (const [name, map] of CONTEXTS) {
+    const rgb = BANDS.map(b => parseCssColor(resolve(map, b) ?? '')!.rgb as [number, number, number]);
+    const pairs: Array<[string, number, number]> = [
+      ['green vs mid', 0, 1], ['mid vs amber', 1, 2], ['green vs amber', 0, 2],
+    ];
+    for (const [label, a, b] of pairs) {
+      const raw = Math.abs(hue(rgb[a]) - hue(rgb[b]));
+      const sep = Math.min(raw, 360 - raw);
+      if (sep < 25) failures.push(`${name} ${label} -> ${sep.toFixed(0)} degrees apart`);
+    }
+  }
+  assert.deepEqual(failures, [],
+    `bands too close in hue to tell apart:\n  ${failures.join('\n  ')}\n` +
+    'The ramp carries information by colour; three bands that read alike stop ' +
+    'carrying it. #774 nearly shipped the opposite mistake - fixing contrast by ' +
+    'flattening an encoding.');
+});
+
+test('CONTROL: the literal this replaced really did fail', () => {
+  /* Without this the sweep passes and proves only that it ran. #a3e635 is the
+     value that shipped; it must still fail both light contexts, or --score-mid
+     is not load-bearing and this file should be revisited rather than kept. */
+  const failed: string[] = [];
+  for (const [name, map] of CONTEXTS) {
+    for (const g of GROUNDS) {
+      const bg = parseCssColor(resolve(map, `var(${g})`) ?? '')!;
+      if (contrastRatio([163, 230, 53], bg.rgb) < 4.5) failed.push(`${name}/${g}`);
+    }
+  }
+  assert.ok(failed.length >= 4,
+    `expected #a3e635 to fail both grounds in both light contexts; it failed ${failed.length} (${failed.join(', ')})`);
+});
+
+test('the component takes the token, and no literal is left in the ramp', () => {
+  const ramp = /const scoreCol[\s\S]{0,240}?;/.exec(SRC);
+  assert.ok(ramp, 'scoreCol not found in AccumulationTracker.tsx - renamed?');
+  assert.match(ramp![0], /var\(--score-mid\)/, 'the middle band no longer takes --score-mid');
+  assert.doesNotMatch(ramp![0], /#[0-9a-fA-F]{3,8}\b/,
+    'a hex literal is back in the score ramp. Two tokens and a literal in one ' +
+    'ternary is exactly how #787 happened - the literal does not follow the theme ' +
+    'and nothing fails.');
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -88,6 +88,21 @@
      __tests__/marketStructureStamp.test.mts rather than asserted here. */
   --txt-stamp: #9aa0a6;
 
+  /* --score-mid: the middle band of the accumulation score ramp (#787).
+     AccumulationTracker prints 75+ in --green, under 60 in --amber, and 60-74
+     in this. The middle branch was the literal #a3e635 while its two
+     neighbours were tokens, so it alone did not follow the theme: 1.15:1
+     against terminal light's card, the worst text contrast measured on this
+     project. Correct where it was chosen - 12.98 in dark - and wrong
+     everywhere else, with no error and no failing test, which is the
+     one-ground family in its purest form.
+     Dark keeps #a3e635 (12.98 current / 12.12 terminal). The light value below
+     clears 6.37 / 5.42 and stays a distinct olive against --green's teal and
+     --amber's brown, because three bands that read alike stop carrying the
+     information the ramp exists for. Verified against both gradient stops in
+     all four contexts in __tests__/scoreMidBand.test.mts. */
+  --score-mid: #a3e635;
+
   /* Borders - neutral white hairline, no indigo tint */
   --bdr:  rgba(255,255,255,0.08);
   --bdr2: rgba(255,255,255,0.14);
@@ -2585,6 +2600,11 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   /* See --txt-stamp in :root. #4f5257 is the value terminal light already uses
      for --txt-dash, reached independently for this ground. */
   --txt-stamp: #4f5257;
+
+  /* See --score-mid in :root. Lime-800: the ramp has to darken in light the
+     way --green and --amber already do, and #4d7c0f - the obvious one step
+     lighter - measures 3.82 in terminal light. */
+  --score-mid: #3f6212;
   --bdr:  rgba(0,0,0,0.08);
   --bdr2: rgba(0,0,0,0.14);
 

--- a/components/AccumulationTracker.tsx
+++ b/components/AccumulationTracker.tsx
@@ -115,7 +115,12 @@ export default function AccumulationTracker() {
       .slice(0, MAX_ROWS);
   }, [store.coins]);
 
-  const scoreCol = (s: number) => s >= 75 ? 'var(--green)' : s >= 60 ? '#a3e635' : 'var(--amber)';
+  /* All three bands are tokens now (#787). The middle one was the literal
+     #a3e635 between two tokens, so it alone did not follow the theme - 1.15:1
+     on this card in terminal light, against 12.98 in the dark it was picked
+     for. A ternary of three colours reads as one ramp; two of them adapted and
+     one did not, and nothing failed. */
+  const scoreCol = (s: number) => s >= 75 ? 'var(--green)' : s >= 60 ? 'var(--score-mid)' : 'var(--amber)';
 
   return (
     <div style={{


### PR DESCRIPTION
## Summary

#787. A `--score-mid` token, `#a3e635` dark and `#3f6212` light, replacing the literal in the middle branch of the score ramp.

```
s >= 75    var(--green)    followed the theme
60-74      '#a3e635'       did not                <- 1.15 on the card, 12.98 in dark
s < 60     var(--amber)    followed the theme
```

Two tokens and a literal in one ternary, reading as one ramp. The tokens adapted; the literal was picked once, for dark.

## One correction to the issue's ground

You measured **1.40** against `--bg0`, the page behind the card. The widget's own background is `linear-gradient(180deg, var(--bg2) 0%, var(--bg1) 100%)`, so a row sits between those two stops — where the same text measures **1.15**. Worse, not better, and the same defect read against a neighbouring surface.

`--bg0` is also undefined in `[data-theme="light"]` (#783), so including it in a sweep reports a near-black ground that widget never renders on. The test uses the gradient stops.

```
                 --green   --score-mid   --amber
current dark      6.06        12.98        9.83
current light     6.44         6.37        5.55
terminal dark     5.49        12.12        9.03
terminal light    4.94         5.42        4.78
```

## Why `#3f6212` and not the obvious step

`#4d7c0f` — lime-700, one step lighter — measures **3.82** in terminal light. `#65a30d` is 2.37. The ramp has to darken in light the way `--green` and `--amber` already do, and lime-800 is the first step that clears both light grounds.

## The distinctness check, and the instrument I got wrong first

Your constraint — *do not reuse `--green`, the three bands need to stay distinct* — is now a test. **My first version measured it with `contrastRatio` and it failed everywhere**, including `green vs amber -> 1.04` in the current design, which has shipped for months and is obviously two different colours.

Contrast ratio measures **luminance**. These bands are deliberately similar in brightness and different in hue, so a contrast floor answers a question nobody asked. **A check that fails on the untouched baseline is measuring the wrong property, not finding a defect** — that is the tell, and it is the fifth instrument fault I have caught on my own work today.

Rewritten as hue separation, floor 25°. All three pairs clear in all four contexts.

## `MarketConditionsWidget.tsx:42` — checked, deliberately not changed

The same hex is one of **five** gradient stops on the fear-and-greed arc:

```
0%  var(--red)   25% #f97316   50% #facc15   75% #a3e635   100% #22c55e
```

Four of the five are literals. Converting one to a per-theme token makes the gradient **discontinuous in light** — a ramp with one stop that moves and four that do not. Either all five move together or none do, and that is a design decision about a data visualisation rather than a contrast fix. Named in the commit so it is not rediscovered.

## How to test (QA)

1. `/scanner`, accumulation tracker, **terminal light**, with a coin scoring **60-74**. Score number and its bar readable. Scores 80+ and under 60 were always fine — that is why this survived review.
2. Same in current light.
3. Dark, both designs — unchanged, `#a3e635` either way.
4. The three bands still read as three colours, not a gradient of one.

## Risk level

**Low-Medium.** Four gates via `npm run verify`: lint 0 errors, typecheck clean, 601/601, build succeeds.

**Not rendered by me** — needs a coin in the 60-74 band. You rendered the failure; the fix is a token substitution measured against the same grounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
