### PR TITLE
docs: correct why the release PR does not open itself

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1022,20 +1022,34 @@ dev can move the release candidate, the guarantee is gone.
 already open it is **commented on, never rewritten** — QA reports failures in
 that thread and replacing the body underneath them would destroy the record.
 
-> ⚠️ **It does not open itself while Actions are switched off, which is most of
-> the time. Verified 2026-09-05.**
+> ⚠️ **It is switched OFF right now, and has been since 2026-08-09.**
+> **Verified 2026-09-05.**
 >
-> The cost control in `ci.yml` is enforced by turning GitHub Actions on for one
-> run against a release candidate and off again. While they are off, a push to
-> `staging` produces **no runs at all** — not `Release signals`, not `Ready for
-> QA`. Measured: **zero workflow runs of any kind between 2026-08-13 and
-> 2026-09-05**, 23 days, and the push that moved `staging` to `9cefa0bb` opened
-> no release PR.
+> The job is gated on a repository variable:
 >
-> All three workflows report `active` in `gh workflow list`, so that command
-> cannot tell you this. **Whoever pushes `staging` checks that a release PR
-> exists and opens it by hand if not.** "It opens itself" is true of the
-> workflow and false of the process it sits in.
+> ```yaml
+> release-pr:
+>   if: github.ref == 'refs/heads/staging' && vars.RELEASE_PR_PAUSED != '1'
+> ```
+>
+> `gh variable list` shows **`RELEASE_PR_PAUSED = 1`**, set 2026-08-09 and never
+> unset. That is deliberate — it lets `staging` accumulate without a release PR
+> existing — but it means **"it opens itself" is currently false**, and both
+> #828 and #842 had to be opened by hand.
+>
+> **Whoever pushes `staging` checks that a release PR exists and opens it by
+> hand if not.** Unset or delete the variable to resume; the next push to
+> `staging` then opens one for everything piled up since.
+>
+> **Do not diagnose this as "Actions are off".** That was this note's first
+> version and it was wrong. Measured: `gh api .../actions/permissions` returns
+> `{"enabled": true}` and all three workflows report `active` in
+> `gh workflow list`. Separately and confusingly, there are **zero workflow runs
+> of any kind between 2026-08-13 and 2026-09-05** — 23 days — which is a real
+> observation with a cause I have not established. It is not this variable, and
+> `docs/HANDOVER.md`'s older claim that the workflows are `disabled_manually`
+> does not match what the API returns today either. Someone should settle it;
+> until then, do not repeat either explanation as fact.
 
 This was missing and it silently broke the handoff. Five changes sat on the
 `qa` site — including the worst Core Web Vital in the product and a bug that

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -280,7 +280,19 @@ android/      Capacitor Android shell
 
 **The release is held and the fix-forward ruling was reversed.** On 2026-09-05 the owner was told #843, #846 and #836 would ship as known defects and answered *"THEN VERIFY IT"*. Nothing ships until all three are fixed and QA has verified them on qa. Do not re-park them.
 
-**CI has been off since 2026-08-13.** Zero workflow runs of any kind between `2026-08-13` and `2026-09-05` — 23 days covering the whole terminal redesign. It is switched on by hand for one run against a release candidate and off again, which is the documented practice, and the consequence is that `release-signals.yml` does not fire on a push to `staging`, so **the release PR has to be opened manually.**
+**Zero workflow runs of any kind between `2026-08-13` and `2026-09-05`** — 23 days covering the whole terminal redesign, so nothing exercised a browser across all of it.
+
+**The cause of that gap is NOT established, and two plausible-sounding explanations are both wrong.** Measured 2026-09-05:
+
+```
+gh api repos/.../actions/permissions   {"enabled": true}
+gh workflow list --all                 CI active · Ready for QA active · Release signals active
+gh variable list                       RELEASE_PR_PAUSED = 1   (set 2026-08-09)
+```
+
+So Actions are **not** disabled at the repository level, and the banner higher up this file claiming all three workflows are `disabled_manually` does not match what the API returns today. Do not repeat either explanation as fact until someone settles it.
+
+**What IS established: the release PR does not open itself.** `release-signals.yml`'s `release-pr` job is gated `vars.RELEASE_PR_PAUSED != '1'`, and that variable has been `1` since 2026-08-09. Deliberate — it lets `staging` accumulate — but it means **the release PR must be opened by hand**, which is why #828 and #842 both were.
 
 **The one E2E run in that window is void.** Run `33932048082` reported 88 failed / 483 passed and it means nothing: the dev Supabase project was unreachable for the entire 66 minutes — **3,308 Cloudflare `522`s**, first at `00:13:25Z` and last at `01:15:34Z`. `/api/labels` returned a Cloudflare error page throughout, which is the exact condition `ci.yml` names as a known defect generator, so every control label on every page came from fallbacks. Read no failure from that run as a product defect without re-running. Detail on #841.
 


### PR DESCRIPTION
**Dev Team** — correcting a wrong cause I wrote into CONTRIBUTING earlier today, before it gets built on. QA already quoted it back as the most valuable thing in #851.

## What I got wrong

I wrote that the release PR does not open itself because *"Actions are switched off"*. Actions are on.

```
gh api repos/.../actions/permissions   {"enabled": true}
gh workflow list --all                 CI active · Ready for QA active · Release signals active
gh variable list                       RELEASE_PR_PAUSED = 1   (set 2026-08-09, never unset)
```

## The actual cause

`release-signals.yml:65`

```yaml
release-pr:
  if: github.ref == 'refs/heads/staging' && vars.RELEASE_PR_PAUSED != '1'
```

One repository variable, deliberately set so `staging` can accumulate without a release PR existing. That is the whole reason #828 and #842 had to be opened by hand — and the fix, when someone wants it back, is unsetting one variable rather than re-enabling anything.

## Why it mattered enough to correct separately

The two diagnoses have different fixes and different costs. "Actions are off" points at billing and at the cost-control practice in `ci.yml`; `RELEASE_PR_PAUSED` points at a switch someone flipped for a reason and can flip back. Acting on the first would have been a wasted afternoon.

## What is still unexplained, and left that way

**Zero workflow runs of any kind between 2026-08-13 and 2026-09-05.** That is a real observation and it is not this variable — the variable only gates one job in one workflow. `HANDOVER.md`'s older claim that all three workflows are `disabled_manually` does not match what the API returns today either.

Recorded as unexplained rather than attributed to a third guess. Guessing twice is how the first note went wrong.

## How to test (QA)

Documentation only, no build impact. Read CONTRIBUTING §7's release-PR block and HANDOVER's "Branch & deploy state as of 2026-09-05" and confirm neither claims Actions are off.

## Risk level

**Low** — two markdown files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y