### PR TITLE
docs: add the MIT licence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 John Dominic Jasmin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ See `CONTRIBUTING.md` and `docs/INFRASTRUCTURE.md` for the full process.
 
 ## License
 
-**No license is currently declared**, which means default copyright applies and the code
-is not yet reusable by others. If this repository is intended as an open-source
-showcase, a license needs to be chosen and added.
+**MIT** — see [`LICENSE`](LICENSE). Owner's decision, 2026-09-05.
+
+That is a permissive choice and worth stating plainly: anyone may use, modify and
+sell this code, including commercially, provided the copyright notice stays. The
+running service, its data and its API accounts are not covered — a licence grants
+rights to the source, not to the deployment.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "liquidity-hq",
   "version": "0.1.0",
+  "license": "MIT",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

Adds the MIT licence. **Owner's decision, given directly in chat on 2026-09-05** when asked to choose between MIT and proprietary.

- `LICENSE` — MIT, © 2026 John Dominic Jasmin
- `package.json` — `"license": "MIT"` (the field was absent)
- `README.md` — the "no license is currently declared" section replaced

## The README says what MIT actually means

The old section correctly flagged that default copyright made the showcase unusable. The new one states the other side plainly, because a permissive licence on a commercial product is a real trade rather than a formality:

> Anyone may use, modify and sell this code, including commercially, provided the copyright notice stays. The running service, its data and its API accounts are not covered — a licence grants rights to the source, not to the deployment.

That last sentence is the one worth having. A reader who sees MIT on a repository that also hosts a paid product should not have to guess whether the subscription is included.

## Risk level

**Low** mechanically — three files, no code.

**Not reversible in practice**, which is the part to say out loud: once a commit is public under MIT, that grant stands for that commit. Relicensing later applies to future versions, not to what people have already copied. The owner was asked to choose and chose; this notes what the choice is, not a doubt about it.

Gates, each read: lint 0 errors / 232 warnings, `tsc --noEmit` exit 0, **709 tests pass**, build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
