### PR TITLE
docs(qa): the entitled-session fixture is Playwright-only by construction (#767)

### DIFF
--- a/qa/e2e/_entitled-session.ts
+++ b/qa/e2e/_entitled-session.ts
@@ -28,6 +28,30 @@ import type { Page } from '@playwright/test';
  * It is a local test double for a client library that reads its session from
  * localStorage, not a key to anything.
  *
+ * IT DOES NOT WORK OUTSIDE PLAYWRIGHT, AND THAT IS NOT A BUG TO FIX (#767)
+ *
+ * The interception is not a convenience wrapped around the fixture — it IS the
+ * fixture. Seeding the same localStorage key by hand in an ordinary browser
+ * does not produce a signed-in app: supabase-js attempts a refresh with the
+ * deliberately-invalid refresh token, the request actually reaches Supabase,
+ * the refresh fails, and the client DISCARDS the session. The page renders
+ * signed out, with no error to explain why.
+ *
+ * That was tried on 2026-09-04 and reported as "the fixture is broken". It is
+ * not: the invalid signature is what makes it safe, and answering its requests
+ * locally is what makes it work. Both halves are load-bearing and neither can
+ * be dropped to make it portable.
+ *
+ * THE CONSEQUENCE IS THE PART TO KNOW. Nothing behind sign-in can be verified
+ * by rendering a deployed environment. On one day that left four findings
+ * source-only: the terminal nav's signed-in avatar (#747), the chart's
+ * price-alert line (#759), the journal's badge dots (#756) and the /alerts
+ * Telegram button (#786). Any of those needs either a Playwright run — which
+ * is owner-gated, it costs real money — or a human signed in at a keyboard.
+ *
+ * So when a QA report says "unverified, behind sign-in", this file is why, and
+ * the fix is not in this file.
+ *
  * HOW IT WORKS
  *
  * `AuthProvider` resolves the user from `sb.auth.getSession()`


### PR DESCRIPTION
## Summary

Closes the **"document it"** half of #767. QA-owned tooling, PR into `dev`.

## What changed

A section in `qa/e2e/_entitled-session.ts`'s header saying the fixture cannot work outside Playwright, why that is **structural rather than a defect**, and what it costs.

## Why

On 2026-09-04 dev seeded the same `localStorage` key by hand in an ordinary browser to check the signed-in terminal avatar, and the app rendered signed out. Reported — reasonably — as *"the fixture is broken outside Playwright"*.

**It is not broken.** The interception is not a convenience wrapped around the fixture, it **is** the fixture:

```
supabase-js attempts a refresh with the deliberately-invalid refresh token
  -> the request actually reaches Supabase
  -> the refresh fails
  -> the client DISCARDS the session
  -> the page renders signed out, with no error to explain why
```

The invalid signature is what makes the token safe to commit. Answering its requests locally is what makes it function. **Both halves are load-bearing and neither can be dropped to make it portable.**

## The consequence is the part worth writing down

Nothing behind sign-in can be verified by rendering a deployed environment. In one day that left four findings source-only:

```
#747   the terminal nav's signed-in avatar
#759   the chart's price-alert line
#756   the journal's badge dots
#786   the /alerts Telegram button
```

Each needs either a Playwright run — **owner-gated, it costs real money** — or a human signed in at a keyboard.

So when a QA report says *"unverified, behind sign-in"*, this file is why, and the fix is not in this file.

## What stays open

The **"find a manual signed-in path"** half of #767. That is a decision for the owner — a real test account, an owner-approved Playwright run, or accepting the gap — not a code change I can make.

## How to test (QA)

Reviewer is dev.

1. Open `qa/e2e/_entitled-session.ts`. The new section sits between the "not a credential" paragraph and `HOW IT WORKS`.
2. Confirm it reads as *this is by construction* rather than *this is a known bug* — the distinction is the whole point.
3. Confirm the four issue numbers are the ones actually left source-only.

## Risk level

**Low.** A comment in a test fixture. No behaviour change, no application code.

— QA Team

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
