### PR TITLE
feat(arena): feed real liquidation clusters into Quick and Deep Research (#814)

### DIFF
--- a/__tests__/liqClusters.test.mts
+++ b/__tests__/liqClusters.test.mts
@@ -15,7 +15,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { topClustersForCoin, acceptClusterEmission, LIQ_CLUSTER_LINES } from '../lib/liqClusters.ts';
+import { topClustersForCoin, acceptClusterEmission, formatClustersForPrompt, LIQ_CLUSTER_LINES } from '../lib/liqClusters.ts';
 
 const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -133,6 +133,62 @@ test('CONTROL: the throttle actually throttles', () => {
      nothing here would notice. */
   assert.equal(accept(true, 8, T0 + 14_999, T0), false);
   assert.equal(accept(true, 0, T0 + 1, T0), false);
+});
+
+/* The prompt line (#814). The old source was permanently empty, so both AI
+ * prompts have been sending a section header followed by "Not available" on
+ * every run since the Coinglass v2 API was retired. */
+const money = (coin: string, price: number, longUsd: number, shortUsd: number) =>
+  ({ coin, price, longUsd, shortUsd, total: longUsd + shortUsd });
+
+test('the prompt line carries price, size and which side was liquidated', () => {
+  const line = formatClustersForPrompt([
+    money('BTC', 109_000, 4_000_000, 200_000),
+    money('BTC', 108_000, 100_000, 2_500_000),
+  ], 'btc');
+  assert.equal(line, '$109,000 $4.2M longs | $108,000 $2.6M shorts');
+});
+
+test('"Not available" survives, because a fresh session genuinely has none', () => {
+  /* #637 settled this for the old dead source and it still holds: a stated
+     absence beats an empty section under a header promising data, which is how
+     a model starts inventing levels. */
+  assert.equal(formatClustersForPrompt([], 'btc'), 'Not available');
+  assert.equal(formatClustersForPrompt(null, 'btc'), 'Not available');
+  assert.equal(formatClustersForPrompt([money('ETH', 4_100, 9e7, 0)], 'btc'), 'Not available',
+    'another coin\'s clusters must not stand in for the analysed one');
+});
+
+test('the prompt line is the analysed coin only - the whole of the #637 fix', () => {
+  /* The old header had to say "BTC-wide, not the analysed coin" because the
+     data was BTC's whatever was being analysed. That caveat comes out of
+     lib/grok.ts only if this filtering is real. */
+  const mixed = [money('ETH', 4_100, 9e7, 0), money('BTC', 109_000, 1e6, 0), money('SOL', 210, 5e6, 0)];
+  assert.equal(formatClustersForPrompt(mixed, 'eth'), '$4,100 $90.0M longs');
+  assert.equal(formatClustersForPrompt(mixed, 'sol'), '$210 $5.0M longs');
+});
+
+test('the prompt header names the coin and says REALIZED', () => {
+  /* Asserted against the source, because nothing in a prompt is visible to
+     check afterwards. A model handed "liquidation clusters" with no qualifier
+     reasons about them as forward levels - the Coinglass product - and will do
+     it confidently. */
+  const grok = readFileSync(path.join(ROOT, 'lib', 'grok.ts'), 'utf8');
+  const header = grok.match(/`=== REALIZED LIQUIDATION CLUSTERS \([^`]*`/);
+  assert.ok(header, 'the prompt header no longer starts with REALIZED LIQUIDATION CLUSTERS');
+  assert.match(header[0], /\$\{ctx\.coin\}/, 'the header no longer names the analysed coin');
+  assert.match(header[0], /ALREADY happened/, 'the header no longer says these are not predicted levels');
+  assert.equal(/BTC-wide, not the analysed coin/.test(grok), false,
+    'the #637 caveat is back in the header - if the data really is BTC-wide again, that is the bug');
+});
+
+test('the prompt is fed from LiqFeed, not from the dead Coinglass array', () => {
+  const arena = readFileSync(path.join(ROOT, 'app', 'arena', 'page.tsx'), 'utf8');
+  const line = arena.match(/const liqLevels = [^;]+;/);
+  assert.ok(line, 'the liqLevels prompt field is gone');
+  assert.match(line[0], /formatClustersForPrompt\(liqClusters, selectedCoin\)/);
+  assert.equal(/const liqLevels =[\s\S]{0,120}btcLiqLevels/.test(arena), false,
+    'liqLevels reads store.btcLiqLevels again, which is permanently empty');
 });
 
 test('CONTROL: the helper returns something, so the assertions above can fail', () => {

--- a/app/arena/page.tsx
+++ b/app/arena/page.tsx
@@ -26,7 +26,7 @@ import EMASignal from '@/components/EMASignal';
 import HigherTfMoveBadge from '@/components/HigherTfMoveBadge';
 import Tip from '@/components/Tip';
 import LiqFeed, { type Bucket } from '@/components/LiqFeed';
-import { topClustersForCoin, acceptClusterEmission } from '@/lib/liqClusters';
+import { topClustersForCoin, acceptClusterEmission, formatClustersForPrompt } from '@/lib/liqClusters';
 import UsageMeter from '@/components/UsageMeter';
 import { useEMAStrategy, strategyToGrokLine, STRATEGY_LOADING, StrategySignal, DEFAULT_FILTER_PARAMS, STRICT_FILTER_PARAMS } from '@/lib/useEMAStrategy';
 import { computeDistributionScore, distributionColor, DistributionInputs } from '@/lib/distribution';
@@ -831,9 +831,22 @@ function ArenaContent() {
        retail-sentiment block on 2026-07-31; its removal comment sits eight
        lines above the LIQUIDATION CLUSTERS header in lib/grok.ts and the
        pattern survived directly beneath it. */
-    const liqLevels = store.btcLiqLevels && store.btcLiqLevels.length > 0
-      ? store.btcLiqLevels.slice(0, 4).map(l => '$' + l.price.toLocaleString() + ' ' + l.side).join(' | ')
-      : 'Not available';
+    /* Sourced from LiqFeed since #814, not from store.btcLiqLevels. That array
+       is permanently empty - Coinglass retired the v2 endpoints this called and
+       the v4 migration is deferred until revenue (MarketProvider.tsx:927-946,
+       pendings/PENDING.md:18) - so this line resolved to 'Not available' on
+       EVERY Quick and Deep run, for every coin, since the API went away. The
+       prompt has been carrying a section header with nothing under it.
+
+       Two things this changes beyond filling it in: the clusters are the
+       ANALYSED coin's rather than BTC's, which is what let the #637 caveat come
+       out of the header in lib/grok.ts, and they are REALIZED rather than the
+       predicted levels the old vendor sold.
+
+       'Not available' still has to be reachable and it is - a fresh session has
+       watched no liquidations, so it has no 24h window, and a stated absence is
+       the honest answer rather than a bug to design away. */
+    const liqLevels = formatClustersForPrompt(liqClusters, selectedCoin);
 
     /* BTC dom trend */
     const btcDomTrend = store.btcDomHistory && store.btcDomHistory.length >= 3
@@ -1284,7 +1297,13 @@ function ArenaContent() {
         return next;
       });
     }
-  }, [selectedCoin, readTf, store, latestHeadlines, econEvents, fundingData, resultsCache]);
+    /* liqClusters is a real dependency, not a lint appeasement (#814). Without
+       it this callback closes over the empty array it had at mount and every
+       Quick and Deep run sends "Not available" - which is precisely the bug
+       #814 exists to fix, reproduced silently and indistinguishable from a
+       browser that has genuinely watched no liquidations. It changes at most
+       once per LIQ_CLUSTER_REFRESH_MS, so the identity churn is bounded. */
+  }, [selectedCoin, readTf, store, latestHeadlines, econEvents, fundingData, resultsCache, liqClusters]);
 
   /* ── Squeeze scanner data - sorted by 24h volume descending (BTC → ETH → ...) ── */
   const btcChange = store.coins['btc']?.change ?? null;

--- a/lib/grok.ts
+++ b/lib/grok.ts
@@ -279,18 +279,29 @@ export function buildPrompt(ctx: GrokContext): string {
     // Quick mode has no tools, so it was a standing instruction the model
     // could not act on, spending tokens to say nothing. Restore alongside a
     // source that actually answers, not as a search prompt.
-    /* BTC in the header, because the data is BTC's whatever coin is being
-       analysed (#637): ctx.liqLevels is built from store.btcLiqLevels, and
-       the string it carries is bare prices and sides with no coin in it. An
-       analysis of SOL was handed a section titled LIQUIDATION CLUSTERS
-       containing BTC's, with nothing marking whose they were - and a model
-       asked for a per-coin read will weave those levels in rather than
-       reject them. Every sibling field in this prompt already names its
-       scope: "CB Premium (Coinbase BTC - Binance BTC)" at :240, "BTC
-       exchange net flow" at :268, "BTC Put/Call Ratio" and "BTC Max Pain
-       Strike" at :232-233. This one was the gap in an otherwise careful
-       set. */
-    '=== BTC LIQUIDATION CLUSTERS (BTC-wide, not the analysed coin) ===',
+    /* THE #637 CAVEAT IS GONE BECAUSE THE DATA CHANGED, NOT BECAUSE IT STOPPED
+       MATTERING. This header used to read "BTC LIQUIDATION CLUSTERS (BTC-wide,
+       not the analysed coin)", because ctx.liqLevels came from
+       store.btcLiqLevels and carried bare prices with no coin in them - an
+       analysis of SOL was handed BTC's levels with nothing marking whose they
+       were, and a model asked for a per-coin read weaves those in rather than
+       rejecting them. The source is now LiqFeed's buckets, which carry `coin`
+       and are filtered to the analysed one before they get here (#814), so the
+       header can finally name the coin instead of warning about it.
+
+       Worth keeping the old sentence's reasoning: every sibling field in this
+       prompt names its scope - "CB Premium (Coinbase BTC - Binance BTC)",
+       "BTC exchange net flow", "BTC Put/Call Ratio". A section that does not
+       is the one a model will misattribute.
+
+       REALIZED IS IN THE HEADER AND HAS TO STAY THERE. These are liquidations
+       that ALREADY happened - price memory, fuel spent. Coinglass sold
+       PREDICTED levels, where open positions WOULD blow up, which reads as a
+       forward magnet. A model handed "liquidation clusters" with no qualifier
+       reasons about them as the second kind, and it will do so confidently.
+       The owner ruled the wording for the chart overlay on #766; it matters
+       more here, because nothing in a prompt is visible to check afterwards. */
+    `=== REALIZED LIQUIDATION CLUSTERS (${ctx.coin}, last 24h - where liquidations ALREADY happened, not predicted levels) ===`,
     ctx.liqLevels,
     '',
     '=== MACRO EVENTS - RELEASED (LAST 72H) + UPCOMING (48H) ===',

--- a/lib/liqClusters.ts
+++ b/lib/liqClusters.ts
@@ -23,6 +23,38 @@
 
 export const LIQ_CLUSTER_LINES = 8;
 
+/** The same clusters as one prompt line, for Quick and Deep Research (#814).
+ *
+ *  RETURNS 'Not available' ON PURPOSE when there is nothing, and that string is
+ *  load-bearing rather than a placeholder. A fresh session has watched no
+ *  liquidations, so it genuinely has no 24h window - and the alternative is
+ *  handing the model an empty section under a header promising data, which is
+ *  how it starts inventing levels. #637 settled this for the old dead source:
+ *  a stated absence beats a blank, and beats "AI will search" even harder,
+ *  since Quick mode has no tools to search with.
+ *
+ *  SIDE, NOT DIRECTION. Each cluster says which side was liquidated, because
+ *  "longs blew up here" and "shorts blew up here" are different facts about the
+ *  same price. What it must never say or imply is that price will return - see
+ *  the header wording in lib/grok.ts. These are realized. */
+export function formatClustersForPrompt<T extends { coin: string; price: number; total: number; longUsd: number; shortUsd: number }>(
+  buckets: readonly T[] | null | undefined,
+  coin: string,
+  limit: number = LIQ_CLUSTER_LINES,
+): string {
+  const top = topClustersForCoin(buckets, coin, limit);
+  if (top.length === 0) return 'Not available';
+  return top
+    .map(b => {
+      const usd = b.total >= 1_000_000 ? `$${(b.total / 1_000_000).toFixed(1)}M`
+                : b.total >= 1_000     ? `$${Math.round(b.total / 1_000)}K`
+                : `$${Math.round(b.total)}`;
+      const side = b.longUsd > b.shortUsd ? 'longs' : b.shortUsd > b.longUsd ? 'shorts' : 'mixed';
+      return `$${b.price.toLocaleString('en-US')} ${usd} ${side}`;
+    })
+    .join(' | ');
+}
+
 /** Whether a consumer should commit this `onClusters` emission, given when it
  *  last committed one.
  *


### PR DESCRIPTION
## Summary

Closes **#814**, the second half of the owner's request — the removal half is #813.

Both AI prompts already had a liquidation-clusters section. **It has said "Not available" on every Quick and Deep run, for every coin, since the Coinglass v2 API was retired.** The model was told the section exists and handed nothing, every time.

## What changed

**`lib/liqClusters.ts`** — `formatClustersForPrompt(buckets, coin)`. One line: `$109,000 $4.2M longs | $108,000 $2.6M shorts`. Price, size, and which side was liquidated, because "longs blew up here" and "shorts blew up here" are different facts about the same price.

**`app/arena/page.tsx`** — `liqLevels` now comes from `LiqFeed`'s buckets and the selected coin, not from `store.btcLiqLevels`. **And `liqClusters` is added to the prompt callback's dependency array** — without it the callback closes over the empty array it had at mount and every run sends "Not available", which is this exact bug reproduced silently and indistinguishable from a browser that has genuinely watched none.

**`lib/grok.ts`** — the header:

```
before   === BTC LIQUIDATION CLUSTERS (BTC-wide, not the analysed coin) ===
after    === REALIZED LIQUIDATION CLUSTERS (BTC, last 24h - where liquidations
             ALREADY happened, not predicted levels) ===
```

**The #637 caveat comes out because the data changed, not because it stopped mattering.** It was there because `btcLiqLevels` was BTC's whatever coin was being analysed — an analysis of SOL got BTC's levels with nothing marking whose they were. `LiqFeed`'s buckets carry `coin` and are filtered before they reach the prompt, so the header can name the coin instead of warning about it.

## The two things #814 said the implementation must keep

**1. "Not available" survives, and it is load-bearing.** A fresh session has watched no liquidations, so it has no 24h window. A stated absence beats an empty section under a header promising data — that is how a model starts inventing levels, and it is why #637 rejected "AI will search" as well.

**2. REALIZED is in the header, not in a comment.** A model handed "liquidation clusters" with no qualifier reasons about them as *forward* levels — the product Coinglass actually sold — and does it confidently. **This matters more in a prompt than on a chart: nothing in a prompt is visible to check afterwards.** A test asserts the word survives, and I confirmed it fails when the qualifier is removed.

## Verification

Unit, 17 tests in `__tests__/liqClusters.test.mts` (5 new), including:

- the line's exact format
- `Not available` for empty, null, and *another coin's* clusters
- the analysed coin only — the assertion the #637 header change rests on
- the header names `${ctx.coin}`, says the clusters already happened, and **no longer contains the "BTC-wide" caveat**
- Arena feeds it from `liqClusters` and not from `btcLiqLevels`

Not rendered. This is prompt text, and the honest check for it is the source assertion plus the format test — a screenshot of Arena would show nothing either way.

**One instrument note.** I read `tsc --noEmit` as exit 1 and nearly recorded a failing typecheck; the 1 was `grep` exiting non-zero because nothing matched its filter. Re-run capturing the compiler's own status: exit 0.

## Risk level

**Low-Medium.**

- Both prompts change on every run — one wiring change serves both, since `buildQuickPrompt` derives from `buildCombinedPrompt` which derives from `buildPrompt`.
- **Not verified:** what a real model does with the new section. It has never had data here, so this is the first time either prompt carries actual clusters.
- **Not verified:** on a deployed build.
- The dependency-array addition makes the prompt callback re-create when clusters change — at most once per `LIQ_CLUSTER_REFRESH_MS`, so the churn is bounded.

Gates, each read: lint 0 errors / 232 warnings, `tsc --noEmit` exit 0, **637 tests pass**, build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
