### PR TITLE
feat(econ-calendar): say "estimated" on the rows, not just in the hero (#696)

### DIFF
--- a/__tests__/_cssContexts.mts
+++ b/__tests__/_cssContexts.mts
@@ -1,0 +1,59 @@
+/* Reading globals.css the way the browser does: four contexts, tokens resolved
+ * through the cascade.
+ *
+ * Extracted from __tests__/readableOn.test.mts when a second test needed it
+ * (#696). Two copies of a CSS parser is the two-sources shape this repo keeps
+ * paying for - and the failure mode is quiet, because a drifted copy still
+ * returns well-formed colours, just not the ones the page renders.
+ *
+ * Not named *.test.mts on purpose: `npm test` globs that pattern, and this file
+ * has no assertions of its own.
+ */
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+export const CSS = readFileSync(path.join(ROOT, 'app', 'globals.css'), 'utf8');
+
+/** Custom-property declarations inside one top-level rule. */
+export function tokens(selector: string): Record<string, string> {
+  const lines = CSS.split('\n');
+  const idx = lines.findIndex(l => l.trim() === selector + ' {');
+  assert.ok(idx >= 0, `token block not found in globals.css: ${selector}`);
+  const from = lines.slice(0, idx).join('\n').length;
+  let i = CSS.indexOf('{', from), depth = 0, end = i;
+  for (; i < CSS.length; i++) {
+    if (CSS[i] === '{') depth++;
+    else if (CSS[i] === '}') { depth--; if (depth === 0) { end = i; break; } }
+  }
+  const body = CSS.slice(CSS.indexOf('{', from) + 1, end);
+  const out: Record<string, string> = {};
+  for (const m of body.matchAll(/(--[a-z0-9-]+)\s*:\s*([^;]+);/g)) out[m[1]] = m[2].trim();
+  return out;
+}
+
+/** Follow `var(--x)` chains, including fallbacks, to a literal. */
+export function resolve(map: Record<string, string>, value: string, depth = 0): string | null {
+  if (depth > 10) return null;
+  const m = /^var\((--[a-z0-9-]+)(?:\s*,\s*([^)]+))?\)$/.exec(value.trim());
+  if (!m) return value.trim();
+  const next = map[m[1]] ?? m[2];
+  return next === undefined ? null : resolve(map, next, depth + 1);
+}
+
+/** The four contexts a page can actually render in. Terminal light layers on
+ *  the light block because that is the cascade order in globals.css. */
+export const CONTEXTS: Array<[string, Record<string, string>]> = (() => {
+  const root = tokens(':root');
+  const light = tokens('[data-theme="light"]');
+  const termDark = tokens('[data-design="terminal"]:not([data-theme="light"])');
+  const termLight = tokens('[data-design="terminal"][data-theme="light"]');
+  return [
+    ['current dark', { ...root }],
+    ['current light', { ...root, ...light }],
+    ['terminal dark', { ...root, ...termDark }],
+    ['terminal light', { ...root, ...light, ...termLight }],
+  ];
+})();

--- a/__tests__/econCalendarEstimated.test.mts
+++ b/__tests__/econCalendarEstimated.test.mts
@@ -1,0 +1,110 @@
+/* The estimated-date marker on /econ-calendar (#696).
+ *
+ * 15 of 19 events on that page are computed from release PATTERNS - "CPI lands
+ * mid-month, FOMC meets eight times a year" - not read from a schedule. Four
+ * come from a real source. The generator is fine and says so in its own header;
+ * the gap was that a user could not tell which row was which, on a page whose
+ * whole affordance is dates you can plan around.
+ *
+ * The hero banner has said "estimated" in words since #245. The ROWS carried a
+ * `~` prefix and a `title` attribute, and a disclosure you have to hover to
+ * find is one nobody sees. The owner ruled: label them.
+ *
+ * WHY THIS IS A SOURCE TEST. The marker is a rendered string whose correctness
+ * is "a human reading the row learns the date is a guess". No unit test reaches
+ * that. What a test CAN pin is the three ways it silently stops being true: the
+ * word disappears back into a tooltip, the gate inverts so scheduled rows get
+ * marked, or the colour drifts below readable in one of the four contexts.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { contrastRatio, parseCssColor } from '../lib/readableOn.ts';
+import { CONTEXTS, resolve } from './_cssContexts.mts';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const PAGE = readFileSync(path.join(ROOT, 'app', 'econ-calendar', 'page.tsx'), 'utf8');
+const API = readFileSync(path.join(ROOT, 'app', 'api', 'econ-calendar', 'route.ts'), 'utf8');
+
+const TEXT_MIN = 4.5;
+const ratio = (a: string, b: string) => contrastRatio(parseCssColor(a)!.rgb, parseCssColor(b)!.rgb);
+
+/** The marker block in the row's TIME cell: `{e.estimated && ( <div …>estimated</div> )}` */
+function rowMarker(): string | null {
+  const at = PAGE.indexOf('{e.estimated && (');
+  return at < 0 ? null : PAGE.slice(at, at + 400);
+}
+
+test('the row marker exists and is a visible word, not only a tooltip', () => {
+  const block = rowMarker();
+  assert.ok(block, 'no {e.estimated && (…)} marker in the row - /econ-calendar is back to a bare tilde');
+  assert.match(block, />\s*estimated\s*</,
+    'the marker no longer renders the word. A title attribute is not a disclosure: ' +
+    'nobody hovers a date to find out whether it is real.');
+});
+
+test('the marker is gated on the data, not re-derived in the view', () => {
+  /* #696 was explicit: read whatever field already separates the four real ones.
+     The API sets `estimated: true` on every entry from computeMacroSchedule and
+     nowhere else, so the view must not invent its own rule - a second definition
+     of "is this a guess" is a second thing to drift. */
+  assert.match(API, /estimated\?: boolean/, 'the API no longer carries an estimated flag');
+  assert.match(API, /estimated: true/, 'computed entries are no longer flagged at the source');
+  assert.equal(/estimated:\s*false/.test(API), false,
+    'a scheduled entry is now explicitly flagged rather than left absent - if that is ' +
+    'deliberate, the view\'s truthiness check still works, but say so here');
+  assert.match(PAGE, /e\.estimated\b/, 'the row no longer reads the flag');
+});
+
+test('a scheduled row gets no marker - silence is the signal for the accurate case', () => {
+  /* The gate is `&&` on the flag, so the marker cannot appear on a row without
+     it. Asserting the shape rather than the absence, because "no marker on
+     scheduled rows" has no rendered artefact to count. */
+  const block = rowMarker()!;
+  assert.ok(block.startsWith('{e.estimated && ('),
+    'the marker is no longer gated on the flag itself');
+  assert.equal(/e\.estimated\s*\?\s*[^:]+:\s*['"`]/.test(block), false,
+    'the marker renders something for the scheduled case too');
+});
+
+test('the marker clears 4.5:1 as text in all four contexts', () => {
+  /* It is text on the row, and the row is transparent over --bg1's card. Read
+     from globals.css through the cascade rather than restated here, so a token
+     change moves the assertion with it. */
+  const colour = /color:\s*'var\((--[a-z0-9-]+)\)'/.exec(rowMarker()!);
+  assert.ok(colour, 'the marker colour is no longer a token - a literal cannot follow the theme');
+  const failures: string[] = [];
+  for (const [name, map] of CONTEXTS) {
+    const fg = resolve(map, `var(${colour[1]})`);
+    const bg = resolve(map, 'var(--bg1)');
+    assert.ok(fg && bg, `${name}: could not resolve ${colour[1]} or --bg1`);
+    const r = ratio(fg, bg);
+    if (r < TEXT_MIN) failures.push(`${name}: ${fg} on ${bg} = ${r.toFixed(2)}:1`);
+  }
+  assert.deepEqual(failures, [],
+    `the estimated marker is unreadable in ${failures.length} context(s):\n  ${failures.join('\n  ')}`);
+});
+
+test('the marker is a word, so colour is not the only channel', () => {
+  /* SC 1.4.1. A coloured dot or a tinted date would carry the same information
+     and vanish for a reader who cannot see the colour. The word survives
+     greyscale, and it is also why no aria is needed: visible text is already
+     the accessible name, read in document order right after the time. */
+  const block = rowMarker()!;
+  assert.match(block, />\s*estimated\s*</);
+  assert.equal(/aria-label|sr-only/.test(block), false,
+    'the marker grew an aria label - if the visible text stopped being the ' +
+    'accessible name, that is the thing to fix rather than to paper over');
+});
+
+test('CONTROL: these assertions can fail', () => {
+  /* Every check above is a regex over a file. A pattern that matched nothing
+     would report success for all of them. */
+  assert.ok(rowMarker(), 'the marker block is findable at all');
+  assert.equal(/{e\.estimated && \(/.test('nothing like the marker'), false);
+  assert.ok(ratio('#7c828a', '#ebe9e6') < TEXT_MIN,
+    'terminal light --txt2 on --bg1 should still measure as failing - if this passes, ' +
+    'the ratio function is not discriminating and the context test above proves nothing');
+});

--- a/__tests__/readableOn.test.mts
+++ b/__tests__/readableOn.test.mts
@@ -15,55 +15,20 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { CSS, CONTEXTS, resolve } from './_cssContexts.mts';
 import {
   readableOn, parseCssColor, compositeOver, contrastRatio, relativeLuminance,
   BLACK, WHITE, type Rgb,
 } from '../lib/readableOn.ts';
 
 const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
-const CSS = readFileSync(path.join(ROOT, 'app', 'globals.css'), 'utf8');
 const PAGE = readFileSync(path.join(ROOT, 'app', 'hours', 'page.tsx'), 'utf8');
 
 const BAR = 4.5;
 
-/** Custom-property declarations inside one top-level rule. */
-function tokens(selector: string): Record<string, string> {
-  const lines = CSS.split('\n');
-  const idx = lines.findIndex(l => l.trim() === selector + ' {');
-  assert.ok(idx >= 0, `token block not found in globals.css: ${selector}`);
-  const from = lines.slice(0, idx).join('\n').length;
-  let i = CSS.indexOf('{', from), depth = 0, end = i;
-  for (; i < CSS.length; i++) {
-    if (CSS[i] === '{') depth++;
-    else if (CSS[i] === '}') { depth--; if (depth === 0) { end = i; break; } }
-  }
-  const body = CSS.slice(CSS.indexOf('{', from) + 1, end);
-  const out: Record<string, string> = {};
-  for (const m of body.matchAll(/(--[a-z0-9-]+)\s*:\s*([^;]+);/g)) out[m[1]] = m[2].trim();
-  return out;
-}
-
-function resolve(map: Record<string, string>, value: string, depth = 0): string | null {
-  if (depth > 10) return null;
-  const m = /^var\((--[a-z0-9-]+)(?:\s*,\s*([^)]+))?\)$/.exec(value.trim());
-  if (!m) return value.trim();
-  const next = map[m[1]] ?? m[2];
-  return next === undefined ? null : resolve(map, next, depth + 1);
-}
-
-const root = tokens(':root');
-const light = tokens('[data-theme="light"]');
-const termDark = tokens('[data-design="terminal"]:not([data-theme="light"])');
-const termLight = tokens('[data-design="terminal"][data-theme="light"]');
-
-/* The four contexts the page can actually render in. Terminal light layers on
-   the light block because that is the cascade order in globals.css. */
-const CONTEXTS: Array<[string, Record<string, string>]> = [
-  ['current dark', { ...root }],
-  ['current light', { ...root, ...light }],
-  ['terminal dark', { ...root, ...termDark }],
-  ['terminal light', { ...root, ...light, ...termLight }],
-];
+/* tokens(), resolve() and CONTEXTS moved to ./_cssContexts.mts when a second
+   test needed them (#696). Two copies of a CSS parser drift quietly: a stale
+   one still returns well-formed colours, just not the page's. */
 
 /** The band colours, read out of the page rather than copied.
  *  `{ start: 4, end: 7, bg: 'rgba(248,113,113,0.45)', labelKey: 'HOURS_SEG_DEAD' … }` */

--- a/app/econ-calendar/page.tsx
+++ b/app/econ-calendar/page.tsx
@@ -306,6 +306,30 @@ export default function EconCalendarPage() {
                       style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt2)', fontVariantNumeric: 'tabular-nums', fontWeight: 500 }}
                     >
                       {e.estimated ? '~' : ''}{fmtTime(e.isoDate)}
+                      {/* THE WORD, not only the tilde and the tooltip (#696).
+                          The hero banner above has said "estimated" in words
+                          since #245; the rows kept a `~` prefix and a title
+                          attribute, and a disclosure you have to hover to find
+                          is one nobody sees. The owner ruled label them, so the
+                          marker is visible text on every estimated row.
+
+                          It is TEXT rather than a colour or an icon, so it is
+                          not a colour-only distinction (1.4.1) and needs no
+                          aria: visible text is already the accessible name a
+                          screen reader reads, in document order, right after
+                          the time it qualifies.
+
+                          var(--amber) is the hero's colour and clears 4.5:1 as
+                          text on --bg1 in all four contexts - 12.07 current
+                          dark, 6.95 current light, 10.94 terminal dark, 5.91
+                          terminal light. A scheduled row gets nothing: silence
+                          is the correct signal for the accurate case. */}
+                      {e.estimated && (
+                        <div style={{ fontSize: 'var(--fs-micro)', fontWeight: 700, letterSpacing: '.04em',
+                                      textTransform: 'uppercase', color: 'var(--amber)', marginTop: 1 }}>
+                          estimated
+                        </div>
+                      )}
                       {!isPast && !ctObj.released && (
                         <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--ec-muted)', marginTop: 1 }}>{t('ECON_CALENDAR_IN_COUNTDOWN', { countdown: ct })}</div>
                       )}


### PR DESCRIPTION
## Summary

Closes **#696**. Every estimated row on `/econ-calendar` now says **estimated** in visible text. Scheduled rows are unchanged and unmarked.

## The split, measured today rather than taken from the issue

```
GET /api/econ-calendar  (deployed qa, d4fd0ae)
source     forexfactory+fed+computed
total      19
estimated  15
scheduled   4
```

Unchanged since #696 was filed. Worth confirming rather than assuming — the issue asked for the count as a check, and a stale 15/4 would have been the easiest thing in the world to repeat.

## Smaller than it sounds, and the reason matters

**The data half already existed.** `app/api/econ-calendar/route.ts` sets `estimated: true` on every entry from `computeMacroSchedule` and nowhere else, and has since #245. **The hero banner already says the word.** What was missing was the rows: a `~` prefix and a `title` attribute.

So this is not a new marker — it is **the row catching up with the banner directly above it**. Nothing is re-derived in the view; it reads the flag the API already sets, which is what #696 asked for.

A tooltip is not a disclosure. Nobody hovers a date to find out whether it is real, and on touch there is no hover at all.

## What changed

**`app/econ-calendar/page.tsx`** — the row's TIME cell renders the word when `e.estimated`, in `var(--amber)`, matching the hero exactly rather than inventing a second treatment.

- **Text, not colour or an icon**, so it is not a colour-only distinction (SC 1.4.1) and survives greyscale.
- **No aria.** Visible text is already the accessible name, read in document order right after the time it qualifies. #696 asked for the marker to be in the row's accessible name; adding `aria-label` on top would duplicate it, not improve it.
- **Nothing removed or reordered**, as ruled. The tilde and the tooltip both stay — the tooltip now carries the detail rather than the fact.

## Contrast, all four contexts

Resolved out of `globals.css` through the cascade, not restated:

| Context | `--amber` | `--bg1` | Ratio |
|---|---|---|---|
| current dark | `#fbbf24` | `#06070a` | **12.07** |
| current light | `#8F4508` | `#FFFFFF` | **6.95** |
| terminal dark | `#fbbf24` | `#141517` | **10.94** |
| terminal light | `#755100` | `#ebe9e6` | **5.91** |

## Verification

**Unit**, 6 new tests in `__tests__/econCalendarEstimated.test.mts`, pinning the three ways this silently stops being true: the word retreats into a tooltip, the gate inverts so scheduled rows get marked, or the colour drifts below 4.5:1 in one context. Plus a control that the assertions can fail.

**Refactor, and it is the kind I keep flagging in other people's work.** The CSS context parser lived inside `readableOn.test.mts`. Rather than copy thirty lines of it, `tokens()`, `resolve()` and `CONTEXTS` moved to `__tests__/_cssContexts.mts` and both tests import it. **Two copies of a CSS parser drift quietly** — a stale one still returns well-formed colours, just not the page's. `readableOn.test.mts` still passes 14/14 unchanged in behaviour.

**Rendered**, localhost, both current-design themes, cross-checked against the API in the same run:

```
                     rows rendered   rows marked   API total   API estimated
current light             19             15           19            15
current dark              19             15           19            15

marker colour, read from the live element:
  current light   rgb(143, 69, 8)   = #8F4508 on #FFFFFF     6.95:1
  current dark    rgb(251,191,36)   = #fbbf24 on #06070a    12.07:1

marked row:    "~20:30 ESTIMATED in 6d 17h US Consumer Price Index (CPI) MoM ..."
unmarked row:  "20:30 US Nonfarm Payrolls (NFP) -23K 55K +162K +107.00K high"
```

**The count is the check, and it is cross-checked rather than asserted.** 15 marked out of 19 rendered, against 15 estimated out of 19 from `/api/econ-calendar` on the same page load — so the marker follows the data rather than a coincidence that happens to total 15.

## Risk level

**Low-Medium.**

- Fifteen of nineteen rows gain a line of text. That is the point, and it is the owner's ruling, but it is a visible density change on a dense page.
- **Not verified:** mobile at 390px. The marker sits under the time in a column that already stacks a countdown line, so it should not reflow the grid, but I have not measured it.
- **Not rendered:** either terminal context. The two terminal ratios in the table above are arithmetic from `globals.css`, same as the two I did render — and those two matched the live element exactly, which is evidence for the method but not for those two rows.
- The count is live data. If ForexFactory returns more real events next week the split moves, and that is correct behaviour rather than drift.

Gates, each read: lint 0 errors / 232 warnings, `tsc --noEmit` exit 0, **665 tests pass**, build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
