### PR TITLE
feat(arena): realized liquidation clusters on the chart (#766)

### DIFF
--- a/__tests__/liqClusters.test.mts
+++ b/__tests__/liqClusters.test.mts
@@ -1,0 +1,101 @@
+/* Cluster selection for the Arena chart overlay (#766).
+ *
+ * The interesting assertion is the coin filter, not the sort. LiqFeed emits
+ * every coin's buckets in one array and the consumer filters - so the way this
+ * overlay goes wrong is not an error or an empty chart, it is eight correct
+ * lines drawn on the wrong coin's candles. That is the shape qa/README.md now
+ * names in its preamble: a plausible result, correctly computed, about the
+ * wrong subject.
+ *
+ * The last test is the control. Without it every assertion here passes on a
+ * helper that returns [] for everything.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { topClustersForCoin, LIQ_CLUSTER_LINES } from '../lib/liqClusters.ts';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+type B = { coin: string; price: number; total: number };
+const b = (coin: string, price: number, total: number): B => ({ coin, price, total });
+
+test('keeps only the requested coin, whatever the casing on either side', () => {
+  const mixed = [b('BTC', 109_000, 9e6), b('ETH', 4_100, 8e6), b('SOL', 210, 7e6)];
+  assert.deepEqual(topClustersForCoin(mixed, 'btc').map(x => x.coin), ['BTC']);
+  assert.deepEqual(topClustersForCoin(mixed, 'BTC').map(x => x.coin), ['BTC']);
+  assert.deepEqual(topClustersForCoin(mixed, 'eth').map(x => x.price), [4_100]);
+  assert.deepEqual(topClustersForCoin(mixed, 'doge'), []);
+});
+
+test('a coin name is matched whole, not as a substring', () => {
+  /* 'ETH' inside 'WETH', and 'BTC' inside 'BTCDOM' - the substring match is
+     trap 7 in qa/README.md and it is one `.includes()` away in this function. */
+  const near = [b('WETH', 4_100, 5e6), b('BTCDOM', 2_400, 5e6), b('BTC', 109_000, 1e6)];
+  assert.deepEqual(topClustersForCoin(near, 'eth'), []);
+  assert.deepEqual(topClustersForCoin(near, 'btc').map(x => x.price), [109_000]);
+});
+
+test('heaviest first, and never more than the ruled 8', () => {
+  const many = Array.from({ length: 20 }, (_, i) => b('BTC', 100_000 + i * 100, (i + 1) * 1e6));
+  const top = topClustersForCoin(many, 'btc');
+  assert.equal(top.length, LIQ_CLUSTER_LINES);
+  assert.equal(LIQ_CLUSTER_LINES, 8, "the owner's ruling on #766 was eight lines");
+  assert.deepEqual(top.map(x => x.total), [20e6, 19e6, 18e6, 17e6, 16e6, 15e6, 14e6, 13e6]);
+  // Descending, so the caller can label the heaviest without re-sorting.
+  for (let i = 1; i < top.length; i++) assert.ok(top[i - 1].total >= top[i].total);
+});
+
+test('the input array is not reordered underneath the caller', () => {
+  /* .sort() mutates in place. LiqFeed holds this array in React state and
+     hands the same reference to every consumer, so sorting it here would
+     silently reorder /liq's list from the Arena chart. .filter() copies
+     first - this test is what keeps it that way. */
+  const original = [b('BTC', 1, 1e6), b('BTC', 2, 9e6), b('BTC', 3, 5e6)];
+  const snapshot = original.map(x => x.price);
+  topClustersForCoin(original, 'btc');
+  assert.deepEqual(original.map(x => x.price), snapshot);
+});
+
+test('a price a chart cannot draw is dropped, not passed through', () => {
+  const junk = [
+    b('BTC', NaN, 9e6), b('BTC', Infinity, 8e6), b('BTC', 0, 7e6), b('BTC', -5, 6e6),
+    b('BTC', 109_000, NaN), b('BTC', 108_000, 0),
+    b('BTC', 107_000, 1e6),
+  ];
+  assert.deepEqual(topClustersForCoin(junk, 'btc'), [b('BTC', 107_000, 1e6)]);
+});
+
+test('empty, null and undefined inputs return an empty list rather than throwing', () => {
+  assert.deepEqual(topClustersForCoin([], 'btc'), []);
+  assert.deepEqual(topClustersForCoin(null, 'btc'), []);
+  assert.deepEqual(topClustersForCoin(undefined, 'btc'), []);
+});
+
+test('the overlay label says REALIZED, and no drawing path can omit it', () => {
+  /* The one defect a reviewer cannot see by looking at the chart: these are
+     liquidations that ALREADY happened. Coinglass sold PREDICTED levels -
+     a forward magnet - and the two are indistinguishable once drawn. So the
+     word is asserted against the source rather than trusted to survive an
+     edit. Both the overlay text and the toggle's tooltip are checked, because
+     a user who never hovers reads only the first. */
+  const chart = readFileSync(path.join(ROOT, 'components', 'KLineProChart.tsx'), 'utf8');
+  const drawText = chart.match(/text: `REALIZED LIQ [^`]*`/);
+  assert.ok(drawText, 'the liqClusterLine label no longer starts with REALIZED LIQ');
+  assert.ok(/not predicted liquidation levels/i.test(chart),
+    'the Liq toggle tooltip no longer says these are not predicted levels');
+  assert.ok(!/PREDICTED LIQ|predicted level[s]? at|liquidation magnet/i.test(drawText[0]),
+    'the drawn label implies a forward prediction');
+});
+
+test('CONTROL: the helper returns something, so the assertions above can fail', () => {
+  /* "0 failures" is the least trustworthy output in this repo. A helper that
+     returned [] unconditionally would satisfy every deepEqual against [] above
+     and most of the rest by vacuous truth. */
+  const one = topClustersForCoin([b('BTC', 109_000, 4.2e6)], 'btc');
+  assert.equal(one.length, 1);
+  assert.equal(one[0].price, 109_000);
+  assert.equal(one[0].total, 4.2e6);
+});

--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -1,5 +1,5 @@
 ﻿'use client';
-import { useState, useEffect, useRef, useCallback, Suspense } from 'react';
+import { useState, useEffect, useMemo, useRef, useCallback, Suspense } from 'react';
 import Link from 'next/link';
 import { useNow } from '@/lib/useNow';
 import { useSearchParams } from 'next/navigation';
@@ -25,7 +25,8 @@ import AbsorptionDetector, { AbsorptionData } from '@/components/AbsorptionDetec
 import EMASignal from '@/components/EMASignal';
 import HigherTfMoveBadge from '@/components/HigherTfMoveBadge';
 import Tip from '@/components/Tip';
-import LiqHeatmap from '@/components/LiqHeatmap';
+import LiqFeed, { type Bucket } from '@/components/LiqFeed';
+import { topClustersForCoin } from '@/lib/liqClusters';
 import UsageMeter from '@/components/UsageMeter';
 import { useEMAStrategy, strategyToGrokLine, STRATEGY_LOADING, StrategySignal, DEFAULT_FILTER_PARAMS, STRICT_FILTER_PARAMS } from '@/lib/useEMAStrategy';
 import { computeDistributionScore, distributionColor, DistributionInputs } from '@/lib/distribution';
@@ -39,6 +40,12 @@ import { GATED_TFS as LIMIT_GATED_TFS, FREE_FALLBACK_TF as LIMIT_FREE_FALLBACK_T
 import { computeSectorRotation } from '@/lib/sectorRotation';
 import { latestStructureSignal, describeStructureSignal, type PASignal } from '@/lib/priceAction';
 import { usePerpSpot } from '@/lib/usePerpSpot';
+
+/* Slowest rate at which realized liquidation clusters are handed to the chart.
+   Matches LiqFeed's own EVENTS_EMIT_MS for the same reason: the clusters
+   accumulate over 24 hours, so a faster refresh redraws overlays without
+   changing what they say. */
+const LIQ_CLUSTER_REFRESH_MS = 15_000;
 
 /* ── Pattern detection - delegates to shared lib/patterns.ts ── */
 function detectPatterns(candles: Candle[]): string { return detectPatternsStr(candles); }
@@ -190,6 +197,33 @@ function ArenaContent() {
   // chart rather than recomputed here so the score votes on the same break the
   // chart marks, on whichever timeframe is being viewed.
   const [chartStructure, setChartStructure] = useState<PASignal | null>(null);
+  /* Realized liquidation clusters, lifted out of the LiqFeed card below the
+     chart so the chart overlay can draw them (#766). Every coin's buckets
+     arrive in this one array - LiqFeed does not apply its own coinFilter to
+     what it emits - so it is stored raw here and narrowed at the point of use. */
+  const [liqClusters, setLiqClusters] = useState<Bucket[]>([]);
+  /* Throttled, and this is not a micro-optimisation. LiqFeed calls onClusters
+     from `rebuild()`, which runs on EVERY liquidation event - not on a timer -
+     and each call is a fresh array. Committing all of them would clear and
+     recreate eight chart overlays several times a second during a cascade,
+     which is exactly when the user is looking at the chart. LiqFeed throttles
+     its other consumer callback for the same reason (EVENTS_EMIT_MS, 15s), and
+     the underlying window is a 24-hour accumulation - being up to 15 seconds
+     behind it is not observable. /liq is unaffected: it keeps every emission. */
+  const liqEmitRef = useRef(0);
+  const handleLiqClusters = useCallback((c: Bucket[]) => {
+    const now = Date.now();
+    if (now - liqEmitRef.current < LIQ_CLUSTER_REFRESH_MS) return;
+    liqEmitRef.current = now;
+    setLiqClusters(c);
+  }, []);
+  /* Narrowed to the displayed coin here, memoised so the chart's draw effect
+     re-runs when the clusters actually change rather than on every Arena
+     re-render - and this page re-renders on every market tick. */
+  const chartLiqClusters = useMemo(
+    () => topClustersForCoin(liqClusters, selectedCoin),
+    [liqClusters, selectedCoin],
+  );
   const absDataRef    = useRef<AbsorptionData | null>(null);
   const emaSignalRef  = useRef<StrategySignal>(STRATEGY_LOADING);
   const oi1h          = useOI1h(selectedCoin);
@@ -1992,7 +2026,7 @@ function ArenaContent() {
       <div className="arena-ws">
         <div className="arena-ws-chart">
       {/* ── CHART - KLineChart with auto Entry/SL/TP overlays ── */}
-      <KLineProChart coin={selectedCoin} tf={readTf} onTfChange={handleTfChange} result={result} emaSignal={emaSignal} chartAlerts={chartAlerts} onAlertMove={handleAlertMove} gexLevels={selectedCoin === 'btc' ? { flip: store.btcGexFlip, maxPain: store.btcMaxPain } : null} onStructure={setChartStructure} />
+      <KLineProChart coin={selectedCoin} tf={readTf} onTfChange={handleTfChange} result={result} emaSignal={emaSignal} chartAlerts={chartAlerts} onAlertMove={handleAlertMove} gexLevels={selectedCoin === 'btc' ? { flip: store.btcGexFlip, maxPain: store.btcMaxPain } : null} liqClusters={chartLiqClusters} onStructure={setChartStructure} />
       {/* Directly under the chart, on the owner's request (#370). The read
           refers to what the chart shows - "price below EMAs", "closing below
           the swing low", "lower wick at Fib support" - so anything between
@@ -2157,13 +2191,22 @@ function ArenaContent() {
 
       {/* ── Evidence + advanced (full width, below the workspace) ── */}
       <div className="arena-below-chart">
-      {/* BTC Liquidation Heatmap - shows only when BTC selected and data available */}
-      {selectedCoin === 'btc' && store.btcLiqLevels.length > 0 && (
-        <LiqHeatmap
-          levels={store.btcLiqLevels}
-          currentPrice={store.coins['btc']?.price ?? 0}
-        />
-      )}
+      {/* Live liquidations for the selected coin, and the source of the chart's
+          realized-cluster lines above (#766).
+
+          REPLACES the BTC Liquidation Heatmap that stood here. That card was
+          unreachable code, not a working feature: it rendered only when
+          `store.btcLiqLevels.length > 0`, and that array is permanently empty -
+          Coinglass retired the v2 endpoints, v4 answers 401 on this tier, and
+          pendings/PENDING.md:18 defers the upgrade until revenue. It had drawn
+          zero times, for every coin, in every theme. `LiqHeatmap.tsx` and its
+          labels are left in the repo untouched, so restoring it is one import
+          if the Coinglass tier is ever bought.
+
+          What replaces it is not the same claim. The heatmap showed PREDICTED
+          liquidation levels bought from a vendor; this shows REALIZED ones
+          streamed from Binance and Bybit - keyless, free, and not BTC-only. */}
+      <LiqFeed onClusters={handleLiqClusters} coinFilter={selectedCoin.toUpperCase()} />
       {/* GEX / Options Market Pressure table removed here 2026-07-25
           (signal-overload pass): biggest single block on the page (~456px),
           BTC-only, and max-pain/net-gamma is background context rather than a

--- a/components/KLineProChart.tsx
+++ b/components/KLineProChart.tsx
@@ -9,6 +9,7 @@ import { detectStructureSignals, type PASignal } from '@/lib/priceAction';
 import { Warn } from '@/components/icons';
 import { useDesignMode } from '@/components/DesignModeProvider';
 import { barsAfter } from '@/lib/candles';
+import { LIQ_CLUSTER_LINES } from '@/lib/liqClusters';
 
 // ── v10 Period mapping ────────────────────────────────────────────────────
 
@@ -352,6 +353,15 @@ export interface ChartAlert {
   label?:       string;
 }
 
+/* One realized-liquidation cluster. Structurally LiqFeed's `Bucket` minus the
+   fields this chart does not draw - declared here rather than imported so the
+   chart does not depend on the feed component, and so a future second source
+   of clusters needs no change on this side. */
+export interface LiqClusterLine {
+  price: number;
+  total: number;
+}
+
 interface Props {
   coin:          CoinId;
   tf:            ChartTf;
@@ -362,6 +372,12 @@ interface Props {
   onAlertMove?:  (id: string, newPrice: number) => void;
   // BTC options context lines (null for non-BTC or before data loads).
   gexLevels?:    { flip: number | null; maxPain: number | null } | null;
+  /* Realized liquidation clusters for the coin this chart is DISPLAYING,
+     heaviest first. Filtering by coin is the caller's job and is not optional -
+     LiqFeed emits every coin's buckets in one array, so passing them
+     unfiltered draws another coin's price levels on these candles. Use
+     lib/liqClusters.ts's topClustersForCoin rather than doing it by hand. */
+  liqClusters?:  LiqClusterLine[] | null;
   // Latest market-structure break on the CURRENTLY DISPLAYED timeframe, or null
   // when there is none. Emitted rather than recomputed by the consumer so the
   // Confluence Score votes on exactly the break the user can see marked on this
@@ -377,9 +393,45 @@ let emaSignalOverlayRegistered = false;
 let emaRibbonLineRegistered = false;
 let srLevelLineRegistered = false;
 let gexLevelLineRegistered = false;
+let liqClusterLineRegistered = false;
 let analysisLevelLineRegistered = false;
 let reversalOverlayRegistered = false;
 let structureOverlayRegistered = false;
+
+/* Realized-liquidation clusters get pink, and the choice is by elimination
+   rather than taste: red and green are S/R and long/short on this chart, violet
+   and cyan are the GEX pair, gold/blue/orange are the EMA ribbon. A cluster line
+   is neither directional nor a forward level, so it must not borrow any of
+   those readings.
+   Measured, not assumed: white on #db2777 is 4.56:1, which clears 4.5:1. The
+   S/R labels next to it do not - white on #f87171 is 2.82:1 - so this is the
+   readable one rather than one matching the neighbours at their own level. */
+const LIQ_CLUSTER_COLOR = '#db2777';
+
+/* A canvas strokeStyle cannot resolve a CSS custom property. Passing
+   'var(--amber)' neither throws nor paints amber - the context keeps whatever
+   colour was set last, so the line silently inherits the previous overlay's.
+   This file already suspected that (see the EMA_PERIODS note) and nothing had
+   confirmed it. Adding the liquidity cluster lines confirmed it by accident:
+   EMA9 and EMA200 were painting GREEN, borrowed from the S/R support line, and
+   turned PINK the moment a pink overlay drew before them. A colour that
+   depends on what else is on the chart is not being read from this file at all.
+   Resolved per paint rather than once at overlay creation - the ribbon is not
+   recreated on a theme switch, only on a coin or timeframe change - and cached
+   per token + theme + design so a repaint is not four getComputedStyle calls. */
+const cssColorCache = new Map<string, string>();
+function resolveCssColor(color: string): string {
+  const m = /^var\(\s*(--[A-Za-z0-9_-]+)\s*\)$/.exec(color.trim());
+  if (!m) return color;
+  const root = document.documentElement;
+  const key = `${m[1]}|${root.getAttribute('data-theme') ?? ''}|${root.getAttribute('data-design') ?? ''}`;
+  const hit = cssColorCache.get(key);
+  if (hit !== undefined) return hit;
+  const value = getComputedStyle(root).getPropertyValue(m[1]).trim();
+  const out = value || color;
+  cssColorCache.set(key, out);
+  return out;
+}
 
 /* One EMA period's ribbon line - drawn as a single continuous polyline overlay,
    not a klinecharts built-in indicator. The indicator system folds every
@@ -523,7 +575,7 @@ function computeSRLevels(
   return [...resistances, ...supports];
 }
 
-export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal, chartAlerts, onAlertMove, gexLevels, onStructure }: Props) {
+export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal, chartAlerts, onAlertMove, gexLevels, liqClusters, onStructure }: Props) {
   const mode = useDesignMode();
   /* The init effect below runs once and must not re-run when the design mode
      resolves - re-creating the chart would throw away its data. So it reads
@@ -540,6 +592,7 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
   const wsRef          = useRef<{ close: () => void } | null>(null);
   const analysisIds    = useRef<string[]>([]);
   const gexLevelIds    = useRef<string[]>([]);
+  const liqClusterIds  = useRef<string[]>([]);
   // One overlay id per EMA_PERIODS entry, in the same order - null until the
   // overlay has actually been created (first sync after data loads).
   const emaRibbonIds   = useRef<Array<string | null>>(EMA_PERIODS.map(() => null));
@@ -599,6 +652,13 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
   // default: the Arena signal-overload pass deliberately reduced what shows on
   // this chart, so a new marker family opts in rather than arriving unasked.
   const [showPA, setShowPA]       = useState(false);
+  /* Realized liquidation clusters. ON by default, unlike showPA above: the
+     owner asked for these to be displayed on the chart (#766) and a feature
+     that has to be discovered through a toolbar button is not displayed. The
+     toggle exists because eight extra horizontal lines is real ink on a chart
+     that had a deliberate signal-reduction pass - a user who wants the candles
+     alone gets one click, not a setting. */
+  const [showLiq, setShowLiq]     = useState(true);
   const [paSignals, setPaSignals] = useState<PASignal[]>([]);
   const paSetRef                  = useRef(setPaSignals);
   const [sqHover, setSqHover]     = useState(false);
@@ -1174,7 +1234,7 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
             return [{
               type: 'line',
               attrs: { coordinates: pts },
-              styles: { style: 'solid', color, size },
+              styles: { style: 'solid', color: resolveCssColor(color), size },
             }];
           },
         });
@@ -1265,6 +1325,56 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
                   color: '#ffffff', size: 9, weight: '700',
                   paddingLeft: 5, paddingRight: 5, paddingTop: 2, paddingBottom: 2,
                   backgroundColor: color,
+                  borderRadius: document.documentElement.getAttribute('data-design') === 'terminal' ? 0 : 3,
+                },
+              },
+            ];
+          },
+        });
+      }
+
+      if (!liqClusterLineRegistered) {
+        liqClusterLineRegistered = true;
+        /* Realized liquidation clusters - the price levels where positions
+           actually blew up over the last 24h, streamed live from Binance
+           forceOrder and Bybit allLiquidation (components/LiqFeed.tsx).
+           THE LABEL IS THE SAFETY-CRITICAL PART, not the geometry. Coinglass
+           sold PREDICTED liquidation levels: where open positions WOULD blow
+           up, which traders read as a forward magnet. These are the opposite -
+           fuel already spent, price memory. Drawn on a chart the two are
+           indistinguishable, so the word REALIZED is in the label itself and
+           __tests__/liqClusters.test.mts asserts it stays there. A line that
+           silently changes tense is confidently wrong with nothing to reveal
+           it.
+           Dotted rather than dashed, and thinner than the GEX pair, because
+           eight of them share the plot with the candles they are context for. */
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (kc as any).registerOverlay({
+          name: 'liqClusterLine',
+          totalStep: 1,
+          needDefaultPointFigure: false,
+          needDefaultXAxisFigure: false,
+          needDefaultYAxisFigure: false,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          createPointFigures: ({ overlay, coordinates, bounding }: { overlay: any; coordinates: Array<{ x: number; y: number }>; bounding: any }) => {
+            const { price, total, labelYOffset } = overlay.extendData as { price: number; total: number; labelYOffset?: number };
+            const y = coordinates[0]?.y;
+            if (y == null || !isFinite(y) || y < 0) return [];
+            const rightX = (bounding?.width ?? 9999);
+            const labelY = y - 3 - (labelYOffset ?? 0);
+            return [
+              {
+                type: 'line',
+                attrs: { coordinates: [{ x: 0, y }, { x: rightX, y }] },
+                styles: { style: 'dashed', color: LIQ_CLUSTER_COLOR, size: 1, dashedValue: [1, 4] },
+              },
+              {
+                type: 'text',
+                attrs: { x: 6, y: labelY, text: `REALIZED LIQ $${fmtPx(price)} · ${fmtLiqUsd(total)}`, align: 'left', baseline: 'bottom' },
+                styles: {
+                  color: '#ffffff', size: 9, weight: '700',
+                  paddingLeft: 5, paddingRight: 5, paddingTop: 2, paddingBottom: 2,
+                  backgroundColor: LIQ_CLUSTER_COLOR,
                   borderRadius: document.documentElement.getAttribute('data-design') === 'terminal' ? 0 : 3,
                 },
               },
@@ -1950,6 +2060,38 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
     }
   }, [gexLevels, chartReady]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // ── Realized liquidation cluster lines (#766) ────────────────────────────
+  /* Deliberately NOT built on store.btcLiqLevels. That array is permanently
+     empty - Coinglass retired the v2 endpoints this app called, v4 answers
+     401 on this tier, and pendings/PENDING.md:18 defers it until revenue
+     (MarketProvider.tsx:927-946). An overlay fed from it would compile, pass
+     review and never draw a single line. The source here is LiqFeed's live
+     keyless streams, lifted through the page - see app/arena/page.tsx.
+     The slice is defensive: the caller already limits to LIQ_CLUSTER_LINES,
+     but this effect is what actually decides how much ink lands on the chart,
+     so it enforces the ruling itself rather than trusting its input. */
+  useEffect(() => {
+    const chart = chartRef.current;
+    if (!chart || !chartReady) return;
+    liqClusterIds.current.forEach(id => chart.removeOverlay({ id }));
+    liqClusterIds.current = [];
+    if (!showLiq || !liqClusters?.length) return;
+    const lines = liqClusters
+      .filter(l => Number.isFinite(l.price) && l.price > 0)
+      .slice(0, LIQ_CLUSTER_LINES);
+    const labelOffsets = computeLabelOffsets(lines);
+    for (const l of lines) {
+      const id = chart.createOverlay({
+        name: 'liqClusterLine',
+        groupId: 'liq_clusters',
+        lock: true,
+        extendData: { price: l.price, total: l.total, labelYOffset: labelOffsets.get(l.price) ?? 0 },
+        points: [{ value: l.price }],
+      } as OverlayCreate);
+      if (typeof id === 'string') liqClusterIds.current.push(id);
+    }
+  }, [liqClusters, showLiq, chartReady]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // ── Restore user-drawn lines for this coin, and swap them out on coin change ──
   useEffect(() => {
     const chart = chartRef.current;
@@ -2113,6 +2255,16 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
         >
           Structure
         </button>
+
+        {liqClusters && liqClusters.length > 0 && (
+          <button
+            className={`klc-tool-btn${showLiq ? ' on' : ''}`}
+            onClick={() => setShowLiq(v => !v)}
+            title="Toggle realized liquidation clusters - the heaviest price levels where positions were actually liquidated in the last 24h. Price memory, not predicted liquidation levels."
+          >
+            Liq
+          </button>
+        )}
 
         {chartAlerts && chartAlerts.length > 0 && (
           <div className="klc-legend">
@@ -2309,6 +2461,16 @@ function fmtPx(n: number): string {
   if (n >= 1)     return n.toFixed(3);
   if (n >= 0.01)  return n.toFixed(4);
   return n.toLocaleString('en-US', { maximumSignificantDigits: 4 });
+}
+
+/* Cluster size for the overlay label. Its own formatter rather than LiqFeed's
+   fmtUSD: this one shares a ~28-character label with a price, so it rounds
+   harder ($4.2M, $840K) than the feed's two-decimal version. */
+function fmtLiqUsd(n: number): string {
+  if (!Number.isFinite(n)) return '';
+  if (n >= 1_000_000) return '$' + (n / 1_000_000).toFixed(1) + 'M';
+  if (n >= 1_000)     return '$' + Math.round(n / 1_000) + 'K';
+  return '$' + Math.round(n);
 }
 
 // ── Helper ────────────────────────────────────────────────────────────────

--- a/lib/liqClusters.ts
+++ b/lib/liqClusters.ts
@@ -1,0 +1,52 @@
+/* Which realized-liquidation clusters reach a price chart.
+ *
+ * THE BUG THIS EXISTS TO PREVENT. LiqFeed emits its top 100 buckets across ALL
+ * COINS - `rebuild()` builds them from the whole event history and never
+ * consults the `coinFilter` prop, so `onClusters` hands the consumer BTC, ETH
+ * and SOL levels in one array (components/LiqFeed.tsx:132-149). The filtering
+ * is the consumer's job and always has been; app/liq/page.tsx:443 does it by
+ * hand. A caller that forgets draws BTC's $109,000 cluster across an ETH
+ * candlestick - a well-formed line, correctly computed, about the wrong coin,
+ * and nothing on screen says so.
+ *
+ * THE NUMBER 8 is the owner's ruling on #766 (2026-09-04): the eight heaviest
+ * clusters, drawn as horizontal lines, chosen explicitly over a right-edge
+ * histogram. It lives here rather than in the chart effect so a second consumer
+ * cannot pick a different eight.
+ *
+ * WHAT THESE ARE, since the naming is the part that can go quietly wrong:
+ * REALIZED liquidations - positions that already blew up, price memory, fuel
+ * already spent. NOT the predicted liquidation levels Coinglass sold, which are
+ * a forward magnet. The two look identical drawn on a chart, so every label
+ * this feeds must say realized.
+ */
+
+export const LIQ_CLUSTER_LINES = 8;
+
+/** The heaviest clusters for one coin, largest first.
+ *
+ *  Structural type rather than LiqFeed's `Bucket` so `lib/` does not import
+ *  from `components/`; `Bucket` satisfies it.
+ *
+ *  `coin` is matched case-insensitively because the two sides spell it
+ *  differently: `CoinId` is lowercase ('btc'), while a bucket's coin comes from
+ *  the exchange symbol and is uppercase ('BTC').
+ *
+ *  Non-finite and non-positive prices are dropped rather than passed on. A
+ *  chart overlay at price 0 or NaN does not throw - it draws at the axis edge
+ *  or vanishes, which is the quiet kind of wrong. */
+export function topClustersForCoin<T extends { coin: string; price: number; total: number }>(
+  buckets: readonly T[] | null | undefined,
+  coin: string,
+  limit: number = LIQ_CLUSTER_LINES,
+): T[] {
+  if (!buckets || buckets.length === 0) return [];
+  const want = coin.toLowerCase();
+  return buckets
+    .filter(b =>
+      typeof b.coin === 'string' && b.coin.toLowerCase() === want &&
+      Number.isFinite(b.price) && b.price > 0 &&
+      Number.isFinite(b.total) && b.total > 0)
+    .sort((a, b) => b.total - a.total)
+    .slice(0, Math.max(0, limit));
+}


### PR DESCRIPTION
## Summary

Realized liquidation clusters on the Arena chart — the 8 heaviest price levels for the displayed coin, drawn as horizontal lines. Owner's decision on #766 (2026-09-04), taking both design calls the issue left open: **top 8 as lines** (over a right-edge histogram) and **labelled realized, not predicted**.

Fed from `LiqFeed`'s live Binance/Bybit streams, **not** from `store.btcLiqLevels` — that array is permanently empty and an overlay built on it would compile, review cleanly and never draw.

One extra fix is in here that I did not go looking for. It is in **What changed**, item 4, with what it exposes.

## What changed

**1. `lib/liqClusters.ts` (new) — `topClustersForCoin()` + `LIQ_CLUSTER_LINES = 8`.**
`LiqFeed` emits its top 100 buckets **across all coins** — `rebuild()` builds them from the whole event history and never consults the `coinFilter` prop, so `onClusters` hands the consumer BTC, ETH and SOL levels in one array. `/liq` filters by hand at its call site. A caller that forgets draws BTC's $109,000 cluster across an ETH candlestick: a well-formed line, correctly computed, about the wrong coin. This helper makes that the hard path.

**2. `KLineProChart.tsx` — a `liqClusterLine` overlay, mirroring `gexLevelLine`.**
New `liqClusters` prop, an id ref, a draw effect that clears and recreates, and a `Liq` toolbar toggle (**on by default** — the owner asked for these to be displayed, and a feature you have to find in a toolbar is not displayed; the toggle exists because 8 lines is real ink on a chart that had a deliberate signal-reduction pass).

Colour is `#db2777`, by elimination rather than taste: red/green are S/R and long/short, violet/cyan are the GEX pair, gold/blue/orange are the EMA ribbon. Measured, not assumed — white on `#db2777` is **4.56:1**. The S/R labels beside it are **2.82:1** (white on `#f87171`), so the new label is the readable one rather than one matched to its neighbours' level.

**3. `app/arena/page.tsx` — the dead `LiqHeatmap` card is replaced by `<LiqFeed>`.**
That card was unreachable code, not a feature: gated on `store.btcLiqLevels.length > 0`, and that array never fills. It had rendered zero times, for every coin, in every theme. `LiqHeatmap.tsx` and its labels are **left in the repo untouched** — restoring it is one import if the Coinglass tier is ever bought.

The replacement does not make the same claim: the heatmap showed **predicted** levels bought from a vendor; `LiqFeed` shows **realized** ones from keyless streams, and it is not BTC-only.

Clusters are throttled to 15s before reaching the chart. `onClusters` fires on **every liquidation event**, not on a timer, so unthrottled this would clear and recreate 8 overlays several times a second during a cascade — exactly when someone is watching the chart. `/liq` is unaffected.

**4. `KLineProChart.tsx` — `resolveCssColor()`, a bug this PR found by accident.**
**A canvas `strokeStyle` cannot resolve `var(--amber)`.** It does not throw and does not paint amber — the context keeps whatever colour was set last. So **EMA9 and EMA200 have been painting a colour borrowed from another overlay**: green, taken from the S/R support line. They turned pink the moment a pink overlay drew ahead of them, which is how I found it. This file had already written the suspicion down — *"a separate, pre-existing 'does a CSS var string resolve inside a canvas fillStyle' question"* — and nothing had confirmed it. Now confirmed by rendering.

Fixed at the ribbon's draw site, resolved per paint (the ribbon is not recreated on a theme switch, only on a coin or timeframe change) and cached per token + theme + design.

## What this fix exposes, and deliberately does not decide

With the tokens actually resolving:

```
terminal dark    --amber #fbbf24   --accent #d9a626
terminal light   --amber #755100   --accent #754e00
```

**EMA9 and EMA200 are near-identical in both terminal contexts** — only line thickness separates them. That was invisible while the colour was leaking. `TERMINAL_EMA_COLOR` already carries a grey ramp for periods 20 and 50; extending it to 9 and 200 is the obvious completion, and it is **not in this PR** because it is a palette decision on a design QA owns the look of. Worth its own issue.

Same class, untouched and unmeasured: `var(--accent-2)` reaches the canvas at `KLineProChart.tsx:139` and `:921` (RSI) through klinecharts' own indicator styles rather than this overlay path.

## Why

The owner asked whether liquidity clusters could go on the Arena chart. Both halves already existed — a live cluster source and a locked-horizontal-line overlay pattern — but the path the code makes look obvious (`store.btcLiqLevels`) is dead, and building on it produces an overlay that silently never draws.

The label is the half that can go quietly wrong. These are liquidations that **already happened** — price memory, fuel already spent. Coinglass sold **predicted** levels, a forward magnet. Two different products, indistinguishable once drawn. `__tests__/liqClusters.test.mts` asserts the word `REALIZED` stays in the drawn label and in the toggle tooltip, and I verified that guard **fails** when the word is removed.

## How to test (QA)

On the **qa** environment, `/arena`:

1. **The lines.** Pick BTC, 1h. Below the chart there is now a live **Liquidations** card instead of nothing. Once it has events, up to 8 pink dotted horizontal lines appear on the chart, each labelled `REALIZED LIQ $<price> · $<size>`. On a quiet market the card may need a few minutes to accumulate — the levels are a 24h window, so they build rather than appear at once.
2. **The word.** Every label reads **REALIZED**. Nothing on the chart should suggest a predicted or forward level. Hover the `Liq` toolbar button: the tooltip says *"Price memory, not predicted liquidation levels."*
3. **The toggle.** `Liq` in the chart toolbar (next to `Structure`). Off removes all lines cleanly and leaves S/R and the EMA ribbon alone; on restores them.
4. **The coin filter — the one worth being suspicious of.** Switch from BTC to ETH. The lines must change to ETH price levels, and **no BTC level may remain**. A stale BTC line on an ETH chart is the exact failure this PR is built to prevent, and it would look completely plausible.
5. **Themes.** Check terminal dark and terminal light. Labels are white on pink, square-cornered in terminal, rounded in the current design.
6. **The EMA ribbon (item 4 above).** EMA9 and EMA200 should now be gold/blue in the current design rather than borrowing another overlay's colour. **In terminal they will look alike** — that is the exposed palette gap, not a new bug.
7. **`/liq` is unchanged** — same feed, same cluster list, no throttling there.

Verified locally on localhost:3016 across BTC and ETH, terminal dark and terminal light, with seeded clusters. The ETH control: an ETH bucket of $99M sat in the array while BTC was displayed and drew nothing; on ETH only ETH's levels drew.

## Risk level

**Medium.**

- **Not verified:** behaviour under a real cascade (hundreds of events/second). The throttle is reasoned from `LiqFeed`'s own emit cadence and tested with seeded data, not observed live.
- **Not verified:** `/arena` now opens Binance and Bybit liquidation websockets that it did not before — the same set `/liq` has always opened, but Arena is the heavier page. No error or slowdown seen locally; sustained load is untested.
- **Not verified:** coins with no liquidation stream (`fet` is Binance-only, `hype`/`xau`/`spx` are Bybit-only). They should simply show no lines and no toggle; I did not sit on each one.
- Item 4 changes the rendered colour of two EMA lines on every chart in the app. That is a fix, but it is a visible change nobody asked for in this PR.
- `LiqHeatmap` is now unreferenced. Intentional, reversible, and the file is untouched.

Gates: lint 0 errors, `tsc --noEmit` clean, 636 tests pass, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
