### PR TITLE
docs(qa): three probe traps — substring matches, dangling prose, and custom-property scope

### DIFF
--- a/qa/README.md
+++ b/qa/README.md
@@ -78,6 +78,26 @@ answer is "the same", it is not measuring. A control that asserts a wrong
 implementation disagrees with the real one stops proving anything the moment
 the real one adopts that answer.
 
+**7. A substring match is not an identifier match.** `grep "\.gchat-coin"`
+reports a hit on `.gchat-coinbar`, so a check written to confirm a class was
+deleted found its own replacement and reported the class still present. Anchor
+on a word boundary — `\.gchat-coin([^a-z-]|$)` — or you are asking a question
+about one name and being answered about another. Trap 3b again, in the check
+rather than the page.
+
+**8. Deleting code is not finished until the prose pointing at it is checked.**
+Not a probe trap — a review one, and this codebase is unusually exposed to it.
+Comments here carry measured ratios, rejected alternatives and owner rulings,
+so they are load-bearing. On 2026-09-04 `.gchat-coin` was deleted and two live
+rules were left describing themselves as *"borrows the .gchat-coin affordance"*
+and *"follows the theme the way .gchat-coin does"* — explanations pointing at
+nothing.
+
+A reader who finds one dangling reference either hunts for a class that does
+not exist or concludes the file is stale. **The second is worse**: the next
+comment they discount might be the one recording that a colour was verified at
+6.42:1 in dark. `grep` for the identifier before deleting it costs seconds.
+
 ## Where QA tests
 
 **Four branches, four services, one each.** Nothing auto-deploys — moving a

--- a/qa/README.md
+++ b/qa/README.md
@@ -98,6 +98,27 @@ not exist or concludes the file is stale. **The second is worse**: the next
 comment they discount might be the one recording that a colour was verified at
 6.42:1 in dark. `grep` for the identifier before deleting it costs seconds.
 
+**9. A custom property's scope is not global, and both obvious ways to look for
+one assume it is.** A `--token` can live in three places: a stylesheet rule, a
+`:root` block, or an **element's inline `style`**. A grep of `globals.css` finds
+the first two. `getComputedStyle(document.documentElement).getPropertyValue()`
+finds the first two. Nothing finds the third.
+
+On 2026-09-04 both sessions independently reported `--ec-muted` as "declared
+nowhere" and filed it. It is set per row at `app/econ-calendar/page.tsx:298` as
+a deliberate switch — inline beats every selector, and an inline value that
+*reads* a custom property still inherits, so one declaration on the row moves
+four cells at once. The technique is documented thirty lines above the code both
+of us measured.
+
+**Two instruments scoped to global agreeing about a property that lives on an
+element is not corroboration**, and the second reading made the first look
+verified. To check: grep the **consuming file** for element-scope declarations
+(`['--x' as string]:` or `'--x':`) before concluding a token is missing. That
+one command separates "genuinely undeclared" from "declared where you did not
+look" — `/news` has no such declarations and its `--border` really is missing;
+`/econ-calendar` has one and its `--ec-muted` was never broken.
+
 ## Where QA tests
 
 **Four branches, four services, one each.** Nothing auto-deploys — moving a


### PR DESCRIPTION
## Summary

Two more entries in `qa/README.md`'s probe-trap list, following #793. QA-owned docs, PR into `dev`.

## 7 — a substring match is not an identifier match

`grep "\.gchat-coin"` reports a hit on `.gchat-coinbar`.

So a check written to confirm `.gchat-coin` had been **deleted** matched its own **replacement** and reported the class still present. I posted that as a review finding on #792; dev had removed all three rules correctly.

Anchor on a word boundary — `\.gchat-coin([^a-z-]|$)`. Otherwise you are asking about one name and being answered about another, which is 3b's shape moved from the page into the check.

## 8 — deleting code is not finished until the prose pointing at it is checked

Not a probe trap. A review one, and **this codebase is unusually exposed to it**: comments here carry measured ratios, rejected alternatives and owner rulings. They are load-bearing, not decorative.

On 2026-09-04 `.gchat-coin` was deleted with the coin button row, and two live rules were left describing themselves as *"borrows the `.gchat-coin` affordance"* and *"follows the theme the way `.gchat-coin` does"* — explanations pointing at a class that no longer existed.

**The second-order damage is why it earns an entry.** A reader who finds one dangling reference either hunts for something that is not there, or concludes the file is stale. The second is worse: the next comment they discount might be

```
/* ... #c8891e is 6.42:1. */
```

which was **true**, and whose scope was not — the figure held in dark and the rule was unscoped, so it shipped 2.33:1 to production light (#769). That is precisely the note nobody can afford to skim.

`grep` for the identifier before deleting it costs seconds.

## Credit

8 is dev's, found on #792 after deleting the class and then catching their own dangling referents — and their framing is the one in the file. 7 is my own grep reporting the fix as the defect.

## How to test (QA)

Reviewer is dev.

1. Open `qa/README.md`; confirm 7 and 8 sit after 6 and before `## Where QA tests`.
2. Confirm 8 reads as a review practice rather than a probe trap — it is the one entry not about measuring.
3. `grep -c "^\*\*7\.\|^\*\*8\.\|^\*\*3b\." qa/README.md` returns 3.

## Risk level

**Low.** Documentation only.

— QA Team

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
