### PR TITLE
fix(chart): per-theme EMA ramp and readable overlay labels (#806, #808)

### DIFF
--- a/__tests__/chartInk.test.mts
+++ b/__tests__/chartInk.test.mts
@@ -1,0 +1,139 @@
+/* The only guard the chart canvas can have (#806, #808).
+ *
+ * qa/e2e/contrast.spec.ts sweeps 32 routes in two designs and has never
+ * measured a single overlay label, because `createPointFigures` returns figures
+ * that klinecharts paints into a 2D context - no DOM node, no computed style,
+ * nothing for axe to walk. "0 violations on /arena" was true and structurally
+ * incomplete. Unlike trap 3's empty /news, no amount of seeding or waiting
+ * closes it.
+ *
+ * So the guard is arithmetic over the constants, which is why they live in
+ * lib/chartInk.ts rather than inline in the component.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { contrastRatio, parseCssColor } from '../lib/readableOn.ts';
+import {
+  CHART_GROUND, TERMINAL_EMA_RAMP, CURRENT_EMA_RAMP, OVERLAY_LABEL_INK,
+  EMA_RIBBON_PERIODS, emaInk, type EmaPeriod,
+} from '../lib/chartInk.ts';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const ratio = (a: string, b: string) => contrastRatio(parseCssColor(a)!.rgb, parseCssColor(b)!.rgb);
+
+const GRAPHIC_MIN = 3;    // SC 1.4.11
+const TEXT_MIN    = 4.5;  // SC 1.4.3
+
+test('every overlay label clears 4.5:1, which no rendered sweep can check', () => {
+  const failures: string[] = [];
+  for (const [name, { bg, text }] of Object.entries(OVERLAY_LABEL_INK)) {
+    const r = ratio(text, bg);
+    if (r < TEXT_MIN) failures.push(`${name}: ${text} on ${bg} = ${r.toFixed(2)}:1`);
+  }
+  assert.deepEqual(failures, [],
+    `${failures.length} overlay label(s) below ${TEXT_MIN}:1:\n  ${failures.join('\n  ')}\n` +
+    'These are canvas text. axe cannot see them and neither can contrast.spec.ts, ' +
+    'so this test is the only thing between a regression and production.');
+});
+
+test('the label fix was the text colour, not the palette', () => {
+  /* Recording WHY each choice is what it is, so a future edit that "tidies"
+     them back to white has to argue with a number. Four of the five are light
+     chips where black wins by a mile; the cluster chip is the one real
+     judgement call, and it is nearly a coin toss. */
+  const measured = Object.fromEntries(
+    Object.entries(OVERLAY_LABEL_INK).map(([k, { bg, text }]) => [k, {
+      chosen: Number(ratio(text, bg).toFixed(2)),
+      white:  Number(ratio('#ffffff', bg).toFixed(2)),
+      black:  Number(ratio('#000000', bg).toFixed(2)),
+    }]),
+  );
+  assert.deepEqual(measured, {
+    srResistance: { chosen: 7.59, white: 2.77, black: 7.59 },
+    srSupport:    { chosen: 10.92, white: 1.92, black: 10.92 },
+    gexMaxPain:   { chosen: 7.72, white: 2.72, black: 7.72 },
+    gexFlip:      { chosen: 11.62, white: 1.81, black: 11.62 },
+    liqCluster:   { chosen: 4.60, white: 4.60, black: 4.57 },
+  });
+});
+
+test('each terminal ramp step clears 3:1 on its own ground', () => {
+  const failures: string[] = [];
+  for (const theme of ['dark', 'light'] as const) {
+    const ground = CHART_GROUND[theme];
+    for (const p of EMA_RIBBON_PERIODS) {
+      const c = TERMINAL_EMA_RAMP[theme][p];
+      const r = ratio(c, ground);
+      if (r < GRAPHIC_MIN) failures.push(`terminal ${theme} EMA${p}: ${c} on ${ground} = ${r.toFixed(2)}:1`);
+    }
+  }
+  assert.deepEqual(failures, [],
+    'A ribbon line below 3:1 on its own ground is not a ribbon line. This is why ' +
+    'the ramp is per THEME and not only per design: #8b8f94 measured 6.45:1 on ' +
+    'black and 2.70:1 on the light ground, and one grey cannot serve both.');
+});
+
+test('the terminal ramp stays distinct - which is the whole of #806', () => {
+  /* These are neutral greys (r=g=b), so a contrast ratio IS the right measure
+     of distinctness here. It is NOT for two different hues - #787 and #756
+     were both filed on a contrastRatio between a brown and a blue that reported
+     1.02 for colours anyone can tell apart. Instrument chosen for the case. */
+  for (const theme of ['dark', 'light'] as const) {
+    const ramp = TERMINAL_EMA_RAMP[theme];
+    for (const p of EMA_RIBBON_PERIODS) {
+      const [r, g, b] = parseCssColor(ramp[p])!.rgb;
+      assert.ok(r === g && g === b, `terminal ${theme} EMA${p} is not a neutral grey, so this test's instrument no longer fits`);
+    }
+    for (let i = 0; i < EMA_RIBBON_PERIODS.length - 1; i++) {
+      const a = EMA_RIBBON_PERIODS[i], z = EMA_RIBBON_PERIODS[i + 1];
+      const sep = ratio(ramp[a], ramp[z]);
+      assert.ok(sep >= 1.4, `terminal ${theme}: EMA${a} and EMA${z} are ${sep.toFixed(2)} apart, too close to read as two lines`);
+    }
+    const ends = ratio(ramp[9], ramp[200]);
+    assert.ok(ends >= 3, `terminal ${theme}: EMA9 and EMA200 are ${ends.toFixed(2)} apart. They were 1.33 (dark) and 1.03 (light) before #806 - do not go back.`);
+  }
+});
+
+test('every ramp covers exactly the periods the ribbon draws', () => {
+  for (const ramp of [TERMINAL_EMA_RAMP.dark, TERMINAL_EMA_RAMP.light, CURRENT_EMA_RAMP.dark, CURRENT_EMA_RAMP.light]) {
+    assert.deepEqual(Object.keys(ramp).map(Number).sort((a, b) => a - b), [...EMA_RIBBON_PERIODS].sort((a, b) => a - b));
+  }
+});
+
+test('no colour in chartInk is a CSS variable', () => {
+  /* The point of the file. A canvas keeps the previous colour when handed an
+     unresolvable value, so a var() here paints whatever drew last and looks
+     deliberate - which is exactly how EMA9 and EMA200 went green, then pink. */
+  const src = readFileSync(path.join(ROOT, 'lib', 'chartInk.ts'), 'utf8');
+  const code = src.replace(/\/\*[\s\S]*?\*\//g, m => m.replace(/[^\n]/g, ' '));
+  assert.equal(/var\(--/.test(code), false, 'a CSS variable reached lib/chartInk.ts');
+});
+
+test('the chart resolves the var() strings it still hands to klinecharts', () => {
+  /* Two `var(--accent-2)` uses survive - the default overlay line in the
+     palettes, and the RSI indicator - because they are klinecharts' own style
+     shapes rather than ours. They are resolved at the call rather than removed.
+     Asserted against the source: if someone drops the wrapper the colour goes
+     back to leaking, and nothing on screen says so. */
+  const chart = readFileSync(path.join(ROOT, 'components', 'KLineProChart.tsx'), 'utf8');
+  const setStyles = [...chart.matchAll(/setStyles\(([^;]*?)\s+as any\)/g)].map(m => m[1]);
+  assert.ok(setStyles.length >= 2, 'expected both setStyles call sites');
+  for (const call of setStyles) {
+    assert.ok(call.includes('resolveStyleVars('), `a setStyles call does not resolve its var()s: ${call.trim()}`);
+  }
+  assert.ok(/lines: \[\{ color: resolveCssColor\('var\(--accent-2\)'\)/.test(chart),
+    "the RSI indicator's colour is no longer resolved");
+});
+
+test('CONTROL: the measurements can fail', () => {
+  /* Every assertion above is a threshold. A ratio function returning something
+     large for everything would satisfy all of them silently. */
+  assert.ok(ratio('#ffffff', '#f87171') < TEXT_MIN, 'white on the S/R red should still measure as failing');
+  assert.ok(ratio('#8b8f94', CHART_GROUND.light) < GRAPHIC_MIN, 'the old terminal grey should still fail on the light ground');
+  assert.ok(ratio('#fbbf24', '#d9a626') < 1.4, 'the two golds #806 is about should still measure as too close');
+  assert.equal(emaInk(9 as EmaPeriod, { terminal: true, dark: true }), TERMINAL_EMA_RAMP.dark[9]);
+  assert.equal(emaInk(200 as EmaPeriod, { terminal: false, dark: false }), CURRENT_EMA_RAMP.light[200]);
+});

--- a/components/KLineProChart.tsx
+++ b/components/KLineProChart.tsx
@@ -10,6 +10,7 @@ import { Warn } from '@/components/icons';
 import { useDesignMode } from '@/components/DesignModeProvider';
 import { barsAfter } from '@/lib/candles';
 import { LIQ_CLUSTER_LINES } from '@/lib/liqClusters';
+import { emaInk, OVERLAY_LABEL_INK, type EmaPeriod } from '@/lib/chartInk';
 
 // ── v10 Period mapping ────────────────────────────────────────────────────
 
@@ -406,7 +407,7 @@ let structureOverlayRegistered = false;
    Measured, not assumed: white on #db2777 is 4.56:1, which clears 4.5:1. The
    S/R labels next to it do not - white on #f87171 is 2.82:1 - so this is the
    readable one rather than one matching the neighbours at their own level. */
-const LIQ_CLUSTER_COLOR = '#db2777';
+const LIQ_CLUSTER_COLOR = OVERLAY_LABEL_INK.liqCluster.bg;
 
 /* A canvas strokeStyle cannot resolve a CSS custom property. Passing
    'var(--amber)' neither throws nor paints amber - the context keeps whatever
@@ -444,6 +445,27 @@ function resolveCssColor(color: string): string {
   return out;
 }
 
+/* Same fix, applied to the styles klinecharts paints itself rather than to our
+   own overlays. `var(--accent-2)` reaches the canvas twice - the default
+   overlay line (the palettes above) and the RSI indicator - and both were
+   measured as unresolved for #806. Walking the palette rather than patching two
+   literals, because the palettes are hand-edited nested objects and the next
+   `var()` someone adds should not need to be found again.
+   The token values themselves are fine, which is the part worth stating: 8.12,
+   5.66, 9.43 and 6.12 against their grounds across the four contexts. They were
+   never the problem - never resolving was. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function resolveStyleVars<T>(styles: T): T {
+  if (typeof styles === 'string') return (styles.startsWith('var(') ? resolveCssColor(styles) : styles) as T;
+  if (Array.isArray(styles)) return styles.map(resolveStyleVars) as unknown as T;
+  if (styles && typeof styles === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(styles)) out[k] = resolveStyleVars(v);
+    return out as T;
+  }
+  return styles;
+}
+
 /* One EMA period's ribbon line - drawn as a single continuous polyline overlay,
    not a klinecharts built-in indicator. The indicator system folds every
    plotted value into the pane's Y-axis regardless of the overrideYAxis range
@@ -457,24 +479,18 @@ function resolveCssColor(color: string): string {
    the real, correct EMA200 value on screen without it dragging the axis on
    fast timeframes for volatile coins (PEPE/BONK 15m, where EMA200's 200-bar
    lookback still reaches a real multi-day-old price level). */
+/* Only the width lives here now. Every colour moved to lib/chartInk.ts, where
+   it can be imported by a test - the reason is #808: nothing painted on this
+   canvas is visible to the contrast sweep, so arithmetic over the constants is
+   the only guard that can catch a regression. The old table here read
+   `{ 20: '#8b8f94', 50: '#5e646b' }` and left 9 and 200 on `var(--amber)` /
+   `var(--accent)`, which never resolved (#806). */
 const EMA_PERIODS = [
-  { period: 9,   color: 'var(--amber)', size: 1   },  // gold
-  { period: 20,  color: '#60a5fa', size: 1.5 },  // blue
-  { period: 50,  color: '#f97316', size: 1.5 },  // orange
-  { period: 200, color: 'var(--accent)', size: 2   },  // blue (thicker)
+  { period:   9, size: 1   },
+  { period:  20, size: 1.5 },
+  { period:  50, size: 1.5 },
+  { period: 200, size: 2   },
 ] as const;
-
-// #598 D1: the canvas draws zero blue/orange anywhere on the chart. Only
-// these two hardcoded hex values need a terminal swap - period 9/200 above
-// already read through --amber/--accent tokens (a separate, pre-existing
-// "does a CSS var string resolve inside a canvas fillStyle" question that
-// applies to every 'var(--x)' color in this file, not something D1 asked
-// for). Picked from QA's confirmed canvas hex list, darker as the period
-// lengthens, same convention the ribbon already uses via size.
-const TERMINAL_EMA_COLOR: Partial<Record<number, string>> = {
-  20: '#8b8f94',
-  50: '#5e646b',
-};
 
 interface EmaPoint { timestamp: number; value: number; }
 
@@ -829,7 +845,20 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
          place beats one whose price readout is at 1.01. That is the end state,
          not a stopgap: no fourth palette is booked. */
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      chartRef.current?.setStyles(paletteFor(dark, mode === 'terminal') as any);
+      chartRef.current?.setStyles(resolveStyleVars(paletteFor(dark, mode === 'terminal')) as any);
+      /* The RSI line has to be re-applied, not just re-styled with the palette.
+         Its colour is an indicator style, resolved from `var(--accent-2)` when
+         createIndicator runs, and createIndicator runs once. Fixing the
+         resolution alone moved the bug from "never resolves" to "resolves once":
+         measured on localhost, a chart opened in terminal dark and switched to
+         light kept painting RSI at #d9a626 while the live token read #754e00.
+         Caught by pixel-sampling the fix rather than by trusting it. */
+      chartRef.current?.overrideIndicator({
+        name: 'RSI',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        styles: { lines: [{ color: resolveCssColor('var(--accent-2)'), size: 1.5 }] } as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
       /* Overlay ink follows the THEME only - the overlays are drawn on a
          transparent canvas over .klc-wrap's var(--bg), which is #000000 in
          both dark themes and #E8EAED in both light ones (#752). Bumping
@@ -872,7 +901,6 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
     const chart = chartRef.current;
     const bars = emaBarsRef.current;
     if (!chart || !bars.length) return;
-    const terminal = document.documentElement.getAttribute('data-design') === 'terminal';
     EMA_PERIODS.forEach((cfg, idx) => {
       const series = computeEmaSeries(bars, cfg.period);
       if (!series.length) return;
@@ -903,7 +931,11 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
           // _figureMouseDownEvent, plus the `!overlay.lock` guard on
           // onPressedMoving), so hover and tooltips are unaffected.
           lock: true,
-          extendData: { color: terminal ? (TERMINAL_EMA_COLOR[cfg.period] ?? cfg.color) : cfg.color, size: cfg.size },
+          /* The PERIOD travels, not the colour. An overlay is created once and
+             only its points are overridden afterwards, so a colour chosen here
+             would survive a theme switch and go stale; createPointFigures runs
+             per repaint and can read the context that is current. */
+          extendData: { period: cfg.period, size: cfg.size },
           // Higher zLevel paints on top. EMA_PERIODS is ordered fast-to-slow
           // (9, 20, 50, 200), so EMA200 (idx 3, thickest) ends up on top and
           // EMA9 (idx 0, thinnest) on the bottom - matches the original
@@ -944,7 +976,7 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
       // Apply current theme via setStyles (avoids DeepPartial type gymnastics)
       const dark = document.documentElement.getAttribute('data-theme') !== 'light';
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      chart.setStyles(paletteFor(dark, modeRef.current === 'terminal') as any);
+      chart.setStyles(resolveStyleVars(paletteFor(dark, modeRef.current === 'terminal')) as any);
 
       // EMA 9/20/50/200 ribbon - drawn as 4 emaRibbonLine overlays (registered
       // below, synced via syncEmaRibbon), not a klinecharts built-in indicator.
@@ -954,7 +986,7 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
       // in the app (marketStore rsi14/rsi1h/rsi4h/rsiDaily), instead of the
       // built-in indicator's default 3-line [6,12,24] preset.
       chart.createIndicator(
-        { name: 'RSI', calcParams: [14], styles: { lines: [{ color: 'var(--accent-2)', size: 1.5 }] } },
+        { name: 'RSI', calcParams: [14], styles: { lines: [{ color: resolveCssColor('var(--accent-2)'), size: 1.5 }] } },
         { pane: { id: 'rsi_pane', height: 110, minHeight: 30 } }
       );
 
@@ -1239,13 +1271,21 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
           needDefaultYAxisFigure: false,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           createPointFigures: ({ overlay, coordinates }: { overlay: any; coordinates: Array<{ x: number; y: number }> }) => {
-            const { color, size } = overlay.extendData as { color: string; size: number };
+            const { period, size } = overlay.extendData as { period: EmaPeriod; size: number };
             const pts = coordinates.filter(c => c && isFinite(c.x) && isFinite(c.y));
             if (pts.length < 2) return [];
+            const root = document.documentElement;
             return [{
               type: 'line',
               attrs: { coordinates: pts },
-              styles: { style: 'solid', color: resolveCssColor(color), size },
+              styles: {
+                style: 'solid',
+                color: emaInk(period, {
+                  terminal: root.getAttribute('data-design') === 'terminal',
+                  dark: root.getAttribute('data-theme') !== 'light',
+                }),
+                size,
+              },
             }];
           },
         });
@@ -1265,7 +1305,8 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
             const { srType, price, labelYOffset } = overlay.extendData as { srType: 'support' | 'resistance'; price: number; labelYOffset?: number };
             const y = coordinates[0]?.y;
             if (y == null || !isFinite(y) || y < 0) return [];
-            const color = srType === 'resistance' ? '#f87171' : '#34d399';
+            const ink = srType === 'resistance' ? OVERLAY_LABEL_INK.srResistance : OVERLAY_LABEL_INK.srSupport;
+            const color = ink.bg;
             const rightX = (bounding?.width ?? 9999);
             const labelY = y - 3 - (labelYOffset ?? 0);
             return [
@@ -1283,7 +1324,7 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
                 // same shape as the priceTag figure above, which already
                 // sets its own backgroundColor and never had the bug.
                 styles: {
-                  color: '#ffffff', size: 9, weight: '700',
+                  color: ink.text, size: 9, weight: '700',
                   paddingLeft: 5, paddingRight: 5, paddingTop: 2, paddingBottom: 2,
                   backgroundColor: color,
                   // registerOverlay is a one-time, module-level registration
@@ -1319,7 +1360,8 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
             const { gexType, price, labelYOffset } = overlay.extendData as { gexType: 'maxpain' | 'flip'; price: number; labelYOffset?: number };
             const y = coordinates[0]?.y;
             if (y == null || !isFinite(y) || y < 0) return [];
-            const color = gexType === 'maxpain' ? '#a78bfa' : '#22d3ee';
+            const ink = gexType === 'maxpain' ? OVERLAY_LABEL_INK.gexMaxPain : OVERLAY_LABEL_INK.gexFlip;
+            const color = ink.bg;
             const label = gexType === 'maxpain' ? 'MAX PAIN' : 'γ FLIP';
             const rightX = (bounding?.width ?? 9999);
             const labelY = y - 3 - (labelYOffset ?? 0);
@@ -1333,7 +1375,7 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
                 type: 'text',
                 attrs: { x: 6, y: labelY, text: `${label} $${fmtPx(price)}`, align: 'left', baseline: 'bottom' },
                 styles: {
-                  color: '#ffffff', size: 9, weight: '700',
+                  color: ink.text, size: 9, weight: '700',
                   paddingLeft: 5, paddingRight: 5, paddingTop: 2, paddingBottom: 2,
                   backgroundColor: color,
                   borderRadius: document.documentElement.getAttribute('data-design') === 'terminal' ? 0 : 3,
@@ -1383,7 +1425,7 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
                 type: 'text',
                 attrs: { x: 6, y: labelY, text: `REALIZED LIQ $${fmtPx(price)} · ${fmtLiqUsd(total)}`, align: 'left', baseline: 'bottom' },
                 styles: {
-                  color: '#ffffff', size: 9, weight: '700',
+                  color: OVERLAY_LABEL_INK.liqCluster.text, size: 9, weight: '700',
                   paddingLeft: 5, paddingRight: 5, paddingTop: 2, paddingBottom: 2,
                   backgroundColor: LIQ_CLUSTER_COLOR,
                   borderRadius: document.documentElement.getAttribute('data-design') === 'terminal' ? 0 : 3,

--- a/lib/chartInk.ts
+++ b/lib/chartInk.ts
@@ -1,0 +1,122 @@
+/* Colours the Arena chart paints onto its CANVAS, and the one place they are
+ * allowed to be decided.
+ *
+ * WHY THESE LIVE IN lib/ RATHER THAN IN THE COMPONENT. Nothing on this canvas
+ * is reachable by the contrast sweep. `createPointFigures` returns text and
+ * line figures that klinecharts paints into a 2D context - they are not DOM
+ * nodes, carry no computed style, and axe cannot see them. So
+ * qa/e2e/contrast.spec.ts sweeping /arena clean has never included a single
+ * overlay label, and never will (#808). That is not a gap that seeding or
+ * waiting closes, the way trap 3's empty /news did: it is structural.
+ *
+ * The only durable guard is arithmetic over the constants themselves, so the
+ * constants have to be importable. __tests__/chartInk.test.mts is that guard.
+ *
+ * A SECOND REASON, learned the hard way: a canvas fillStyle cannot resolve
+ * `var(--amber)`. It does not throw and it does not fail to invisible - the
+ * context KEEPS THE PREVIOUS COLOUR, so the line paints in whatever the last
+ * overlay set and looks deliberate. EMA9 and EMA200 were painting green
+ * borrowed from the S/R support line, then pink when a pink overlay drew ahead
+ * of them. Everything here is a literal for that reason.
+ */
+
+/** The chart canvas is transparent; the ground is .klc-wrap's `background:
+ *  var(--bg)` (globals.css:2042). There is no terminal override of --bg, so
+ *  the four design x theme contexts collapse to these two grounds. */
+export const CHART_GROUND = { dark: '#000000', light: '#E8EAED' } as const;
+
+export type EmaPeriod = 9 | 20 | 50 | 200;
+export const EMA_RIBBON_PERIODS: EmaPeriod[] = [9, 20, 50, 200];
+
+/* THE TERMINAL RAMPS (#806).
+ *
+ * Ruled by QA on 2026-09-04: extend the existing grey ramp to periods 9 and
+ * 200, which had been reading through --amber and --accent and therefore never
+ * rendered at all. Nothing visible is lost by replacing them - nobody has ever
+ * seen "EMA9 is amber" on this chart.
+ *
+ * ONE RAMP PER THEME, and that is not extra scope - it is what "distinct in
+ * all four contexts" costs. The old ramp was design-aware but theme-blind, so
+ * the same greys had to serve both grounds, and #8b8f94 measured 6.45:1 on
+ * black and 2.70:1 on the light ground. A single fixed grey cannot clear 3:1
+ * on both.
+ *
+ * Chosen for EQUAL CONTRAST-RATIO STEPS rather than equal byte steps: for
+ * neutral greys the separation between neighbours is the quotient of their
+ * ground ratios, so evenly spaced ground ratios give evenly spaced neighbours,
+ * which byte spacing does not.
+ *
+ *   dark ground     12.04  8.03  5.03  3.19      adjacent 1.50 / 1.60 / 1.58
+ *   light ground     3.19  4.98  7.95 12.07      adjacent 1.56 / 1.60 / 1.52
+ *   9 vs 200         3.78 dark, 3.79 light       (was 1.33 and 1.03)
+ *
+ * "Darker as the period lengthens" is the convention the file already used,
+ * and both ramps obey it - which is why they run in opposite directions
+ * against their grounds. On black, darker means less contrast; on the light
+ * ground it means more.
+ *
+ * NOTE ON THE INSTRUMENT: these are neutral greys, r=g=b, so hue separation is
+ * not in play and a contrast ratio IS the right measure of distinctness. For
+ * two different HUES it is not - #787 and #756 were both filed on a
+ * contrastRatio between colours that differ in hue, where it reported 1.02 for
+ * a brown and a blue anyone can tell apart. */
+export const TERMINAL_EMA_RAMP = {
+  dark:  { 9: '#c4c4c4', 20: '#a0a0a0', 50: '#7c7c7c', 200: '#5d5d5d' },
+  light: { 9: '#828282', 20: '#636363', 50: '#454545', 200: '#292929' },
+} as const satisfies Record<'dark' | 'light', Record<EmaPeriod, string>>;
+
+/* The current design keeps its hues: gold and blue read as different lines
+ * without relying on lightness, so they stay distinct in both themes.
+ *
+ * Literals rather than tokens for the canvas reason at the top of this file.
+ * Periods 9 and 200 are the values --amber and --accent resolve to, pinned -
+ * which is a VISIBLE change, because until now they resolved to nothing and
+ * painted a borrowed colour. Periods 20 and 50 are byte-for-byte what the file
+ * already had.
+ *
+ * KNOWN AND DELIBERATELY UNTOUCHED: on the light ground, 20 (#60a5fa) measures
+ * 2.11:1 and 50 (#f97316) measures 2.33:1, against 3:1 for graphics. Both
+ * predate this work, both are in the design the owner uses daily, and changing
+ * four ribbon colours nobody asked about is not what #806 ruled. Reported on
+ * the issue instead of fixed here. */
+export const CURRENT_EMA_RAMP = {
+  dark:  { 9: '#fbbf24', 20: '#60a5fa', 50: '#f97316', 200: '#1a7aff' },
+  light: { 9: '#8F4508', 20: '#60a5fa', 50: '#f97316', 200: '#0052CC' },
+} as const satisfies Record<'dark' | 'light', Record<EmaPeriod, string>>;
+
+/** The colour one EMA ribbon line paints, for the context it is painting in.
+ *
+ *  Called per repaint rather than captured when the overlay is created: the
+ *  ribbon is only recreated on a coin or timeframe change, so a colour chosen
+ *  at creation survives a theme switch and goes stale. */
+export function emaInk(period: EmaPeriod, ctx: { terminal: boolean; dark: boolean }): string {
+  const ramp = ctx.terminal ? TERMINAL_EMA_RAMP : CURRENT_EMA_RAMP;
+  return (ctx.dark ? ramp.dark : ramp.light)[period];
+}
+
+/* OVERLAY LABEL INK (#808).
+ *
+ * Each overlay label is white or black text on a filled chip whose colour is
+ * the line's own. The line colours are fine; the TEXT on them was not. Measured
+ * with lib/readableOn.ts:
+ *
+ *                        white   black
+ *   S/R resistance        2.77    7.59
+ *   S/R support           1.92   10.92
+ *   GEX max pain          2.72    7.72
+ *   GEX gamma flip        1.81   11.62
+ *   realized liq cluster  4.60    4.57
+ *
+ * Four of the five failed 4.5:1 on white and clear it comfortably on black, so
+ * the fix is the text colour and not the palette - no line changes hue, and
+ * nothing about how the chart reads changes. The cluster chip keeps white: it
+ * is the only background dark enough to sit mid-scale, where white is the
+ * marginally better of two passing options.
+ */
+export const OVERLAY_LABEL_INK = {
+  srResistance: { bg: '#f87171', text: '#000000' },
+  srSupport:    { bg: '#34d399', text: '#000000' },
+  gexMaxPain:   { bg: '#a78bfa', text: '#000000' },
+  gexFlip:      { bg: '#22d3ee', text: '#000000' },
+  liqCluster:   { bg: '#db2777', text: '#ffffff' },
+} as const;


### PR DESCRIPTION
## Summary

Closes **#806** (EMA9 and EMA200 were never rendering their intended colour, and the two are indistinguishable once they do) and **#808** (four overlay labels between 1.81:1 and 2.77:1).

Both are the same underlying fact: **a canvas `strokeStyle` cannot resolve a CSS variable, and nothing on this canvas is visible to the contrast sweep.** So the colours move to `lib/chartInk.ts` where a test can import them, because arithmetic over the constants is the only guard this surface can have.

Every figure below was measured with `lib/readableOn.ts` or read out of the rendered canvas with `getImageData`. Nothing here is arithmetic I did in my head.

## #806 — the ribbon

**Two ramps, one per theme, and the second one is not extra scope.** The old table was design-aware but theme-blind, so one grey had to serve both grounds: `#8b8f94` measures **6.45:1 on black and 2.70:1 on the light ground**. A single fixed grey cannot clear 3:1 on both, so "distinct in all four contexts" costs a second ramp.

```
terminal dark    9 #c4c4c4 12.04   20 #a0a0a0 8.03   50 #7c7c7c 5.03   200 #5d5d5d 3.19
terminal light   9 #828282  3.19   20 #636363 4.98   50 #454545 7.95   200 #292929 12.07
adjacent steps   1.50 / 1.60 / 1.58  and  1.56 / 1.60 / 1.52
9 vs 200         3.78 and 3.79       (they were 1.33 and 1.03)
```

Chosen for **equal contrast-ratio steps, not equal byte steps** — for neutral greys the separation between neighbours is the quotient of their ground ratios, so evenly spaced ground ratios give evenly spaced neighbours, which byte spacing does not.

"Darker as the period lengthens" is the convention the file already had, and both ramps obey it — which is why they run in opposite directions against their grounds.

**This is not the fourth palette the owner declined.** `paletteFor` still returns `LIGHT` for terminal + light theme (#758, unchanged). The ribbon was never governed by `paletteFor`: the old code branched on design alone and gave terminal-light the same greys as terminal-dark. This keeps that structure and fixes the ground contrast inside it.

**The period travels, not the colour.** An overlay is created once and only its points are overridden afterwards, so a colour chosen at creation survives a theme switch and goes stale. `createPointFigures` now reads the live context per repaint.

## #806 — the two unmeasured `var(--accent-2)` uses

Measured, and the answer is in two halves:

```
current dark  #5aa3ff on #000000  8.12       terminal dark  #d9a626  9.43
current light #0052CC on #E8EAED  5.66       terminal light #754e00  6.12
```

**The token values were never the problem. Never resolving was.** Both sites now resolve — the palette through `resolveStyleVars`, which walks the object rather than patching two literals, and the RSI indicator at its call.

**And fixing that exposed a second bug in my own fix**, caught by sampling pixels rather than trusting the change: an indicator's colour is resolved when `createIndicator` runs, and that runs once. A chart opened in terminal dark and switched to light kept painting RSI at `#d9a626` while the live token read `#754e00`. Resolution alone moved the bug from *never resolves* to *resolves once*. The theme effect now re-applies it via `overrideIndicator`.

## #808 — the labels

The fix is the **text colour, not the palette**. No line changes hue:

```
                       white   black
S/R resistance          2.77    7.59
S/R support             1.92   10.92
GEX max pain            2.72    7.72
GEX gamma flip          1.81   11.62
realized liq cluster    4.60    4.57   ← keeps white
```

Two of these are worse than the pair #808 was opened from. I published the two I happened to quote; the sweep found four.

## What changed

- **`lib/chartInk.ts`** (new) — `CHART_GROUND`, `TERMINAL_EMA_RAMP`, `CURRENT_EMA_RAMP`, `emaInk()`, `OVERLAY_LABEL_INK`. Every value a literal, with the measurements in the comments.
- **`components/KLineProChart.tsx`** — `EMA_PERIODS` keeps only widths; `extendData` carries the period; labels read from `OVERLAY_LABEL_INK`; `resolveStyleVars` on both `setStyles` sites; `overrideIndicator` on theme change.
- **`__tests__/chartInk.test.mts`** (new) — 8 tests.

## Verification

**Unit**, 8 tests including a control that the thresholds can fail. I broke two things on purpose and confirmed the suite catches them:

```
srSupport text back to #ffffff        3 tests fail
resolveStyleVars removed from one     "a setStyles call does not resolve its var()s"
  setStyles call
```

**Rendered**, by reading the canvas rather than looking at it — `getImageData` over every `.klc-wrap canvas`, two samples three seconds apart in each context, because a probe that disagrees with itself is not a measurement:

```
current dark     #fbbf24 #60a5fa #f97316 #1a7aff   all four exact, plus #5aa3ff for --accent-2
terminal dark    #c4c4c4 #a0a0a0 #7c7c7c #5d5d5d   559 / 990 / 819 / 1261 px, identical across runs
                 #fbbf24                            0 px — the leaked gold is gone
terminal light   #828282 #636363 #454545 #292929   364 / 756 / 667 / 1184 px, identical across runs
RSI pane         light #754e00 → dark #d9a626      follows the live token both ways
```

The RSI check is isolated to the pane's own canvas (909×88 at y=1187). An earlier whole-page count found `#d9a626` and I nearly reported it as the RSI line without knowing which canvas held it — the same "which component am I measuring" question that #792 turned on.

## Risk level

**Medium.**

- Four ribbon line colours change in the terminal design. Intended, ruled on #806, and nothing visible is lost — the previous colours were borrowed from whatever drew last, not chosen.
- Four label text colours change from white to black. Intended.
- **Not verified:** any of this on a deployed build. Rendered on localhost across three of the four contexts (current dark, terminal dark, terminal light); **current light was not rendered** — its ramp is unchanged from what shipped except for periods 9 and 200, whose literals are the values `--amber` and `--accent` resolve to there.
- **Known and deliberately untouched:** on the light ground, EMA20 `#60a5fa` measures **2.11:1** and EMA50 `#f97316` **2.33:1** against 3:1 for graphics. Both predate this work and live in the design the owner uses daily. Changing four ribbon colours nobody asked about is not what #806 ruled — reported on the issue instead.

Gates, each read: lint 0 errors / 232 warnings, `tsc --noEmit` exit 0, **641 tests pass**, build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
