### PR TITLE
feat(arena): run the liquidations feed headless, keep the chart fed (#811)

### DIFF
--- a/__tests__/liqFeedHeadless.test.mts
+++ b/__tests__/liqFeedHeadless.test.mts
@@ -1,0 +1,88 @@
+/* Headless LiqFeed (#811): mounted, streaming, rendering nothing.
+ *
+ * The failure this guards is silent in both directions. Move the early return
+ * above a hook and React throws on the NEXT render, not this one - and the
+ * effects that open the sockets and emit onClusters stop running, so the
+ * chart's cluster lines quietly stop appearing while the card is already
+ * invisible and nobody is looking at it. Drop the `headless` prop at the Arena
+ * call site and 844px of duplicated card comes back.
+ *
+ * Neither shows up in a type check and neither has a rendered symptom on the
+ * page the change was about.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (...p: string[]) => readFileSync(path.join(ROOT, ...p), 'utf8');
+
+/** Comments blanked, newlines kept - #785 twice over: a scanner that reads
+ *  comments finds its own explanations, and a strip that eats newlines breaks
+ *  every line number computed afterwards. */
+function stripComments(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, m => m.replace(/[^\n]/g, ' '))
+    .replace(/\/\/[^\n]*/g, m => ' '.repeat(m.length));
+}
+
+const FEED = stripComments(read('components', 'LiqFeed.tsx'));
+const GUARD = /if \(headless\) return null;/;
+const HOOK = /\buse(?:Effect|LayoutEffect|State|Ref|Callback|Memo|Context|Reducer)\s*\(/g;
+
+test('the headless guard exists at all', () => {
+  assert.ok(GUARD.test(FEED),
+    'components/LiqFeed.tsx no longer returns null for headless. Arena would render ' +
+    'the 844px card the owner asked to remove (#811).');
+});
+
+test('every hook runs before the guard', () => {
+  /* The whole correctness argument for #811. Returning early above a hook
+     breaks hook order AND skips the effects that open the sockets, seed from
+     localStorage and emit onClusters - the exact work headless mode exists to
+     keep running. */
+  const at = FEED.search(GUARD);
+  assert.ok(at > 0);
+  const after = [...FEED.slice(at).matchAll(HOOK)].map(m => m[0]);
+  assert.deepEqual(after, [],
+    `${after.length} hook(s) are called after the headless guard: ${after.join(', ')}. ` +
+    'Move the guard below them - a headless LiqFeed that skips its effects stops ' +
+    'feeding the chart, and the chart is the only reason it is still mounted.');
+});
+
+test('CONTROL: the hook scanner sees the hooks it is meant to be ordering', () => {
+  /* Without this, a regex that matched nothing would report "0 hooks after the
+     guard" and pass forever. */
+  const at = FEED.search(GUARD);
+  const before = [...FEED.slice(0, at).matchAll(HOOK)].map(m => m[0]);
+  assert.ok(before.length >= 8,
+    `only ${before.length} hooks found before the guard - the scanner is not matching ` +
+    'this component, so the assertion above proves nothing');
+  assert.ok(before.includes('useEffect('), 'no useEffect found before the guard');
+});
+
+test('Arena mounts it headless and /liq does not', () => {
+  /* Two call sites, opposite requirements. /liq IS the liquidations page - the
+     card is the product there - while Arena wants only what it collects. */
+  const arena = stripComments(read('app', 'arena', 'page.tsx'));
+  const liq   = stripComments(read('app', 'liq', 'page.tsx'));
+
+  const arenaTag = arena.match(/<LiqFeed[^>]*\/>/);
+  assert.ok(arenaTag, 'Arena no longer mounts LiqFeed - the chart loses its cluster lines');
+  assert.match(arenaTag[0], /\bheadless\b/,
+    'Arena mounts LiqFeed visibly again: ' + arenaTag[0]);
+
+  const liqTag = liq.match(/<LiqFeed[^>]*\/>/);
+  assert.ok(liqTag, '/liq no longer mounts LiqFeed');
+  assert.doesNotMatch(liqTag[0], /\bheadless\b/,
+    '/liq went headless, which hides the card that page exists for: ' + liqTag[0]);
+});
+
+test('Arena still passes onClusters, which is why it mounts this at all', () => {
+  const arena = stripComments(read('app', 'arena', 'page.tsx'));
+  const tag = arena.match(/<LiqFeed[^>]*\/>/)![0];
+  assert.match(tag, /onClusters=/,
+    'a headless LiqFeed with no onClusters is a websocket connection that feeds nothing');
+});

--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -2205,8 +2205,19 @@ function ArenaContent() {
 
       {/* ── Evidence + advanced (full width, below the workspace) ── */}
       <div className="arena-below-chart">
-      {/* Live liquidations for the selected coin, and the source of the chart's
-          realized-cluster lines above (#766).
+      {/* The source of the chart's realized-cluster lines above (#766), running
+          headless since #811 — mounted and streaming, rendering nothing.
+
+          The owner looked at the deployed page and did not want the card: it
+          was 844px whose HOT PRICE LEVELS bars are the same eight clusters the
+          chart draws as lines directly above them. That reads as duplication
+          only once both are on screen together, which is one deploy after the
+          feature landed — not something the diff showed.
+
+          It cannot simply be unmounted. This component owns the Binance and
+          Bybit sockets and the 24h accumulation, and the chart's lines come
+          from its onClusters. Removing it removes the feature the owner asked
+          for.
 
           REPLACES the BTC Liquidation Heatmap that stood here. That card was
           unreachable code, not a working feature: it rendered only when
@@ -2220,7 +2231,7 @@ function ArenaContent() {
           What replaces it is not the same claim. The heatmap showed PREDICTED
           liquidation levels bought from a vendor; this shows REALIZED ones
           streamed from Binance and Bybit - keyless, free, and not BTC-only. */}
-      <LiqFeed onClusters={handleLiqClusters} coinFilter={selectedCoin.toUpperCase()} />
+      <LiqFeed onClusters={handleLiqClusters} coinFilter={selectedCoin.toUpperCase()} headless />
       {/* GEX / Options Market Pressure table removed here 2026-07-25
           (signal-overload pass): biggest single block on the page (~456px),
           BTC-only, and max-pain/net-gamma is background context rather than a

--- a/components/LiqFeed.tsx
+++ b/components/LiqFeed.tsx
@@ -83,7 +83,22 @@ function fmtEventPrice(price: number): string {
   return '$' + price.toLocaleString('en-US', { maximumFractionDigits: price < 10 ? 3 : 2 });
 }
 
-export default function LiqFeed({ onClusters, coinFilter }: { onClusters?: (clusters: Bucket[]) => void; coinFilter: string }) {
+/** `headless` runs the feed and renders nothing (#811).
+ *
+ *  Arena needs what this component COLLECTS - the 24h cluster accumulation off
+ *  the Binance and Bybit sockets, handed up through onClusters - and not what
+ *  it DRAWS: the chart already draws those same eight clusters as lines, so the
+ *  card was 844px repeating them. Unmounting it would take the chart's data
+ *  with it, which is why this is a render flag and not a conditional mount.
+ *
+ *  Deliberately NOT `display: none`: that keeps the whole subtree in the DOM
+ *  and in the accessibility tree, so a screen reader still walks a live-region
+ *  feed the owner asked to remove. Returning null is the honest version.
+ *
+ *  The live event ticker goes with it. The owner was offered "keep the ticker,
+ *  drop the duplicated bars" and chose to hide the card - recorded here so it
+ *  does not come back as an oversight. */
+export default function LiqFeed({ onClusters, coinFilter, headless = false }: { onClusters?: (clusters: Bucket[]) => void; coinFilter: string; headless?: boolean }) {
   const { t } = useLabels();
   const [feed,     setFeed]     = useState<LiqEvent[]>([]);
   const [stats,    setStats]    = useState<Stats>({ longUsd: 0, shortUsd: 0, count: 0 });
@@ -369,6 +384,13 @@ export default function LiqFeed({ onClusters, coinFilter }: { onClusters?: (clus
   const longDom   = stats.longUsd  > stats.shortUsd * 1.2;
   const shortDom  = stats.shortUsd > stats.longUsd  * 1.2;
   const anyLive   = bnStatus === 'live' || bbStatus === 'live';
+
+  /* AFTER every hook, and that placement is the whole correctness argument.
+     Returning early above them would break the rules-of-hooks order and, worse,
+     skip the effects that open the sockets, seed from localStorage and emit
+     onClusters - the exact work headless mode exists to keep running. The
+     cleanup at the bottom of the mount effect has to stay reachable too. */
+  if (headless) return null;
 
   return (
     <div className="liqfeed-wrap">


### PR DESCRIPTION
## Summary

Closes **#811**. `LiqFeed` gains a `headless` prop; Arena passes it. The card is gone from `/arena`, the chart's cluster lines are not.

The owner looked at the deployed page and did not want 844px whose HOT PRICE LEVELS bars are the same eight clusters the chart draws as lines directly above them. That reads as duplication only once both are on screen together — one deploy after the feature landed, and not something the diff showed.

## What changed

**`components/LiqFeed.tsx`** — `headless?: boolean`, default false, and a single `if (headless) return null;`.

**Placed after every hook, and that placement is the whole correctness argument.** Returning early above them breaks hook order *and* skips the effects that open the Binance and Bybit sockets, seed from localStorage and emit `onClusters` — the exact work headless mode exists to keep running. The mount effect's cleanup has to stay reachable too.

**Not `display: none`.** That keeps the whole subtree in the DOM and in the accessibility tree, so a screen reader still walks a live-region feed the owner asked to remove. Returning null is the honest version of "hidden".

**`app/arena/page.tsx`** — `headless` on the one call site. `/liq` untouched: the card is the product there.

**`__tests__/liqFeedHeadless.test.mts`** (new) — 5 tests.

## Why it needs tests at all

Both ways of breaking this are silent, and neither has a symptom on the page the change was about:

- Move the guard above a hook and React throws on the *next* render, not this one — while the effects stop running, so the chart's cluster lines quietly stop appearing behind an already-invisible card.
- Drop `headless` at the Arena call site and 844px of duplicate comes back.

So the suite asserts the guard exists, that **no hook is called after it**, that Arena passes `headless` and `/liq` does not, and that Arena still passes `onClusters` — a headless LiqFeed with no `onClusters` is a websocket connection feeding nothing.

The hook-order assertion has a control: without it, a regex matching nothing would report "0 hooks after the guard" forever. I also moved a `useEffect` below the guard on purpose and confirmed the test fails with `1 hook(s) are called after the headless guard`.

## Verification

Rendered on localhost, seeded with 8 BTC buckets:

```
.liqfeed-wrap on /arena     0        the card is gone
Liq toggle                  present  so the clusters still reach the chart
REALIZED LIQ lines drawn    8        $80,800 · $1.1M  down to  $78,000 · $7.5M
```

**That second and third line are the verification that matters** — "the card is gone" is also what unplugging it would look like. Screenshot on the issue.

One instrument note, because it disagreed with the screen: my `getImageData` sampler reported **0% painted across 630,000 pixels and five samples over 12.5 seconds** while the screenshot plainly showed candles, EMA lines and eight pink labels. I did not chase it and I did not report a blank chart — the screenshot is the direct reading of the same pixels. Worth knowing before anyone trusts that sampler alone.

## Not in this PR

QA noticed that `/liq`'s 1h stats band renders oddly at 1300px — "Longs liq'd (1h)" on one line while "Shorts liq'd (1h)" wraps to four and centres itself. **I did not touch that block**, so it is unchanged here and still worth its own issue.

## Risk level

**Low-Medium.** One prop, one call site, no change to what the chart draws.

- **Deliberately lost:** the live event ticker on Arena. The owner was offered "keep the ticker, drop only the duplicated bars" and chose to hide the whole card — recorded so it does not come back as an oversight.
- **Not verified:** on a deployed build. Rendered on localhost in terminal dark only; the change is theme-independent.
- Arena still opens the liquidation sockets. That is unchanged from #805 and is the point of keeping the component mounted.

Gates, each read: lint 0 errors / 232 warnings, `tsc --noEmit` exit 0, **637 tests pass**, build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
