### PR TITLE
feat(dashboard): eight coins in the rail, and the rail stops scrolling (#745)

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -112,7 +112,14 @@ function MarketPulseStrip() {
 
 
 /* ── Coin Sidebar v2 - signal cards ── */
-const SIDEBAR_DEFAULT = 7;
+/* EIGHT, on the owner's ruling for #745: "show a fixed number of coins and
+   then show the data below". Eight fills the rail to roughly its natural height
+   so the data panels start without a gap and no row is cut mid-way.
+   The count alone was never the scroll - the list was already capped at 7 while
+   the rail held 1128px in a 548px box - so globals.css removes the rail's own
+   overflow in the same change. This number is the owner's; that removal is what
+   makes it visible. */
+const SIDEBAR_DEFAULT = 8;
 
 function CoinSidebar() {
   const { store, selectCoin } = useMarket();

--- a/app/globals.css
+++ b/app/globals.css
@@ -401,27 +401,43 @@ body::after {
      FAB even at that natural, un-stuck top (measured empirically, not
      derived from the 68px sticky offset - that offset only applies once
      stuck, and stuck is always a *smaller* top, so it's the safer case). */
+  /* THE RAIL NO LONGER SCROLLS INSIDE ITSELF (#745). Owner: "I don't want it
+     to be scrollable. So what I want you to do is show a fixed number of coins
+     and then show the data below."
+
+     It was `max-height: calc(100vh - 265px); overflow-y: auto`, and QA measured
+     548px of box around 1128px of content - roughly 580px of BTC.D, PERPS VS
+     SPOT and GLOBAL MACRO CONTEXT reachable only by scrolling inside a rail
+     most people never think to scroll.
+
+     Capping the coin list alone would not have fixed it: the list was already
+     capped at 7 and the 1128 is mostly the three panels, so the count is the
+     owner's framing of the layout and the scroll is a separate thing to
+     remove. Both are done here - eight coins, and the rail flows.
+
+     `position: sticky` goes with it. A sticky box taller than the viewport
+     pins its top and puts its bottom permanently out of reach, which is the
+     same defect wearing different clothes. The rail now scrolls with the page,
+     so everything in it is reachable by the scroll people already use. The
+     cost is real and deliberate: the rail no longer follows the viewport on a
+     long page. */
   .dash-right {
     display: flex;
     flex-direction: column;
     gap: 8px;
-    position: sticky;
-    top: 68px;
-    max-height: calc(100vh - 265px);
-    overflow-y: auto;
-    scrollbar-width: thin;
-    scrollbar-color: rgba(255,255,255,0.05) transparent;
   }
-  .dash-right::-webkit-scrollbar { display: block; width: 3px; }
-  .dash-right::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.06); border-radius: 2px; }
 
   /* Sticky left sidebar */
 
-  /* Sticky right rail */
-  .dash-right {
-    position: sticky;
-    top: 68px;
-  }
+  /* NOT sticky any more (#745). A sticky box taller than the viewport pins its
+     top and puts its bottom permanently out of reach - the same content being
+     unreachable that removing the rail's own overflow was meant to fix, just
+     achieved a different way. Measured after that removal: the rail is 1206px,
+     which exceeds every laptop viewport and most desktop ones.
+     Left in place as a comment rather than deleted, because "why is the rail
+     not sticky" is a question someone will ask, and the answer is that it
+     cannot be both taller than the screen and pinned to it. */
+  .dash-right { position: static; }
 
   /* Hide mobile-only elements on desktop */
 }
@@ -462,8 +478,7 @@ body::after {
   /* min-width:0 stops the 1fr track expanding to its widest child (news
      banner) and overflowing - same guard the >=1100 block uses. */
   .dash-main { min-width: 0; overflow-x: hidden; }
-  .dash-sidebar,
-  .dash-right {
+  .dash-sidebar {
     display: flex;
     flex-direction: column;
     gap: 8px;
@@ -474,8 +489,15 @@ body::after {
     scrollbar-width: thin;
     scrollbar-color: rgba(255,255,255,0.05) transparent;
   }
-  /* Trimmed shorter than .dash-sidebar - see the >=1100 rule for why. */
-  .dash-right { max-height: calc(100vh - 265px); }
+  /* Split out of the rule above (#745). The left sidebar keeps its own scroll;
+     the right rail does not, for the reason given at the >=1100 rule. They
+     shared a declaration block only because they happened to want the same
+     thing, and they no longer do. */
+  .dash-right {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
   /* Don't render both the sidebar AND the mobile stacked coin block */
 }
 

--- a/components/DashboardTerminal.tsx
+++ b/components/DashboardTerminal.tsx
@@ -44,7 +44,14 @@ const OI_TREND_META: Record<string, { txtKey: LabelKey; subKey: LabelKey; col: s
   weak_down:   { txtKey: 'OI_TREND_WEAK_DOWN_TXT',   subKey: 'OI_TREND_WEAK_DOWN_SUB',   col: 'var(--txt3)' },
 };
 
-const SIDEBAR_DEFAULT = 7;
+/* EIGHT, on the owner's ruling for #745: "show a fixed number of coins and
+   then show the data below". Eight fills the rail to roughly its natural height
+   so the data panels start without a gap and no row is cut mid-way.
+   The count alone was never the scroll - the list was already capped at 7 while
+   the rail held 1128px in a 548px box - so globals.css removes the rail's own
+   overflow in the same change. This number is the owner's; that removal is what
+   makes it visible. */
+const SIDEBAR_DEFAULT = 8;
 
 function TMarketPulseStrip() {
   const { store } = useMarket();


### PR DESCRIPTION
## Summary

#745, on the owner's ruling. Eight coins, and the rail stops being its own scroll container.

```
before   548px box around 1128px of content   ~580px hidden behind an inner scroll
after    1209px rail, no inner scroll, page scrolls instead
```

## The count was never the scroll, and that matters for reviewing this

The list was **already capped at 7** while QA measured 1128px in a 548px box. The hidden ~580px was `BTC.D / ALT`, `PERPS VS SPOT` and `GLOBAL MACRO CONTEXT` — the three panels, not the coins.

So capping at eight *without* removing the overflow would have made the rail taller and hidden **more**. Eight is the owner's framing of the layout; removing the overflow is what makes it visible. Both are here.

## Sticky had to go too, and this is the part I would want challenged

`position: sticky` with content taller than the viewport pins the top and puts the bottom **permanently out of reach** — the same unreachable content the overflow removal was meant to fix, arrived at a different way. The rail measures **1209px**, which exceeds every laptop viewport and most desktop ones.

It is now `position: static` and flows with the page, so everything in it is reachable by the scroll people already use.

**The cost is real and deliberate: the rail no longer follows the viewport on a long page.** If the owner wanted the panels to stay in view while scrolling the main column, this trades that away — and I would rather you put that in front of them than have it arrive as a surprise.

## A shared block that stopped being shared

At 900–1099 `.dash-sidebar` and `.dash-right` shared one declaration block. They shared it because they happened to want the same thing, and they no longer do — the left sidebar keeps its own scroll, the right rail does not. Split rather than special-cased.

## Verified by rendering

`/dashboard`, desktop, after a clean rebuild:

```
position       static
max-height     none
overflow-y     visible
clientHeight   1209  ==  scrollHeight 1209     no inner scroll
tickers        BTC ETH SOL XRP BNB HYPE NEAR SUI     eight
expander       "▼ +42 more coins"                    50 total, consistent
```

**One process note, because it nearly became a false finding.** My first three render checks reported `position: sticky` on correct on-disk CSS. It was a stale Next bundle — `rm -rf .next/static/css` was not enough, and the served stylesheet still carried the old merged rule. Fetching the actual `.css` the page loaded and grepping it is what showed the served text differed from the file. `rm -rf .next` fixed it.

I was one step from reporting a CSS specificity problem that did not exist. The check that saved it was reading what the browser was *served* rather than what the browser *computed*.

## How to test (QA)

1. **`/dashboard`, desktop width.** Eight coins, then the three panels, **no scrollbar inside the rail**.
2. **Scroll the page.** The rail scrolls with it and the panels are reachable. Confirm nothing is cut off at the bottom.
3. **900–1099px width.** Left sidebar still has its own scroll; right rail does not.
4. **The `▼ +42 more coins` expander** still opens the full list.
5. **Mobile** — untouched; the rail stacks below as before.

## Risk level

**Medium.** Layout change on the busiest screen, and it removes a sticky behaviour some people may be relying on.

Four gates via `npm run verify`: lint 0 errors, typecheck clean, 601/601, build succeeds.

**What is not verified:** how it looks at 768px tall, which is where QA measured the original defect. The change is structural rather than height-tuned, so it holds — but I rendered at a tall viewport and the framing at a short one is worth an eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
