### PR TITLE
fix(chart): darken six overlay colours for the light ground (#816)

### DIFF
--- a/__tests__/chartInk.test.mts
+++ b/__tests__/chartInk.test.mts
@@ -17,8 +17,8 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { contrastRatio, parseCssColor } from '../lib/readableOn.ts';
 import {
-  CHART_GROUND, TERMINAL_EMA_RAMP, CURRENT_EMA_RAMP, OVERLAY_LABEL_INK,
-  EMA_RIBBON_PERIODS, emaInk, type EmaPeriod,
+  CHART_GROUND, TERMINAL_EMA_RAMP, CURRENT_EMA_RAMP, OVERLAY_LINE_INK,
+  EMA_RIBBON_PERIODS, emaInk, lineInk, type EmaPeriod, type OverlayKind,
 } from '../lib/chartInk.ts';
 
 const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -29,9 +29,11 @@ const TEXT_MIN    = 4.5;  // SC 1.4.3
 
 test('every overlay label clears 4.5:1, which no rendered sweep can check', () => {
   const failures: string[] = [];
-  for (const [name, { bg, text }] of Object.entries(OVERLAY_LABEL_INK)) {
-    const r = ratio(text, bg);
-    if (r < TEXT_MIN) failures.push(`${name}: ${text} on ${bg} = ${r.toFixed(2)}:1`);
+  for (const theme of ['dark', 'light'] as const) {
+    for (const [name, { bg, text }] of Object.entries(OVERLAY_LINE_INK[theme])) {
+      const r = ratio(text, bg);
+      if (r < TEXT_MIN) failures.push(`${theme} ${name}: ${text} on ${bg} = ${r.toFixed(2)}:1`);
+    }
   }
   assert.deepEqual(failures, [],
     `${failures.length} overlay label(s) below ${TEXT_MIN}:1:\n  ${failures.join('\n  ')}\n` +
@@ -45,7 +47,7 @@ test('the label fix was the text colour, not the palette', () => {
      chips where black wins by a mile; the cluster chip is the one real
      judgement call, and it is nearly a coin toss. */
   const measured = Object.fromEntries(
-    Object.entries(OVERLAY_LABEL_INK).map(([k, { bg, text }]) => [k, {
+    Object.entries(OVERLAY_LINE_INK.dark).map(([k, { bg, text }]) => [k, {
       chosen: Number(ratio(text, bg).toFixed(2)),
       white:  Number(ratio('#ffffff', bg).toFixed(2)),
       black:  Number(ratio('#000000', bg).toFixed(2)),
@@ -58,6 +60,53 @@ test('the label fix was the text colour, not the palette', () => {
     gexFlip:      { chosen: 11.62, white: 1.81, black: 11.62 },
     liqCluster:   { chosen: 4.60, white: 4.60, black: 4.57 },
   });
+});
+
+test('every overlay LINE clears 3:1 on its own ground - the whole of #816', () => {
+  /* The rule and the chip are one colour with two jobs. #808 fixed the text on
+     the chip; this is the rule against the page, which failed on the light
+     ground for six of the seven and passed on dark for all of them. */
+  const failures: string[] = [];
+  for (const theme of ['dark', 'light'] as const) {
+    for (const [name, { bg }] of Object.entries(OVERLAY_LINE_INK[theme])) {
+      const r = ratio(bg, CHART_GROUND[theme]);
+      if (r < GRAPHIC_MIN) failures.push(`${theme} ${name}: ${bg} on ${CHART_GROUND[theme]} = ${r.toFixed(2)}:1`);
+    }
+  }
+  assert.deepEqual(failures, [],
+    'An overlay rule below 3:1 on the ground it is drawn against is a price level ' +
+    'the user cannot see. SC 1.4.11 - these carry information, they are not decoration.');
+});
+
+test('the light values keep their hue - lightness is what moved', () => {
+  /* Hue is what makes these tellable apart from each other; a contrast ratio
+     between two of them is the wrong instrument for that (#787, #756). So the
+     fix had to darken rather than recolour, and this asserts it did. */
+  const hue = (hex: string) => {
+    const [r, g, b] = parseCssColor(hex)!.rgb.map(v => v / 255);
+    const max = Math.max(r, g, b), min = Math.min(r, g, b), d = max - min;
+    if (d === 0) return 0;
+    let h = max === r ? ((g - b) / d) % 6 : max === g ? (b - r) / d + 2 : (r - g) / d + 4;
+    h *= 60; return h < 0 ? h + 360 : h;
+  };
+  for (const kind of Object.keys(OVERLAY_LINE_INK.dark) as OverlayKind[]) {
+    const drift = Math.abs(hue(OVERLAY_LINE_INK.light[kind].bg) - hue(OVERLAY_LINE_INK.dark[kind].bg));
+    assert.ok(drift <= 1, `${kind} shifted hue by ${drift.toFixed(1)} degrees - it should have been darkened, not recoloured`);
+  }
+});
+
+test('the realized-cluster pink is the one that did not move', () => {
+  /* It passes at 3.81 on the light ground, and its white label text beats black
+     by 0.03. Retuning it would force that coin-toss to be re-made for no gain. */
+  assert.equal(OVERLAY_LINE_INK.light.liqCluster.bg, OVERLAY_LINE_INK.dark.liqCluster.bg);
+  assert.equal(OVERLAY_LINE_INK.light.liqCluster.text, '#ffffff');
+  assert.ok(ratio('#db2777', CHART_GROUND.light) >= GRAPHIC_MIN);
+});
+
+test('lineInk hands back the table entry for the theme asked for', () => {
+  assert.deepEqual(lineInk('srResistance', true), OVERLAY_LINE_INK.dark.srResistance);
+  assert.deepEqual(lineInk('srResistance', false), OVERLAY_LINE_INK.light.srResistance);
+  assert.notDeepEqual(lineInk('gexFlip', true), lineInk('gexFlip', false));
 });
 
 test('each terminal ramp step clears 3:1 on its own ground', () => {
@@ -95,6 +144,29 @@ test('the terminal ramp stays distinct - which is the whole of #806', () => {
     const ends = ratio(ramp[9], ramp[200]);
     assert.ok(ends >= 3, `terminal ${theme}: EMA9 and EMA200 are ${ends.toFixed(2)} apart. They were 1.33 (dark) and 1.03 (light) before #806 - do not go back.`);
   }
+});
+
+test('every CURRENT ribbon line clears 3:1 too - the other half of #816', () => {
+  /* #806 left EMA20 at 2.11 and EMA50 at 2.33 on the light ground, flagged and
+     deliberately unfixed because changing four ribbon colours nobody asked
+     about was not that issue's ruling. #816 ruled them in. */
+  const failures: string[] = [];
+  for (const theme of ['dark', 'light'] as const) {
+    for (const p of EMA_RIBBON_PERIODS) {
+      const r = ratio(CURRENT_EMA_RAMP[theme][p], CHART_GROUND[theme]);
+      if (r < GRAPHIC_MIN) failures.push(`current ${theme} EMA${p}: ${CURRENT_EMA_RAMP[theme][p]} = ${r.toFixed(2)}:1`);
+    }
+  }
+  assert.deepEqual(failures, []);
+});
+
+test('CONTROL: the values #816 replaced would still fail this', () => {
+  /* Otherwise the assertion above passes on any palette and proves nothing
+     about the change that was made. */
+  assert.ok(ratio('#60a5fa', CHART_GROUND.light) < GRAPHIC_MIN, 'old EMA20 should still measure as failing');
+  assert.ok(ratio('#f97316', CHART_GROUND.light) < GRAPHIC_MIN, 'old EMA50 should still measure as failing');
+  assert.ok(ratio('#22d3ee', CHART_GROUND.light) < GRAPHIC_MIN, 'old gamma-flip cyan should still measure as failing');
+  assert.ok(ratio('#34d399', CHART_GROUND.light) < GRAPHIC_MIN, 'old support green should still measure as failing');
 });
 
 test('every ramp covers exactly the periods the ribbon draws', () => {

--- a/components/KLineProChart.tsx
+++ b/components/KLineProChart.tsx
@@ -10,7 +10,7 @@ import { Warn } from '@/components/icons';
 import { useDesignMode } from '@/components/DesignModeProvider';
 import { barsAfter } from '@/lib/candles';
 import { LIQ_CLUSTER_LINES } from '@/lib/liqClusters';
-import { emaInk, OVERLAY_LABEL_INK, type EmaPeriod } from '@/lib/chartInk';
+import { emaInk, lineInk, type EmaPeriod } from '@/lib/chartInk';
 
 // ── v10 Period mapping ────────────────────────────────────────────────────
 
@@ -411,7 +411,6 @@ let structureOverlayRegistered = false;
    hundred lines apart in the same repo, is the shape #736 and #663 are both
    about; QA caught it reviewing #812. Restating them here again is how it
    comes back. */
-const LIQ_CLUSTER_COLOR = OVERLAY_LABEL_INK.liqCluster.bg;
 
 /* A canvas strokeStyle cannot resolve a CSS custom property. Passing
    'var(--amber)' neither throws nor paints amber - the context keeps whatever
@@ -1309,7 +1308,8 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
             const { srType, price, labelYOffset } = overlay.extendData as { srType: 'support' | 'resistance'; price: number; labelYOffset?: number };
             const y = coordinates[0]?.y;
             if (y == null || !isFinite(y) || y < 0) return [];
-            const ink = srType === 'resistance' ? OVERLAY_LABEL_INK.srResistance : OVERLAY_LABEL_INK.srSupport;
+            const ink = lineInk(srType === 'resistance' ? 'srResistance' : 'srSupport',
+                                   document.documentElement.getAttribute('data-theme') !== 'light');
             const color = ink.bg;
             const rightX = (bounding?.width ?? 9999);
             const labelY = y - 3 - (labelYOffset ?? 0);
@@ -1364,7 +1364,8 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
             const { gexType, price, labelYOffset } = overlay.extendData as { gexType: 'maxpain' | 'flip'; price: number; labelYOffset?: number };
             const y = coordinates[0]?.y;
             if (y == null || !isFinite(y) || y < 0) return [];
-            const ink = gexType === 'maxpain' ? OVERLAY_LABEL_INK.gexMaxPain : OVERLAY_LABEL_INK.gexFlip;
+            const ink = lineInk(gexType === 'maxpain' ? 'gexMaxPain' : 'gexFlip',
+                                   document.documentElement.getAttribute('data-theme') !== 'light');
             const color = ink.bg;
             const label = gexType === 'maxpain' ? 'MAX PAIN' : 'γ FLIP';
             const rightX = (bounding?.width ?? 9999);
@@ -1419,19 +1420,20 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
             if (y == null || !isFinite(y) || y < 0) return [];
             const rightX = (bounding?.width ?? 9999);
             const labelY = y - 3 - (labelYOffset ?? 0);
+            const ink = lineInk('liqCluster', document.documentElement.getAttribute('data-theme') !== 'light');
             return [
               {
                 type: 'line',
                 attrs: { coordinates: [{ x: 0, y }, { x: rightX, y }] },
-                styles: { style: 'dashed', color: LIQ_CLUSTER_COLOR, size: 1, dashedValue: [1, 4] },
+                styles: { style: 'dashed', color: ink.bg, size: 1, dashedValue: [1, 4] },
               },
               {
                 type: 'text',
                 attrs: { x: 6, y: labelY, text: `REALIZED LIQ $${fmtPx(price)} · ${fmtLiqUsd(total)}`, align: 'left', baseline: 'bottom' },
                 styles: {
-                  color: OVERLAY_LABEL_INK.liqCluster.text, size: 9, weight: '700',
+                  color: ink.text, size: 9, weight: '700',
                   paddingLeft: 5, paddingRight: 5, paddingTop: 2, paddingBottom: 2,
-                  backgroundColor: LIQ_CLUSTER_COLOR,
+                  backgroundColor: ink.bg,
                   borderRadius: document.documentElement.getAttribute('data-design') === 'terminal' ? 0 : 3,
                 },
               },

--- a/lib/chartInk.ts
+++ b/lib/chartInk.ts
@@ -74,14 +74,14 @@ export const TERMINAL_EMA_RAMP = {
  * painted a borrowed colour. Periods 20 and 50 are byte-for-byte what the file
  * already had.
  *
- * KNOWN AND DELIBERATELY UNTOUCHED: on the light ground, 20 (#60a5fa) measures
- * 2.11:1 and 50 (#f97316) measures 2.33:1, against 3:1 for graphics. Both
- * predate this work, both are in the design the owner uses daily, and changing
- * four ribbon colours nobody asked about is not what #806 ruled. Reported on
- * the issue instead of fixed here. */
+ * 20 and 50 on the LIGHT ground were #60a5fa (2.11:1) and #f97316 (2.33:1) -
+ * both under 3:1 - until #816 ruled them in scope alongside the four overlay
+ * colours. They carry the same hue at lower lightness, so the ribbon reads the
+ * same and the ground contrast is 3.30 and 3.31. Dark is untouched; 9 and 200
+ * already cleared both grounds. */
 export const CURRENT_EMA_RAMP = {
   dark:  { 9: '#fbbf24', 20: '#60a5fa', 50: '#f97316', 200: '#1a7aff' },
-  light: { 9: '#8F4508', 20: '#60a5fa', 50: '#f97316', 200: '#0052CC' },
+  light: { 9: '#8F4508', 20: '#187cf8', 50: '#d45a05', 200: '#0052CC' },
 } as const satisfies Record<'dark' | 'light', Record<EmaPeriod, string>>;
 
 /** The colour one EMA ribbon line paints, for the context it is painting in.
@@ -94,29 +94,67 @@ export function emaInk(period: EmaPeriod, ctx: { terminal: boolean; dark: boolea
   return (ctx.dark ? ramp.dark : ramp.light)[period];
 }
 
-/* OVERLAY LABEL INK (#808).
+/* OVERLAY LINE INK (#808, then #816).
  *
- * Each overlay label is white or black text on a filled chip whose colour is
- * the line's own. The line colours are fine; the TEXT on them was not. Measured
- * with lib/readableOn.ts:
+ * NOT to be confused with KLineProChart's own OVERLAY_INK, which is a different
+ * table for the buy/sell marker glow, chevron and alert line (#752). These are
+ * the S/R, GEX and cluster RULES and the chips that label them.
  *
- *                        white   black
- *   S/R resistance        2.77    7.59
- *   S/R support           1.92   10.92
- *   GEX max pain          2.72    7.72
- *   GEX gamma flip        1.81   11.62
- *   realized liq cluster  4.60    4.57
+ * Each overlay is a coloured rule plus a filled chip carrying its label. The
+ * rule's colour IS the chip's background, so one value has two accessibility
+ * jobs: a graphic against the chart ground (3:1, SC 1.4.11) and a text
+ * background under the label (4.5:1, SC 1.4.3).
  *
- * Four of the five failed 4.5:1 on white and clear it comfortably on black, so
- * the fix is the text colour and not the palette - no line changes hue, and
- * nothing about how the chart reads changes. The cluster chip keeps white: it
- * is the only background dark enough to sit mid-scale, where white is the
- * marginally better of two passing options.
+ * #808 fixed the second by switching the label text to black. #816 fixes the
+ * first, which only failed on the LIGHT ground: every one of these clears its
+ * ground comfortably on #000000 and six of the seven failed on #E8EAED.
+ *
+ *   gexFlip 1.50   srSupport 1.59   ema20 2.11
+ *   gexMaxPain 2.26   srResistance 2.30   ema50 2.33
+ *
+ * HUE IS KEPT AND LIGHTNESS IS LOWERED, deliberately. What makes these tellable
+ * apart from each other is hue, not lightness - a contrast ratio between two of
+ * them is the wrong instrument for "can a user distinguish them", which is what
+ * #787 and #756 were both filed on. So each light value is its dark value with
+ * the same H and S walked down in L until it clears the ground. Measured hue
+ * drift is at most 0.2 degrees.
+ *
+ * TARGETED AT 3.3 RATHER THAN 3.0. The threshold is 3:1; landing on 3.05 leaves
+ * nothing for a future change to --bg, and the ground has moved before. The
+ * realized-cluster pink sits at 3.81 untouched, so this keeps the set in one
+ * band.
+ *
+ * DARK IS UNTOUCHED. Every dark value clears #000000 already and a change there
+ * would be a redesign nobody asked for.
  */
-export const OVERLAY_LABEL_INK = {
-  srResistance: { bg: '#f87171', text: '#000000' },
-  srSupport:    { bg: '#34d399', text: '#000000' },
-  gexMaxPain:   { bg: '#a78bfa', text: '#000000' },
-  gexFlip:      { bg: '#22d3ee', text: '#000000' },
-  liqCluster:   { bg: '#db2777', text: '#ffffff' },
+export const OVERLAY_LINE_INK = {
+  dark: {
+    srResistance: { bg: '#f87171', text: '#000000' },
+    srSupport:    { bg: '#34d399', text: '#000000' },
+    gexMaxPain:   { bg: '#a78bfa', text: '#000000' },
+    gexFlip:      { bg: '#22d3ee', text: '#000000' },
+    liqCluster:   { bg: '#db2777', text: '#ffffff' },
+  },
+  light: {
+    srResistance: { bg: '#f52c2c', text: '#000000' },
+    srSupport:    { bg: '#1f9067', text: '#000000' },
+    gexMaxPain:   { bg: '#8964f8', text: '#000000' },
+    gexFlip:      { bg: '#0c8ca0', text: '#000000' },
+    /* Unchanged, and that is a decision rather than an oversight: #db2777
+       measures 3.81 on the light ground, and its white label text wins over
+       black by 0.03 (4.60 against 4.57). Retune the chip and that coin-toss has
+       to be re-made for no accessibility gain. */
+    liqCluster:   { bg: '#db2777', text: '#ffffff' },
+  },
 } as const;
+
+export type OverlayKind = keyof (typeof OVERLAY_LINE_INK)['dark'];
+
+/** The ink one overlay paints in, for the theme it is painting in.
+ *
+ *  Read per repaint, not captured at overlay creation - the overlays outlive a
+ *  theme switch, and a colour chosen when the overlay was created goes stale
+ *  exactly the way the RSI indicator's did (#806). */
+export function lineInk(kind: OverlayKind, dark: boolean): { bg: string; text: string } {
+  return dark ? OVERLAY_LINE_INK.dark[kind] : OVERLAY_LINE_INK.light[kind];
+}


### PR DESCRIPTION
## Summary

Closes **#816**. All six overlay colours that failed 3:1 on the light ground now clear it, as a per-theme table in `lib/chartInk.ts`. Dark is untouched. `#db2777` does not move.

## The four contexts, measured

The chart canvas is transparent, so the ground is `.klc-wrap`'s `background: var(--bg)`. There is no terminal override of `--bg`, so **design × theme collapses to two grounds** — `#000000` for both darks, `#E8EAED` for both lights — and the overlay ink keys on theme alone. That is the same rule the marker ink already follows (`KLineProChart.tsx`: *"Overlay ink follows the THEME only"*), not a new one.

| Overlay | dark | on `#000000` | light | on `#E8EAED` | was |
|---|---|---|---|---|---|
| GEX gamma flip | `#22d3ee` | 11.62 | `#0c8ca0` | **3.30** | 1.50 |
| S/R support | `#34d399` | 10.92 | `#1f9067` | **3.32** | 1.59 |
| EMA20 | `#60a5fa` | 8.26 | `#187cf8` | **3.30** | 2.11 |
| GEX max pain | `#a78bfa` | 7.72 | `#8964f8` | **3.32** | 2.26 |
| S/R resistance | `#f87171` | 7.59 | `#f52c2c` | **3.30** | 2.30 |
| EMA50 | `#f97316` | 7.49 | `#d45a05` | **3.31** | 2.33 |
| realized cluster | `#db2777` | 4.57 | `#db2777` | 3.81 | unchanged |

Label text stays black on every chip except the cluster's, and on the new light chips black measures **5.24–5.28**.

## Hue kept, lightness moved

Each light value is its dark value with the same hue and saturation, walked down in lightness until it clears the ground. **Measured hue drift is at most 0.2°**, and a test asserts ≤1°.

That constraint is the point rather than a nicety: **what makes these tellable apart from each other is hue, not lightness.** A contrast ratio between two of them is the wrong instrument for "can a user distinguish them" — which is what #787 and #756 were both filed on. Recolouring to hit a number would have fixed the measurement and broken the thing the measurement is a proxy for.

## Targeted at 3.3, not 3.0

The threshold is 3:1. Landing on 3.05 leaves nothing for a future change to `--bg`, and that ground has moved before. 3.3 also puts the six in the same band as the cluster pink's 3.81, so the set reads as one decision.

## What is deliberately unchanged

- **Dark.** Every value already clears `#000000`; changing them would be a redesign nobody asked for.
- **`#db2777`.** It passes at 3.81, and its white label text beats black by 0.03 (4.60 vs 4.57). Retuning the chip forces that coin-toss to be re-made for no accessibility gain.
- **`paletteFor`.** Still returns `LIGHT` for terminal + light theme. #758 stands. This is not a fourth palette — it is the shape #812 shipped for the EMA ramp.
- **Current-design EMA 9 and 200.** Already clear both grounds (5.76 / 5.66 light).

## Naming, because there was a collision

`KLineProChart.tsx` already owns an `OVERLAY_INK` — the buy/sell marker glow, chevron and alert line from #752. The new table is `OVERLAY_LINE_INK` with a `lineInk()` accessor, and `chartInk.ts` says so at the top. Two tables called the same thing in one file is the kind of thing that reads fine until someone edits the wrong one.

## Verification

**Unit**, 14 tests in `__tests__/chartInk.test.mts` (6 new):

- every line clears 3:1 on its own ground, both themes
- every label clears 4.5:1, both themes
- hue drift ≤1° between a colour's dark and light values
- the cluster pink is identical across themes and still white-texted
- `lineInk()` returns the right theme's entry, and the two differ
- **CONTROL:** the four replaced values still measure as failing, so the assertion cannot pass on any palette

**Rendered**, localhost, **terminal + light**, two samples three seconds apart, both identical:

```
srResistance  #f52c2c  3705 px      old #f87171   0
srSupport     #1f9067  2902 px      old #34d399   0
gexFlip       #0c8ca0  1377 px      old #22d3ee   0
liqCluster    #db2777 20590 px      unchanged, as ruled
precondition  61924 painted pixels
```

`ema20`/`ema50` read 0 there and that is correct rather than a miss — terminal uses the grey ramp, so the current-design values cannot appear in that context.

**The precondition line is not decoration.** My first three attempts at this returned **0 painted pixels and zeros for every colour**, which reads exactly like the change having failed. The page was rendering the whole time — a screenshot showed candles, S/R chips and eight cluster labels. `getImageData` returns an empty buffer on a canvas that has not repainted since the tab was backgrounded (`document.visibilityState: "hidden"`), and a window resize forces the repaint that makes it readable. **That is trap 13's guard earning its place on the second day it existed**, and trap 12's question — could this input have produced a visible result at all.

## Risk level

**Medium.**

- Six overlay colours change in light themes, on every chart in the app. Intended and ruled.
- **`gexMaxPain` cannot be rendered on qa or staging** — `/api/version` reports `coinglass: false`, so `store.btcMaxPain` is null and the overlay never draws. Its new value is arithmetic and source review only, the same position #808 left its text colour in. **"Not drawn" is not "verified"** and I am not counting it.
- **Not measured: current design + light theme.** I loaded it and the sampler's precondition failed there and stayed failed across two forced repaints, so I have no numbers. A screenshot shows the page rendering with a visibly darker ribbon, which is consistent with the change and is **not** a measurement. This is the context #812 also left unrendered.

Gates, each read: lint 0 errors / 232 warnings, `tsc --noEmit` exit 0, **657 tests pass**, build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
