### PR TITLE
test(tokens): ratchet rule 1 of #663 - terminal-only components keep constants in CSS

### DIFF
--- a/__tests__/terminalOnlyConstants.test.mts
+++ b/__tests__/terminalOnlyConstants.test.mts
@@ -1,0 +1,155 @@
+/* Rule 1 of #663's convention, as a ratchet: a terminal-only component puts
+ * constant typography in CSS, not inline.
+ *
+ * THE CONVENTION, ruled by QA on 2026-09-04 after dev declined to pick it:
+ *
+ *   1. A TERMINAL-ONLY component puts all typography and constant colour in
+ *      CSS. There is no second design to serve, so a constant has no reason to
+ *      be inline.
+ *   2. In a DUAL-DESIGN component, inline is for COMPUTED values only.
+ *
+ * This file enforces rule 1. Rule 2 is not enforced here and the reason is
+ * measured rather than assumed - see the note at the bottom.
+ *
+ * WHY COUNTS AND NOT AN ENUMERATED BASELINE. The #751 detector lists its 25
+ * collisions individually, so fixing one requires deleting its line. That does
+ * not scale here: there are 361 constant-inline typography declarations across
+ * seven files, and QA's ruling on #663 was explicit that a PR fixing them
+ * wholesale is "churn on shared chrome for no measured user-facing gain" and
+ * that they should be worked "as the files are touched".
+ *
+ * So the ratchet is per-file counts. New code cannot add one; touching a file
+ * to remove some lets the number fall. PER FILE rather than a total, so moving
+ * debt from one component to another still fails - a single number would let
+ * LandingTerminal's 169 absorb another file's additions silently.
+ *
+ * WHAT COUNTS AS A CONSTANT. A literal - a quoted string, a template literal,
+ * or a number. `fontSize: 'var(--fs-caption)'` IS a constant by this
+ * definition: the token adapts, but the decision to use that token is fixed at
+ * write time and belongs in a stylesheet. `fontWeight: bold ? 700 : 400` is
+ * not, and neither is `fontSize: size`.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Terminal-only components, by the naming convention the codebase already
+ *  uses: a `*Terminal.tsx` renders only under [data-design="terminal"]. */
+function terminalOnlyFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap(name => {
+    const full = path.join(dir, name);
+    if (name === 'node_modules' || name === '.next') return [];
+    if (statSync(full).isDirectory()) return terminalOnlyFiles(full);
+    return /Terminal\.tsx$/.test(name) ? [full] : [];
+  });
+}
+
+/** Block comments blanked, newlines kept - the #785 lesson twice over: a
+ *  scanner that reads comments counts its own explanations, and a strip that
+ *  eats newlines breaks any line number computed afterwards. */
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, m => m.replace(/[^\n]/g, ' '));
+}
+
+function objectAt(src: string, from: number): string {
+  const open = src.indexOf('{', from);
+  if (open < 0) return '';
+  let depth = 0;
+  for (let i = open; i < src.length && i < open + 4000; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') { depth--; if (depth === 0) return src.slice(open, i + 1); }
+  }
+  return '';
+}
+
+const TYPOGRAPHY = /(fontSize|fontWeight|fontFamily|letterSpacing|textTransform)\s*:\s*('[^']*'|`[^`]*`|[0-9.]+)/g;
+
+function constantTypographyCount(file: string): number {
+  const src = stripComments(readFileSync(file, 'utf8'));
+  let n = 0;
+  for (const m of src.matchAll(/style=\{\{/g)) {
+    const obj = objectAt(src, m.index! + 6);
+    for (const d of obj.matchAll(TYPOGRAPHY)) {
+      /* A literal opens with a quote, a backtick or a digit. Anything else is
+         an identifier or an expression - a computed value, which rule 2 allows
+         and rule 1 does not forbid. */
+      if (/^('|`|[0-9])/.test(d[2])) n++;
+    }
+  }
+  return n;
+}
+
+/** Measured 2026-09-04. These only go DOWN. */
+const BASELINE: Record<string, number> = {
+  'components/BriefingTerminal.tsx': 43,
+  'components/CorrelationTerminal.tsx': 9,
+  'components/DashboardTerminal.tsx': 16,
+  'components/FundingTerminal.tsx': 35,
+  'components/LandingTerminal.tsx': 169,
+  'components/LiqTerminal.tsx': 56,
+  'components/MarketsTerminal.tsx': 33,
+  'components/ScannerTerminal.tsx': 0,
+};
+
+test('the file set is the one the baseline was measured against', () => {
+  /* A component renamed out of the *Terminal.tsx pattern would silently leave
+     the sweep, and its count would vanish rather than fail. */
+  const found = terminalOnlyFiles(path.join(ROOT, 'components'))
+    .map(f => path.relative(ROOT, f).split(path.sep).join('/')).sort();
+  assert.deepEqual(found, Object.keys(BASELINE).sort(),
+    'the set of terminal-only components changed. A new one starts at 0 in ' +
+    'BASELINE; a renamed one keeps its count under the new name.');
+});
+
+test('no terminal-only component gains a constant inline typography value', () => {
+  const regressions: string[] = [];
+  const improvements: string[] = [];
+  for (const [rel, allowed] of Object.entries(BASELINE)) {
+    const n = constantTypographyCount(path.join(ROOT, rel));
+    if (n > allowed) regressions.push(`${rel}: ${allowed} -> ${n}`);
+    if (n < allowed) improvements.push(`${rel}: ${allowed} -> ${n}`);
+  }
+  assert.deepEqual(regressions, [],
+    `${regressions.length} file(s) added constant inline typography:\n  ${regressions.join('\n  ')}\n` +
+    'Rule 1 of #663: a terminal-only component has no second design to serve, so ' +
+    'a constant belongs in globals.css. Move it there rather than raising the number.');
+  assert.deepEqual(improvements, [],
+    `${improvements.length} file(s) improved - lower the BASELINE so the ratchet keeps its new position:\n  ${improvements.join('\n  ')}`);
+});
+
+test('CONTROL: the counter sees a constant and ignores a computed one', () => {
+  /* Without this the ratchet passes on a counter that matches nothing, which
+     is how a check becomes decoration. Both directions, because a counter that
+     also counts computed values would fail every honest edit and get deleted.  */
+  const constant = `<div style={{ fontSize: '12px', fontWeight: 700 }}>`;
+  const computed = `<div style={{ fontSize: size, fontWeight: bold ? 700 : 400 }}>`;
+  const count = (s: string) => {
+    let n = 0;
+    for (const m of s.matchAll(/style=\{\{/g)) {
+      for (const d of objectAt(s, m.index! + 6).matchAll(TYPOGRAPHY)) {
+        if (/^('|`|[0-9])/.test(d[2])) n++;
+      }
+    }
+    return n;
+  };
+  assert.equal(count(constant), 2, 'the counter no longer sees constant typography');
+  assert.equal(count(computed), 0, 'the counter is counting computed values, which rule 2 allows');
+});
+
+/* RULE 2 IS NOT ENFORCED HERE, AND THAT IS A MEASUREMENT NOT AN OMISSION.
+ *
+ * Rule 2 says a dual-design component may use inline only for computed values.
+ * "Dual-design component" is every .tsx that is not a *Terminal.tsx, and a
+ * constant inline value there is the codebase's normal idiom - the same sweep
+ * over those files returns thousands, not hundreds.
+ *
+ * A ratchet at that size measures the codebase's age rather than its
+ * discipline, and a number nobody can move is a number nobody reads. Rule 2
+ * wants a lint rule that fires at the moment of writing, on the file being
+ * edited, the way local/no-bare-hex-colour does - not a suite-wide count.
+ * Recorded here so the next person does not conclude rule 2 was forgotten.
+ */

--- a/__tests__/terminalOnlyConstants.test.mts
+++ b/__tests__/terminalOnlyConstants.test.mts
@@ -38,7 +38,21 @@ import { fileURLToPath } from 'node:url';
 const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 /** Terminal-only components, by the naming convention the codebase already
- *  uses: a `*Terminal.tsx` renders only under [data-design="terminal"]. */
+ *  uses: a `*Terminal.tsx` renders only under [data-design="terminal"].
+ *
+ *  THE SUFFIX IS LOAD-BEARING. A terminal-only component named anything else
+ *  is not in this sweep and never will be - the file-set test below catches a
+ *  component renamed OUT of the pattern, but nothing can catch one that never
+ *  matched it. So naming a new terminal component `FooPanel.tsx` silently
+ *  exempts it from rule 1.
+ *
+ *  Worth knowing that the convention is doing real work rather than describing
+ *  what someone remembered: asked to list the terminal-only components from
+ *  memory, QA would have missed CorrelationTerminal, LiqTerminal and
+ *  MarketsTerminal. The suffix found them.
+ *
+ *  If a terminal-only component ever lands under another name, add it to
+ *  BASELINE by hand at its current count. */
 function terminalOnlyFiles(dir: string): string[] {
   return readdirSync(dir).flatMap(name => {
     const full = path.join(dir, name);


### PR DESCRIPTION
## Summary

#663's rule 1, made checkable. A per-file count ratchet over the eight `*Terminal.tsx` components.

```
BriefingTerminal      43        LandingTerminal   169
CorrelationTerminal    9        LiqTerminal        56
DashboardTerminal     16        MarketsTerminal    33
FundingTerminal       35        ScannerTerminal     0
```

**These only go down.**

## Counts, not an enumerated baseline — and that follows from your ruling

#751's detector lists its 25 collisions individually, so fixing one requires deleting its line. **That does not scale to 361.** Your ruling on #663 was explicit:

> *"Do not open a PR fixing them. They are ownership ambiguities, not measured failures. Work them under the convention as the files are touched."*

A count ratchet is what permits exactly that and forbids the opposite. New code cannot add one; touching a file to remove some lets the number fall.

**Per file rather than a total**, so moving debt between components still fails — a single number would let `LandingTerminal`'s 169 absorb another file's additions silently.

The file-set assertion exists because a component renamed out of the `*Terminal.tsx` pattern would **leave the sweep and take its count with it**: a silent exit rather than a failure. Same shape as the `.gchat-coin` overrides surviving their own deletion.

## Rule 2 is deliberately not enforced, and that is measured

Rule 2 governs dual-design components — **every other `.tsx`** — where a constant inline value is the codebase's normal idiom. The same sweep there returns thousands, not hundreds.

A ratchet at that size measures the codebase's age rather than its discipline, and **a number nobody can move is a number nobody reads.** Rule 2 wants a lint rule that fires while the file is being edited, the way `local/no-bare-hex-colour` does. That is a different mechanism, not a smaller version of this one.

It is recorded in the test file so it reads as a decision rather than an omission. If you would rather I built the lint rule, say so — it is a bigger piece than this and I would want it sequenced rather than slipped in.

## What counts as a constant

A literal: a quoted string, a template literal, or a number.

`fontSize: 'var(--fs-caption)'` **is** a constant by this definition — the token adapts, but the decision to use that token is fixed at write time and belongs in a stylesheet. `fontWeight: bold ? 700 : 400` is not, and neither is `fontSize: size`. The control asserts both directions, because a counter that also caught computed values would fail every honest edit and get deleted within a week.

## Control

Added a constant inline style to `ScannerTerminal.tsx`, which sits at **0**. The ratchet failed and named the file. Removed.

## How to test (QA)

1. `npm test` — three tests.
2. **The control is the one to read**: it checks that the counter sees a constant *and* ignores a computed value. A counter that matched nothing would pass the ratchet forever.
3. Try it yourself: add `style={{ fontSize: 12 }}` anywhere in `ScannerTerminal.tsx` and watch it fail with the file named.

## Risk level

**Low.** Test-only. Four gates via `npm run verify`: lint 0 errors, typecheck clean, 619/619, build succeeds.

**One judgement worth challenging:** `*Terminal.tsx` is how I identified terminal-only components, on the codebase's own naming convention. If a terminal-only component ever lands under another name it is outside this sweep, and the file-set test will not catch that — it catches renames *out*, not omissions *in*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
