### PR TITLE
test(payments): cover the webhook's signature and ownership gates (#243)

### DIFF
--- a/__tests__/lemonsqueezyGates.test.mts
+++ b/__tests__/lemonsqueezyGates.test.mts
@@ -1,0 +1,131 @@
+/* The two gates in front of the payments webhook (#243).
+ *
+ * `patchForEvent` has had eleven tests since it was extracted. The two checks
+ * that decide whether it runs at all had none, because reaching them meant a
+ * live endpoint, a real secret and a database — so the most security-sensitive
+ * code on the payments path was the least tested code on it.
+ *
+ * WHAT THIS DOES NOT DO. It does not prove the deployed endpoint works. Dedup
+ * and the write still need the database, and the checkout click still needs a
+ * card. This is the half that can be proven without either, and the file it
+ * tests says so in its own header: the harness proves the route verifies,
+ * dedupes and writes; this proves the decisions.
+ *
+ * The HMAC below is computed independently in each test rather than pasted, so
+ * a signature that stops matching fails here rather than being frozen into a
+ * fixture that agrees with a bug.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { verifyWebhookSignature, payerOwnsAccount } from '../lib/lemonsqueezy.ts';
+
+const SECRET = 'test_secret_not_a_real_one';
+const sign = (payload: string, secret = SECRET) =>
+  crypto.createHmac('sha256', secret).update(payload).digest('hex');
+
+/* Shaped like a LemonSqueezy subscription_created delivery. Not a captured
+   payload — the fields the route reads are what matter, and a real one would
+   carry a real customer's email. */
+const PAYLOAD = JSON.stringify({
+  meta: { event_name: 'subscription_created', custom_data: { user_id: 'user-abc' } },
+  data: {
+    id: 'sub_123',
+    attributes: {
+      status: 'active', user_email: 'Buyer@Example.com',
+      renews_at: '2027-09-05T00:00:00.000000Z', test_mode: true,
+    },
+  },
+});
+
+test('a correctly signed payload verifies', () => {
+  assert.equal(verifyWebhookSignature(PAYLOAD, sign(PAYLOAD), SECRET), true);
+});
+
+test('one changed byte in the body invalidates the signature', () => {
+  /* The point of signing. If this passes, the payload is not actually bound to
+     the digest and an attacker can rewrite `user_id` in transit. */
+  const good = sign(PAYLOAD);
+  const tampered = PAYLOAD.replace('"user-abc"', '"user-victim"');
+  assert.notEqual(tampered, PAYLOAD, 'the tamper did not change the payload - this test proves nothing');
+  assert.equal(verifyWebhookSignature(tampered, good, SECRET), false);
+});
+
+test('a signature from a different secret is rejected', () => {
+  assert.equal(verifyWebhookSignature(PAYLOAD, sign(PAYLOAD, 'someone_elses_secret'), SECRET), false);
+});
+
+test('no configured secret fails CLOSED, not open', () => {
+  /* An unset env var must never become an open endpoint. On a public repo that
+     is the difference between a misconfiguration and anyone granting themselves
+     Pro — and the empty-string case is exactly what a missing Render variable
+     produces. */
+  assert.equal(verifyWebhookSignature(PAYLOAD, sign(PAYLOAD), ''), false);
+  assert.equal(verifyWebhookSignature(PAYLOAD, '', ''), false);
+});
+
+test('a malformed signature is rejected rather than throwing', () => {
+  /* `Buffer.from(x, 'hex')` silently DROPS invalid characters instead of
+     throwing, so 'zz' becomes an empty buffer and timingSafeEqual throws on the
+     length mismatch. Uncaught that is a 500 — which tells an attacker their
+     input got further than a 401 would, and makes LemonSqueezy retry it. */
+  for (const bad of ['', 'zz', 'not-hex-at-all', 'abc', sign(PAYLOAD).slice(0, -2)]) {
+    assert.equal(verifyWebhookSignature(PAYLOAD, bad, SECRET), false, `signature ${JSON.stringify(bad)} was accepted`);
+  }
+});
+
+test('verification does not depend on the payload being JSON', () => {
+  /* The route verifies the RAW body before parsing it, which is the only order
+     that works: parse-then-verify would run JSON.parse on unauthenticated
+     input, and re-serialising to verify would compare a different byte string
+     than the one that was signed. */
+  const raw = 'not json at all {{{';
+  assert.equal(verifyWebhookSignature(raw, sign(raw), SECRET), true);
+});
+
+test('CONTROL: the verifier can say true, so the rejections above mean something', () => {
+  /* Every assertion above except the first is `false`. A function that returned
+     false unconditionally would satisfy all of them. */
+  assert.equal(verifyWebhookSignature('x', sign('x'), SECRET), true);
+  assert.equal(verifyWebhookSignature('y', sign('y'), SECRET), true);
+});
+
+test('the payer must own the account the checkout named', () => {
+  /* The signature proves LemonSqueezy sent the event. It never proves the payer
+     owns the account named in custom_data — lib/checkout.ts writes that into a
+     CLIENT-SIDE url, so the payer picks it. Edit the id in your own browser,
+     buy once, and Pro lands wherever you said. */
+  assert.equal(payerOwnsAccount('buyer@example.com', 'buyer@example.com'), true);
+  assert.equal(payerOwnsAccount('attacker@example.com', 'victim@example.com'), false);
+});
+
+test('the comparison is case- and whitespace-insensitive, because the sources differ', () => {
+  /* LemonSqueezy echoes what the payer typed; Supabase stores what they
+     registered with. Treating "Buyer@Example.com " as a different person from
+     "buyer@example.com" would refuse legitimate purchases, and a refusal on
+     this path costs a customer their Pro after they have paid. */
+  assert.equal(payerOwnsAccount(' Buyer@Example.COM ', 'buyer@example.com'), true);
+});
+
+test('an empty side is a refusal, never a match', () => {
+  /* The shape where a failed lookup authorises everything: getUserById returns
+     no user, acctEmail is '', and a bare equality check on two empty strings
+     says yes. */
+  assert.equal(payerOwnsAccount('', ''), false);
+  assert.equal(payerOwnsAccount('buyer@example.com', ''), false);
+  assert.equal(payerOwnsAccount('', 'buyer@example.com'), false);
+  assert.equal(payerOwnsAccount(null, undefined), false);
+  assert.equal(payerOwnsAccount('   ', 'buyer@example.com'), false);
+});
+
+test('the route still calls both gates', () => {
+  /* Extracting a check into a tested function does nothing if the caller stops
+     using it. Asserted against the source: the route must reference both, and
+     must no longer carry its own inline copy of the HMAC comparison. */
+  const route = readFileSync(new URL('../app/api/lemonsqueezy/webhook/route.ts', import.meta.url), 'utf8');
+  assert.match(route, /verifyWebhookSignature\(payload, signature, SECRET\)/);
+  assert.match(route, /payerOwnsAccount\(payerEmail, acctEmail\)/);
+  assert.equal(/timingSafeEqual/.test(route), false,
+    'the route has its own signature comparison again - two copies of this check is one too many');
+});

--- a/app/api/lemonsqueezy/webhook/route.ts
+++ b/app/api/lemonsqueezy/webhook/route.ts
@@ -3,25 +3,15 @@ import crypto from 'crypto';
 import { apiError } from '@/lib/apiError';
 import { getSupabaseAdmin } from '@/lib/supabase-admin';
 import { T } from '@/lib/tables';
-import { patchForEvent } from '@/lib/lemonsqueezy';
+import { patchForEvent, payerOwnsAccount, verifyWebhookSignature } from '@/lib/lemonsqueezy';
 
 const SECRET = process.env.LEMONSQUEEZY_WEBHOOK_SECRET ?? '';
-
-function verifySignature(payload: string, signature: string): boolean {
-  if (!SECRET) return false;
-  const digest = crypto.createHmac('sha256', SECRET).update(payload).digest('hex');
-  try {
-    return crypto.timingSafeEqual(Buffer.from(signature, 'hex'), Buffer.from(digest, 'hex'));
-  } catch {
-    return false;
-  }
-}
 
 export async function POST(req: NextRequest) {
   const signature = req.headers.get('x-signature') ?? '';
   const payload = await req.text();
 
-  if (!verifySignature(payload, signature)) {
+  if (!verifyWebhookSignature(payload, signature, SECRET)) {
     return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
   }
 
@@ -92,7 +82,7 @@ export async function POST(req: NextRequest) {
   const { data: acct } = await sb.auth.admin.getUserById(userId);
   const acctEmail = (acct?.user?.email ?? '').trim().toLowerCase();
 
-  if (!acctEmail || !payerEmail || acctEmail !== payerEmail) {
+  if (!payerOwnsAccount(payerEmail, acctEmail)) {
     apiError('lemonsqueezy/webhook', new Error(
       `Payer/account email mismatch - refusing to grant. event=${eventName} user_id=${userId} ` +
       `payer=${payerEmail || '(none)'} account=${acctEmail || '(unknown user)'}`,

--- a/lib/lemonsqueezy.ts
+++ b/lib/lemonsqueezy.ts
@@ -151,3 +151,66 @@ export function patchForEvent(
 function pickDate(v: unknown): string | null {
   return typeof v === 'string' && v.length > 0 ? v : null;
 }
+
+/* ── The two gates in front of patchForEvent ──────────────────────────────────
+ *
+ * This file's header says the route's harness "proves the route verifies,
+ * dedupes and writes; this proves the decision itself. Different halves." Two
+ * of those three are pure and were only reachable through a live endpoint with
+ * a real secret and a real database - so they had no tests at all, while the
+ * decision they guard had eleven.
+ *
+ * Verification and ownership move here. Dedup and the write stay in the route:
+ * both need the database and neither can be honestly faked.
+ */
+
+import crypto from 'crypto';
+
+/** Does this body carry LemonSqueezy's HMAC for our secret?
+ *
+ *  FAILS CLOSED IN EVERY DIRECTION, and each guard is a real case rather than
+ *  defensive noise:
+ *
+ *  - **No secret configured** returns false. An unset env var must not become
+ *    an open endpoint - on a public repo that is the difference between a
+ *    misconfiguration and anyone being able to grant themselves Pro.
+ *  - **`timingSafeEqual` throws on length mismatch**, which a wrong-length or
+ *    non-hex signature produces. Caught, not propagated: a 500 tells an
+ *    attacker their input reached further than a 401 does, and LemonSqueezy
+ *    RETRIES a 500.
+ *  - **Constant-time compare**, not `===`. The digest is derived from
+ *    attacker-supplied bytes, so an early-exit comparison leaks how much of a
+ *    guessed prefix was right.
+ *
+ *  Buffer.from(x, 'hex') silently drops invalid characters rather than
+ *  throwing, so a signature of "zz" becomes an empty buffer and the length
+ *  check is what rejects it. That is why the try/catch is load-bearing and not
+ *  belt-and-braces. */
+export function verifyWebhookSignature(payload: string, signature: string, secret: string): boolean {
+  if (!secret) return false;
+  const digest = crypto.createHmac('sha256', secret).update(payload).digest('hex');
+  try {
+    return crypto.timingSafeEqual(Buffer.from(signature, 'hex'), Buffer.from(digest, 'hex'));
+  } catch {
+    return false;
+  }
+}
+
+/** Does the payer own the account the checkout named?
+ *
+ *  THE SIGNATURE PROVES LEMONSQUEEZY SENT THIS. IT NEVER PROVES THE PAYER OWNS
+ *  THE ACCOUNT THEY NAMED. `custom_data.user_id` is written into a CLIENT-SIDE
+ *  checkout URL by lib/checkout.ts, so the payer chooses it: edit the id in
+ *  your own browser, make one genuine purchase, and Pro lands on any account
+ *  you like. This comparison is the only thing between that and a working
+ *  attack.
+ *
+ *  Empty on either side is a refusal, not a pass. An account with no email and
+ *  a payer with no email are not "the same"; that is the shape where a missing
+ *  lookup silently authorises everything. */
+export function payerOwnsAccount(payerEmail: string | null | undefined, accountEmail: string | null | undefined): boolean {
+  const payer = String(payerEmail ?? '').trim().toLowerCase();
+  const account = String(accountEmail ?? '').trim().toLowerCase();
+  if (!payer || !account) return false;
+  return payer === account;
+}


### PR DESCRIPTION
## Summary

Toward **#243**. The webhook's two gates — signature verification and payer/account ownership — move into `lib/lemonsqueezy.ts` and get 11 tests. Behaviour unchanged.

**`patchForEvent` has had eleven tests since it was extracted. The two checks that decide whether it runs at all had none**, because reaching them meant a live endpoint, a real secret and a database. The most security-sensitive code on the payments path was the least tested code on it.

## What this is not

QA asked for a real payload replayed against staging with its signature. **I did not do that, and the reason is not effort.** It needs the production webhook secret and Supabase admin access — I handle neither, and my Supabase credential cannot reach either project anyway (measured on #757). A replay I could run would use a secret I invented, which proves the same thing this does with more moving parts.

So this is the half that is honestly provable without a card, a secret or a database, and the file's own header already drew that line: *"the harness proves the route verifies, dedupes and writes; this proves the decision itself."* Dedup and the write stay in the route, both database-bound, neither faked.

**Still needed for #243:** the checkout click with a real card, which only the owner can do.

## What the tests cover

**Signature** — a correct HMAC verifies; one changed byte in the body fails; a different secret fails; **an unset secret fails CLOSED**; malformed and truncated hex are rejected rather than throwing; verification works on a non-JSON body, because the route verifies the raw bytes *before* parsing.

That last one is an ordering property worth pinning: parse-then-verify would run `JSON.parse` on unauthenticated input, and re-serialising to verify would compare different bytes than the ones that were signed.

The malformed case is subtler than it looks. `Buffer.from('zz', 'hex')` **silently drops invalid characters** rather than throwing, so it yields an empty buffer and `timingSafeEqual` throws on the length mismatch. Uncaught that is a 500 — which tells an attacker their input got further than a 401 would, and makes LemonSqueezy retry it. The try/catch is load-bearing, not decorative.

**Ownership** — the signature proves LemonSqueezy sent the event; it never proves the payer owns the account named in `custom_data`, which `lib/checkout.ts` writes into a **client-side** URL. Edit the id in your own browser, buy once, and Pro lands wherever you said. Tests cover the match, the mismatch, case/whitespace normalisation (the two sources spell emails differently, and a false refusal costs a customer their Pro after paying), and **empty on either side being a refusal** — the shape where a failed `getUserById` leaves two empty strings that a bare `===` calls a match.

## Controls

- The verifier can return `true` — otherwise every rejection assertion is satisfied by a function stuck on `false`.
- The tamper test asserts the payload actually changed before checking the signature fails.
- A source test that the route still calls both gates and no longer carries its own `timingSafeEqual`. **Extracting a check into a tested function does nothing if the caller stops using it.**
- Ran a deliberate break: removing the empty-side guard fails `an empty side is a refusal, never a match` and nothing else.

Every HMAC is computed in the test rather than pasted, so a signature that stops matching fails here instead of being frozen into a fixture that agrees with a bug.

## Risk level

**Low.** Two functions moved, call sites updated, no logic changed. The route reads identically.

- **Not verified:** the deployed endpoint. Unchanged from before this PR — it had no coverage then either.
- **Not verified:** the `test_mode`-in-production branch and the replay guard. Both need the database.

Gates, each read: lint 0 errors / 232 warnings, `tsc --noEmit` exit 0, **677 tests pass**, build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
