### PR TITLE
fix(settings): --bg0 gets a light-theme value, and the html rule collapses back to one (#783)

### DIFF
--- a/__tests__/bgLadder.test.mts
+++ b/__tests__/bgLadder.test.mts
@@ -1,0 +1,143 @@
+/* Every background token resolves in every context (#783).
+ *
+ * --bg0 was declared at :root and in both terminal blocks, and NOT in the
+ * current design's light block. So `var(--bg0)` in a light, non-terminal
+ * context fell through to :root's #030405 - near-black behind light text, no
+ * error, nothing failing.
+ *
+ * Nothing rendered wrong, and that is the interesting part. The two places
+ * that reach for it had already been worked around: the html background rule
+ * was SPLIT into a literal for the current design and a token for terminal,
+ * specifically to dodge this, and its comment says so in as many words. The
+ * workaround was correct; the hole it dodged stayed open for the next caller.
+ * A defect that has been routed around is still a defect, and it is harder to
+ * see precisely because the route around it works.
+ *
+ * This test is the general version: not "is --bg0 declared in light" but "does
+ * every background token resolve to a real colour in all four contexts", so
+ * the next token added to three blocks out of four fails here rather than
+ * being discovered by a probe measuring a near-black ground it never renders
+ * on.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseCssColor, relativeLuminance } from '../lib/readableOn.ts';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CSS = readFileSync(path.join(ROOT, 'app', 'globals.css'), 'utf8');
+
+function tokens(selector: string): Record<string, string> {
+  const lines = CSS.split('\n');
+  const idx = lines.findIndex(l => l.trim() === selector + ' {');
+  assert.ok(idx >= 0, `token block not found: ${selector}`);
+  const from = lines.slice(0, idx).join('\n').length;
+  let i = CSS.indexOf('{', from), depth = 0, end = i;
+  for (; i < CSS.length; i++) {
+    if (CSS[i] === '{') depth++;
+    else if (CSS[i] === '}') { depth--; if (depth === 0) { end = i; break; } }
+  }
+  const body = CSS.slice(CSS.indexOf('{', from) + 1, end);
+  const out: Record<string, string> = {};
+  for (const m of body.matchAll(/(--[a-z0-9-]+)\s*:\s*([^;\n]+)/g)) {
+    out[m[1]] = m[2].split('/*')[0].trim().replace(/;$/, '');
+  }
+  return out;
+}
+function resolve(map: Record<string, string>, value: string, depth = 0): string | null {
+  if (depth > 10) return null;
+  const m = /^var\((--[a-z0-9-]+)(?:\s*,\s*([^)]+))?\)$/.exec(value.trim());
+  if (!m) return value.trim();
+  const next = map[m[1]] ?? m[2];
+  return next === undefined ? null : resolve(map, next, depth + 1);
+}
+
+const root = tokens(':root');
+const light = tokens('[data-theme="light"]');
+const termDark = tokens('[data-design="terminal"]:not([data-theme="light"])');
+const termLight = tokens('[data-design="terminal"][data-theme="light"]');
+
+const DARK_CONTEXTS: Array<[string, Record<string, string>]> = [
+  ['current dark', { ...root }],
+  ['terminal dark', { ...root, ...termDark }],
+];
+const LIGHT_CONTEXTS: Array<[string, Record<string, string>]> = [
+  ['current light', { ...root, ...light }],
+  ['terminal light', { ...root, ...light, ...termLight }],
+];
+const ALL = [...DARK_CONTEXTS, ...LIGHT_CONTEXTS];
+
+const BG_TOKENS = ['--bg0', '--bg1', '--bg2', '--bg3', '--bg4'];
+
+test('every background token resolves to a colour in all four contexts', () => {
+  const missing: string[] = [];
+  for (const [name, map] of ALL) {
+    for (const tok of BG_TOKENS) {
+      const raw = resolve(map, `var(${tok})`);
+      if (!raw || !parseCssColor(raw)) missing.push(`${name}: ${tok} -> ${raw ?? 'unresolved'}`);
+    }
+  }
+  assert.deepEqual(missing, [], `background token(s) that do not resolve:\n  ${missing.join('\n  ')}`);
+});
+
+test('no light context inherits a DARK background value', () => {
+  /* The failure #783 actually was. A token declared only at :root resolves
+     fine - it just resolves to the wrong theme's colour, which is why "does it
+     resolve" alone would have passed while --bg0 was near-black in light.
+     Luminance is the tell: every light-theme surface is light. */
+  const wrong: string[] = [];
+  for (const [name, map] of LIGHT_CONTEXTS) {
+    for (const tok of BG_TOKENS) {
+      const c = parseCssColor(resolve(map, `var(${tok})`) ?? '');
+      if (!c) continue;
+      const l = relativeLuminance(c.rgb);
+      if (l < 0.5) wrong.push(`${name}: ${tok} luminance ${l.toFixed(3)} - a dark value in a light theme`);
+    }
+  }
+  assert.deepEqual(wrong, [], `${wrong.length} light-theme background(s) inherited from a dark block:\n  ${wrong.join('\n  ')}`);
+});
+
+test('no dark context inherits a LIGHT background value', () => {
+  /* The mirror image, so the check is not one-directional. Nothing fails this
+     today; it exists so a token added to the light block alone is caught by the
+     same file rather than by a different investigation. */
+  const wrong: string[] = [];
+  for (const [name, map] of DARK_CONTEXTS) {
+    for (const tok of BG_TOKENS) {
+      const c = parseCssColor(resolve(map, `var(${tok})`) ?? '');
+      if (!c) continue;
+      const l = relativeLuminance(c.rgb);
+      if (l > 0.5) wrong.push(`${name}: ${tok} luminance ${l.toFixed(3)} - a light value in a dark theme`);
+    }
+  }
+  assert.deepEqual(wrong, [], `${wrong.length} dark-theme background(s) inherited from a light block:\n  ${wrong.join('\n  ')}`);
+});
+
+test('CONTROL: the check can see a token that is missing from one block', () => {
+  /* Feed it the pre-fix state - --bg0 absent from the light block - and require
+     both the resolve check to pass and the luminance check to fail, which is
+     exactly the shape that made this invisible: it resolved, to the wrong
+     theme's colour. */
+  /* The pre-fix cascade is root's --bg0 surviving because the light block
+     declared none - NOT the token being absent altogether. Deleting it models
+     a different bug: it makes the value unresolvable, which the first
+     assertion would then catch, and the whole point is that the real one
+     resolved cleanly. */
+  const preFix = { ...root, ...light, '--bg0': root['--bg0'] };
+  const raw = resolve(preFix, 'var(--bg0)');
+  assert.ok(raw && parseCssColor(raw), 'the pre-fix state should still RESOLVE - that is why it was invisible');
+  assert.ok(relativeLuminance(parseCssColor(raw!)!.rgb) < 0.5,
+    'the pre-fix --bg0 no longer reads as a dark value in a light context; this control is stale');
+});
+
+test('the html light background takes the token rather than a literal', () => {
+  /* The split rule existed only because the token could not be used here. It
+     can now, and a literal that has to stay in step with a token is one more
+     thing to keep in step. */
+  assert.match(CSS, /html\[data-theme="light"\]\s*\{\s*background:\s*var\(--bg0\)/,
+    'the html light background is not taking var(--bg0)');
+  assert.doesNotMatch(CSS, /html\[data-theme="light"\]:not\(\[data-design="terminal"\]\)\s*\{\s*background:\s*#E8EAED/,
+    'the old split rule is back - if it is needed again, --bg0 has probably been removed from the light block');
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -2571,6 +2571,17 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 [data-theme="light"] {
   /* Clean neutral - white cards on light gray canvas */
   --bg:  #E8EAED;
+  /* --bg0 DECLARED HERE AT LAST (#783). It was the one background token the
+     current design's light block did not set, so `var(--bg0)` in a light,
+     non-terminal context fell through to :root's #030405 - near-black behind
+     light text, with no error and nothing failing.
+     Nothing rendered wrong, because the two places that reach for it were
+     already worked around: the html rule below was SPLIT into a literal and a
+     token specifically to dodge this, and its comment says so. The workaround
+     was correct and the hole it dodged was still there for the next caller.
+     #E8EAED is the literal that split rule already used, so this declares what
+     the design was already painting rather than choosing a new colour. */
+  --bg0: #E8EAED;
   --bg1: #FFFFFF;
   --bg2: #F2F3F5;
   --bg3: #E4E6E9;
@@ -2688,8 +2699,12 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
    Split the same way as the body rules directly below, and for the same reason
    given in their comment: --bg0 is not declared in the current design's own
    light block, so terminal takes it and the current design keeps its literal. */
-html[data-theme="light"]:not([data-design="terminal"]) { background: #E8EAED; }
-html[data-design="terminal"][data-theme="light"] { background: var(--bg0); }
+/* ONE RULE AGAIN (#783). This was split in two because --bg0 was undeclared in
+   the current design's light block, so the token could not be used there. It is
+   declared now, and it resolves to the same #E8EAED this rule used to hardcode,
+   so the split has nothing left to protect against and a literal that has to
+   stay in step with a token is one more thing to keep in step. */
+html[data-theme="light"] { background: var(--bg0); }
 /* #557 investigation (QA, terminal-light audit): unscoped, so terminal+light
    pages rendered the current design's #E8EAED canvas instead of terminal's
    own --bg0 (#f7f6f3) - close enough in hue that it went unnoticed visually,


### PR DESCRIPTION
## Summary

#783. `[data-theme="light"]` declares `--bg0: #E8EAED`, and the two `html` background rules that existed to work around its absence collapse back into one.

## What made this worth more than a one-line declaration

Nothing rendered wrong, and the reason is the finding: **both places that reach for `--bg0` had already been worked around.**

`globals.css:2691` was split into a literal for the current design and a token for terminal, *specifically* to dodge this, and its own comment says so:

> *"--bg0 isn't declared in the current design's own light block … reading it there would fall through to root's dark value and blacken the current design's light body."*

The workaround was correct. The hole it dodged stayed open for the next caller. **A defect that has been routed around is harder to see than one that has not, because the route around it works** — and the note explaining the detour reads as documentation rather than as an open bug.

With the token declared, the split has nothing left to protect against, so it collapses. A literal that has to stay in step with a token is one more thing to keep in step.

`#E8EAED` is the value that split rule already hardcoded — this declares what the design was already painting rather than choosing a colour.

## The test is the general shape, not the instance

```
every background token resolves in all four contexts
no LIGHT context inherits a dark value
no DARK context inherits a light value
```

**The middle one is the assertion that matters.** The pre-fix state *resolved cleanly* — it just resolved to the wrong theme's colour. A "is it declared" check would have passed. Luminance is what separates "resolves" from "resolves to something sane".

The third exists so the check is not one-directional; nothing fails it today.

**The control reproduces the real pre-fix cascade** — `:root`'s value surviving because the light block declared none — rather than deleting the token. My first version deleted it, which models a *different* and more visible bug: unresolvable rather than wrongly resolved. It failed, correctly, and the fix to the control is in the comment.

## Impact on measurements taken today

This is the token that made two sweeps report nonsense: my first `/correlation` run reported *"current light fails at 0% alpha"* against a near-black `--bg0`, and #787's ground was measured against it. Both were caught by looking at what the widget actually renders on — but the trap was real and is now closed.

## How to test (QA)

1. **`/learn` and any light non-terminal page** — canvas unchanged, `#E8EAED` as before.
2. **Terminal light** — unchanged, `#f7f6f3` via the token, which is what the split rule already did.
3. There is no visual change anywhere. This removes a trap rather than fixing a symptom.
4. `npm test` — the light-inherits-dark assertion is the one to read.

## Risk level

**Low.** No rendered change intended. Four gates via `npm run verify`: lint 0 errors, typecheck clean, 606/606, build succeeds.

**One thing to watch:** collapsing the two rules means the current design's light canvas now comes from a token rather than a literal. If anything did depend on that literal being immune to the token, this would surface it — I found nothing that does, and the assertion above pins the resolved value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
