### PR TITLE
test(cron): cover the gate in front of every scheduled write route (#757)

### DIFF
--- a/__tests__/cronAuth.test.mts
+++ b/__tests__/cronAuth.test.mts
@@ -1,0 +1,135 @@
+/* The gate in front of every scheduled write route (#757).
+ *
+ * `checkCronAuth` guards `news/ingest`, `telegram/alert`, `macro-alert`,
+ * `signals/track`, `alert-outcomes/resolve` and `telegram/setup-webhook` — every
+ * route that writes on a schedule with no user session behind it. On a public
+ * repository it is the difference between a cron endpoint and an open one.
+ *
+ * It had no tests. It was rewritten once already, from a fail-OPEN shape where
+ * `if (secret) { check }` meant an unset `CRON_SECRET` ran every one of those
+ * routes unauthenticated.
+ *
+ * WHY THIS FILE EXISTS NOW. #757 asked why no non-prod environment receives
+ * news. Measured on the deployed services:
+ *
+ *   qa       /api/version  configured.cronSecret = false   unsigned POST -> 401
+ *   staging  /api/version  configured.cronSecret = true    unsigned POST -> 401
+ *
+ * The two 401s look identical and mean opposite things. On staging it is a
+ * gate refusing an unsigned caller. On qa there is no secret configured, so
+ * `checkCronAuth` denies EVERYONE — including a correctly signed scheduler.
+ * The ingest route cannot run there at all, and that is a configuration fact
+ * rather than a missing feature.
+ *
+ * These tests pin the behaviour that makes that true, so a future "make it
+ * work on qa" change cannot quietly reintroduce fail-open.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { checkCronAuth } from '../lib/cronAuth.ts';
+
+const SECRET = 'a-test-cron-secret';
+const original = process.env.CRON_SECRET;
+
+function withSecret<T>(value: string | undefined, fn: () => T): T {
+  if (value === undefined) delete process.env.CRON_SECRET;
+  else process.env.CRON_SECRET = value;
+  try { return fn(); } finally {
+    if (original === undefined) delete process.env.CRON_SECRET;
+    else process.env.CRON_SECRET = original;
+  }
+}
+
+const req = (init: { header?: string; query?: string } = {}) => {
+  const url = init.query === undefined
+    ? 'https://example.test/api/news/ingest'
+    : `https://example.test/api/news/ingest?secret=${encodeURIComponent(init.query)}`;
+  return new Request(url, {
+    method: 'POST',
+    headers: init.header === undefined ? {} : { 'x-cron-secret': init.header },
+  });
+};
+
+test('an unset CRON_SECRET denies everyone, including a correct caller', () => {
+  /* THE qa CASE. This is not a hypothetical: /api/version reports
+     configured.cronSecret = false on liquidity-hq-qa today, so its ingest route
+     401s every request and no news can reach that environment by any path.
+     The previous implementation returned TRUE here — `if (secret) { check }`
+     with no secret skipped the check entirely and ran the route. */
+  withSecret(undefined, () => {
+    assert.equal(checkCronAuth(req({ header: SECRET })), false);
+    assert.equal(checkCronAuth(req({})), false);
+    assert.equal(checkCronAuth(req({ query: SECRET })), false);
+  });
+});
+
+test('an empty CRON_SECRET is unset, not a secret equal to empty', () => {
+  /* What an env var declared-but-blank in a Render dashboard produces. A
+     length-only comparison would match a caller sending no header at all. */
+  withSecret('', () => {
+    assert.equal(checkCronAuth(req({})), false);
+    assert.equal(checkCronAuth(req({ header: '' })), false);
+  });
+});
+
+test('the matching secret is accepted from the header', () => {
+  withSecret(SECRET, () => {
+    assert.equal(checkCronAuth(req({ header: SECRET })), true);
+  });
+});
+
+test('the matching secret is accepted from the query string', () => {
+  /* Both forms are live: cron-job.org jobs send the header, and the query
+     param exists for schedulers that cannot set one. Dropping either silently
+     stops a live job. */
+  withSecret(SECRET, () => {
+    assert.equal(checkCronAuth(req({ query: SECRET })), true);
+  });
+});
+
+test('a wrong secret is rejected however it arrives', () => {
+  withSecret(SECRET, () => {
+    assert.equal(checkCronAuth(req({ header: 'wrong' })), false);
+    assert.equal(checkCronAuth(req({ query: 'wrong' })), false);
+    assert.equal(checkCronAuth(req({})), false);
+  });
+});
+
+test('a prefix of the real secret is rejected', () => {
+  /* The length check runs before timingSafeEqual, which throws on unequal
+     lengths. A caller probing one character at a time must not be able to tell
+     "right so far" from "wrong" by the response. */
+  withSecret(SECRET, () => {
+    assert.equal(checkCronAuth(req({ header: SECRET.slice(0, -1) })), false);
+    assert.equal(checkCronAuth(req({ header: SECRET + 'x' })), false);
+  });
+});
+
+test('the header wins over the query string', () => {
+  /* Not a security property, a predictability one: a scheduler that sends both
+     must not depend on which the implementation happens to read first. */
+  withSecret(SECRET, () => {
+    const both = new Request(`https://example.test/x?secret=wrong`, {
+      method: 'POST', headers: { 'x-cron-secret': SECRET },
+    });
+    assert.equal(checkCronAuth(both), true);
+  });
+});
+
+test('CONTROL: the gate can return true, so the refusals above mean something', () => {
+  /* Nine assertions in this file expect false. A function stuck on false
+     satisfies every one of them and would also break every scheduled job in
+     production — silently, because a cron failure is invisible until someone
+     notices the data stopped. */
+  withSecret(SECRET, () => {
+    assert.equal(checkCronAuth(req({ header: SECRET })), true);
+    assert.equal(checkCronAuth(req({ query: SECRET })), true);
+  });
+});
+
+test('CONTROL: the environment is restored between tests', () => {
+  /* These tests mutate process.env. If the restore leaks, a later test file
+     runs against a secret this one set, and the failure lands somewhere
+     unrelated. */
+  assert.equal(process.env.CRON_SECRET, original);
+});


### PR DESCRIPTION
## Summary

**#757's answer is a configuration fact, not a missing feature — and the two environments differ.** Measured on the deployed services just now:

```
                /api/version              unsigned POST /api/news/ingest
qa              cronSecret: false         401
staging         cronSecret: true          401
```

**Those two 401s look identical and mean opposite things.** On staging it is the gate refusing an unsigned caller — a correctly signed scheduler would be let through. On qa there is no `CRON_SECRET` configured, so `checkCronAuth` returns false for **everyone**, including a correct one. The ingest route cannot run on qa by any path.

So the reason no non-prod environment receives news is not that the route is prod-only. `T.news` already resolves to `lhq_dev_news` when `NEXT_PUBLIC_APP_ENV=dev` — both services report `appEnv: dev` — and both have `finnhub: true`. **The pipeline is already environment-correct.** What is missing is a secret on qa and something to call it on either.

## What this PR is, and what it deliberately is not

**Not a new endpoint.** Building a second ingest path would have added a write route to a public repo to work around a service that is one dashboard field short. The existing route is correct.

**It is the tests the gate never had.** `checkCronAuth` guards `news/ingest`, `telegram/alert`, `macro-alert`, `signals/track`, `alert-outcomes/resolve` and `telegram/setup-webhook` — every route that writes on a schedule with no session behind it — and had **zero** tests. It was already rewritten once, from a fail-**open** shape where `if (secret) { check }` meant an unset `CRON_SECRET` ran all of them unauthenticated.

Nine tests pin: unset denies everyone including a correct caller; an empty string is unset rather than a secret equal to empty; the header and query forms both work; a wrong secret, a prefix and an over-long value are all rejected; the header wins when both are sent.

Proved they catch the regression that matters — flipping `if (!secret) return false` to `return true` fails two tests, the two describing the fail-open shape.

## What the owner needs to do for #757 to close

1. **Set `CRON_SECRET` on `liquidity-hq-qa`.** Until then its ingest route 401s every caller.
2. **Schedule or manually trigger** `POST /api/news/ingest` against a non-prod host with that header. Staging can already receive it today.

Neither is mine: one is a dashboard field, the other is a scheduler outside this repo (`docs/INFRASTRUCTURE.md` §2).

## One thing worth knowing about the diagnosis

`/api/version` has been reporting `configured.cronSecret: false` on qa this whole time. **The signal was already published and nobody read it** — the same shape as `canvases = 0` in `qa/README.md` trap 13, one layer out in the infrastructure.

## Risk level

**Low.** Tests only, no production code changed.

- **Not verified:** an authenticated ingest run on any non-prod host. That needs `CRON_SECRET`, which I do not handle.
- **Not verified:** that `/news` renders once rows exist. That is the half #757 was originally about and it stays open until someone can trigger the ingest.

Gates, each read: lint 0 errors / 232 warnings, `tsc --noEmit` exit 0, **709 tests pass**, build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
