### PR TITLE
test(econ-calendar): measure the marker on the ground it is painted on

### DIFF
--- a/__tests__/econCalendarEstimated.test.mts
+++ b/__tests__/econCalendarEstimated.test.mts
@@ -21,7 +21,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { contrastRatio, parseCssColor } from '../lib/readableOn.ts';
+import { compositeOver, contrastRatio, parseCssColor } from '../lib/readableOn.ts';
 import { CONTEXTS, resolve } from './_cssContexts.mts';
 
 const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -69,22 +69,60 @@ test('a scheduled row gets no marker - silence is the signal for the accurate ca
     'the marker renders something for the scheduled case too');
 });
 
-test('the marker clears 4.5:1 as text in all four contexts', () => {
-  /* It is text on the row, and the row is transparent over --bg1's card. Read
-     from globals.css through the cascade rather than restated here, so a token
-     change moves the assertion with it. */
+/** The ground the marker is actually painted on.
+ *
+ *  NOT `--bg1`, and the difference is the whole point of this helper. The row
+ *  sets `background: color-mix(in srgb, var(--txt) 2.5%, transparent)` when it
+ *  is the next event and transparent otherwise, so the next row composites a
+ *  2.5% veil of `--txt` over the card. Trap 2: a background is not the first
+ *  non-transparent ancestor.
+ *
+ *  This test measured `--bg1` until QA caught it on the deployed build (#696).
+ *  Every ratio the PR published was right about the tokens and wrong about the
+ *  pixels. Recomputed here independently, and it reproduces their reading of the
+ *  rendered page exactly:
+ *
+ *    current dark    #06070a -> #0c0d10    12.07 -> 11.64
+ *    current light   #FFFFFF -> #f9f9f9     6.95 ->  6.60
+ *    terminal dark   #141517 -> #191a1c    10.94 -> 10.43
+ *    terminal light  #ebe9e6 -> #e6e4e1     5.91 ->  5.64
+ *
+ *  The composited ground is the WORSE case in all four - it lightens under light
+ *  text and darkens under dark - so asserting against it is strictly stricter
+ *  than `--bg1` as well as being the ground a real row paints on. */
+function rowGround(map: Record<string, string>): string {
+  const bg1 = resolve(map, 'var(--bg1)');
+  const txt = resolve(map, 'var(--txt)');
+  assert.ok(bg1 && txt, 'could not resolve --bg1 or --txt');
+  const rgb = compositeOver(parseCssColor(txt)!.rgb, parseCssColor(bg1)!.rgb, 0.025);
+  return '#' + rgb.map(v => Math.round(v).toString(16).padStart(2, '0')).join('');
+}
+
+test('the marker clears 4.5:1 as text in all four contexts, on the ground it is painted on', () => {
   const colour = /color:\s*'var\((--[a-z0-9-]+)\)'/.exec(rowMarker()!);
   assert.ok(colour, 'the marker colour is no longer a token - a literal cannot follow the theme');
   const failures: string[] = [];
   for (const [name, map] of CONTEXTS) {
     const fg = resolve(map, `var(${colour[1]})`);
-    const bg = resolve(map, 'var(--bg1)');
-    assert.ok(fg && bg, `${name}: could not resolve ${colour[1]} or --bg1`);
+    assert.ok(fg, `${name}: could not resolve ${colour[1]}`);
+    const bg = rowGround(map);
     const r = ratio(fg, bg);
     if (r < TEXT_MIN) failures.push(`${name}: ${fg} on ${bg} = ${r.toFixed(2)}:1`);
   }
   assert.deepEqual(failures, [],
     `the estimated marker is unreadable in ${failures.length} context(s):\n  ${failures.join('\n  ')}`);
+});
+
+test('the composited ground is not the card colour - if it ever is, this test lost its point', () => {
+  /* A guard on the guard. If the row's 2.5% veil is removed, rowGround() starts
+     returning --bg1 and the assertion above quietly reverts to measuring the
+     thing QA corrected, while still passing. */
+  const differs = CONTEXTS.filter(([, map]) =>
+    rowGround(map).toLowerCase() !== resolve(map, 'var(--bg1)')!.toLowerCase());
+  assert.equal(differs.length, CONTEXTS.length,
+    'the row background no longer composites over --bg1 in every context - if the veil ' +
+    'was deliberately removed then --bg1 is correct again, and this test should say so ' +
+    'rather than keep compositing a layer that is not there');
 });
 
 test('the marker is a word, so colour is not the only channel', () => {

--- a/__tests__/econCalendarEstimated.test.mts
+++ b/__tests__/econCalendarEstimated.test.mts
@@ -87,9 +87,15 @@ test('a scheduled row gets no marker - silence is the signal for the accurate ca
  *    terminal dark   #141517 -> #191a1c    10.94 -> 10.43
  *    terminal light  #ebe9e6 -> #e6e4e1     5.91 ->  5.64
  *
- *  The composited ground is the WORSE case in all four - it lightens under light
- *  text and darkens under dark - so asserting against it is strictly stricter
- *  than `--bg1` as well as being the ground a real row paints on. */
+ *  ONLY THE NEXT-EVENT ROW COMPOSITES. The other fourteen estimated rows sit on
+ *  `--bg1` unveiled, so a reader checking this against the page will find one
+ *  row that matches the assertion and fourteen that do not. That is deliberate:
+ *  the composited ground is the WORSE case in all four contexts - each ratio
+ *  drops - so asserting against it covers the unveiled rows too. **Stricter on
+ *  purpose, not measuring the wrong row.**
+ *
+ *  It is also the row a user looks at first, and the one QA's deployed
+ *  measurement happened to sample. */
 function rowGround(map: Record<string, string>): string {
   const bg1 = resolve(map, 'var(--bg1)');
   const txt = resolve(map, 'var(--txt)');


### PR DESCRIPTION
## Summary

Test-only. `__tests__/econCalendarEstimated.test.mts` measured the estimated marker against `--bg1`. **The row does not paint on `--bg1`** — the next-event row lays a 2.5% `--txt` veil over it, so every ratio I published on #823 was right about the tokens and wrong about the pixels.

QA caught it verifying #696 on the deployed build. The test is now measured against the composited ground.

## Reproduced independently before accepting it

```
                --bg1      composited   claimed   actual
current dark    #06070a -> #0c0d10       12.07 -> 11.64
current light   #FFFFFF -> #f9f9f9        6.95 ->  6.60
terminal dark   #141517 -> #191a1c       10.94 -> 10.43
terminal light  #ebe9e6 -> #e6e4e1        5.91 ->  5.64
```

All four grounds and all four ratios match QA's reading of the rendered page exactly. **Nothing fails** — the worst case is 5.64 against a 4.5 bar — but the number was measured against a colour the page never paints.

## Trap 2, in the test written to prevent this class of thing

> *A background is not the first non-transparent ancestor. Composite.*

`app/econ-calendar/page.tsx` sets `background: color-mix(in srgb, var(--txt) 2.5%, transparent)` on the next row and `transparent` on the rest. I read that line while writing the change, concluded "transparent, so the ground is the card", and stopped one row short — the *one* row that is not transparent is the one the user looks at first.

**The composited ground is the worse case in all four contexts** — it lightens under light text and darkens under dark — so asserting against it is strictly stricter than `--bg1`, as well as being the ground a real row paints on.

## What changed

- `rowGround(map)` composites the veil with `compositeOver` from `lib/readableOn.ts` and returns the real ground.
- The contrast test uses it.
- **A guard on the guard:** if the veil is ever removed, `rowGround()` silently starts returning `--bg1` and the contrast assertion quietly reverts to the thing being corrected here — while still passing. A second test asserts the composited ground differs from `--bg1` in every context, so that reversion fails loudly instead.

## How to test (QA)

`node --test __tests__/econCalendarEstimated.test.mts` — 7 pass. The contrast test's failure message now names the composited ground, so a future failure says which colour it measured.

## Risk level

**Low.** No production code. The assertion got stricter and still passes.

Gates, each read: lint 0 errors / 232 warnings, `tsc --noEmit` exit 0, **666 tests pass**, build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
