### PR TITLE
chore(security): move spike-alert recipients to env, trim infra doc

### DIFF
--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -147,7 +147,13 @@ cheap to remove or needed a dedicated bot first. It was cheap.
 
 Self-hosted, see §1. Login is separate from Render/Supabase/cron-job.org — another credential silo an assistant can't see into without being handed the URL.
 
-Project: **Personal** → folder **`liquidityhq`** (`https://n8n-workflows-6ig6.onrender.com/projects/9B0VhqigwtxZEqpc/folders/wiWQZx7PhztvoBTv/workflows`).
+Project: **Personal** → folder **`liquidityhq`**, on the n8n host in §1.
+
+> The full admin deep link used to sit here, project and folder IDs included.
+> Trimmed 2026-09-05: **this repo is public**, and a direct link into the
+> workflow editor is a starting point rather than a maintainer's need — the
+> host is already in §1 and anyone with a login reaches the folder by name in
+> two clicks. Nothing operational is lost; the reconnaissance shortcut is.
 
 | Workflow | Trigger | Action | Status |
 |---|---|---|---|
@@ -195,10 +201,20 @@ A local Claude Code **scheduled-tasks** entry (`mcp__scheduled-tasks`, `lhq-aler
 > over-corrected it, calling the dev project "stale/superseded" — also wrong.
 > This version is the owner-confirmed final state.
 
-| Project name | Ref | Region | Status | Used by LHQ? |
-|---|---|---|---|---|
-| **`liquidity-hq-prod`** | `qdpwhnvmhqgzijuwopso` | ap-northeast-2 | Active | **Yes — production only.** The `liquidity-hq-prod` Render service points here. Holds `lhq_*` (prod) tables. |
-| **`liquidity-hq-dev`** | `wdtjhrilakoitfcezxpx` | ap-northeast-1 | Active | **Yes — all dev.** Both the `liquidity-hq-dev` Render service AND local `.env.local` point here. Holds the parallel `lhq_dev_*` table set. |
+| Project name | Region | Status | Used by LHQ? |
+|---|---|---|---|
+| **`liquidity-hq-prod`** | ap-northeast-2 | Active | **Yes — production only.** The `liquidity-hq-prod` Render service points here. Holds `lhq_*` (prod) tables. |
+| **`liquidity-hq-dev`** | ap-northeast-1 | Active | **Yes — all dev.** Both the `liquidity-hq-dev` Render service AND local `.env.local` point here. Holds the parallel `lhq_dev_*` table set. |
+
+**Refs are deliberately not listed here.** They are public by design — a
+Supabase ref is the hostname in every `NEXT_PUBLIC_SUPABASE_URL`, so it ships in
+the browser bundle and hiding it would achieve nothing. What is worth not
+publishing is this file **telling a reader which ref is production**, on a page
+that also documents that production has no backups. Read the ref off
+`NEXT_PUBLIC_SUPABASE_URL` for the environment you are actually in — the Render
+service's env vars, or `.env.local` locally. That is one lookup, it cannot go
+stale, and it answers for the environment in front of you rather than for a
+table someone edited months ago.
 
 > **Corrected 2026-08-01:** the two rows above were named `LiquidityHq` and
 > `Automations` — stale. Confirmed directly against the Supabase API
@@ -209,15 +225,13 @@ A local Claude Code **scheduled-tasks** entry (`mcp__scheduled-tasks`, `lhq-aler
 > **Render services** now share the exact names `liquidity-hq-prod` /
 > `liquidity-hq-dev`. When it matters which system you mean, say "Supabase
 > project" or "Render service" — don't rely on the bare name. Identify
-> Supabase unambiguously by ref (`qdpwhnvmhqgzijuwopso` = prod,
-> `wdtjhrilakoitfcezxpx` = dev); Render by service id (`srv-d8aluf6l51nc73e1ijp0`
-> = prod, `srv-d8prs6po3t8c739aepdg` = dev).
+> Supabase unambiguously by ref — read from `NEXT_PUBLIC_SUPABASE_URL`, not from
+> this file — and Render by service id, which is in the §1 table.
 >
 > **Corrected 2026-07-30:** the row above previously said local `.env.local`
 > pointed at prod. It does not - verified by reading
-> `NEXT_PUBLIC_SUPABASE_URL` in `.env.local`, which is `wdtjhrilakoitfcezxpx`
-> (`liquidity-hq-dev`), with `NEXT_PUBLIC_APP_ENV=dev` so it uses the `lhq_dev_`
-> prefix. Local development has never touched the prod database. Check the env
+> `NEXT_PUBLIC_SUPABASE_URL` in `.env.local`, which resolves to the **dev**
+> project, with `NEXT_PUBLIC_APP_ENV=dev` so it uses the `lhq_dev_` prefix. Local development has never touched the prod database. Check the env
 > file rather than this table if it matters - that is what made the old claim
 > detectable.
 | `MotoTracker` | `bseewwodijmuvpbqdgcc` | ap-northeast-2 | Inactive | No - unrelated project. |
@@ -333,7 +347,7 @@ deliberate exceptions. Set as of 2026-08-05:
 | `NEXT_PUBLIC_APP_ENV` | `dev` | **Not `qa`** — see §4b |
 | `NEXT_PUBLIC_SENTRY_ENV` | `qa` | The one place qa may call itself qa. Separates its errors from dev's in GlitchTip without touching table selection — see §4b. **Set — confirmed in the dashboard 2026-08-08** (this row previously read "not yet set") |
 | `NEXT_PUBLIC_APP_URL` | `https://liquidity-hq-qa.onrender.com` | Its own URL, never dev's. Telegram webhook registration and email links build absolute URLs from this |
-| `NEXT_PUBLIC_SUPABASE_URL` / `_ANON_KEY` | dev project `wdtjhrilakoitfcezxpx` | Shares the dev database — see §1 |
+| `NEXT_PUBLIC_SUPABASE_URL` / `_ANON_KEY` | the **dev** Supabase project | Shares the dev database — see §1 |
 | `SUPABASE_SERVICE_ROLE_KEY` | dev project's | Server routes return empty results without it. `/api/labels` answered `{}` until it was set |
 | `AI_GLOBAL_DAILY_MAX` | `25` | Low cap. QA testing spends real xAI credit |
 | `CMC_API_KEY`, `FINNHUB_KEY`, `GROK_API_KEY` | copied from dev | Shares dev's quota |

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -57,9 +57,28 @@ async function brevoFetch(init: RequestInit): Promise<Response> {
 
 const APP_NAME = 'LiquidityHQ';
 
-// Fixed recipient list for the AI-spend spike alert - the owner's own
-// addresses, not a per-user setting, so no env var / admin UI for this list.
-const SPIKE_ALERT_RECIPIENTS = ['johndominicbuilds@gmail.com', 'mikocabal27@gmail.com'];
+/* Recipients for the AI-spend spike alert. Still not a per-user setting and
+   still no admin UI - but out of the source, because this repo is public.
+   The two addresses that used to sit here were real inboxes readable by anyone
+   who cloned it; the risk is spam and social engineering rather than access,
+   which is why this is a scrub and not an incident.
+
+   Comma-separated and server-only, the same shape as ADMIN_EMAILS
+   (lib/admin-auth.ts:28). NOT NEXT_PUBLIC_ - a NEXT_PUBLIC_ var is inlined
+   into the browser bundle at build time, which would put the addresses back in
+   public view by a longer route.
+
+   EMPTY IS THE CORRECT FALLBACK and it is a deliberate trade. With the var
+   unset the alert is built and sent to nobody, so the spend spike goes
+   unannounced - that is worse than mail arriving, and better than a repo that
+   hardcodes someone's inbox. Every service that should page a human needs
+   SPIKE_ALERT_RECIPIENTS set; see the PR for which ones. */
+function spikeAlertRecipients(): string[] {
+  return (process.env.SPIKE_ALERT_RECIPIENTS ?? '')
+    .split(',')
+    .map(e => e.trim())
+    .filter(Boolean);
+}
 
 function appUrl(path: string): string {
   const base = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, '') || 'https://liquidity-hq.com';
@@ -116,7 +135,7 @@ export async function sendAdminAddedEmail(args: AdminAddedArgs): Promise<boolean
 
 // Owner-only warning: today's xAI call volume crossed 80% of the global
 // daily cap (app/api/ops/spike-alert/route.ts). Fixed recipient list, not
-// per-user - see SPIKE_ALERT_RECIPIENTS above.
+// per-user - see spikeAlertRecipients() above.
 export interface HealthAlertArgs {
   down: Array<{ source: string; category: string; detail: string; failures: number; lastOkAt: string | null }>;
   recovered: string[];
@@ -185,7 +204,7 @@ export async function sendHealthAlertEmail(args: HealthAlertArgs): Promise<boole
       },
       body: JSON.stringify({
         sender: { name: `${APP_NAME} Ops`, email: from },
-        to: SPIKE_ALERT_RECIPIENTS.map(email => ({ email })),
+        to: spikeAlertRecipients().map(email => ({ email })),
         subject,
         htmlContent: html,
       }),
@@ -224,7 +243,7 @@ export async function sendSpikeAlertEmail(args: SpikeAlertArgs): Promise<boolean
       },
       body: JSON.stringify({
         sender: { name: `${APP_NAME} Ops`, email: from },
-        to: SPIKE_ALERT_RECIPIENTS.map(email => ({ email })),
+        to: spikeAlertRecipients().map(email => ({ email })),
         subject,
         htmlContent: html,
       }),

--- a/lib/envCheck.ts
+++ b/lib/envCheck.ts
@@ -35,9 +35,16 @@
  * Everything else logs and returns.
  */
 
-// Project refs, not secrets - these appear in every NEXT_PUBLIC_SUPABASE_URL
-// and in docs/INFRASTRUCTURE.md 4. Named so the comparison below reads as
-// intent rather than as a magic string.
+// Project refs, not secrets - these appear in every NEXT_PUBLIC_SUPABASE_URL,
+// so they ship in the browser bundle and hiding them achieves nothing. Named so
+// the comparison below reads as intent rather than as a magic string.
+//
+// docs/INFRASTRUCTURE.md 4 NO LONGER LISTS THEM (trimmed 2026-09-05, public
+// repo): what was worth not publishing is a doc telling a reader which ref is
+// production, next to the note that production has no backups. This constant is
+// the opposite case and stays - it is the check that stops a non-prod service
+// pointing at the prod database, which CONTRIBUTING calls a hard rule. Deleting
+// it to tidy the string away would remove the guard and keep the exposure.
 const PROD_SUPABASE_REF = 'qdpwhnvmhqgzijuwopso';
 
 export interface EnvFinding {


### PR DESCRIPTION
## Summary

Two owner-approved scrub items for a repo that turned out to already be public. **Not filed as an issue on purpose** — the tracker is the same public surface.

**Neither of these is the incident.** The keys are the incident and they are the owner's to rotate. These are the things that were never secrets but read differently once anyone can browse the repo.

## 1. `lib/email.ts` — spike-alert recipients to env

Two real Gmail addresses were hardcoded as the AI-spend alert recipients. Now `SPIKE_ALERT_RECIPIENTS`, comma-separated, server-only, same shape as `ADMIN_EMAILS` (`lib/admin-auth.ts:28`).

**Not `NEXT_PUBLIC_`, deliberately** — that prefix inlines the value into the browser bundle at build time, which would put the addresses back in public view by a longer route.

**Empty is the correct fallback, and it is a real trade rather than a default.** With the var unset the alert is built and sent to nobody, so a spend spike goes unannounced. That is worse than mail arriving and better than a repo hardcoding someone's inbox — but it is a live consequence, not a no-op.

**Services that need the var set:** `liquidity-hq-prod` (the only one that runs the spike alert — it is triggered by n8n against the prod host, `docs/INFRASTRUCTURE.md` §3). The non-prod services do not run it; setting it there is harmless and unnecessary.

## 2. `docs/INFRASTRUCTURE.md` — trimmed, not gutted

**The n8n admin deep link** carried project and folder IDs. The host stays in §1 and the folder is named; anyone with a login reaches it in two clicks. Nothing operational is lost.

**The Supabase ref table** no longer maps refs to environments. The refs themselves are public by design — a ref is the hostname in every `NEXT_PUBLIC_SUPABASE_URL`, so it ships in the browser bundle and hiding it achieves nothing. **What was worth not publishing is this file telling a reader which ref is production, on a page that also documents that production has no backups.** The section now says to read the ref off the env var for the environment you are actually in, which cannot go stale.

## The part that changes what this is worth, and it is not good news

The mapping is not only in that file. Searching the repo:

```
20+ files contain a prod or dev Supabase ref
including  CLAUDE.md  CONTRIBUTING.md  docs/ARCHITECTURE.md  docs/HANDOVER.md
           qa/README.md  lib/envCheck.ts  two test files  eight pendings/ docs
```

**So this PR does not achieve "the repo no longer labels production."** It cleans the file it was scoped to. Anyone reading `CLAUDE.md` learns the same thing in one line. Whether to go further is the owner's call and it is a bigger one than it looks, because at least one of those uses must stay:

`lib/envCheck.ts:41` holds `PROD_SUPABASE_REF` as the check that stops a non-prod service pointing at the production database — the hard rule in `CONTRIBUTING.md`. **Deleting that constant to tidy the string away would remove the guard and keep the exposure.** Its comment now says so, and also that INFRASTRUCTURE.md no longer lists the refs, so the next reader does not go looking for a table that has been trimmed (trap 8 — deleting content while prose points at it).

## How to test (QA)

Nothing renders. On `qa`:

1. `grep -rn "qdpwhnvmhqgzijuwopso\|wdtjhrilakoitfcezxpx" docs/INFRASTRUCTURE.md` → no matches.
2. `grep -n "9B0VhqigwtxZEqpc\|wiWQZx7PhztvoBTv" docs/INFRASTRUCTURE.md` → no matches.
3. `grep -n "gmail.com" lib/email.ts` → no matches.
4. The spike alert is the one behaviour change: with `SPIKE_ALERT_RECIPIENTS` unset it sends to an empty list rather than to two hardcoded inboxes.

## Risk level

**Medium**, and the risk is behavioural rather than structural.

- **The spike alert is silent until the var is set on prod.** That is the intended trade and it is the thing most likely to be forgotten.
- **Not verified:** an actual send with the var set. I did not exercise the Brevo path.
- Documentation trimming cannot break a build, but it can remove something a maintainer needed. I kept every operational fact and removed only the two shortcuts.

Gates, each read: lint 0 errors / 232 warnings, `tsc --noEmit` exit 0, **659 tests pass**, build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
