### PR TITLE
fix: /learn heading amber and the grade-F badge (#836)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5033,9 +5033,39 @@ body.landing {
   --txt3:   #7c7c82;
   --bdr:    rgba(255,255,255,0.07);
   --accent: #1a7aff;
+  /* --accent-2 MUST be declared here too, and this is the exact failure the
+     --txt3 comment above describes, one token along (#836).
+
+     `.lp-h1-accent` and `.learn-category-title` read --accent-2, not --accent.
+     Terminal declares `--accent-2: var(--accent)` at :root, and a custom
+     property is substituted where it is DECLARED, not where it is used - so
+     that resolves against :root's --accent and inherits into this block as an
+     already-computed colour. Redeclaring --accent here does not reach it.
+
+     Measured on /learn, terminal, ground #050505 (this block's own --bg0,
+     which does not change with theme - the whole point of the scope):
+
+         dark   #d9a626   9.15:1
+         light  #754e00   2.76:1   <- 12 instances, worst on the platform
+
+     The token was not wrong and the ground was not wrong; the PAIRING was.
+     A light-palette accent, correct on a light ground, was being painted on a
+     region that is deliberately dark in both themes.
+
+     Per design rather than one value, because the two designs have different
+     brand accents and neither look should change: current keeps its blue, and
+     terminal gets the amber it already shows in dark. */
+  --accent-2: #5aa3ff;
   display: flex; flex-direction: column; min-height: 100vh; color: var(--txt); background: var(--bg0); font-family: inherit;
   animation: lp-content-in 0.5s var(--ease-settle);
 }
+/* Terminal's half of the pair above (#836). #d9a626 is what this region already
+   renders in dark, so dark is unchanged at 9.15:1 and light stops being 2.76:1.
+   Deliberately a literal rather than `var(--accent)`: --accent is redeclared to
+   #1a7aff inside .lp-root for the current design, so pointing at it here would
+   paint terminal's landing accent blue. */
+[data-design="terminal"] .lp-root { --accent-2: #d9a626; }
+
 @keyframes lp-content-in {
   from { opacity: 0; transform: translateY(8px); }
   to   { opacity: 1; transform: translateY(0); }

--- a/lib/marketStore.ts
+++ b/lib/marketStore.ts
@@ -347,7 +347,45 @@ export function computeCoinHealth(coin: CoinData | undefined): {
     grade === 'B' ? 'var(--green-2)' :   // green
     grade === 'C' ? 'var(--txt2)' :   // gray
     grade === 'D' ? 'var(--orange)' :   // orange
-                    'var(--txt3)';  // muted (F)
+                    /* F was --txt3 and measured 4.31-4.46:1 on its own tinted
+                       chip - under AA in all three places it renders (#836).
+
+                       THE CHIP IS A SELF-TINT, so changing this token moves the
+                       GROUND as well as the ink: DashboardTerminal.tsx paints
+                       `color: health.color` and
+                       `background: withAlpha(health.color, '22')`, the same
+                       value at 13.3%. The surface therefore moves toward the
+                       text rather than away, which is exactly the trap
+                       globals.css:600 describes - and it means a naive
+                       new-ink-on-old-ground calculation reads high. Modelled
+                       properly, backing the card colour out of QA's measured
+                       ground and recompositing:
+
+                         /dashboard dark   4.30 -> 5.02
+                         /dashboard light  4.44 -> 4.83
+                         /arena     dark   4.34 -> 5.07
+
+                       The before column reproduces QA's measurement on the
+                       deployed build (4.31 / 4.46 / 4.33) to rounding, which is
+                       what makes the after column trustworthy.
+
+                       NOT --txt, which would be 12.9-13.9 but makes the WORST
+                       grade the brightest text on the card. F is the muted
+                       state and should read as muted; it just has to be
+                       readable while it does.
+
+                       This is the line globals.css:597 assumed was already
+                       --txt when #614 removed the terminal override that used
+                       to force it. It was not, and removing the override
+                       reinstated the defect it was written to fix. The grade
+                       letter is what separates C from F, not the ink - they
+                       share --txt2 now and that is fine.
+
+                       Both render paths read this one value: /dashboard's
+                       span.csb2-health-badge.grade-f and /arena's bare span.
+                       Whether those two should share a component is a real
+                       question and a separate one. */
+                    'var(--txt2)';  // muted (F)
 
   const label =
     grade === 'A' ? 'Strong setup' :


### PR DESCRIPTION
**Dev Team** — the last 18 contrast instances from QA's sweep on deployed `qa` @ `122423d`. Two defects, neither from my earlier batch, both fixed here.

## Summary

`/learn`'s heading amber was `#754e00` on `#050505` — **2.76:1**, the worst text ratio on the platform, 12 instances. The grade-F health badge was under AA in all three places it renders, 6 instances. Different causes, one shape: **an ink paired with a ground it was never measured against.**

## What changed

| File | Change |
|---|---|
| `app/globals.css` | `.lp-root` declares `--accent-2`; a terminal-scoped companion rule sets its amber |
| `lib/marketStore.ts` | grade F's colour `var(--txt3)` → `var(--txt2)` |

## Why — /learn

`.lp-root` is an always-dark scope. It already forces `--bg0`, `--bg1`, `--txt`, `--txt2`, `--txt3`, `--bdr` and `--accent` to the dark palette so the region survives a saved light theme. It did **not** declare `--accent-2` — which is the token `.lp-h1-accent` and `.learn-category-title` actually read.

Terminal declares `--accent-2: var(--accent)` at `:root`. **A custom property is substituted where it is declared, not where it is used**, so that resolves against `:root`'s `--accent` and inherits into `.lp-root` as an already-computed colour. Redeclaring `--accent` inside the block cannot reach it.

In light, that delivered `#754e00` — a dark amber that is correct on a light ground — onto `#050505`. The token was not wrong and the ground was not wrong; **the pairing was.**

That block's own comment records the identical failure one token along: a stale `--txt3` there once caused 17 contrast failures across the landing page. This is the same mistake, and the governance note at `globals.css:6055` states the rule it breaks — *"every alias/derived token that block declares, this one must declare too, or it falls through."*

Fixed per design so neither look changes: current keeps `#5aa3ff`, terminal gets the `#d9a626` it already renders in dark.

## Why — grade F

`lib/marketStore.ts` returns `var(--txt3)` for grade F. `globals.css:597` records that #614 removed a terminal override forcing `color: var(--txt)`, on the stated grounds that F already paints `--txt`. **It does not, and never has** — so removing the override reinstated the defect it had been written to fix.

**The chip is a self-tint, and that changes the arithmetic.** `DashboardTerminal.tsx:195-196`:

```js
color: health.color,
background: withAlpha(health.color, '22'),
```

The background is the ink at 13.3%, so the surface moves *toward* the text rather than away — exactly the trap `globals.css:600` describes. A new-ink-on-old-ground calculation therefore reads high, and my first one did. Backing the card colour out of QA's measured ground and recompositing gives the real numbers.

`--txt2`, not `--txt`. `--txt` would clear 11.5–11.7 but makes the **worst** grade the brightest text on the card. F is the muted state; it only has to be readable while it is muted. The grade letter separates C from F, not the ink.

## How to test (QA)

1. **`/learn`, terminal, LIGHT** — the italic "Glossary" in the heading and the five category titles should read as clear amber, not dark brown on black. This is the one that was broken.
2. **`/learn`, terminal, DARK** — unchanged. Then both **current-design** themes — also unchanged. This half is the regression check and matters as much as step 1.
3. **The badge needs a coin actually grading F** on `/dashboard` or `/arena`. The "F" chip should be legible rather than close to the colour of its own background. If nothing is grading F, say so rather than passing it — see Risk.
4. `contrast.spec.ts` against the terminal baseline: 12 `/learn` entries and 6 badge entries should leave. **Assert on the set, not the count.**

## Verified before opening this

**`/learn` — rendered**, production build, both designs × both themes:

```
terminal  dark   9.15 -> 9.15      light  2.76 -> 9.15
current   dark   7.88 -> 7.88      light  7.88 -> 7.88
```

**Grade F — computed, not rendered.** With the self-tint modelled:

```
/dashboard dark   4.30 -> 5.02
/dashboard light  4.44 -> 4.83
/arena     dark   4.34 -> 5.07
```

The *before* column reproduces QA's deployed measurement (4.31 / 4.46 / 4.33) to rounding. That agreement between two independent instruments is what makes the *after* column worth anything.

Gates: lint 0 errors (232 pre-existing warnings) · tsc 0 · 722/722 unit tests · build clean.

## Risk level

**Medium**, and the two reasons are asymmetric.

**The badge is computed, not rendered.** It only draws when a coin actually grades F, and I cannot force that locally. The model is validated against QA's before-numbers, which is the strongest evidence available without an F coin — but it is not the same as having seen it. **This one is not closed until QA sees a real F badge.**

**`/learn` touches a shared token scope.** `.lp-root` is the landing page as well as the glossary, and landing is the surface CLAUDE.md names as a hard gate on any `globals.css` change. `--accent-2` was previously undeclared there, so nothing that reads it inside `.lp-root` was getting a scoped value — anything else in that region using `--accent-2` will change with this. I checked the two failing selectors and did not audit every consumer; a look at landing in all four contexts is worth QA's time.

**Not verified:** mobile. All measurements are 1440x900. QA's harness runs 390 in both themes by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
