### PR TITLE
feat(ops): report which label rows override the shipped defaults (#675)

### DIFF
--- a/__tests__/labelOverrides.test.mts
+++ b/__tests__/labelOverrides.test.mts
@@ -1,0 +1,131 @@
+/* The label-override diff (#675).
+ *
+ * A row in `lhq_labels` silently wins over the shipped default, so a label fix
+ * can be merged, deployed and verified on staging and still not appear in
+ * production — and nothing in the build, the deploy or /api/version says so.
+ * `DASH_EDGE_CB_LABEL` is the live instance: shipped "BTC CB prem", production
+ * shows "CB Premium".
+ *
+ * This does not fix that row. It makes the class of bug readable, and the
+ * comparison is pure so it can be tested without the database neither session
+ * can reach.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { diffLabels, summarise } from '../lib/labelOverrides.ts';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+test('a row that differs from the default is the finding', () => {
+  const rows = [{ key: 'DASH_EDGE_CB_LABEL', value: 'CB Premium' }];
+  const defaults = { DASH_EDGE_CB_LABEL: 'BTC CB prem' };
+  assert.deepEqual(diffLabels(rows, defaults), [
+    { key: 'DASH_EDGE_CB_LABEL', dbValue: 'CB Premium', codeDefault: 'BTC CB prem', kind: 'overridden' },
+  ]);
+});
+
+test('a row that AGREES with the default is not reported at all', () => {
+  /* The healthy case, and the one that must stay quiet. Reporting every stored
+     row would bury the handful that matter under thousands that do not — the
+     same reason the ops view lists overrides rather than labels. */
+  const rows = [{ key: 'A', value: 'same' }];
+  assert.deepEqual(diffLabels(rows, { A: 'same' }), []);
+});
+
+test('a stored key that no longer exists in code is an orphan, not an override', () => {
+  /* Different problem, so a different kind. It usually means a key was renamed
+     and the old row was left behind, which puts the rename one restored backup
+     away from coming back. */
+  const out = diffLabels([{ key: 'GONE_KEY', value: 'x' }], { KEPT: 'y' });
+  assert.equal(out.find(r => r.key === 'GONE_KEY')?.kind, 'orphan');
+  assert.equal(out.find(r => r.key === 'GONE_KEY')?.codeDefault, null);
+});
+
+test('a shipped key with no row is normal and says so', () => {
+  const out = diffLabels([], { ONLY_IN_CODE: 'v' });
+  assert.deepEqual(out, [{ key: 'ONLY_IN_CODE', dbValue: null, codeDefault: 'v', kind: 'defaultOnly' }]);
+});
+
+test('an empty stored value is an override, not a missing row', () => {
+  /* The case a truthiness check gets wrong. A row storing '' means the label
+     renders blank in production while the code ships real text — strictly worse
+     than a wrong string, and `value || default` would hide it completely. */
+  const out = diffLabels([{ key: 'K', value: '' }], { K: 'Real text' });
+  assert.equal(out[0].kind, 'overridden');
+  assert.equal(out[0].dbValue, '');
+});
+
+test('a key whose default is inherited from Object.prototype is not treated as shipped', () => {
+  /* `defaults['toString']` is a function on every object literal, so a naive
+     `defaults[key] !== undefined` reports every row named `toString`,
+     `constructor` or `hasOwnProperty` as agreeing with a default that does not
+     exist. hasOwnProperty is why. */
+  const out = diffLabels([{ key: 'toString', value: 'x' }], { REAL: 'y' });
+  assert.equal(out.find(r => r.key === 'toString')?.kind, 'orphan');
+});
+
+test('the output is sorted, so two runs of the same data diff cleanly by eye', () => {
+  const out = diffLabels(
+    [{ key: 'Z', value: '1' }, { key: 'A', value: '1' }],
+    { Z: '2', A: '2' },
+  );
+  assert.deepEqual(out.map(r => r.key), ['A', 'Z']);
+});
+
+test('summarise counts the one number that matters', () => {
+  const counts = summarise(diffLabels(
+    [{ key: 'OVER', value: 'db' }, { key: 'ORPHAN', value: 'x' }, { key: 'SAME', value: 's' }],
+    { OVER: 'code', SAME: 's', UNSTORED: 'u' },
+  ));
+  assert.deepEqual(counts, { overridden: 1, orphan: 1, defaultOnly: 1 });
+});
+
+test('the real defaults file is a flat string map, which the diff assumes', () => {
+  /* If labelDefaults.en.json ever nests, every value comparison becomes an
+     object identity comparison and the endpoint reports the entire catalogue as
+     overridden. Cheap to assert, and it fails at the moment the assumption
+     breaks rather than in production. */
+  const defaults = JSON.parse(readFileSync(path.join(ROOT, 'lib', 'labelDefaults.en.json'), 'utf8'));
+  const bad = Object.entries(defaults).filter(([, v]) => typeof v !== 'string');
+  assert.deepEqual(bad, [], 'labelDefaults.en.json has non-string values');
+  assert.ok(Object.keys(defaults).length > 100, 'the defaults file looks empty - the diff would report every stored row as an orphan');
+});
+
+test('the endpoint compares English only', () => {
+  /* A Spanish row is a translation, not an override of the English default.
+     Comparing them would report the whole translated catalogue as overridden,
+     which is the loudest possible way to say nothing. */
+  const route = readFileSync(path.join(ROOT, 'app', 'api', 'ops', 'label-overrides', 'route.ts'), 'utf8');
+  assert.match(route, /\.eq\('locale', 'en'\)/);
+});
+
+test('the endpoint is owner-gated and read-only', () => {
+  /* It reports which production rows are masking shipped defaults - a list of
+     what to change and where. And writes to the shared database go to the
+     owner, so this must not grow a PATCH without that conversation. */
+  const route = readFileSync(path.join(ROOT, 'app', 'api', 'ops', 'label-overrides', 'route.ts'), 'utf8');
+  assert.match(route, /withOwner\(/);
+  assert.equal(/export const (POST|PATCH|PUT|DELETE)/.test(route), false,
+    'the label-overrides endpoint gained a write method');
+});
+
+test('the endpoint pages its query', () => {
+  /* PostgREST clamps to a 1000-row cap a client .range() cannot raise, and this
+     catalogue crossed it during the i18n migration. Unpaged, every key past the
+     first 1000 reads as `defaultOnly` - a wrong answer that looks healthy. */
+  const route = readFileSync(path.join(ROOT, 'app', 'api', 'ops', 'label-overrides', 'route.ts'), 'utf8');
+  assert.match(route, /PAGE_SIZE/);
+  assert.match(route, /\.range\(from, from \+ PAGE_SIZE - 1\)/);
+});
+
+test('CONTROL: the diff reports something, so the empty results above mean something', () => {
+  /* Four assertions here expect `[]` or a single kind. A function returning []
+     unconditionally passes most of this file. */
+  const out = diffLabels([{ key: 'K', value: 'db' }], { K: 'code' });
+  assert.equal(out.length, 1);
+  assert.equal(out[0].kind, 'overridden');
+  assert.notDeepEqual(diffLabels([{ key: 'A', value: '1' }], { A: '2' }), []);
+});

--- a/app/api/ops/label-overrides/route.ts
+++ b/app/api/ops/label-overrides/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server';
+import { withOwner } from '@/lib/admin-auth';
+import { getSupabaseAdmin } from '@/lib/supabase-admin';
+import { T } from '@/lib/tables';
+import { diffLabels, summarise } from '@/lib/labelOverrides';
+import defaults from '@/lib/labelDefaults.en.json';
+
+export const dynamic = 'force-dynamic';
+
+/* GET /api/ops/label-overrides — which label keys the database is overriding.
+ *
+ * #675: a row in `lhq_labels` silently wins over the shipped default, so a
+ * label fix can be merged, deployed and verified on staging and still not
+ * appear in production. Nothing in the build, the deploy or /api/version
+ * reveals it. This is the read that makes it visible.
+ *
+ * READ ONLY, deliberately. Fixing an override means changing a row, and writes
+ * to the shared database go to the owner — see CLAUDE.md. This endpoint tells
+ * you which row and what it should say; a human runs the UPDATE.
+ *
+ * ENGLISH ONLY. `labelDefaults.en.json` is the shipped default set; a
+ * translated row is not an override of anything, it is a translation. Comparing
+ * `es` rows against English defaults would report the entire Spanish catalogue
+ * as overridden, which is the loudest possible way to say nothing.
+ */
+export const GET = withOwner(async () => {
+  const admin = getSupabaseAdmin();
+
+  /* Paged for the same reason /api/labels is: PostgREST clamps to a
+     server-side db-max-rows cap (1000 here) that a client .range() cannot
+     raise, and this catalogue crossed that during the i18n migration. A single
+     unpaged request would silently return the first 1000 rows and every key
+     past them would read as `defaultOnly` — a wrong answer that looks like a
+     healthy one. */
+  const PAGE_SIZE = 1000;
+  const rows: { key: string; value: string }[] = [];
+  for (let page = 0; ; page++) {
+    const from = page * PAGE_SIZE;
+    const { data: batch, error } = await admin
+      .from(T.labels)
+      .select('key, value')
+      .eq('locale', 'en')
+      .range(from, from + PAGE_SIZE - 1);
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    if (!batch || batch.length === 0) break;
+    rows.push(...batch);
+    if (batch.length < PAGE_SIZE) break;
+  }
+
+  const all = diffLabels(rows, defaults as Record<string, string>);
+  const counts = summarise(all);
+
+  /* `defaultOnly` is the normal state for most keys and there are thousands of
+     them, so it is counted and not listed. The two that need eyes are returned
+     in full. */
+  return NextResponse.json({
+    counts,
+    storedRows: rows.length,
+    overridden: all.filter(r => r.kind === 'overridden'),
+    orphans: all.filter(r => r.kind === 'orphan'),
+  });
+});

--- a/lib/labelOverrides.ts
+++ b/lib/labelOverrides.ts
@@ -1,0 +1,91 @@
+/* Which label keys the database is overriding, and what the code would have said
+ * (#675).
+ *
+ * THE BUG THIS MAKES VISIBLE, which it does not fix. A row in `lhq_labels`
+ * silently wins over the shipped default in `lib/labelDefaults.en.json`. So a
+ * label fix can be written, reviewed, merged, deployed and verified on staging
+ * — and still not appear in production, because production's database holds an
+ * older value for that key and nothing anywhere says so.
+ *
+ * That is what #675 is: `DASH_EDGE_CB_LABEL` shipped as "BTC CB prem" and prod
+ * shows "CB Premium". The fix for that one row is a single UPDATE by someone
+ * with the dashboard. **This is the part that stops the next one being
+ * invisible.**
+ *
+ * Nothing here writes. It is a read and a comparison, and it is deliberately
+ * pure so it can be tested without a database — the same split as
+ * lib/lemonsqueezy.ts, and for the same reason: the interesting decision should
+ * not need credentials to exercise.
+ */
+
+export type OverrideKind = 'overridden' | 'orphan' | 'defaultOnly';
+
+export interface LabelOverride {
+  key: string;
+  /** What the database says. `null` for a key that exists only in code. */
+  dbValue: string | null;
+  /** What the code ships. `null` for a row whose key is not in the defaults. */
+  codeDefault: string | null;
+  kind: OverrideKind;
+}
+
+/** Compare the stored labels against the shipped defaults.
+ *
+ *  Three findings, and they are different problems rather than three severities
+ *  of one:
+ *
+ *  - **`overridden`** — both exist and differ. This is #675's shape: a deploy
+ *    that appears to do nothing. The most important of the three, and the only
+ *    one anybody has been bitten by so far.
+ *  - **`orphan`** — a row whose key no longer exists in code. Harmless to
+ *    render and a real signal: it usually means a key was renamed and the old
+ *    row was left behind, so the rename is one stale row away from being
+ *    reverted by whoever restores a backup.
+ *  - **`defaultOnly`** — shipped but never stored. **Normal, not a finding.**
+ *    Most keys are in this state; the app falls back to the default and that is
+ *    the design. Included so a caller can count it and so "the table is empty"
+ *    can be told apart from "the query returned nothing".
+ *
+ *  A key present in both with the SAME value is not reported at all: the
+ *  database agreeing with the code is the state everything else is measured
+ *  against.
+ *
+ *  Sorted by key so two runs of the same data produce the same list — an ops
+ *  page that reshuffles between refreshes is one nobody can diff by eye. */
+export function diffLabels(
+  dbRows: ReadonlyArray<{ key: string; value: string }>,
+  defaults: Readonly<Record<string, string>>,
+): LabelOverride[] {
+  const out: LabelOverride[] = [];
+  const seen = new Set<string>();
+
+  for (const row of dbRows) {
+    if (typeof row?.key !== 'string') continue;
+    seen.add(row.key);
+    const codeDefault = Object.prototype.hasOwnProperty.call(defaults, row.key)
+      ? defaults[row.key]
+      : null;
+    if (codeDefault === null) {
+      out.push({ key: row.key, dbValue: row.value, codeDefault: null, kind: 'orphan' });
+    } else if (codeDefault !== row.value) {
+      out.push({ key: row.key, dbValue: row.value, codeDefault, kind: 'overridden' });
+    }
+    // Equal values are the healthy case and are not reported.
+  }
+
+  for (const key of Object.keys(defaults)) {
+    if (!seen.has(key)) {
+      out.push({ key, dbValue: null, codeDefault: defaults[key], kind: 'defaultOnly' });
+    }
+  }
+
+  return out.sort((a, b) => a.key.localeCompare(b.key));
+}
+
+/** Counts for a summary line. `overridden` is the number that matters — it is
+ *  the count of deploys that would silently do nothing. */
+export function summarise(rows: ReadonlyArray<LabelOverride>): Record<OverrideKind, number> {
+  const counts: Record<OverrideKind, number> = { overridden: 0, orphan: 0, defaultOnly: 0 };
+  for (const r of rows) counts[r.kind]++;
+  return counts;
+}


### PR DESCRIPTION
## Summary

Toward **#675**. An owner-gated endpoint that lists which `lhq_labels` rows are overriding shipped defaults, and what the code would have said.

**This does not fix #675.** That still needs one `UPDATE` from someone with the dev Supabase dashboard — writes to the shared database go to the owner. **It stops the next instance being invisible**, which is what the issue is actually about.

## The bug it makes readable

A row in `lhq_labels` silently wins over `lib/labelDefaults.en.json`. So a label fix can be written, reviewed, merged, deployed and **verified on staging** — and still not appear in production, because production's database holds an older value and nothing in the build, the deploy or `/api/version` reveals it.

`DASH_EDGE_CB_LABEL` is the live instance: ships as "BTC CB prem", production shows "CB Premium".

## Three findings, not three severities

| Kind | Meaning |
|---|---|
| **`overridden`** | Both exist and differ. #675's shape — a deploy that appears to do nothing. The one that matters. |
| **`orphan`** | A row whose key no longer exists in code. Usually a rename with the old row left behind, which puts the rename one restored backup away from returning. |
| **`defaultOnly`** | Shipped, never stored. **Normal.** Most keys. Counted, not listed. |

A key present in both with the **same** value is not reported at all — the database agreeing with the code is the state everything else is measured against, and listing it would bury the handful that matter under thousands that do not.

## What the tests cover

13 tests on the pure diff, including three cases a plausible implementation gets wrong:

- **An empty stored value is an override, not a missing row.** A row storing `''` renders blank in production while the code ships real text — strictly worse than a wrong string, and `value || default` hides it completely.
- **`toString` is not a shipped default.** `defaults['toString']` is a function on every object literal, so `defaults[key] !== undefined` reports rows named `toString`, `constructor` or `hasOwnProperty` as agreeing with a default that does not exist. `hasOwnProperty` is why.
- **The defaults file is a flat string map.** If it ever nests, every comparison becomes object identity and the endpoint reports the entire catalogue as overridden. Asserted so it fails at the moment the assumption breaks.

Plus source assertions that the endpoint is `withOwner`-gated, has **no write method**, compares `locale = 'en'` only, and **pages its query**.

That last one is not theoretical: PostgREST clamps to a 1000-row cap a client `.range()` cannot raise, this catalogue crossed it during the i18n migration, and unpaged **every key past the first 1000 would read as `defaultOnly` — a wrong answer that looks like a healthy one.**

English-only for a related reason: a Spanish row is a translation, not an override. Comparing them would report the whole translated catalogue as overridden, which is the loudest possible way to say nothing.

## Risk level

**Low-Medium.**

- New endpoint, owner-gated, read-only. No writes, no schema change.
- **Not verified against a real database.** My Supabase credential reaches neither project (measured on #757), so the diff is tested against fixtures and the query shape is asserted from source. The first real run will be whoever opens it on a deployed environment.
- **No UI yet.** This is the API; a panel on `/ops/config` is the obvious next step and is deliberately not in this PR — the endpoint is useful alone via `adminFetch`, and shipping the read first means the data can be looked at before anyone designs a table for it.

Gates, each read: lint 0 errors / 232 warnings, `tsc --noEmit` exit 0, **700 tests pass**, build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
