### PR TITLE
fix: terminal contrast (#836) and duplicate control names (#846)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1022,6 +1022,21 @@ dev can move the release candidate, the guarantee is gone.
 already open it is **commented on, never rewritten** — QA reports failures in
 that thread and replacing the body underneath them would destroy the record.
 
+> ⚠️ **It does not open itself while Actions are switched off, which is most of
+> the time. Verified 2026-09-05.**
+>
+> The cost control in `ci.yml` is enforced by turning GitHub Actions on for one
+> run against a release candidate and off again. While they are off, a push to
+> `staging` produces **no runs at all** — not `Release signals`, not `Ready for
+> QA`. Measured: **zero workflow runs of any kind between 2026-08-13 and
+> 2026-09-05**, 23 days, and the push that moved `staging` to `9cefa0bb` opened
+> no release PR.
+>
+> All three workflows report `active` in `gh workflow list`, so that command
+> cannot tell you this. **Whoever pushes `staging` checks that a release PR
+> exists and opens it by hand if not.** "It opens itself" is true of the
+> workflow and false of the process it sits in.
+
 This was missing and it silently broke the handoff. Five changes sat on the
 `qa` site — including the worst Core Web Vital in the product and a bug that
 was getting users' IPs banned — with nothing anywhere saying so. Every

--- a/app/econ-calendar/page.tsx
+++ b/app/econ-calendar/page.tsx
@@ -140,7 +140,13 @@ export default function EconCalendarPage() {
         </div>
         <div style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)' }}>
           {t('ECON_CALENDAR_SUBTITLE')}
-          {source && <span style={{ marginLeft: 8, opacity: .5 }}>· {source}</span>}
+          {/* No `opacity` (#836). The parent is already `--txt3` and 0.5 of it
+              computed to #abacad = 2.10:1 in light terminal. Same trap the
+              comment at line ~272 of this file already refuses for the
+              estimated-date fade (#692), and the same one globals.css names at
+              .lp-footer-ack. The separator dot is what marks this as secondary;
+              it does not need dimmer ink as well. */}
+          {source && <span style={{ marginLeft: 8 }}>· {source}</span>}
         </div>
       </div>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -2471,7 +2471,14 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .liq-section-hdr { display: flex; align-items: center; gap: 8px; padding: 7px 14px; font-size: var(--fs-caption); font-weight: 700; letter-spacing: 0.02em; }
 .liq-section-hdr-short { color: var(--green-2); background: rgba(52,211,153,0.06); border-bottom: 0.5px solid rgba(52,211,153,0.12); }
 .liq-section-hdr-long  { color: var(--red); background: rgba(248,113,113,0.06); border-top: 0.5px solid rgba(248,113,113,0.12); border-bottom: 0.5px solid rgba(248,113,113,0.12); }
-.liq-section-sub { font-size: var(--fs-caption); font-weight: 500; opacity: 0.75; text-transform: none; letter-spacing: 0; }
+/* No `opacity` (#836). This inherits the header's --green-2 or --red, and 0.75
+   computed to #458c57 = 3.03:1 and #af4a50 = 3.90:1 in light terminal, over the
+   6%-tinted header ground. At full strength the same two measure 4.96 and 6.33
+   light, 6.54 and 4.87 dark - so the opacity was the entire defect and there is
+   nothing to retint. Fifth and sixth instances of the trap named at
+   .lp-footer-ack. Kept visually secondary by weight 500 against the header's
+   700, which is what was actually wanted. */
+.liq-section-sub { font-size: var(--fs-caption); font-weight: 500; text-transform: none; letter-spacing: 0; }
 
 /* Derived from --accent-2, was rgba(26,122,255,...) (#652). Those literals
    are the current design's dark --accent-2, and the [data-theme="light"]
@@ -2492,6 +2499,25 @@ body.nav-drawer-open .gchat-fab { opacity: 0; pointer-events: none; }
 .liq-current-chg { font-size: var(--fs-data); font-weight: 700; font-variant-numeric: tabular-nums; }
 .liq-current-tag { font-size: var(--fs-caption); font-weight: 700; color: var(--purple); background: var(--purple-bg); border: 0.5px solid var(--purple-bdr); padding: 2px 7px; border-radius: 6px; letter-spacing: 0.06em; animation: liq-pulse 2s infinite; }
 .liq-current-oi { font-size: var(--fs-caption); color: var(--txt3); margin-left: auto; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0; }
+/* THE ONE ON /liq THAT IS NOT AN OPACITY BUG (#836).
+ *
+ * Every other entry in that issue is `opacity` multiplied onto an already-tuned
+ * token, and removing the multiplier fixes it. This one has no multiplier -
+ * `--txt3` at FULL strength measures 4.09:1 here, because `.liq-current-bar` is
+ * not a panel ground: it is `--accent-2` at 9% composited over the panel, which
+ * lifts the ground toward the ink instead of away from it. A background is not
+ * the first non-transparent ancestor, and this row is why that matters.
+ *
+ * Measured over the composited ground rather than over --bg1:
+ *     --txt3  dark 4.09  light 4.66      <- what ships today
+ *     --txt2  dark 4.87  light 5.11      <- this
+ *     --txt   dark 13.04 light 13.51     <- would read as primary, which it is not
+ *
+ * --txt2 is the smallest step that clears AA in both themes and keeps the OI
+ * figure secondary to the price beside it. Scoped to terminal because that is
+ * where it was measured; the current design's tint is the same rule but its
+ * numbers have not been checked and I am not changing what I did not measure. */
+:root[data-design="terminal"] .liq-current-oi { color: var(--txt2); }
 
 .liq-row { display: grid; grid-template-columns: 72px 30px 38px 1fr 48px; align-items: center; gap: 5px; padding: 3.5px 14px; border-bottom: 0.5px solid rgba(255,255,255,0.02); transition: background 0.12s; }
 .liq-row:last-child { border-bottom: none; }
@@ -3989,7 +4015,18 @@ html[data-theme="light"] { background: var(--bg0); }
    inactive components does not apply. Light theme keeps its 0.6 over a white
    card, where the base colour has the headroom to absorb it. */
 .st-locked-list { color: var(--txt2); }
-[data-theme="light"] .st-locked-list { opacity: 0.6; }
+/* SCOPED OFF TERMINAL, not deleted (#836). The justification above - "over a
+   white card, where the base colour has the headroom to absorb it" - was
+   measured against the current design and holds there. Terminal light has
+   neither the white card nor the same --txt2, and the same 0.6 computed to
+   #9b9da0 = 2.71:1, reported seven times on /settings. So the multiplier keeps
+   the design it was tuned for and loses the one it was never checked against,
+   rather than being removed from both on the strength of one theme's number.
+
+   `data-theme` and `data-design` are BOTH on <html>, so this is one compound
+   selector rather than a descendant pair - same shape as the
+   `:root[data-theme="light"]:not([data-design="terminal"])` rule above. */
+:root[data-theme="light"]:not([data-design="terminal"]) .st-locked-list { opacity: 0.6; }
 
 /* ── Coin multi-select dropdown (replaces the full chip-grid watchlist picker) ── */
 .cms-trigger {

--- a/components/FundingTerminal.tsx
+++ b/components/FundingTerminal.tsx
@@ -501,7 +501,13 @@ export default function FundingTerminal() {
             {t(RANGE_LABEL_KEYS[r.key])}
           </button>
         ))}
-        <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', marginLeft: 4, alignSelf: 'center', opacity: 0.6 }}>
+        {/* No `opacity` (#836). `--txt3` is already tuned to just above 4.5:1,
+            so 0.6 of it computed to #9b9d9f = 2.51:1 light and #4d5157 = 2.52:1
+            dark. This is a hint telling the reader what the range buttons do -
+            the copy people read when they do not already know - so it is the
+            worst text on the row to dim. See .lp-footer-ack in globals.css for
+            the four earlier instances of the same mistake. */}
+        <span style={{ fontSize: 'var(--fs-caption)', color: 'var(--txt3)', marginLeft: 4, alignSelf: 'center' }}>
           {t('FUNDING_RANGE_ROW_HINT')}
         </span>
       </div>

--- a/components/GexTable.tsx
+++ b/components/GexTable.tsx
@@ -33,7 +33,14 @@ export default function GexTable() {
     <div className="gex-table">
       {/* Title + net GEX chip */}
       <div className="gex-title-row">
-        <div className="gex-title">{t('GEX_TABLE_TITLE')} <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 400, opacity: 0.5 }}>{t('GEX_TABLE_TITLE_SUFFIX')}</span></div>
+        {/* No `opacity` here (#836). The parent is already `--txt3`, which is
+            tuned to sit just above 4.5:1, so multiplying it computed #a1a2a2 =
+            1.95:1 in light terminal - the worst text ratio measured anywhere on
+            the platform. Same trap as .pf-footer-bottom-note, .mr-scale-good,
+            .st-locked-list and .lp-footer-ack; this is the fifth instance.
+            The suffix is de-emphasised by size and weight, which it already
+            was, rather than by dimming ink that has no room left to dim. */}
+        <div className="gex-title">{t('GEX_TABLE_TITLE')} <span style={{ fontSize: 'var(--fs-caption)', fontWeight: 400 }}>{t('GEX_TABLE_TITLE_SUFFIX')}</span></div>
         {gexLoaded ? (
           <div
             className="gex-net-chip"

--- a/components/GrokChat.tsx
+++ b/components/GrokChat.tsx
@@ -954,8 +954,19 @@ export default function GrokChat() {
                            aliases it to var(--accent) and now follows. */
                         style={{ marginTop: 10, fontSize: 'var(--fs-caption)', color: 'var(--accent-2)', background: 'none', border: `0.5px solid ${withAlpha('var(--accent-2)', '44')}`, borderRadius: 8, padding: '6px 16px', cursor: 'pointer' }}
                         onClick={() => setShowLoginModal(true)}
+                        /* Named for what it DOES, not for what it is (#846).
+                           This read "Sign In →", the same words as
+                           `.usage-auth-link` on /arena - and the two do
+                           different things: that one is a <Link> to /login,
+                           this one opens a modal in place. Two controls with
+                           one name on the same screen is a coin flip for anyone
+                           navigating by name rather than by position.
+                           aria-label as well as visible text, so the accessible
+                           name is right regardless of how a checker computes
+                           it. */
+                        aria-label="Sign in to chat"
                       >
-                        Sign In →
+                        Sign in to chat →
                       </button>
                     </>
                   )}

--- a/components/KLineProChart.tsx
+++ b/components/KLineProChart.tsx
@@ -2353,7 +2353,19 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
             }}>
               {setupQuality.label}
               <span className="sq-info" style={{ '--sq-bdr': setupQuality.bdr } as React.CSSProperties}>
-                <span style={{ opacity: 0.6, fontSize: '0.6875rem', lineHeight: 1 }}>ⓘ</span>
+                {/* No `opacity` (#836) - eighth instance of the trap named
+                    above `.lp-footer-ack` in globals.css. Inherits the setup
+                    badge's colour, and 0.6 of any of the badge tones lands
+                    under AA on the badge's own tinted ground.
+
+                    NOT FIXED HERE, filed instead: this ⓘ is keyboard-dead.
+                    `.sq-info` is `cursor: help` with a hover-only tooltip -
+                    no tabIndex, no role, no Escape. `Tip.tsx` solved exactly
+                    this (role="button", tabIndex, aria-label, Enter/Space,
+                    Escape) and the fix here is to use it rather than to
+                    re-derive it. That is a behaviour change on the chart
+                    toolbar and does not belong in a contrast batch. */}
+                <span style={{ fontSize: '0.6875rem', lineHeight: 1 }}>ⓘ</span>
                 <div className="sq-tooltip">
                   <div style={{
                     width: 240,

--- a/components/NavDrawer.tsx
+++ b/components/NavDrawer.tsx
@@ -151,7 +151,23 @@ const NAV_SECTIONS: NavSection[] = [
   ] },
   { headerKey: 'NAV_SECTION_MY_TOOLS', items: [
     { path: '/journal',  labelKey: 'NAV_JOURNAL',        Icon: NavJournal },
-    { path: '/calc',     labelKey: 'NAV_POSITION_SIZER', Icon: NavCalc },
+    /* NAV_CALCULATORS, not NAV_POSITION_SIZER (#846).
+     *
+     * Two bugs in one label. The route is a six-tool hub - sizer, liquidation,
+     * PnL, R:R, funding, DCA - and "Position Sizer" names one of the six, which
+     * is also the name of the FIRST TAB on the page it opens. On mobile that put
+     * two controls reading "Position Sizer" on the same screen: this one
+     * navigates, the tab does not. Same name, different action, no way to tell
+     * them apart by ear.
+     *
+     * It was also drift. `lib/navRoutes.ts` - the module #714 created precisely
+     * so the two navs could not disagree - already called this route
+     * NAV_CALCULATORS. This tile is the copy that was left behind, from when
+     * /calc really was only a position sizer.
+     *
+     * Renaming the TAB instead would be wrong: that tab genuinely is the
+     * position sizer, and the hub is genuinely the calculators. */
+    { path: '/calc',     labelKey: 'NAV_CALCULATORS', Icon: NavCalc },
     { path: '/alerts',   labelKey: 'NAV_ALERTS',         Icon: NavAlerts },
     { path: '/hours',    labelKey: 'NAV_BEST_HOURS',     Icon: NavHours },
     { path: '/playbook', labelKey: 'NAV_PLAYBOOK',       Icon: NavPlaybook },

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -54,3 +54,52 @@ landing, upgrade, 404.
 3. Landing: MindPillar-style italic serif accent words in hero headline; footer as
    multi-column link grid (Crypto Planet footer).
 4. Pagination pattern (`1–10 of N · page numbers · jump to page`) for long tables.
+
+---
+
+## Contrast: never dim ink that is already at its floor
+
+**Added 2026-09-05 after the same defect was found for the seventh time (#836).**
+
+`--txt3` is not "muted text you can mute further". It is tuned to sit **just above 4.5:1**
+and has no headroom left. Measured at full strength on a production build, across every
+panel ground in both terminal themes:
+
+```
+dark   #7c828a   4.71 – 5.20
+light  #5e6267   4.70 – 5.88
+```
+
+Every one of those clears AA. Multiply any of them by an `opacity` and it does not:
+
+| Multiplier | Computes to | Ratio | Where |
+|---|---|---|---|
+| `0.5` | `#a1a2a2` | **1.95:1** | `.gex-title > span` — worst text on the platform |
+| `0.5` | `#abacad` | 2.10:1 | `/econ-calendar` source suffix |
+| `0.6` | `#9b9d9f` | 2.51:1 | `/funding` range hint |
+| `0.6` | `#9b9da0` | 2.71:1 | `.st-locked-list`, light |
+| `0.75` | `#458c57` / `#af4a50` | 3.03 / 3.90 | `.liq-section-sub` |
+
+**The rule.** De-emphasise with **size, weight, or a separator** — never by dimming ink.
+The seven known instances are listed in `docs/HANDOVER.md` §14; `globals.css` names the trap
+in the comment above `.lp-footer-ack`. Read it before adding `opacity` to any text.
+
+**Two corollaries, both learned the expensive way:**
+
+1. **A fix scoped to one theme is not a fix.** `.st-locked-list` was corrected in dark and its
+   light multiplier survived for weeks, because the justification — *"over a white card, where
+   the base colour has the headroom to absorb it"* — was measured against the current design
+   and never re-checked against terminal. Measure all four contexts: design × theme.
+2. **A background is not the first non-transparent ancestor.** `.liq-current-oi` has no
+   multiplier and still failed at **4.09:1**, because `.liq-current-bar` is `--accent-2` at 9%
+   composited over the panel — a tint that lifts the ground *toward* the ink. Composite the
+   tint over its ground and measure against the result, or the number comes out wrong in the
+   direction that looks safe.
+
+**Contrast ratio is the wrong instrument for two different hues.** It reports 1.02 for a brown
+against a blue. Use it for same-hue pairs; for different hues, judge distinctness another way.
+
+> ⚠️ **The token table at the top of this file is stale.** It lists
+> `--txt / txt2 / txt3` as `#eef0fa / #9296b5 / #4e5374`; `globals.css` `:root` today has
+> `--txt3: #7b8297`, and the terminal blocks override all three again per theme. Treat
+> `app/globals.css` as authoritative and this table as historical until someone re-derives it.

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -269,7 +269,22 @@ android/      Capacitor Android shell
   body explaining the real cause and why the fix is shaped that way. Look at recent commits
   before writing one. Trailer: `Co-Authored-By: Claude <model> <noreply@anthropic.com>`.
 
-### Branch & deploy state as of 2026-09-03
+### Branch & deploy state as of 2026-09-05
+
+| Branch | Commit | Note |
+|---|---|---|
+| `origin/dev` | `24aa188a` | PR #847 merged — the app nav no longer covers marketing pages (#845) |
+| `origin/qa` | `24aa188a` | promoted by dev; **deploy is QA's** — dev is under a standing owner hold on every environment since 2026-09-03 |
+| `origin/staging` | `9cefa0bb` | behind `qa` by the #845 fix |
+| `origin/main` | `1ee554ee` | production. Release **held by the owner** on #836, #843 and #846 |
+
+**The release is held and the fix-forward ruling was reversed.** On 2026-09-05 the owner was told #843, #846 and #836 would ship as known defects and answered *"THEN VERIFY IT"*. Nothing ships until all three are fixed and QA has verified them on qa. Do not re-park them.
+
+**CI has been off since 2026-08-13.** Zero workflow runs of any kind between `2026-08-13` and `2026-09-05` — 23 days covering the whole terminal redesign. It is switched on by hand for one run against a release candidate and off again, which is the documented practice, and the consequence is that `release-signals.yml` does not fire on a push to `staging`, so **the release PR has to be opened manually.**
+
+**The one E2E run in that window is void.** Run `33932048082` reported 88 failed / 483 passed and it means nothing: the dev Supabase project was unreachable for the entire 66 minutes — **3,308 Cloudflare `522`s**, first at `00:13:25Z` and last at `01:15:34Z`. `/api/labels` returned a Cloudflare error page throughout, which is the exact condition `ci.yml` names as a known defect generator, so every control label on every page came from fallbacks. Read no failure from that run as a product defect without re-running. Detail on #841.
+
+#### Superseded: branch state as of 2026-09-03
 
 | Branch | Commit | Note |
 |---|---|---|
@@ -295,6 +310,16 @@ The owner stopped the canvas-mirror initiative. Their words: *"we are repackagin
 2. **Terminal ships on the landing page only** (#719, not yet built). `/` renders terminal by default; every app screen stays on the current design. Until this ships, `lib/designMode.ts` defaults everyone to `current` and **no user has ever seen any of the terminal work.**
 
 The sorting rule that follows from #2, and it governs triage: **after #719, a terminal-mode defect on any route except `/` is invisible to users and does not earn dev time.** A defect on the current design, or on landing, is real. #707, #698 and #663 were parked under exactly this rule with their measurements intact; #656 and #652 were closed as superseded; #620, #622 and #712 are parked.
+
+> ## ⚠️ THAT SORTING RULE IS DEAD. It reversed on 2026-09-04 and it is now exactly backwards.
+>
+> `7435d87c feat(dashboard): terminal is the default design on every route` (#748/#768) removed the "only `/`" half. **Terminal is what every visitor gets on every route**, and `?design=current` is the rollback rather than the default.
+>
+> So the sentence above now reads as "the defect every user sees does not earn dev time". Anything parked under it needs re-triage, not inheritance — and the paragraph is left in place rather than deleted because several closed issues cite it as their reason.
+>
+> This is not theoretical. #836, #843 and #846 are all terminal-mode defects on routes other than `/`; the old rule would park all three; the owner has **held the release** for exactly those three. If you are about to park a terminal defect because of the paragraph above, stop.
+>
+> One rule from #2 that did NOT change: terminal styling still goes **over the existing production layout**. Do not restructure a screen to match a canvas. #843 is what happens when that line is crossed and then reverted — see §14.
 
 **The one exception is landing.** The owner likes the canvas-mirrored landing (`ad6b08c`, #592) and it was deliberately excluded from the revert. Never revert it, and treat "landing renders identically" as a hard gate on any work touching `app/globals.css`, `lib/labelKeys.ts`, `lib/labelDefaults.en.json` or `components/AppShell.tsx` — all four are shared between landing and the reverted screens, and `AppShell.tsx` is the one that bit us (it rendered `PriceTickerStrip` on `/` gated on design mode rather than pathname).
 
@@ -419,6 +444,20 @@ These wasted real time in earlier sessions. All are documented as recurring:
 ---
 
 ## 9. Current issues
+
+### 🔴 Holding the 2026-09-05 release
+
+Three issues, all terminal-mode on routes other than `/`, all of which the dead sorting rule in §6 would have parked. The owner reversed the fix-forward ruling and held the release for them.
+
+| Issue | What it actually is | State |
+|---|---|---|
+| **#836** contrast | Seven instances of `opacity` over `--txt3`, plus one genuine tint-ground failure. Worst was `#a1a2a2` **1.95:1** on `/liq` `.gex-title > span` — the worst text ratio measured anywhere on the platform. `/liq` carried 5 of 9 light and 4 of 6 dark. | dev fixing |
+| **#846** duplicate accessible names | **Three of the five are a spec defect, not app code.** `no-duplicate-controls.spec.ts:79` reads `innerText \|\| aria-label` — precedence backwards. `Tip.tsx` sets a distinct `aria-label` per instance but its `innerText` is always `ⓘ`, so every Tip collides with every other Tip. Real ones: `/calc` "Position Sizer" (nav-tile vs ps-preset, one navigates and one does not) and `/arena` "Sign In →". | QA's file to fix |
+| **#843** Arena geometry | **Not a width.** The terminal Arena component was reverted and never restored — see §14. Cannot be fixed by a CSS number. | awaiting owner |
+
+**#845 shipped** — the terminal app nav covered `/learn`'s logo and both hero buttons including the primary CTA. Root cause: #714 fixed the same bug on `/` and wrote the gate as `pathname === '/'` — one route, not a family. Now `rendersOwnNav()` in `lib/navRoutes.ts`, covering `/`, `/learn`, `/ko`, `/zh`.
+
+> **The landing locales are `['ko','zh']` from `lib/i18n/dictionaries.ts`, NOT the ten in `lib/locales.ts`.** Two different lists. `app/[locale]/page.tsx` generates from the small one and `dynamicParams = false` 404s the rest — on a running build `/ko` is **200** and `/es` is **404**. Gating on the wide list claims eight routes that do not exist. A test binds the copy to `dictionaries.ts`.
 
 ### 🔴 Live risk
 
@@ -729,6 +768,41 @@ Context for the move off the desktop GUI.
   cards** - qa and staging share the dev database. Missing local API keys are *not* the
   cause and deploying to dev does not help. Any change to `/news` reaches production
   unverified; say so in the PR rather than letting the reader assume it was checked.
+
+### Three that cost the most time on 2026-09-05
+
+**1. `opacity` multiplied onto `--txt3` is now SEVEN instances of the same defect.**
+
+`--txt3` is tuned to sit just above 4.5:1 — measured at full strength it is **4.70 to 5.88 across every panel ground in both terminal themes**. It has no headroom left, so any multiplier at all drops it under AA. The instances, in the order they were found:
+
+```
+1  .pf-footer-bottom-note      2  .mr-scale-good        3  .st-locked-list  (dark half only)
+4  .lp-footer-ack              5  .gex-title > span     0.5 -> #a1a2a2  1.95:1
+6  .liq-section-sub            0.75 -> #458c57 3.03, #af4a50 3.90
+7  .st-locked-list             0.6 light -> #9b9da0  2.71:1   (the half #3 missed)
+   + FundingTerminal hint 0.6, econ-calendar source 0.5
+```
+
+**The rule: de-emphasise with size, weight or a separator — never by dimming ink that is already at its floor.** `globals.css` names the trap at `.lp-footer-ack`; read that comment before adding an `opacity` to any text.
+
+The corollary, and the thing that made #3 half-fixed for weeks: **a fix scoped to one theme is not a fix.** `.st-locked-list` was "fixed" in dark and its light multiplier survived because the justification — *"over a white card, where the base colour has the headroom"* — was true of the current design and never re-checked against terminal.
+
+**2. A background is not the first non-transparent ancestor.** `.liq-current-oi` was the only entry on #836 that is *not* an opacity bug: `--txt3` at full strength still measures **4.09:1** there, because `.liq-current-bar` is `--accent-2` at 9% composited over the panel, which lifts the ground toward the ink. Measure over the composited ground or the number is wrong in the safe-looking direction.
+
+**3. CSS can outlive the component it styles, and the CSS is not evidence the screen exists.**
+
+`components/ArenaTerminal.tsx` **does not exist.** `dd39c9bb` reverted the terminal-Arena branch — 1,212 lines including the component (355), `lib/arenaColour.ts`, `lib/arenaTimeframes.ts` and their tests — and `ccefc0de` (#413) then restored **939 lines of `globals.css` and not the component.** So `[data-design="terminal"] .at-rail { flex: 0 0 352px }` is correct, present, and styles markup that nothing renders.
+
+A sweep of every `[data-design="terminal"]` selector against every `className` in `app/` and `components/` found **194 of 349 terminal classes have no markup**. That number is an upper bound on dead CSS, **not a defect count** — and the difference matters:
+
+| Cluster | n | Component | Verdict |
+|---|---|---|---|
+| `at-*` | 66 | `ArenaTerminal.tsx` — **gone** | `/arena` is not converted. Real. |
+| `lt-*` | 88 | `LandingTerminal.tsx` — exists, renders `lpt-*` | dead CSS, no user impact |
+| `dterm-*` | 19 | `DashboardTerminal.tsx` — exists, renders `dash-*` | dead CSS |
+| `sshell*` | 5 | none | dead CSS |
+
+`lt-*` looked identical to `at-*` from the grep and was nearly reported as breakage; only opening `LandingTerminal.tsx` separated them. **Run the control in both directions before trusting a sweep** — and `/arena` sits in `CONVERTED_ROUTES` today, so the ledger says converted where the screen is current-design markup plus `border-radius: 0`.
 
 ### The failure that looks like success — 2026-09-03
 


### PR DESCRIPTION
Closes #836. Partially closes #846 — the two real entries. **#843 is not in here** and is waiting on the owner; see below.

## Summary

Two commits. The first stops dimming text that has no contrast headroom left; the second stops two pairs of controls sharing one name. Both were held for by the owner after the fix-forward ruling was reversed.

## What changed

### #836 — contrast

Five `opacity` multipliers removed, one token swapped. **No token value moved.**

| Site | Was | Now |
|---|---|---|
| `GexTable` title suffix | `opacity: 0.5` | removed |
| `.liq-section-sub` | `opacity: 0.75` | removed |
| `.st-locked-list` light | `opacity: 0.6` | scoped off terminal |
| `FundingTerminal` range hint | `opacity: 0.6` | removed |
| `econ-calendar` source suffix | `opacity: 0.5` | removed |
| `.liq-current-oi` | `--txt3` | `--txt2`, terminal-scoped |

### #846 — duplicate accessible names

| Site | Was | Now |
|---|---|---|
| nav drawer `/calc` tile | `NAV_POSITION_SIZER` | `NAV_CALCULATORS` |
| `GrokChat` signed-out button | "Sign In →" | "Sign in to chat →" + `aria-label` |
| `KLineProChart` `.sq-info` ⓘ | `opacity: 0.6` | removed (8th instance of the #836 trap) |

## Why

**Seven of the eight contrast entries are one defect.** `--txt3` is tuned to sit just above 4.5:1 and has no headroom — measured at full strength it is **4.70 to 5.88** across every panel ground in both terminal themes. Multiplying it put `.gex-title > span` at `#a1a2a2` = **1.95:1**, the worst text ratio measured anywhere on this platform. `globals.css` already names this trap above `.lp-footer-ack` and cites three earlier instances; these are five, six and seven, and one of the three — `.st-locked-list` — turned out to have been only half-fixed, because its justification (*"over a white card, where the base colour has the headroom to absorb it"*) was measured against the current design and never re-checked against terminal. **A fix scoped to one theme is not a fix.**

**The eighth is not an opacity bug at all.** `.liq-current-oi` had no multiplier and still measured 4.09:1, because `.liq-current-bar` is `--accent-2` at 9% composited over the panel — a tint that lifts the ground *toward* the ink. A background is not the first non-transparent ancestor.

**Both duplicate names were two controls doing different things.** On `/calc` the drawer tile and the page's first tab both said "Position Sizer"; one navigates, one switches tab. That was drift as well as a duplicate — `lib/navRoutes.ts`, the module #714 created so the two navs could not disagree, already called the route `NAV_CALCULATORS`. On `/arena` signed out, `.usage-auth-link` is a `<Link>` to `/login` and GrokChat's button opens a modal in place, both reading "Sign In →".

## How to test (QA)

On the qa environment, in **terminal**, both themes:

1. **`/liq`** — the GEX table's title suffix, the LONG/SHORT section subtitles, and the OI figure on the current-price bar. All should read as normal muted text, not ghosted. Nothing should look bolder or larger than before.
2. **`/funding`** — the hint beside the range buttons. **`/settings`** — the locked feature list. **`/econ-calendar`** — the source suffix under the heading.
3. **`/calc` at 390 wide** — open the nav drawer: the tile reads **"Calculators"**. Open the page: the first tab still reads **"Position Sizer"**. Two names, two controls.
4. **`/arena`, signed out** — the notice link reads "Sign In →"; the chat panel's button reads **"Sign in to chat →"**.
5. `contrast.spec.ts` against the terminal baseline — the numbers must go **down** and no new token may appear.

## Verified before opening this

Measured on a production build, compositing the full alpha stack down to the first opaque layer:

```
/liq            dark 4.77  6.63  4.94  5.77      light 4.70  4.61  5.89  4.53
/funding        dark 5.20                        light 5.68
/settings       dark 5.62                        light 6.73
/econ-calendar  dark 5.20                        light 5.68
```

**14 of 14 pass.** Gates: lint 0 errors (232 pre-existing warnings) · tsc exit 0 · 722/722 unit tests · build clean.

## Risk level

**Medium**, and the two reasons are worth reading rather than skimming.

**`.liq-current-oi` light is 4.53.** Three hundredths over the line. If that bar's tint changes it goes under. Recorded rather than reported as a comfortable pass.

**My first verification script reported four false failures.** It read the first non-transparent ancestor's `backgroundColor` and treated `rgba(52,211,153,0.06)` as an opaque green, so `.liq-section-sub` came back at 1.32:1. That is the exact trap documented in this PR, appearing in my own instrument minutes after I wrote it down. The numbers above are from the corrected version. **If QA's harness reads a single ancestor background, it has the same bug.**

**Not verified:** mobile for the contrast entries — measurements are 1440x900. Step 3 is the only mobile-specific check and `/calc` reproduces only at 390.

## Not in here

**#843.** It is not a rail width. `components/ArenaTerminal.tsx` was deleted by `dd39c9bb` and `ccefc0de` restored only its stylesheet, so `[data-design="terminal"] .at-rail { flex: 0 0 352px }` already says 352 and nothing renders `.at-rail`. The measured values are rail **320** (not 304 — that number is from the spec's comment, never rendered) and ticker **`null`** — element absent. Fixing it means rebuilding a 355-line component plus two lib modules. Awaiting the owner's call between pulling `/arena` from `CONVERTED_ROUTES` and rebuilding.

**Three of #846's five entries.** `qa/e2e/no-duplicate-controls.spec.ts:79` computes `innerText || aria-label` — precedence backwards. `Tip.tsx` sets a distinct `aria-label` per instance but its `innerText` is always `ⓘ`, so every Tip collides with every other Tip. QA's file.

**`KLineProChart`'s `.sq-info` is keyboard-dead** — `cursor: help`, hover-only tooltip, no `tabIndex`, no `role`, no Escape. Worse than any duplicate name, and invisible to a detector that reads `innerText`. `Tip.tsx` already solved it; the fix is to use it. Filed rather than bolted on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
