### PR TITLE
fix(arena): draw liquidation clusters on first paint, not 15s later

### DIFF
--- a/__tests__/liqClusters.test.mts
+++ b/__tests__/liqClusters.test.mts
@@ -15,7 +15,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { topClustersForCoin, LIQ_CLUSTER_LINES } from '../lib/liqClusters.ts';
+import { topClustersForCoin, acceptClusterEmission, LIQ_CLUSTER_LINES } from '../lib/liqClusters.ts';
 
 const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -88,6 +88,51 @@ test('the overlay label says REALIZED, and no drawing path can omit it', () => {
     'the Liq toggle tooltip no longer says these are not predicted levels');
   assert.ok(!/PREDICTED LIQ|predicted level[s]? at|liquidation magnet/i.test(drawText[0]),
     'the drawn label implies a forward prediction');
+});
+
+/* The throttle. These are regression tests for a defect that shipped: an empty
+ * first emission ate the window and the real batch was dropped for 15 seconds,
+ * which read as "the feature does not work on a deployed build" to two people.
+ * Every case fixes the clock rather than sleeping - a timing test that waits is
+ * a timing test that flakes. */
+const GAP = 15_000;
+/* A real page mount, not a toy clock. `lastCommitAt` starts at 0 meaning
+   "never committed", and Date.now() is an epoch millisecond - so on the very
+   first emission the window has trivially elapsed. Writing the first version of
+   these tests with now=1000 modelled a page mounting one second after 1970 and
+   failed for that reason, which is the same class of mistake as measuring the
+   wrong component: the arithmetic was right about a situation that never
+   happens. */
+const T0 = 1_757_000_000_000;
+const accept = (hasFilled: boolean, incoming: number, now: number, lastCommitAt: number) =>
+  acceptClusterEmission({ hasFilled, incoming, now, lastCommitAt, minGapMs: GAP });
+
+test('the first emission carrying clusters lands however recently one was committed', () => {
+  // LiqFeed's mount order: rebuild([]) at :153, then the seeded rebuild at :280
+  // a millisecond later. The second one is the whole feature.
+  assert.equal(accept(false, 0, T0, 0), true, 'the empty first emission commits and starts the window');
+  assert.equal(accept(false, 8, T0 + 1, T0), true, 'the seeded batch 1ms later must not be dropped');
+});
+
+test('once filled, the window applies', () => {
+  assert.equal(accept(true, 8, T0 + 5_000, T0), false, '5s after a commit is inside the 15s window');
+  assert.equal(accept(true, 8, T0 + 15_000, T0), true, 'exactly at the window boundary commits');
+  assert.equal(accept(true, 8, T0 + 20_000, T0), true, 'past the window commits');
+});
+
+test('an empty emission never counts as the first fill', () => {
+  /* Otherwise a page that legitimately has no clusters would consume the
+     bypass, and the first real batch would wait out the window after all -
+     the original bug with one extra step. */
+  assert.equal(accept(false, 0, T0, 0), true, 'it still commits, to clear a stale list');
+  assert.equal(accept(false, 8, T0 + 1, T0), true, 'and the bypass is still available to the real batch');
+});
+
+test('CONTROL: the throttle actually throttles', () => {
+  /* A predicate stuck on `true` would satisfy every "must land" case above and
+     nothing here would notice. */
+  assert.equal(accept(true, 8, T0 + 14_999, T0), false);
+  assert.equal(accept(true, 0, T0 + 1, T0), false);
 });
 
 test('CONTROL: the helper returns something, so the assertions above can fail', () => {

--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -26,7 +26,7 @@ import EMASignal from '@/components/EMASignal';
 import HigherTfMoveBadge from '@/components/HigherTfMoveBadge';
 import Tip from '@/components/Tip';
 import LiqFeed, { type Bucket } from '@/components/LiqFeed';
-import { topClustersForCoin } from '@/lib/liqClusters';
+import { topClustersForCoin, acceptClusterEmission } from '@/lib/liqClusters';
 import UsageMeter from '@/components/UsageMeter';
 import { useEMAStrategy, strategyToGrokLine, STRATEGY_LOADING, StrategySignal, DEFAULT_FILTER_PARAMS, STRICT_FILTER_PARAMS } from '@/lib/useEMAStrategy';
 import { computeDistributionScore, distributionColor, DistributionInputs } from '@/lib/distribution';
@@ -209,11 +209,25 @@ function ArenaContent() {
      which is exactly when the user is looking at the chart. LiqFeed throttles
      its other consumer callback for the same reason (EVENTS_EMIT_MS, 15s), and
      the underlying window is a 24-hour accumulation - being up to 15 seconds
-     behind it is not observable. /liq is unaffected: it keeps every emission. */
+     behind it is not observable. /liq is unaffected: it keeps every emission.
+
+     The first emission that carries anything bypasses the window, and that is
+     not a nicety - LiqFeed's mount order emits an EMPTY array before it emits
+     the seeded one, so a plain throttle commits the empty and drops the real
+     batch. See acceptClusterEmission in lib/liqClusters.ts for the mechanism;
+     it cost a "the feature does not work on staging" report to find. */
   const liqEmitRef = useRef(0);
+  const liqFilledRef = useRef(false);
   const handleLiqClusters = useCallback((c: Bucket[]) => {
     const now = Date.now();
-    if (now - liqEmitRef.current < LIQ_CLUSTER_REFRESH_MS) return;
+    if (!acceptClusterEmission({
+      hasFilled: liqFilledRef.current,
+      incoming: c.length,
+      now,
+      lastCommitAt: liqEmitRef.current,
+      minGapMs: LIQ_CLUSTER_REFRESH_MS,
+    })) return;
+    if (c.length > 0) liqFilledRef.current = true;
     liqEmitRef.current = now;
     setLiqClusters(c);
   }, []);

--- a/lib/liqClusters.ts
+++ b/lib/liqClusters.ts
@@ -23,6 +23,41 @@
 
 export const LIQ_CLUSTER_LINES = 8;
 
+/** Whether a consumer should commit this `onClusters` emission, given when it
+ *  last committed one.
+ *
+ *  THE BUG THIS ENCODES A FIX FOR. `LiqFeed` runs two effects on mount, in
+ *  declaration order: the coinFilter sync at LiqFeed.tsx:153 calls `rebuild()`
+ *  against an EMPTY history, and only then does the seeding effect at :280 read
+ *  localStorage and rebuild again with real events. So the first emission any
+ *  consumer sees is `[]`, milliseconds before the real one.
+ *
+ *  A plain time throttle commits that empty array, starts its window, and drops
+ *  the batch that actually had the clusters in it - so a page with a full 24h
+ *  history renders nothing for the length of the window and then everything.
+ *  On staging that was a 15-second blank, which read as "the feature does not
+ *  work on a deployed build" to two separate people, including its author.
+ *
+ *  So the first emission that carries anything always lands. After that the
+ *  window applies: the clusters accumulate over 24 hours, so redrawing faster
+ *  changes nothing on screen and costs a full overlay teardown per liquidation.
+ *
+ *  Pure and parameterised rather than inline in the handler, because the
+ *  failure is a timing one - the only way to test it is to control the clock. */
+export function acceptClusterEmission(opts: {
+  /** Has a non-empty batch ever been committed by this consumer? */
+  hasFilled: boolean;
+  /** How many clusters are in the emission being offered. */
+  incoming: number;
+  now: number;
+  /** When this consumer last committed, in the same clock as `now`. */
+  lastCommitAt: number;
+  minGapMs: number;
+}): boolean {
+  if (!opts.hasFilled && opts.incoming > 0) return true;
+  return opts.now - opts.lastCommitAt >= opts.minGapMs;
+}
+
 /** The heaviest clusters for one coin, largest first.
  *
  *  Structural type rather than LiqFeed's `Bucket` so `lib/` does not import


### PR DESCRIPTION
## Summary

The cluster lines from #805 did not appear for the **first 15 seconds** after a page load, on any environment. Two people concluded from that that the feature did not work on a deployed build — one of them was me, about my own code, and I had the evidence on screen and explained it away.

The throttle I added on Arena commits `LiqFeed`'s **empty** first emission and drops the real one.

## The mechanism

`LiqFeed` runs two effects on mount, in declaration order:

```
LiqFeed.tsx:153   coinFilter sync   rebuild(historyRef.current)   history EMPTY   onClusters([])
LiqFeed.tsx:280   seeding effect    rebuild(valid)                real events     onClusters(buckets)
```

A plain time throttle sees `[]` first, commits it, starts its 15-second window, and throws away the batch that arrived a millisecond later carrying every cluster. So a browser with a full 24h history renders **nothing for 15 seconds and then everything**.

Measured on staging `9ed3bd1`, same page and same seed at two times:

```
t ≈ 9s    LiqFeed card: 8 cluster rows      Liq toggle ABSENT    no lines
t ≈ 29s   LiqFeed card: 8 cluster rows      Liq toggle PRESENT   8 lines
```

The clusters existed throughout. The chart did not have them. The `Liq` toggle is gated on the same state, which is why searching for the button by text found nothing and looked like a broken selector.

## What changed

**`lib/liqClusters.ts`** — `acceptClusterEmission({ hasFilled, incoming, now, lastCommitAt, minGapMs })`. The first emission that carries anything always lands; after that the window applies. Pure and clock-parameterised rather than inline in the handler, because a timing bug can only be tested with a controlled clock and a test that sleeps is a test that flakes.

**`app/arena/page.tsx`** — the handler calls it, and tracks `hasFilled` in a ref alongside the existing timestamp.

**`__tests__/liqClusters.test.mts`** — four cases (first fill bypasses; window applies once filled; an empty emission never consumes the bypass; boundary at exactly `minGapMs`) plus a control that the throttle still throttles. A predicate stuck on `true` would satisfy every "must land" case and nothing else would notice.

## Two things worth reading, both about how this was missed

**I had the finding and overrode it.** My localhost run showed no toggle and no lines at 8 seconds. I recorded it as a screenshot timing artefact, waited, saw the lines, and stopped looking. The check ran and returned the truth. That is worse than not checking, because a check that is explained away also stops anyone else from running it.

**My first version of these tests failed, correctly.** I wrote `now = 1000, lastCommitAt = 0` — a page mounting one second after 1970, where the 15-second window has not yet elapsed. Real `Date.now()` makes it trivially elapsed. The arithmetic was right about a situation that never happens, in the test written to prove the code was right. The fixture now uses a realistic epoch and says why.

## A correction to #805's own PR body

I wrote "636 tests pass" there. **That number was inferred, not read** — 628 from an earlier run plus the 8 I had just written, when the 628 run already included them. The measured count before this PR was **628**; with the four added here it is **632**. Nothing depended on it, but it was a figure published without being measured, in a PR whose whole subject is figures published without being measured.

## How to test (QA)

On `qa`, `/arena`, with a browser that has `liq-events-v2` history — either one that has been open long enough to accumulate liquidations, or a seeded context:

1. **Load the page and start looking immediately.** The lines and the `Liq` toggle must appear within a second or two of the chart, not after fifteen. This is the whole fix.
2. Everything from #805 still holds: 8 lines maximum, `REALIZED LIQ` in every label, the toggle removes and restores them, and switching BTC → ETH leaves no BTC level behind.
3. **A browser with no history still shows no lines and no toggle** — that is correct, and it is the state that made this hard to see.

## Risk level

**Low.** One predicate, one call site, no change to what is drawn. The behaviour it removes is a delay.

Not verified: the fix on a deployed environment. It is verified on localhost and by unit test; the staging measurement above is of the **bug**, not of the fix.

Gates, each run and read rather than inferred: lint 0 errors / 232 warnings, `tsc --noEmit` exit 0, **632 tests pass**, build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
