### PR TITLE
fix(heatmap): give the red ramp a per-context text colour (#835)

### DIFF
--- a/__tests__/coinHeatmapRamp.test.mts
+++ b/__tests__/coinHeatmapRamp.test.mts
@@ -1,0 +1,98 @@
+/* CoinHeatmap's red ramp, in every context and every bucket (#835).
+ *
+ * The tile is a TINT of `--red` over the context's own ground, and the text sat
+ * on `--red-soft`. In both dark themes that is a light text on a dark tint and
+ * measures 8-10:1. In both light themes `--red-soft` resolves to `var(--red)`,
+ * so the text was the tint's own colour painted onto itself.
+ *
+ * QA found one failure by rendering: 4.17:1 on the -10% bucket in current+light.
+ * Sweeping all four contexts found SIX:
+ *
+ *   current light   5.75  5.01  4.17  1.63
+ *   terminal dark   4.91  4.44  3.81  8.66
+ *   terminal light  5.94  5.15  4.30  1.98
+ *   current dark   10.42  9.48  7.97  9.26     the one that was measured when the ramp was written
+ *
+ * THE 1.63 AND 1.98 ARE THE DEEPEST BUCKET and nobody saw them, because that
+ * bucket only renders when a coin is down more than 10% — the board is live
+ * data, so the worst case is also the rarest. A rendered audit measures the
+ * market that happened to exist that minute.
+ *
+ * Reading the tokens out of globals.css rather than restating them, so a
+ * palette change moves this assertion with it.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { compositeOver, contrastRatio, parseCssColor } from '../lib/readableOn.ts';
+import { CONTEXTS, resolve } from './_cssContexts.mts';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const COMPONENT = readFileSync(path.join(ROOT, 'components', 'CoinHeatmap.tsx'), 'utf8');
+
+const TEXT_MIN = 4.5;
+const hex = (rgb: number[]) => '#' + rgb.map(v => Math.round(v).toString(16).padStart(2, '0')).join('');
+
+/** The tint percentages the ramp uses, read from the component so a new bucket
+ *  cannot be added without this test seeing it. */
+function bucketsFromComponent(): Array<{ pct: number; token: string }> {
+  const out: Array<{ pct: number; token: string }> = [];
+  for (const m of COMPONENT.matchAll(/var\(--red\) (\d+)%, transparent\)',\s*text: 'var\((--[a-z-]+)\)'/g)) {
+    out.push({ pct: Number(m[1]), token: m[2] });
+  }
+  return out;
+}
+
+test('the component still has four red buckets, each with a token colour', () => {
+  /* If this drops to three, the sweep below silently stops covering one. A
+     hardcoded hex would also fail here, which is what the deepest bucket had
+     before this fix. */
+  const buckets = bucketsFromComponent();
+  assert.equal(buckets.length, 4, 'expected four red buckets reading token colours');
+  assert.deepEqual(buckets.map(b => b.pct), [7, 15, 25, 38]);
+});
+
+test('every bucket clears 4.5:1 in all four contexts', () => {
+  const failures: string[] = [];
+  for (const [name, map] of CONTEXTS) {
+    const ground = resolve(map, 'var(--bg1)');
+    const red = resolve(map, 'var(--red)');
+    assert.ok(ground && red, `${name}: could not resolve --bg1 or --red`);
+    for (const { pct, token } of bucketsFromComponent()) {
+      const fg = resolve(map, `var(${token})`);
+      assert.ok(fg, `${name}: could not resolve ${token}`);
+      const tile = hex(compositeOver(parseCssColor(red)!.rgb, parseCssColor(ground)!.rgb, pct / 100));
+      const r = contrastRatio(parseCssColor(fg)!.rgb, parseCssColor(tile)!.rgb);
+      if (r < TEXT_MIN) failures.push(`${name} ${pct}%: ${fg} on ${tile} = ${r.toFixed(2)}:1`);
+    }
+  }
+  assert.deepEqual(failures, [],
+    `${failures.length} heatmap bucket(s) below ${TEXT_MIN}:1:\n  ${failures.join('\n  ')}\n` +
+    'The tile is a tint of --red over the context ground, so a text colour that ' +
+    'works in dark can be the tint\'s own colour in light.');
+});
+
+test('the ramp text is not --red-soft any more, in either direction', () => {
+  /* --red-soft is `var(--red)` in three of the four contexts, so using it as
+     the ramp's foreground is the bug rather than a value that happened to be
+     wrong. Named so a future edit does not reach for it again. */
+  assert.equal(/text: 'var\(--red-soft\)'/.test(COMPONENT), false,
+    'the ramp reads --red-soft again - in the light themes that resolves to --red, the tint\'s own colour');
+  assert.equal(/text: '#[0-9a-fA-F]{3,6}'/.test(COMPONENT), false,
+    'a bucket has a hardcoded hex - it cannot follow the theme, which is how the deepest bucket reached 1.63:1');
+});
+
+test('CONTROL: the old values still measure as failing', () => {
+  /* Without this the sweep passes on any palette. These are the four worst
+     readings from before the fix, recomputed from first principles. */
+  const bad = (ground: string, red: string, pct: number, fg: string) => {
+    const tile = hex(compositeOver(parseCssColor(red)!.rgb, parseCssColor(ground)!.rgb, pct / 100));
+    return contrastRatio(parseCssColor(fg)!.rgb, parseCssColor(tile)!.rgb);
+  };
+  assert.ok(bad('#FFFFFF', '#B91C1C', 25, '#B91C1C') < TEXT_MIN, 'current light -10% should still fail');
+  assert.ok(bad('#FFFFFF', '#B91C1C', 38, '#fee2e2') < TEXT_MIN, 'current light worst bucket should still fail');
+  assert.ok(bad('#141517', '#f0524d', 25, '#f0524d') < TEXT_MIN, 'terminal dark -10% should still fail');
+  assert.ok(bad('#ebe9e6', '#9d1a23', 38, '#fee2e2') < TEXT_MIN, 'terminal light worst bucket should still fail');
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -205,6 +205,12 @@
   --red-bg:  rgba(248,113,113,0.08);
   --red-bdr: rgba(248,113,113,0.22);
   --red-soft: #fca5a5;
+  /* CoinHeatmap's red ramp text (#835). PER CONTEXT, because the tile is a
+     tint of --red over that context's ground: light text works on a dark
+     tint and fails on a light one. Reusing --red-soft made both light
+     themes paint the tint's own colour onto itself. */
+  --heat-red-fg: #fca5a5;
+  --heat-red-deep-fg: #fee2e2;
 
   --amber:     #fbbf24;
   --amber-2:   #fcd34d;
@@ -2764,6 +2770,12 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
   --red-bg:  rgba(185,28,28,0.07);
   --red-bdr: rgba(185,28,28,0.20);
   --red-soft: var(--red);
+  /* CoinHeatmap's red ramp text (#835). PER CONTEXT, because the tile is a
+     tint of --red over that context's ground: light text works on a dark
+     tint and fails on a light one. Reusing --red-soft made both light
+     themes paint the tint's own colour onto itself. */
+  --heat-red-fg: #6b1414;
+  --heat-red-deep-fg: #6b1414;
   /* was #B45309 - 3.59:1 on --bg4 and the amber-tinted panel #f3eee0. */
   --amber:     #8F4508;
   --amber-2:   #92400E;

--- a/components/CoinHeatmap.tsx
+++ b/components/CoinHeatmap.tsx
@@ -37,10 +37,10 @@ function changeColor(chg: number | null): { bg: string; text: string } {
      The green side has the same shape but does not fail (its worst bucket is
      5.71:1) because green is inherently light; left as-is rather than churning
      a passing palette, but the same rule applies if that ramp is ever extended. */
-  if (chg >= -2)  return { bg: 'color-mix(in srgb, var(--red) 7%, transparent)', text: 'var(--red-soft)' };
-  if (chg >= -5)  return { bg: 'color-mix(in srgb, var(--red) 15%, transparent)', text: 'var(--red-soft)' };
-  if (chg >= -10) return { bg: 'color-mix(in srgb, var(--red) 25%, transparent)', text: 'var(--red-soft)' };
-  return              { bg: 'color-mix(in srgb, var(--red) 38%, transparent)',     text: '#fee2e2' };
+  if (chg >= -2)  return { bg: 'color-mix(in srgb, var(--red) 7%, transparent)', text: 'var(--heat-red-fg)' };
+  if (chg >= -5)  return { bg: 'color-mix(in srgb, var(--red) 15%, transparent)', text: 'var(--heat-red-fg)' };
+  if (chg >= -10) return { bg: 'color-mix(in srgb, var(--red) 25%, transparent)', text: 'var(--heat-red-fg)' };
+  return              { bg: 'color-mix(in srgb, var(--red) 38%, transparent)',     text: 'var(--heat-red-deep-fg)' };
 }
 
 function fmtPrice(p: number): string {
@@ -278,7 +278,7 @@ export default function CoinHeatmap() {
         {[
           { label: '>+10%', c: 'var(--green-2)' }, { label: '+5%', c: 'var(--green-soft)' },
           { label: '+2%', c: 'var(--green-soft)' },   { label: '0', c: 'var(--txt-dim)' },
-          { label: '-2%', c: 'var(--red-soft)' },   { label: '-5%', c: 'var(--red-soft)' },
+          { label: '-2%', c: 'var(--heat-red-fg)' },   { label: '-5%', c: 'var(--heat-red-fg)' },
           /* NOT '#fee2e2' (#761). That is the TILE's text colour, and it is
              correct there - the worst bucket's tile is var(--red) at 38%, and
              pale text on a saturated tile measures 8.6-9.6, which is the rule


### PR DESCRIPTION
## Summary

Closes **#835**. The heatmap's red ramp text becomes two per-context tokens instead of `--red-soft`.

**QA found one failure by rendering. Sweeping all four contexts found six.**

```
                 -2%    -5%   -10%  worst      before
current dark    10.42   9.48   7.97   9.26      all pass
current light    5.75   5.01   4.17   1.63      two fail
terminal dark    4.91   4.44   3.81   8.66      two fail
terminal light   5.94   5.15   4.30   1.98      two fail
```

## Why `--red-soft` was the wrong foreground

The tile is a **tint of `--red` over the context's own ground**. In dark themes that is light text on a dark tint and measures 8–10:1 — which is where the component's comment gets its *"8.6:1 to 9.6:1 across the whole ramp"*, and it was true where it was measured.

In both light themes `--red-soft` resolves to `var(--red)`. So the text was **the tint's own colour painted onto itself**. Not a value that happened to be too low — a foreground that cannot work by construction.

Terminal dark fails differently: `--red` there is `#f0524d`, lighter than the current design's, so the tint is lighter and the same-colour text lands at 3.81 in the middle bucket.

## The worst two readings are the ones nobody saw

**1.63 and 1.98 are the deepest bucket**, which only renders when a coin is down more than 10%. The board is live data, so the worst case is also the rarest — QA's audit measured the market that existed that minute. Their own warning on the issue said not to treat the tile count as severity; the same applies to which buckets appear at all.

## The fix

`--heat-red-fg` (first three buckets) and `--heat-red-deep-fg` (the deepest), declared in `:root` and in `[data-theme="light"]` only. **The terminal blocks declare neither and inherit** — terminal dark takes `:root`'s light pair, terminal light takes the light block's dark pair, which is the cascade doing exactly what it should. That also keeps them out of `TERMINAL_ALIASES`, which the existing `terminalTokens` guard correctly demanded when I first declared them there.

Worst case across all sixteen combinations is now **5.01**.

The deepest bucket's hardcoded `#fee2e2` is gone. A literal cannot follow the theme, which is how it reached 1.63.

## Tests

Four, reading the tint percentages **out of the component** and the tokens **out of `globals.css`**, so neither a new bucket nor a palette change can slip past:

- every bucket clears 4.5:1 in all four contexts
- the component still has four token-coloured buckets, and no hardcoded hex
- the ramp never reads `--red-soft` again — named, because it is the specific wrong answer
- **CONTROL:** the four worst pre-fix readings still measure as failing

## Risk level

**Low-Medium.** Colour only, no logic.

- **Not rendered.** Arithmetic over the real tokens, composited the way the browser does. The four-context table is the evidence; a render would confirm the two buckets that need a coin down >10% only by luck.
- The green ramp is untouched and still passes — worst 5.71 — for the reason the component already gives.

Gates, each read: lint 0 errors / 232 warnings, `tsc --noEmit` exit 0, **713 tests pass**, build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
