### PR TITLE
fix(telegram): darken the Open Telegram gradient until white reads on it (#786)

### DIFF
--- a/app/alerts/page.tsx
+++ b/app/alerts/page.tsx
@@ -651,8 +651,26 @@ export default function AlertsPage() {
                       rel="noreferrer"
                       style={{
                         display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 6,
+                        /* TELEGRAM'S BRAND BLUE, DARKENED UNTIL WHITE READS
+                           ON IT (#786). The brand pair #0088cc -> #229ed9
+                           measures 3.89 and 3.02 against white, and
+                           --fs-caption at 700 is small text, so the bar is
+                           4.5. WCAG 1.4.3 exempts logotypes; it does not
+                           exempt a text button that borrows a brand's palette.
+
+                           These are the same two hues scaled to 90% and 78%
+                           lightness - the least darkening that clears the bar,
+                           so the button still reads as Telegram rather than as
+                           a generic blue.
+
+                           SWEPT ALONG THE WHOLE GRADIENT, not just the stops.
+                           QA's recommendation of #0077b3 -> #1b86b8 clears at
+                           the dark end and measures 4.08 at the light one; a
+                           gradient's worst point is wherever it is lightest,
+                           and checking two endpoints is not checking a
+                           gradient. This pair's worst is 4.69, at 0%. */
                         fontSize: 'var(--fs-caption)', fontWeight: 700, color: '#fff',
-                        background: 'linear-gradient(135deg, #0088cc 0%, #229ed9 100%)',
+                        background: 'linear-gradient(135deg, #007ab8 0%, #1b7ba9 100%)',
                         padding: '10px 18px', borderRadius: 8, textDecoration: 'none',
                       }}
                     >


### PR DESCRIPTION
## Summary

#786. The gradient darkens from `#0088cc → #229ed9` to `#007ab8 → #1b7ba9`.

```
                                    worst along the gradient
brand pair      #0088cc → #229ed9        3.02   at 100%   fail
your option 1   #0077b3 → #1b86b8        4.08   at 100%   fail
this pair       #007ab8 → #1b7ba9        4.69   at   0%   pass
```

## Your recommendation does not clear, and the reason is the interesting part

You recommended `#0077b3 → #1b86b8` as "clears 4.5 with white". The dark end does — **4.90**. The light end is **4.08**.

**A gradient's worst point is wherever it is lightest, and checking two endpoints is not checking a gradient.** I swept 101 points along it; the failure sits at the far stop, which is exactly where a two-value check that starts from the brand's dark colour would stop looking.

That is the same shape as everything else today, one level along: the figure was real, the sampling was narrower than the thing being sampled. It would have shipped a still-failing button under a comment saying it was fixed — which is `.arena-deep-locked`'s #769 failure repeated in a PR fixing #769's sibling.

## Why these two values

The same two brand hues at **90%** and **78%** lightness — the least darkening that clears the bar. The button still reads as Telegram rather than as a generic blue, which is the whole reason not to reach for a token here.

**Options 2 and 3, considered and rejected:**
- Black text measures 6.95 and looks wrong on every Telegram button anyone has seen.
- Accepting and documenting is legitimate, and it is what the issue offers — but the owner has spent today choosing to fix rather than exempt, including overriding a *written* exemption on #775 cause 2 an hour ago. Accepting this one would be reading their pattern backwards.

## How to test (QA)

1. `/alerts`, **signed in with a Telegram link code generated** — the "Open Telegram" button. Neither of us can reach this state, so it needs someone who can.
2. It should still read as Telegram blue. If it reads as "some blue button", the darkening went too far and that is worth saying — the brand read is the reason this is not a token.
3. The white label should be comfortable rather than marginal at both ends of the gradient.

## Risk level

**Low.** Two hex values on one button. Four gates via `npm run verify`: lint 0 errors, typecheck clean, 610/610, build succeeds.

**Not rendered, by either of us.** The button is behind `linkCode.deepLink`, which needs a signed-in account with a generated code — the same wall as #767. The colours are literals, so the arithmetic does not depend on design or theme, which is the one thing that makes it safe to state without rendering.

**Brand judgement is not mine.** I can measure contrast; whether `#007ab8 → #1b7ba9` still says "Telegram" is a call for someone looking at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
