### PR TITLE
fix(onboarding): the landing feature-card route strings take --txt3 (#775 cause 2)

### DIFF
--- a/components/LandingTerminal.tsx
+++ b/components/LandingTerminal.tsx
@@ -367,16 +367,29 @@ export default function LandingTerminal({ dict, locale, dir }: Props) {
                   <span style={{ fontSize: 10.5, fontFamily: 'var(--font-mono), monospace', letterSpacing: '.12em', color: 'var(--accent)', textTransform: 'uppercase' }}>
                     {dict.features.openLabel} {stepArrow}
                   </span>
-                  {/* --txt4 is correct here and measured 1.88:1 on purpose:
-                      the design's accessibility section exempts it by name -
+                  {/* --txt3, not --txt4 (#775 cause 2, OWNER RULING).
+                      The design's accessibility section exempted this by name:
                       "--txt4 is used only for the excluded-feature ✕ and the
                       route string in card footers. Both are non-essential
                       decoration paired with a text label, so they are exempt
                       from 4.5:1 - but if either ever becomes the only carrier
-                      of meaning, it must be re-tokened." Checked on #593
-                      against the design project itself, not the repo's copy.
-                      Do not "fix" this without re-reading that clause. */}
-                  <span style={{ fontSize: 10, fontFamily: 'var(--font-mono), monospace', color: 'var(--txt4)' }}>{FEATURE_ROUTES[i]}</span>
+                      of meaning, it must be re-tokened."
+
+                      That clause is not being ignored, it is being overridden,
+                      and by the person whose screen this is: shown the 1.88:1
+                      figure they chose to fix it rather than keep the
+                      exemption. Recorded rather than deleted, so the next
+                      reader can see the exemption existed and who set it
+                      aside - #593 checked it against the design project and
+                      that check was correct at the time.
+
+                      Re-derived rather than trusted: --txt4 is 1.88 terminal
+                      dark and 2.14 terminal light on --bg0; --txt3 is 5.14 and
+                      5.68. The relayed figure was ~4.6, which was conservative
+                      by half a point - it predated #790 giving --bg0 a light
+                      value at all. --txt4 is a terminal-only token, so this
+                      element does not exist in the current design. */}
+                  <span style={{ fontSize: 10, fontFamily: 'var(--font-mono), monospace', color: 'var(--txt3)' }}>{FEATURE_ROUTES[i]}</span>
                 </div>
               )}
             </Link>


### PR DESCRIPTION
## Summary

#775 cause 2, on the owner's ruling. The landing feature-card route strings take `var(--txt3)`.

```
              --txt4 (was)    --txt3 (now)
terminal dark    1.88            5.14
terminal light   2.14            5.68
```

on `--bg0`. **That closes the last six of #775's failures**, and the issue with them.

## Re-derived, as you asked, and your figure was conservative

You relayed ~4.6 and flagged it as unverified from the #738 thread. Measured now: **5.14 and 5.68**.

The gap has a cause worth knowing — that estimate predates **#790**, which gave `--bg0` a light value at all. Any earlier measurement of `--txt3` on a *light* `--bg0` was against `:root`'s near-black `#030405`, so a conservative number was the best that instrument could produce. Two of my own sweeps hit the same thing today.

**`--txt4` is a terminal-only token**, undeclared in the current design — so this element does not exist there and the change cannot reach it. My first measurement script crashed on that (null where a colour was expected), which is how I found it rather than assuming four contexts.

## The exemption is overridden, not ignored

The code carried a documented exemption for exactly this element:

> *"--txt4 is used only for the excluded-feature ✕ and the route string in card footers. Both are non-essential decoration paired with a text label, so they are exempt from 4.5:1 — but if either ever becomes the only carrier of meaning, it must be re-tokened."*

…and a warning: *"Do not 'fix' this without re-reading that clause."*

I read it. **The clause is being overridden by the person whose screen this is** — shown the 1.88 figure, the owner chose to fix rather than keep the exemption. The comment now records that, rather than deleting the exemption as if it had never applied. #593 checked it against the design project and was correct at the time; what changed is the ruling, not the reading.

That distinction matters for the next person: a deleted exemption looks like an oversight, an overridden one looks like a decision.

## Measured and deliberately not changed

`--txt4` also colours `.dterm-toc-num` and `.at-snapcells .edge-card-signal`. Different elements, different surfaces, neither named in cause 2, and **neither measured on its own ground** — the route-string figures do not transfer to them. Named here so the next sweep reports them as their own finding rather than as this one recurring.

## How to test (QA)

1. **`/` in terminal, dark.** The route string under each feature card — `/dashboard`, `/arena` and so on — reads rather than smudges.
2. **`/` in terminal, light.** Same.
3. The `✕` on excluded features is **unchanged** and still `--txt4`. That half of the exemption stands; only the route string was ruled on.
4. Current design — element does not exist there.

## Risk level

**Low.** One token substitution on one element. Four gates via `npm run verify`: lint 0 errors, typecheck clean, 610/610, build succeeds.

**Not rendered by me** — `/` in terminal needs the deployed build for a like-for-like against your sweep; the arithmetic is against the same tokens you would measure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
