### PR TITLE
docs(qa): a decoy element is worse than a missing one

### DIFF
--- a/qa/README.md
+++ b/qa/README.md
@@ -52,6 +52,18 @@ returns a clean result, and so does a page whose data never loaded. Count what
 you matched and say so. `.frh-sig-hint` reported clean because it renders zero
 instances; `/news` reported clean on staging because it had no articles.
 
+**3b. Worse than zero elements: the WRONG element answering.** Trap 3 is an
+absence, which at least looks like one. A decoy looks like data. On 2026-09-04 a
+probe measured `.cms-trigger` on `/settings` and reported `inputType: radio` —
+but the LiquidityAI panel stays mounted across navigation, so the only
+`.cms-trigger` on that page was Grok's own. The reading was of a real element,
+correctly measured, on the wrong component; it was very nearly filed as
+"Settings multi-select is broken". The tell was domain knowledge, not the
+output: a multi-select cannot render radios.
+
+Assert what you matched — count, and check an identifying attribute — before
+believing what it says. A globally-mounted overlay is the usual culprit.
+
 **4. Live data is not a fixture.** Single samples of a moving value are not
 measurements — run three times and report only what is stable. The `↑ 47` in
 one report read 39, 40 and 41 across three runs an hour later, which is why


### PR DESCRIPTION
## Summary

One entry in `qa/README.md`'s probe-trap list. QA-owned docs, PR into `dev`.

## What changed

A **3b** between traps 3 and 4: *the wrong element answering for the right one*.

Trap 3 already covers a selector matching nothing. This is the harder case — a selector matching **something else**.

## Why it earns its own entry rather than a line under trap 3

An absence produces a suspicious zero. A decoy produces a **plausible number**, and nothing about the reading looks wrong.

The instance: on 2026-09-04 a probe measured `.cms-trigger` on `/settings` and reported `inputType: radio`. The element was real and the measurement was correct — but the LiquidityAI panel stays mounted across navigation, so the only `.cms-trigger` on that page belonged to Grok, not to Settings. It was nearly filed as *"Settings multi-select is broken"*.

**What caught it was domain knowledge, not the output:** a multi-select cannot render radios. If the value had been anything less self-contradictory it would have shipped as a finding.

The mitigation in the entry is the cheap one — assert what you matched, count it, check an identifying attribute — plus the usual culprit, a globally-mounted overlay.

## Credit

Found by dev on #792, while writing down what they could **not** verify rather than what they could. That half of a report is usually the half nobody writes.

## How to test (QA)

Reviewer is dev.

1. Open `qa/README.md`. Confirm 3b sits between 3 and 4.
2. Confirm it reads as a distinct failure mode rather than a restatement of 3 — the distinction is absence versus substitution.
3. No other section changed.

## Risk level

**Low.** Documentation only.

— QA Team

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
