### PR TITLE
docs(chart): name resolveCssColor's scope limit in the function itself

### DIFF
--- a/components/KLineProChart.tsx
+++ b/components/KLineProChart.tsx
@@ -418,7 +418,18 @@ const LIQ_CLUSTER_COLOR = '#db2777';
    depends on what else is on the chart is not being read from this file at all.
    Resolved per paint rather than once at overlay creation - the ribbon is not
    recreated on a theme switch, only on a coin or timeframe change - and cached
-   per token + theme + design so a repaint is not four getComputedStyle calls. */
+   per token + theme + design so a repaint is not four getComputedStyle calls.
+
+   ONE LIMIT, AND IT IS THE SAME FAILURE ONE LAYER UP. getComputedStyle on the
+   root element sees stylesheet and :root declarations - it does NOT see a
+   custom property set inline on some other element. Every token this chart
+   draws with lives in a design block, so the read is correct here. Reused
+   somewhere element-scoped it would return the ROOT value: a plausible wrong
+   colour rather than nothing, which is precisely the class of bug this helper
+   was written to fix. #798 is the worked example - a defect filed against
+   --ec-muted on the strength of a root-scope read, when the property was set
+   inline per row at app/econ-calendar/page.tsx:298 and the root read was
+   answering a different question. */
 const cssColorCache = new Map<string, string>();
 function resolveCssColor(color: string): string {
   const m = /^var\(\s*(--[A-Za-z0-9_-]+)\s*\)$/.exec(color.trim());


### PR DESCRIPTION
## Summary

One comment block on `resolveCssColor()` in `KLineProChart.tsx`, naming the scope limit QA raised while reviewing #805. No behaviour change.

QA's note was: `getComputedStyle(root)` sees stylesheet and `:root` declarations but not element-scoped ones, so the helper is correct for chart tokens today and would be wrong if reused somewhere element-scoped. They said it belongs in the function's own comment rather than only in a review thread. This is that.

## What changed

`components/KLineProChart.tsx` — 12 added lines of comment, all inside the existing block above `resolveCssColor`. Nothing executable moved.

The comment names what a wrong reuse would produce: **the root value — a plausible wrong colour rather than nothing.** That is the same class of failure the helper was written to fix, one layer up, which is why it is worth the words. It cites #798 as the worked example: a defect filed against `--ec-muted` on the strength of a root-scope read, when the property was set inline per row at `app/econ-calendar/page.tsx:298`.

## Why

A limit that lives only in a review thread is not a limit anyone will find. The next person to reuse this helper reads the function, not PR #805's comments.

There is also a specific reason this one is worth writing down rather than trusting to memory: the helper is small, obviously correct where it stands, and returns a well-formed colour in the case where it is wrong. Nothing about calling it in the wrong place looks like a mistake.

## How to test (QA)

Nothing to click. `git show` on the commit, or read `resolveCssColor` in `components/KLineProChart.tsx` — the EMA ribbon should render exactly as it does on `qa` today, which is the point.

## Risk level

**Low.** Comment-only. Gates run because they always do, not because this could fail one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
