### PR TITLE
docs(qa): fix the trap-family definition that excluded two of its members

### DIFF
--- a/qa/README.md
+++ b/qa/README.md
@@ -22,10 +22,19 @@ written *inside* those tools, which is exactly where nobody looks while writing
 a replacement for them. So they are repeated here.
 
 **Ten of the thirteen below are one shape: an instrument answering a question
-ADJACENT to the one asked, and returning something well-formed.** Not an error,
-not a zero — a plausible number, correctly computed, about the wrong thing. Only
-7 (a substring match), 8 (prose citing deleted code) and 13 (a probe that broke
-the page it was measuring) sit outside it.
+ADJACENT to the one asked, and returning something well-formed.** Not an error
+and not a crash — a well-formed result, correctly computed, about the wrong
+thing. Sometimes a plausible number; **sometimes a clean zero, which is worse,
+because a zero reads as good news.** Only 7 (a substring match), 8 (prose citing
+deleted code) and 13 (a probe that broke the page it was measuring) sit outside
+it.
+
+That sentence read *"not an error, not a zero"* until 2026-09-04, and it had
+excluded two of its own members from the day it was written: **trap 3 is titled
+"Zero elements is not zero failures"**, and both its examples return clean zeros.
+Trap 12 doubled the exposure. Corrected here rather than deleted, because how the
+definition drifted from the list is the same failure the list is about — a
+sentence that sounds right and describes something adjacent to what it names.
 
 That is the durable part. A reader who internalises **"well-formed output is not
 evidence of the right question"** has ten of these already; the numbered
@@ -228,12 +237,20 @@ could have produced a visible result at all. Derive the fixture from the live
 subject — the seed here now reads the chart's own klines and places bands inside
 that range — rather than choosing plausible-looking constants.
 
-The reason this is worth its own entry is what it nearly cost. #766 was filed as
-*"I could not get the lines to draw"* when the measurement was right and the
-defect was real; the lesson taken from it was *distrust the clean result*.
-Applied here, that lesson would have produced the opposite error at the same
-speed. **Neither "my instrument is wrong" nor "the code is wrong" is the default
-— the precondition check is what separates them, and it is cheap.**
+**Neither "my instrument is wrong" nor "the code is wrong" is the default — the
+precondition check is what separates them, and it is cheap.**
+
+That is the whole entry, and the pair of incidents behind it is why. #766 was
+filed as *"I could not get the lines to draw"* when the measurement was right
+and the defect was real. Trap 12 nearly reported a working component as broken
+when the fixture was the problem. **They are not opposite errors. They are the
+same error** — a verdict reached without the precondition check — and they only
+look opposite because the verdicts happened to point different ways.
+
+So the lesson taken from #766, *distrust the clean result*, is not the guard.
+Applied here it produces the second failure at exactly the speed it prevented
+the first. What separates them is one question asked before either verdict:
+**could this input have produced a visible result at all?**
 
 **13. A probe can break the page it is measuring, and this one did.** Same run:
 capturing the research prompt meant wrapping `window.fetch` to intercept


### PR DESCRIPTION
## Summary

Both corrections dev raised on #818, applied. Neither was a nit — one of them means the paragraph defining that list has been excluding two of its own members since the day it was written.

## 1. The family definition excluded trap 3, and now excludes nothing

The sentence read:

```
Not an error, not a zero — a plausible number, correctly computed,
about the wrong thing.
```

**Trap 3 is titled "Zero elements is not zero failures."** It has always been inside the family — the original count excluded only 7 and 8 — and both its examples return clean zeros: `.frh-sig-hint` rendering zero instances, `/news` sweeping clean on an empty page. Trap 12's finding was also a zero, so #818 doubled the exposure rather than creating it.

Replaced with:

```
Not an error and not a crash — a well-formed result, correctly computed,
about the wrong thing. Sometimes a plausible number; sometimes a clean zero,
which is worse, because a zero reads as good news.
```

The property the ten share is not the *shape* of the output — it is that a correct-looking process produced a well-formed result about a question nobody asked. **A clean zero qualifies, and is the most dangerous member, because it is the one nobody investigates.**

The old wording is recorded in place rather than deleted, because **the way the definition drifted from the list is the same failure the list is about** — a sentence that sounds right and describes something adjacent to what it names. That is worth one paragraph of self-reference in a file that exists to catch exactly that.

## 2. #766 and trap 12 are the same error, not opposite ones

#818 said the #766 lesson — *distrust the clean result* — would have produced "the opposite error at the same speed." Dev's reading is sharper and it is right: **both are a verdict reached without the precondition check.** #766 was "my instrument is broken" applied to a true reading; 12 was "the code is broken" applied to a fixture artefact. They look opposite only because the verdicts happened to point different ways.

The entry now leads with the precondition check and treats the two incidents as one shape. The sentence that should have led the paragraph was already in it, two lines too late.

## How to test (QA)

Docs only, no behaviour, nothing to deploy.

Read the opening paragraph of **"Before you write a probe"** and confirm nothing it excludes is a member of the list below it — specifically that trap 3, whose examples are zeros, is no longer excluded by the sentence defining the family.

## Risk level

**Low.** Single markdown file, two paragraphs, no code.

---
*QA Team*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
