### PR TITLE
fix(news): the economic-calendar dividers take --bdr, not the undeclared --border (#798)

### DIFF
--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -658,9 +658,27 @@ export default function NewsPage() {
             return groups.map((g, gi) => (
               <div key={gi} style={{ marginBottom: 20 }}>
                 {/* Date header */}
+                {/* var(--bdr), not var(--border) (#798). --border has NEVER been
+                    declared - `git log -S"--border:"` on globals.css returns
+                    nothing, so it is not a rename casualty, it is a typo. All
+                    three uses arrived in one commit, "Redesign Events tab as
+                    Economic Calendar with date-grouped rows", which modelled
+                    this block on /econ-calendar - and that screen writes the
+                    same divider as `0.5px solid var(--bdr)`.
+
+                    An unresolvable var() with no fallback invalidates the WHOLE
+                    declaration, and an invalid `border` shorthand does not
+                    degrade to a default: there was no divider here at all. That
+                    is why nothing measured it - a missing border leaves no
+                    element behind to measure.
+
+                    Widths left as written, 1px and 3px rather than
+                    /econ-calendar's 0.5px. Only the colour was broken, and
+                    changing the width would be a visual decision riding along
+                    with a defect fix. */}
                 <div style={{
                   display: 'flex', alignItems: 'center', gap: 8, padding: '6px 0 8px',
-                  borderBottom: '1px solid var(--border)',
+                  borderBottom: '1px solid var(--bdr)',
                 }}>
                   <span style={{ fontSize: 'var(--fs-label)', fontWeight: 700, color: g.isToday ? 'var(--amber)' : 'var(--txt)' }}>
                     {g.isToday ? t('NEWS_EVENTS_TODAY_PREFIX', { date: g.dateLabel }) : g.dateLabel}
@@ -684,8 +702,8 @@ export default function NewsPage() {
                     <div key={ei} style={{
                       display: 'grid', gridTemplateColumns: '70px 1fr 72px 72px 72px 52px',
                       gap: 4, padding: '10px 8px', minWidth: 370,
-                      borderLeft: `3px solid ${past && !urgent ? 'var(--border)' : borderColor}`,
-                      borderBottom: '1px solid var(--border)',
+                      borderLeft: `3px solid ${past && !urgent ? 'var(--bdr)' : borderColor}`,
+                      borderBottom: '1px solid var(--bdr)',
                       opacity: past && !urgent ? 0.55 : 1,
                       alignItems: 'start',
                     }}>


### PR DESCRIPTION
## Summary

#798's surviving half. Three inline styles in `app/news/page.tsx` take `var(--bdr)`.

## Typo, not a missing token — and that is evidence, not a guess

```
git log -S"--border:" -- app/globals.css      no commits
```

`--border` has **never** been declared, so it is not a rename casualty. All three uses arrived in **one commit** — *"Redesign Events tab as Economic Calendar with date-grouped rows"* — which modelled this block on `/econ-calendar`, and that screen writes the same divider as `0.5px solid var(--bdr)`.

So the question your ruling asked — *typo for an existing token, or a token meant to be added?* — has a documented answer rather than a plausible one.

## What was actually broken

An unresolvable `var()` with no fallback invalidates the **whole declaration**, and an invalid `border` shorthand does not degrade to a default. **There was no divider at all** — not a wrong colour, an absent element:

```
date header      rule underneath        missing
event row        rule underneath        missing
event row        3px left marker        missing
```

That is why all three of our instruments called it clean, and it is worth keeping as the reason: a missing border leaves nothing behind to measure, the terminal-token test sweeps terminal-scoped selectors rather than inline styles, and the lint rule hunts hardcoded colours — the opposite shape.

## The value, measured

```
                --bdr                        vs --bg1   vs --bg2
current dark    rgba(255,255,255,0.08)         1.17       1.19
current light   rgba(0,0,0,0.08)               1.20       1.19
terminal dark   #1f2225                        1.14       1.16
terminal light  #d5d2cd                        1.24       1.15
```

A hairline by design. **A separator is not required to clear 3:1**, and these are the same figures every other divider in the app carries — matching them is the point, not a compromise.

## Widths left alone

1px and 3px as written, rather than `/econ-calendar`'s 0.5px. Only the colour was broken; changing the width would be a visual decision riding along with a defect fix.

## How to test (QA)

1. **`/news`, Events tab** — each date header has a rule under it, each event row has one beneath it, and past non-urgent rows have a 3px marker at the left edge. All three were absent.
2. Both themes, both designs — `--bdr` is defined in all four, so this is the first time these dividers render anywhere.
3. **Same wall as before:** `/news` is empty outside production (#757), so neither of us can render it. This is a source fix on an unrenderable route, and the mechanism is the argument.

## Risk level

**Low.** Three token references. Four gates via `npm run verify`: lint 0 errors, typecheck clean, 610/610, build succeeds.

**Not rendered, and cannot be by either of us.** The claim rests on: `--border` is undeclared in every scope including element scope, an invalid shorthand drops entirely, and `--bdr` resolves in all four contexts. Each of those is checkable without the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
