### PR TITLE
docs(qa): name the shape the traps share, so eleven incidents read as one principle

### DIFF
--- a/qa/README.md
+++ b/qa/README.md
@@ -21,6 +21,28 @@ The tools in this folder encode traps that a fresh script re-hits. They are
 written *inside* those tools, which is exactly where nobody looks while writing
 a replacement for them. So they are repeated here.
 
+**Nine of the eleven below are one shape: an instrument answering a question
+ADJACENT to the one asked, and returning something well-formed.** Not an error,
+not a zero — a plausible number, correctly computed, about the wrong thing. Only
+7 (a substring match) and 8 (prose citing deleted code) sit outside it.
+
+That is the durable part. A reader who internalises **"well-formed output is not
+evidence of the right question"** has nine of these already; the numbered
+incidents below are just the ways it has actually happened here.
+
+Three of them form a sequence, and each passes the previous check:
+
+```
+3    did I match anything at all?
+3b   did I match the right component?
+11   do the things I matched carry the property I am claiming about?
+```
+
+#756's twenty borders existed, were on the right page, were correctly measured,
+and were neutral. Every guard in place was satisfied. **A wrong subject that
+happens to pass is more durable than one that fails**, because nothing ever
+comes back to it.
+
 **If a committed tool already answers your question, run it.** When an ad-hoc
 script and a purpose-built one disagree, the ad-hoc one is the hypothesis, not
 the finding. On 2026-09-04 a fresh probe reported `/correlation` terminal at


### PR DESCRIPTION
## Summary

One framing paragraph at the top of `qa/README.md`'s trap list. Dev's observation on #803, and it is worth more than any single entry in the list.

## What changed

**Nine of the eleven traps are one shape:** an instrument answering a question *adjacent* to the one asked, and returning something **well-formed**. Not an error, not a zero — a plausible number, correctly computed, about the wrong thing.

Only **7** (a substring match) and **8** (prose citing deleted code) sit outside it.

And three of them form a sequence where each passes the previous check:

```
3    did I match anything at all?
3b   did I match the right component?
11   do the things I matched carry the property I am claiming about?
```

## Why this earns a place at the top

Eleven numbered incidents read as **eleven things to remember**. *"Well-formed output is not evidence of the right question"* gets a reader nine of them at once, and turns the incidents into examples rather than the lesson.

The sequence is the part to put in front of someone first. `#756`'s twenty `.coin-icon` borders **existed**, were on the **right page**, were **correctly measured** — and were neutral. Every guard in place was satisfied.

**A wrong subject that happens to pass is more durable than one that fails**, because nothing ever comes back to it.

## Not a restructure

The entries are unchanged and still numbered as filed. Dev's read was that the grouping is the durable part and a restructure was not worth doing today — I agree, and this is the two-line version of the grouping rather than the reorganisation.

## How to test (QA)

Reviewer is dev.

1. Open `qa/README.md`. The paragraph sits between the section's opening sentence and the "if a committed tool already answers your question" rule.
2. The sequence block should read as three checks in order, not three separate traps.
3. No entry text changed — `git diff` should touch only the section opener.

## Risk level

**Low.** Documentation only.

— QA Team

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
