### PR TITLE
docs(infra): record SPIKE_ALERT_RECIPIENTS and what unset costs

### DIFF
--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -390,6 +390,32 @@ admins (`sendSpikeAlertEmail`, `sendHealthAlertEmail`, `sendAdminAddedEmail`, an
 users — and on dev, qa and staging those tables are the **dev** Supabase project,
 so the recipients are test accounts rather than real customers.
 
+### `SPIKE_ALERT_RECIPIENTS` — a second way to send nothing and look fine
+
+Added 2026-09-05 (#824). The AI-spend spike alert used to hold its two recipient
+addresses in `lib/email.ts`; this repo is public, so they moved to an env var:
+**comma-separated, server-only, NOT `NEXT_PUBLIC_`** — that prefix inlines the
+value into the browser bundle and would publish them again by a longer route.
+
+| Service | Needs it | Why |
+|---|---|---|
+| `liquidity-hq-prod` | **Yes** | The only service that runs the alert. n8n triggers `LHQ - AI Spike Alert` against the prod host — see §3. |
+| dev / qa / staging | No | They do not run it. Setting it is harmless and buys nothing. |
+
+**Unset means the alert is built and sent to an empty list.** It does not throw
+and it does not warn: `sendSpikeAlertEmail` returns the same way it would if the
+send had worked.
+
+That is deliberate — an alert going nowhere beats one hardcoded to a person's
+inbox in a public repo — but read it against the paragraphs above, because it is
+**the same failure shape as a missing `BREVO_API_KEY`, one layer in.** Brevo
+missing means no environment can send; this missing means one environment sends
+to nobody. Both are indistinguishable from "nobody was due", and the spike alert
+is the one that only fires when something has already gone wrong with spend.
+
+If the alert is what you are relying on to notice a runaway xAI bill, **check the
+variable is set rather than inferring it from silence.**
+
 ### Telegram on QA — currently dev's bot, safe only by accident
 
 **`TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID` and `TELEGRAM_WEBHOOK_SECRET` on the


### PR DESCRIPTION
## Summary

Documents `SPIKE_ALERT_RECIPIENTS` in `docs/INFRASTRUCTURE.md` §4c, where the related lesson already lives. Docs only.

QA's review of #824 said the behaviour change belongs in the deploy checklist rather than only a PR body, and they are right — **a consequence recorded only in a merged PR is a consequence nobody reads.**

## Why it went where it went

§4c already explains that `lib/email.ts` **fails silently**: every sender returns `false` when Brevo keys are missing rather than throwing, so an unconfigured environment is indistinguishable from "nobody was due". QA hit that exact wall on the trial-reminder path.

`SPIKE_ALERT_RECIPIENTS` unset is **the same failure shape, one layer in**:

```
BREVO_API_KEY missing        no environment can send
SPIKE_ALERT_RECIPIENTS unset one environment sends to nobody
```

Both look like "nobody was due". Putting the new one next to the old one means a reader meets the pattern once instead of twice, and the section's existing argument does the explaining.

## What it says

- Comma-separated, server-only, **not `NEXT_PUBLIC_`** — that prefix inlines the value into the browser bundle and would republish the addresses by a longer route.
- A per-service table: **`liquidity-hq-prod` needs it** (the only service that runs the alert — n8n triggers it against the prod host, §3). dev, qa and staging do not.
- Unset means the alert is built, sent to an empty list, and returns as though it worked.
- **The line that matters:** if the alert is what you rely on to notice a runaway xAI bill, check the variable is set rather than inferring it from silence. It is the alert that only fires when something has already gone wrong.

## How to test (QA)

Read §4c. `grep -n "SPIKE_ALERT_RECIPIENTS" docs/INFRASTRUCTURE.md` returns the new subsection.

## Risk level

**Low.** Documentation only. It changes no behaviour and does not set the variable — that is a dashboard action on `liquidity-hq-prod` and still outstanding.

Gates, each read: lint 0 errors / 232 warnings, `tsc --noEmit` exit 0, **665 tests pass**, build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
