### PR TITLE
test(qa): pin the design in specs that inherited it, scope the coverage guard (#844)

### DIFF
--- a/qa/README.md
+++ b/qa/README.md
@@ -293,6 +293,121 @@ number that comes back.
 answer, and I read past it. **That is a different failure from not having a
 check**, and the only guard on offer for it is knowing it is possible.
 
+**14. The sweep that runs every time could not see the defect class that
+shipped.** 2026-09-05, and this is the most expensive entry on the page because
+it is about coverage rather than a single wrong number.
+
+`qa/platform-audit.mjs` swept `/learn` on every audit — 124 page loads, four
+design/theme combinations — and reported it **clean** while the page's logo and
+**both hero buttons, the primary CTA included, could not be clicked**. The
+terminal app nav was painted over them. Nothing in the audit was wrong. Contrast,
+overflow, radius, tap-target size and empty labels all pass on a button nobody
+can press, because **not one of those checks asks whether a control is
+reachable.**
+
+The check that caught it was `layout.spec.ts`, in the Playwright suite, which
+runs on exactly one trigger: a PR into `main`. The three releases before it —
+2026-08-29, 09-02 and 09-03 — shipped with that workflow disabled for cost. So
+the defect class was invisible to the tooling that runs constantly and visible
+only to a gate that was switched off.
+
+**Two lessons, and the second is the one that generalises.**
+
+A clean audit means "clean on the properties this tool measures", never "clean".
+Say which properties when reporting one. `/learn` was reported clean for weeks
+and the report was accurate; it just never made a claim about clickability and
+nobody noticed the gap between what was measured and what was believed.
+
+And **a defect class that only the expensive release-time gate can see is a
+defect class that ships whenever that gate is off.** The fix is not to run the
+suite more often — it costs real money and the owner switched it off deliberately.
+It is to move the cheap half of the check into the tool that already runs: a
+hit-test at each control's centre costs nothing when the sweep is already on the
+page with a laid-out DOM. `platform-audit.mjs` now reports `coveredCount` per
+row for this reason.
+
+**15. Reading `innerText` before `aria-label` invents duplicate names that no
+screen reader would ever announce.** Same day, found by Dev Team while fixing
+what QA had filed.
+
+`no-duplicate-controls.spec.ts` computed a control's label as
+`innerText || aria-label`. Accessible-name precedence is the other way round —
+`aria-labelledby`, then `aria-label`, then content. `components/Tip.tsx` renders
+`<span role="button" aria-label={text}>ⓘ</span>`, so every tooltip's accessible
+name is its own distinct text and its `innerText` is always `ⓘ`. Content-first
+meant the `aria-label` was never reached and **every Tip on a page collided with
+every other Tip.**
+
+#846 was filed with five findings. Three were this. A screen reader announces
+those correctly and distinctly today.
+
+**What makes it worse than an ordinary false positive is where the fix would
+have landed.** The only way to satisfy the broken measurement is to give each
+`ⓘ` a different visible glyph — so acting on the finding degrades the interface
+to please an instrument that was wrong. A false positive that costs a round trip
+is cheap; one whose remedy damages the product is not.
+
+The general form: **when a probe computes a value the platform also defines,
+implement the platform's rule, not an approximation of it.** Accessible name,
+visibility, focus order and stacking all have specifications, and a plausible
+two-term fallback is the shape this error takes every time.
+
+**16. A list that looks like a rename is usually a different measurement.**
+Three instances on 2026-09-05, all caught the same way, which is what makes it a
+trap rather than three mistakes.
+
+`layout.spec.ts`'s mobile baseline named `nav.mobile-tab-bar` on every entry.
+That element is the CURRENT design's bottom bar; after #748 the bar at
+`bottom: 0` is `nav.tnav-tabs`. The obvious move — and the one I was one edit
+from making — is to copy the list and swap the element name. **Measured
+instead:**
+
+```
+only in terminal   /alerts, /arena
+only in current    /funding, /scanner, /journal, /news, /playbook
+in both            /briefing, /calc, /dashboard, /faq, /offline
+```
+
+Seven entries against ten, five shared. The two designs lay their pages out
+differently, so *which* control ends up under a fixed bar differs with them —
+the bar being 4px taller is not the only variable. The renamed copy would have
+asserted five overlaps that do not happen and missed two that do, and it would
+have looked completely reasonable in review.
+
+Same shape twice more the same afternoon. A `--accent-2: #0052CC` declaration
+found by grep, correctly computed at 2.99:1, in a scope a guard at
+`globals.css:4880` means never governs the element — a confident correction to
+dev, half-written, that would have been wrong. And dev computing a fix against a
+measured ground that the fix itself moves, because the chip is a self-tint: the
+ground is the ink at 13.3%, so changing the token changes the surface too.
+
+**Three different mechanisms, one last step that saved all three: check what is
+actually behind the number before believing it.** The transformation is always
+the cheap-looking part, and it is always the part that is wrong — a rename, a
+grep hit, a ground held constant. If you are about to derive a measurement from
+another measurement instead of taking it, take it.
+
+**And the fourth instance is the one that says when the check gets skipped.**
+Two hours after writing the paragraph above, I found `.lp-footer-col a:hover`
+reading `--accent-2`, computed the token's value in terminal light, and reported
+a 2.76:1 failure that #854 had fixed as a bonus. **The selector does not render
+in terminal at all** — terminal's landing uses a different root, so there is no
+`.lp-root` and no `.lp-footer-col` on that page. A CSS rule existing is not an
+element rendering. Trap 3 with an extra step, walked into by the person who had
+just written trap 16.
+
+Dev Team did the same thing in the same hour, repeating the finding onward
+without checking it. Their diagnosis is the durable part and it belongs here:
+
+> **the check gets skipped on findings that flatter, not on findings that are
+> hard.**
+
+Neither of us failed at the technique — we had both just used it successfully on
+harder problems. We skipped it on a result we liked. A fix that quietly does more
+than it claims, a bug found in someone else's blind spot, a number that confirms
+what you already argued: those are the ones to re-check, and the pleasure of
+having found them is the signal, not the reward.
+
 ## Where QA tests
 
 **Four branches, four services, one each.** Nothing auto-deploys — moving a
@@ -481,10 +596,39 @@ nagging is not approval.
 
 ### CI is switched off on purpose
 
-The repo is private, so every Actions minute is billed to the owner personally.
-All workflows are `disabled_manually`. **A cost decision, not an outage** — do
-not enable one, do not file it as a defect, do not caveat every PR with "no CI
+Every Actions minute is billed to the owner. **A cost decision, not an outage** —
+do not enable one, do not file it as a defect, do not caveat every PR with "no CI
 ran".
+
+**Two claims in this section were stale and are corrected rather than quietly
+edited, because both were quoted at people.**
+
+*"The repo is private."* It is **public**, and has been since before 2026-09-05 —
+found while preparing it for publication, at which point it was already
+published. Nothing in the reasoning changes; the minutes are still billed.
+
+*"All workflows are `disabled_manually`."* **They are not, and were not when this
+was written.** The API reports Actions `{"enabled": true}` and all three
+workflows `active`. `Ready for QA` fires on pushes to `qa` — issue #849 is
+evidence, since a workflow that never runs cannot post "0 PRs waiting". Caught by
+PM/DevOps Team on their first day, from this file.
+
+**What is actually switched off is one job**, gated on a repository variable:
+
+```
+release-signals.yml:65   if: … && vars.RELEASE_PR_PAUSED != '1'
+RELEASE_PR_PAUSED = 1    set 2026-08-09, never unset
+```
+
+So the release PR does not open itself, and **`gh workflow list` cannot tell you
+that** — it reports `active` regardless. Whoever pushes `staging` checks a
+release PR exists and opens it by hand.
+
+**And one thing remains genuinely unexplained: zero workflow runs of ANY kind
+between 2026-08-13 and 2026-09-05.** 23 days. That variable gates one job in one
+workflow and cannot account for it. Two sessions have each produced one confident
+wrong explanation for it already — billing, then the pause variable. It is
+recorded as unexplained on purpose. Measure before adding a third.
 
 The substitute is free and stronger: lint, `tsc`, unit tests, and Playwright
 **against a deployed host**.

--- a/qa/TEST_GAPS.md
+++ b/qa/TEST_GAPS.md
@@ -45,6 +45,37 @@ Three rules for keeping it honest:
 
 Everything below is outside that.
 
+### 🔴 What the ROUTINE sweep does not cover — added 2026-09-05, after it shipped
+
+**The table above is the Playwright suite, which runs on one trigger: a PR into
+`main`.** Between releases the thing that actually runs is
+`qa/platform-audit.mjs`, and its checks are **contrast, overflow, border-radius,
+tap-target size and empty labels**. That list is the whole of it.
+
+**None of those can see an unclickable control**, and on 2026-09-05 that shipped:
+`/learn`'s logo and both hero buttons — the primary CTA included — were painted
+over by the terminal app nav for every visitor, and the routine sweep reported
+the page clean on every run. It was clean, on the five properties it measures.
+
+Worse, the suite that *would* have caught it was **switched off for the three
+releases before that one** (2026-08-29, 09-02, 09-03), so those shipped with
+nothing exercising a browser at all. See `qa/README.md` trap 14.
+
+Two rules out of it, and neither is optional:
+
+- **Never report "clean" without naming the properties.** "No contrast or
+  overflow failures across 124 loads" is a true statement; "the page is clean"
+  is not the same claim and is the one that got believed.
+- **A check only the release gate can run is a check that does not run.** The
+  cheap half belongs in the routine sweep. Control reachability is now measured
+  there (`coveredCount` per row) because a hit-test costs nothing once the sweep
+  is already on a laid-out page.
+
+Still only in the suite, and still therefore only at release time: axe's full
+WCAG rule set, entitlement boundaries, BOLA, payments, offline/service worker,
+performance budgets and SEO. Those are not cheap to move and are named here so
+nobody assumes the routine sweep covers them.
+
 ---
 
 ## 🟡 1. Data and clock are controllable; SERVER time is not
@@ -245,6 +276,19 @@ case, which bites in production and is invisible on the test environments.
 
 Recorded here rather than hidden, because the suite is code and has defects too.
 
+- **`no-duplicate-controls.spec.ts` computed the accessible name backwards, and
+  filed three defects that did not exist.** It read `innerText || aria-label`;
+  the accname spec resolves `aria-labelledby`, then `aria-label`, then content.
+  `components/Tip.tsx` renders `<span role="button" aria-label={text}>ⓘ</span>`,
+  so every tooltip's real name is distinct and its `innerText` is always `ⓘ` —
+  content-first collided every Tip on a page with every other one. Three of the
+  five findings on #846 were this. **Fixed 2026-09-05**; the danger it leaves
+  behind is the shape, not the line: the only way to satisfy the broken
+  measurement was to give each `ⓘ` a different visible glyph, so acting on the
+  finding would have damaged the UI to please the instrument. When a probe
+  computes something the platform specifies — accessible name, visibility, focus
+  order, stacking — implement the specification, not a two-term fallback that
+  looks reasonable. `qa/README.md` trap 15.
 - **`perf.spec`'s LCP budget was calibrated on a laptop and fails in CI.**
   `< 2500ms` was set against a local 84–720ms measurement — 3× headroom over a
   dev machine and none over a GitHub runner. Measured 2026-08-10 on the same

--- a/qa/e2e/_design-tokens.ts
+++ b/qa/e2e/_design-tokens.ts
@@ -37,10 +37,45 @@
  *   /refund         — #503 @ 701d368, verified 2026-08-29 (static)
  *   /upgrade        — #503 @ 701d368, verified 2026-08-29 (static)
  */
+/* `/arena` IS NOT IN THIS LIST, and its absence is the finding (#843, #853).
+ *
+ * It was here, and the four `arena-structure.spec.ts` tests measured it against
+ * `specs/arena.md` and failed — rail 320 where the spec says 352, ticker strip
+ * absent entirely. Neither number is a styling slip. **The terminal Arena
+ * component does not exist.** `components/ArenaTerminal.tsx` was removed by the
+ * `dd39c9bb` revert, 1,212 lines including `lib/arenaColour.ts`,
+ * `lib/arenaTimeframes.ts` and their tests; `ccefc0de` later restored 939 lines
+ * of CSS and never restored the component. So
+ * `[data-design="terminal"] .at-rail { flex: 0 0 352px }` is already in
+ * `globals.css` and **nothing renders `.at-rail`** — along with `.at-body`,
+ * `.at-main`, `.at-pair`, `.at-ev*`, `.at-verdict` and the ticker strip. 66
+ * orphaned `at-*` classes styling markup that is not emitted. The 320 the spec
+ * measured is `.arena-ws`, the CURRENT design's Arena grid column.
+ *
+ * Setting `.arena-ws` to 352 under terminal was on the table and the owner
+ * rejected it on 2026-09-05: one criterion goes green, four stay red, and the
+ * screen is still not the one the spec describes. **A check made to pass without
+ * making the thing true is the failure this whole folder is about.**
+ *
+ * Removed rather than left failing, because a route in this list is a claim that
+ * the screen was converted, and that claim is false — what `/arena` has is
+ * current-design markup plus `border-radius: 0 !important` from #505. Leaving it
+ * would have the suite reporting a conversion that was reverted eight weeks ago.
+ *
+ * PUT IT BACK IN THE PR THAT REBUILDS THE COMPONENT — #853. The four structural
+ * tests arm themselves off this list and are the acceptance criteria for that
+ * work, so they need no edit when it lands.
+ *
+ * What this does NOT do, stated because the absence is easy to misread: it fixes
+ * nothing a visitor sees, and since #748 made terminal the default everywhere,
+ * whatever `/arena` looks like is now what every visitor gets. Swept on deployed
+ * `qa` @ 122423d — it renders coherently: title, category filters, coin row, the
+ * three research controls, chart with timeframe row, and a market-snapshot rail.
+ * Not the spec's screen, not a broken one.
+ */
 export const CONVERTED_ROUTES: string[] = [
   '/',
   '/disclaimer',
-  '/arena',
   '/dashboard',
   '/briefing',
   '/liq',

--- a/qa/e2e/_shared.ts
+++ b/qa/e2e/_shared.ts
@@ -313,6 +313,22 @@ export const BASELINE = {
      * Measured 2026-08-08 against a local production build at c3a7571, all 32
      * routes, 1440x900 - the same shape of environment CI runs.
      */
+    /* KEYED BY DESIGN SINCE 2026-09-05 (#844). These are two different sets of
+     * rendered surfaces, and they were being compared against one list.
+     *
+     * `contrast.spec.ts` seeded no design, so it swept whatever the app's
+     * default was. Everything below `current` was recorded while that default
+     * WAS the current design. #748 made terminal the default on every route and
+     * the same sweep started walking terminal, which surfaced 6 new dark tokens
+     * and 9 new light ones - while the totals FELL, dark 7 against a baseline of
+     * 13 and light 20 against 26. A design change reported as a contrast
+     * regression.
+     *
+     * The lists are not merged, and merging them is the wrong fix even though it
+     * would go green: a token that fails in one design and passes in the other
+     * is a real difference, and one list cannot say which design it belongs to.
+     */
+    current: {
     darkTokens: [
       // Near-white foregrounds collapse to one bucket - see bucket() in
       // contrast.spec.ts. In dark that is the /hours session badges, white-ish
@@ -364,6 +380,65 @@ export const BASELINE = {
       '#f3ba2f', '#f472b6', '#f69f9f',
       '#f87171', '#f97316', '#fbbf24',
     ] as readonly string[],
+    },
+
+    /* TERMINAL - the design a visitor actually gets after #748, and therefore
+     * the one an ordinary CI run measures.
+     *
+     * RECORDED 2026-09-05 against staging `9cefa0b`, both themes, 1440x900,
+     * consent seeded `denied`, market fixtures `as-recorded`. This is a
+     * deliberate recording sweep rather than tokens copied out of a failure
+     * message - the difference matters, because a failure message only lists
+     * what was NOT already in a list and would silently omit any token the two
+     * designs happen to share.
+     *
+     * NONE OF THIS IS A BLESSING. Every entry is a real SC 1.4.3 failure on a
+     * surface a visitor now reaches by default, and they are tracked on #836
+     * with selectors and worst-case ratios. The list exists so the NEXT one is
+     * visible, not to make these acceptable. Six of the light entries are below
+     * 3:1, and `#a1a2a2` on `/liq`'s `.gex-title` measures 1.95:1 - worse than
+     * `/learn`'s h1, which this project has been calling its worst for weeks.
+     *
+     * Delete entries as they are fixed. Do not add one without a note saying
+     * which route and which element put it here.
+     */
+    terminal: {
+      /* ONE SWEEP IS NOT THE WHOLE SET, and this list is honest about that.
+       * A recording run on the same build an hour earlier reported dark as 7
+       * tokens; this one reports 8. The difference is `#41454a` on
+       * /econ-calendar, a surface the first sweep did not reach. Server-side
+       * fetches are not covered by `installMarketFixtures` - see the long note
+       * in contrast.spec.ts - so which states render still varies run to run.
+       * A token appearing here later is therefore case (a), not automatically a
+       * regression; check the diff before deciding. */
+      darkTokens: [
+        // Same bucket as the current design's - see bucket() in contrast.spec.ts.
+        'near-white',
+        '#41454a',   // 2.08:1  /econ-calendar
+        '#474b50',   // 2.10:1  /liq
+        '#51565c',   // 2.49:1  /liq
+        '#4d5157',   // 2.52:1  /funding
+        '#bc4441',   // 3.30:1  /liq
+        '#7c828a',   // 4.16:1  /liq   - --txt3, and #836's div.liq-current-bar
+        '#349344',   // 4.34:1  /liq
+      ] as readonly string[],
+
+      /* Six of these nine are below 3:1. `#a1a2a2` at 1.95:1 is the worst text
+       * ratio measured anywhere on this platform, /learn's h1 included - and
+       * /liq carries five of the nine. If this gets triaged rather than fixed
+       * wholesale, /liq is where to start. */
+      lightTokens: [
+        '#a1a2a2',   // 1.95:1  /liq             .gex-title > span
+        '#abacad',   // 2.10:1  /econ-calendar   .econ-term-wrap > div:nth-child(1) > div:nth-child(2) > span
+        '#939596',   // 2.30:1  /liq             .gex-meta > span
+        '#9b9d9f',   // 2.51:1  /funding         .frh-range-row > span
+        '#9b9da0',   // 2.71:1  /settings        .st-locked-list > div:nth-child(1)   x7
+        '#754e00',   // 2.76:1  /learn           .lp-h1-accent                        x6, pre-existing, #836
+        '#458c57',   // 3.03:1  /liq             .liq-section-hdr-short > .liq-section-sub
+        '#af4a50',   // 3.90:1  /liq             .liq-section-hdr-long > .liq-section-sub
+        '#5e6267',   // 4.32:1  /liq             .liq-current-oi   - #836's div.liq-current-bar
+      ] as readonly string[],
+    },
   },
   /** §6.4 - pages with no <h1>, desktop. */
   pagesWithoutH1: 13,

--- a/qa/e2e/clock.spec.ts
+++ b/qa/e2e/clock.spec.ts
@@ -29,12 +29,37 @@ import { installMarketFixtures } from './_fixtures';
  * than claiming the gap is closed.
  */
 
-/** A page with the clock pinned, fixtures served, and the banner dismissed. */
-async function pinnedTo(browser: Browser, iso: string, timezoneId?: string) {
+/** The two designs, and the element each one uses to name the active window.
+ *
+ * PIN THE DESIGN, NEVER INHERIT IT (#844). This file used to seed no design and
+ * read `div.session-pill`, which is the CURRENT design's app bar. That was
+ * correct right up until #748 made terminal the default on every route, at
+ * which point the selector stopped existing and the test failed with "the
+ * session pill never rendered" - a message that reads like a broken feature and
+ * was actually a spec looking at the wrong design.
+ *
+ * The feature is not missing in terminal. `TerminalNav.tsx` renders
+ * `.tnav-session` from the same `getCurrentWindow()` in `lib/session.ts`. Two
+ * components, one source of truth - so the clock behaviour is asserted in BOTH,
+ * which is strictly more than this file used to prove. */
+const DESIGNS = [
+  { design: 'current',  selector: 'div.session-pill'   },
+  { design: 'terminal', selector: 'span.tnav-session'  },
+] as const;
+
+/** A page with the clock pinned, fixtures served, the banner dismissed, and the
+ *  design pinned rather than inherited. */
+async function pinnedTo(browser: Browser, iso: string, timezoneId?: string, design: 'current' | 'terminal' = 'terminal') {
   const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 }, timezoneId });
   await ctx.addInitScript(() => {
     try { localStorage.setItem('lhq_analytics_consent_v1', 'denied'); } catch { /* private mode */ }
   });
+  /* Seeded, not passed as `?design=`, so the preference is in place before the
+   * `design-init` script in app/layout.tsx reads it - the same route the query
+   * param takes, one step earlier, and with no first frame on the default. */
+  await ctx.addInitScript((d) => {
+    try { localStorage.setItem('lhq-design-mode', d); } catch { /* private mode */ }
+  }, design);
   const page = await ctx.newPage();
   /* BEFORE navigation, and before fixtures. The app reads the clock during
    * hydration, so installing it after a goto measures the real time on first
@@ -91,29 +116,43 @@ test.describe('clock-dependent behaviour', () => {
    *
    * `.session-pill` is the single element that names the CURRENTLY active
    * window, which is the thing that actually depends on the clock. */
-  async function sessionPill(browser: Browser, iso: string): Promise<string> {
-    const { page, close } = await pinnedTo(browser, iso);
+  async function sessionPill(
+    browser: Browser, iso: string, design: 'current' | 'terminal', selector: string,
+  ): Promise<string> {
+    const { page, close } = await pinnedTo(browser, iso, undefined, design);
     try {
       await gotoGuarded(page, '/hours', { waitUntil: 'domcontentloaded' });
-      const pill = page.locator('div.session-pill');
-      await expect(pill, 'the session pill never rendered - nothing can be concluded from its text')
+
+      /* PROVE THE DESIGN APPLIED BEFORE CONCLUDING ANYTHING FROM A SELECTOR.
+       * Without this, seeding the wrong key or the app ignoring it both surface
+       * as "the element never rendered", which is the exact failure this file
+       * just spent a release misreading. */
+      await expect
+        .poll(() => page.evaluate(() => document.documentElement.getAttribute('data-design')),
+          { message: `the ${design} design never applied - the selector below would be measuring the other one`, timeout: 10_000 })
+        .toBe(design === 'terminal' ? 'terminal' : null);
+
+      const pill = page.locator(selector);
+      await expect(pill, `${selector} never rendered in the ${design} design - nothing can be concluded from its text`)
         .toBeVisible({ timeout: 20_000 });
       return ((await pill.innerText()) || '').replace(/\s+/g, ' ').trim();
     } finally { await close(); }
   }
 
-  test('the active session window follows the clock', async ({ browser }) => {
-    const asia = await sessionPill(browser, '2026-08-10T02:00:00Z');
-    expect(asia, 'Monday 02:00 UTC is inside the Asia window').toMatch(/ASIA SESSION/i);
+  for (const { design, selector } of DESIGNS) {
+    test(`the active session window follows the clock (${design} design)`, async ({ browser }) => {
+      const asia = await sessionPill(browser, '2026-08-10T02:00:00Z', design, selector);
+      expect(asia, 'Monday 02:00 UTC is inside the Asia window').toMatch(/ASIA SESSION/i);
 
-    const monEvening = await sessionPill(browser, '2026-08-10T14:00:00Z');
-    expect(monEvening, 'Monday 14:00 UTC is the Monday-evening window').toMatch(/MON EVENING/i);
+      const monEvening = await sessionPill(browser, '2026-08-10T14:00:00Z', design, selector);
+      expect(monEvening, 'Monday 14:00 UTC is the Monday-evening window').toMatch(/MON EVENING/i);
 
-    /* The negative cases are what make the two above mean anything: a pill that
-     * says the same thing at every instant would satisfy both otherwise. */
-    expect(monEvening, '14:00 UTC must NOT also claim the Asia session').not.toMatch(/ASIA SESSION/i);
-    expect(asia, '02:00 UTC must NOT also claim the Monday-evening window').not.toMatch(/MON EVENING/i);
-  });
+      /* The negative cases are what make the two above mean anything: a pill that
+       * says the same thing at every instant would satisfy both otherwise. */
+      expect(monEvening, '14:00 UTC must NOT also claim the Asia session').not.toMatch(/ASIA SESSION/i);
+      expect(asia, '02:00 UTC must NOT also claim the Monday-evening window').not.toMatch(/MON EVENING/i);
+    });
+  }
 
   /* TIMEZONES, and the harness question had to be settled first.
    *

--- a/qa/e2e/contrast.spec.ts
+++ b/qa/e2e/contrast.spec.ts
@@ -22,9 +22,43 @@ import { installMarketFixtures } from './_fixtures';
  * tell", so it says "fine".
  */
 
-/** Seed the theme and prove it applied before measuring anything. */
+/** WHICH DESIGN THIS SWEEP MEASURES, pinned rather than inherited (#844).
+ *
+ * This file used to seed no design at all, so it swept whatever the app's
+ * default happened to be. That was the current design when the baselines were
+ * recorded, and became terminal the day #748 landed - which reported a DESIGN
+ * change as a CONTRAST change. Six dark tokens and nine light ones arrived as
+ * "not in baseline" while the totals FELL (dark 7 against a baseline of 13,
+ * light 20 against 26), because the sweep had started walking a different set
+ * of rendered surfaces. Nothing had regressed and the ratchet said otherwise.
+ *
+ * Terminal is the default, so terminal is what a visitor gets and what this
+ * sweep holds by default. `?design=current` is a supported escape hatch and is
+ * NOT swept on an ordinary run - one sweep is 9-10 minutes in CI and doubling
+ * the slowest spec in the suite for the rollback path is not worth the minutes.
+ * Measure it deliberately when the current design changes:
+ *
+ *     QA_CONTRAST_DESIGN=current npx playwright test qa/e2e/contrast.spec.ts
+ *
+ * Both baselines live in `_shared.ts` and neither is deleted, so switching back
+ * costs nothing. Say which design a contrast number came from when reporting
+ * one - a ratio without a design is the ambiguity this whole comment exists to
+ * remove.
+ */
+const DESIGN_UNDER_TEST: 'current' | 'terminal' =
+  process.env.QA_CONTRAST_DESIGN === 'current' ? 'current' : 'terminal';
+
+/** Seed the theme and the design, and prove both applied before measuring. */
 async function themedPage(browser: Browser, theme: 'dark' | 'light'): Promise<{ page: Page; close: () => Promise<void> }> {
   const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  /* Seeded the same way the theme is, and for the same reason: the `design-init`
+   * script in app/layout.tsx reads localStorage before hydration, so the page
+   * never renders a frame of the design we are not measuring. A `?design=` query
+   * param would arrive one step later and would have to be re-appended to all 58
+   * route navigations. */
+  await ctx.addInitScript((d) => {
+    try { localStorage.setItem('lhq-design-mode', d); } catch { /* private mode */ }
+  }, DESIGN_UNDER_TEST);
   // app/layout.tsx runs an inline script that reads localStorage BEFORE
   // hydration and stamps data-theme, so seeding the key is enough — no click on
   // a theme toggle, and no race with hydration.
@@ -373,22 +407,22 @@ test.describe('colour contrast', () => {
       colours.set(key, { n: e.n + 1, worst: Math.min(e.worst, v.ratio), where: e.where });
     }
 
-    const known = new Set(BASELINE.contrast.darkTokens);
+    const known = new Set(BASELINE.contrast[DESIGN_UNDER_TEST].darkTokens);
     const unexpected = [...colours].filter(([fg]) => !known.has(fg));
-    const fixed = BASELINE.contrast.darkTokens.filter(fg => !colours.has(fg));
+    const fixed = BASELINE.contrast[DESIGN_UNDER_TEST].darkTokens.filter(fg => !colours.has(fg));
 
     /* Printed as well as attached. Attachments are only uploaded on failure
      * (`ci.yml` uses `if: failure()`), so on a GREEN run these numbers exist
      * nowhere a reader can reach them - which is how "did the sweep get weaker?"
      * became unanswerable without re-running it locally. One line costs
      * nothing and makes the measurement legible in the gate log itself. */
-    console.log(`[contrast] dark: ${all.length} violations across ${colours.size} tokens (baseline ${BASELINE.contrast.darkTokens.length})`);
+    console.log(`[contrast] ${DESIGN_UNDER_TEST} dark: ${all.length} violations across ${colours.size} tokens (baseline ${BASELINE.contrast[DESIGN_UNDER_TEST].darkTokens.length})`);
 
     testInfo.attach('contrast-dark.txt', {
       body: `${all.length} violations across ${colours.size} tokens\n\n`
         + [...colours].sort((a, b) => a[1].worst - b[1].worst)
             .map(([fg, e]) => `${fg}  worst ${e.worst.toFixed(2)}:1  x${e.n}  first seen ${e.where}`).join('\n')
-        + (fixed.length ? `\n\nno longer failing (remove from BASELINE.contrast.darkTokens):\n${fixed.join('\n')}` : ''),
+        + (fixed.length ? `\n\nno longer failing (remove from BASELINE.contrast.${DESIGN_UNDER_TEST}.darkTokens):\n${fixed.join('\n')}` : ''),
       contentType: 'text/plain',
     });
 
@@ -414,7 +448,7 @@ test.describe('colour contrast', () => {
     expect(
       unexpected.map(([fg]) => fg),
       `Dark theme: ${unexpected.length} foreground token(s) failing SC 1.4.3 that are not in ` +
-      `BASELINE.contrast.darkTokens.
+      `BASELINE.contrast.${DESIGN_UNDER_TEST}.darkTokens (design under test: ${DESIGN_UNDER_TEST}).
 
 ` +
       unexpected.map(([fg, e]) => `  ${fg}  worst ${e.worst.toFixed(2)}:1  on ${e.where}`).join('\n') +
@@ -508,17 +542,17 @@ This is NOT automatically a regression. It is either:
       });
     }
 
-    const known = new Set(BASELINE.contrast.lightTokens);
+    const known = new Set(BASELINE.contrast[DESIGN_UNDER_TEST].lightTokens);
     const unexpected = [...byColour].filter(([fg]) => !known.has(fg));
-    const fixed = BASELINE.contrast.lightTokens.filter(fg => !byColour.has(fg));
+    const fixed = BASELINE.contrast[DESIGN_UNDER_TEST].lightTokens.filter(fg => !byColour.has(fg));
 
-    console.log(`[contrast] light: ${all.length} violations across ${byColour.size} tokens (baseline ${BASELINE.contrast.lightTokens.length})`);
+    console.log(`[contrast] ${DESIGN_UNDER_TEST} light: ${all.length} violations across ${byColour.size} tokens (baseline ${BASELINE.contrast[DESIGN_UNDER_TEST].lightTokens.length})`);
 
     testInfo.attach('contrast-light.txt', {
       body: `${all.length} violations across ${byColour.size} tokens\n\n`
         + [...byColour].sort((a, b) => a[1].worst - b[1].worst)
             .map(([fg, e]) => `${fg}  worst ${e.worst.toFixed(2)}:1  x${e.n}  worst at ${e.where}  ${e.what}`).join('\n')
-        + (fixed.length ? `\n\nno longer failing (remove from BASELINE.contrast.lightTokens):\n${fixed.join('\n')}` : ''),
+        + (fixed.length ? `\n\nno longer failing (remove from BASELINE.contrast.${DESIGN_UNDER_TEST}.lightTokens):\n${fixed.join('\n')}` : ''),
       contentType: 'text/plain',
     });
 
@@ -544,7 +578,7 @@ This is NOT automatically a regression. It is either:
     expect(
       unexpected.map(([fg]) => fg),
       `Light theme: ${unexpected.length} foreground token(s) failing that are not in ` +
-      `BASELINE.contrast.lightTokens.
+      `BASELINE.contrast.${DESIGN_UNDER_TEST}.lightTokens (design under test: ${DESIGN_UNDER_TEST}).
 
 ` +
       unexpected.map(([fg, e]) => `  ${fg}  worst ${e.worst.toFixed(2)}:1  x${e.n}  worst at ${e.where}  ${e.what}`).join('\n') +

--- a/qa/e2e/layout.spec.ts
+++ b/qa/e2e/layout.spec.ts
@@ -207,7 +207,42 @@ async function findLayoutDefects(page: Page): Promise<LayoutDefects> {
  *
  * If a future diff shows these flipping back, the attribution changed - not
  * the layout. */
-const KNOWN_OBSCURED: Record<string, string[]> = {
+/* ── AND THE WHOLE MAP IS DESIGN-SCOPED. Added 2026-09-05 (#844) ────────────
+ *
+ * Every mobile entry below names `nav.mobile-tab-bar`, and that element is
+ * rendered by `NavDrawer.tsx` inside the `{!terminal && ...}` branch — it is the
+ * CURRENT design's bottom bar. This baseline was derived on 2026-08-12, when the
+ * current design was what the app served by default.
+ *
+ * #748 made terminal the default on every route. The bar at `bottom: 0` is now
+ * `nav.tnav-tabs`, from TerminalNav, and this spec pins no design — so on
+ * 2026-09-05 it reported **eight new obscured controls** against a build where
+ * nothing had regressed. Seven were the same overlaps under the new element's
+ * name.
+ *
+ * MEASURED BEFORE CONCLUDING THAT, because "same overlap, new name" is exactly
+ * the sort of thing that is convenient to believe. Both designs, 390x844, on
+ * deployed `qa`:
+ *
+ *     terminal   bar=tnav-tabs       h=60  top=784
+ *     current    bar=mobile-tab-bar  h=56  top=788
+ *
+ * with the same controls covered on the same routes in both columns. Terminal's
+ * bar is 4px taller and sits 4px higher; that is the entire difference. So the
+ * overlaps are pre-existing and NOT a consequence of #748 — but the names are
+ * design-specific and one flat list cannot hold both.
+ *
+ * Keyed by design for the same reason `BASELINE.contrast` is: merging the two
+ * would go green and would be wrong, because a control covered in one design and
+ * clear in the other is a real difference that a single list cannot express.
+ *
+ * `/arena: button.klc-tool-btn is covered by button.gchat-fab` is the one entry
+ * that is NOT the bottom bar. It is present in both designs, so it is also
+ * pre-existing rather than introduced — but nobody had filed it, because until
+ * the design flip forced a re-derivation nobody had looked at this list again.
+ */
+const KNOWN_OBSCURED_BY_DESIGN: Record<'current' | 'terminal', Record<string, string[]>> = {
+  current: {
     desktop: [],
     /* RE-DERIVED 2026-08-12 against deployed `qa` @ ae213e7, after the coverer
      * normalisation above. Three entries were RENAMED rather than fixed, and one
@@ -238,7 +273,52 @@ const KNOWN_OBSCURED: Record<string, string[]> = {
       '/playbook: button.pb-star is covered by button.gchat-fab',
       '/scanner: button is covered by nav.mobile-tab-bar',
     ],
-  };
+  },
+
+  /* TERMINAL — the design a visitor gets after #748, and therefore the one an
+   * ordinary run measures. RECORDED 2026-09-05 against deployed `qa`, filled in
+   * from an actual sweep rather than by substituting the element name into the
+   * `current` list above. The substitution would almost certainly have been
+   * right, and "almost certainly" is how the contrast baseline went wrong
+   * earlier the same day. */
+  terminal: {
+    /* ZERO, and that is the #845 fix showing up as a number. Before it, this
+     * held /learn's a.lp-logo, a.lp-btn-ghost and a.lp-btn-primary, all covered
+     * by header.tnav. Measured on deployed `qa` @ 122423d: 0 across 30 routes. */
+    desktop: [],
+
+    /* AND THE SUBSTITUTION WOULD HAVE BEEN WRONG. The plan was to take the
+     * `current` list and swap `nav.mobile-tab-bar` for `nav.tnav-tabs`. These
+     * are not the same set:
+     *
+     *   only in terminal   /alerts, /arena
+     *   only in current    /funding, /scanner, /journal, /news, /playbook
+     *   in both            /briefing, /calc, /dashboard, /faq, /offline
+     *
+     * Seven against ten, five shared. The two designs lay their pages out
+     * differently, so which control ends up under a fixed bar differs with
+     * them - the bar being 4px taller in terminal is not the only variable.
+     * A renamed copy of the other list would have asserted five overlaps that
+     * do not happen and missed two that do. */
+    mobile: [
+      '/alerts: a.auth-gate-btn is covered by nav.tnav-tabs',
+      '/arena: button.klc-tool-btn is covered by button.gchat-fab',
+      '/briefing: a is covered by nav.tnav-tabs',
+      '/calc: input.ps-inp is covered by nav.tnav-tabs',
+      '/dashboard: button.sotd-refresh is covered by nav.tnav-tabs',
+      '/faq: button is covered by nav.tnav-tabs',
+      '/offline: button.pf-footer-expand is covered by nav.tnav-tabs',
+    ],
+  },
+};
+
+/** The design this run measures. Terminal is the default after #748; the spec
+ *  seeds it rather than inheriting it, so the baseline above cannot silently
+ *  come to describe a different design than the one on screen. */
+const LAYOUT_DESIGN: 'current' | 'terminal' =
+  process.env.QA_LAYOUT_DESIGN === 'current' ? 'current' : 'terminal';
+
+const KNOWN_OBSCURED: Record<string, string[]> = KNOWN_OBSCURED_BY_DESIGN[LAYOUT_DESIGN];
 
 test.describe('layout', () => {
   /* Runs on BOTH projects, unlike the HTTP-level specs which skip mobile. That
@@ -255,6 +335,16 @@ test.describe('layout', () => {
     consent: 'denied' | 'first-visit' = 'denied',
   ) {
     const ctx = await browser.newContext({ viewport });
+    /* PIN THE DESIGN (#844). Seeded before navigation so the `design-init`
+     * script in app/layout.tsx reads it pre-hydration, the same route the query
+     * param takes one step later. Unpinned, this spec swept whatever the app's
+     * default happened to be, and KNOWN_OBSCURED — derived on 2026-08-12 against
+     * the current design — silently came to describe a different one the day
+     * #748 landed. Seeded even on the first-visit path: consent is what that
+     * test varies, and the design must not vary with it. */
+    await ctx.addInitScript((d) => {
+      try { localStorage.setItem('lhq-design-mode', d); } catch { /* private mode */ }
+    }, LAYOUT_DESIGN);
     if (consent === 'denied') {
       await ctx.addInitScript(() => {
         try { localStorage.setItem('lhq_analytics_consent_v1', 'denied'); } catch { /* private mode */ }

--- a/qa/e2e/no-duplicate-controls.spec.ts
+++ b/qa/e2e/no-duplicate-controls.spec.ts
@@ -76,7 +76,36 @@ test.describe('no duplicate controls on a converted screen', () => {
           const r = el.getBoundingClientRect();
           if (r.width < 1 || r.height < 1) continue;            // not painted
           if (!(el as HTMLElement).offsetParent && getComputedStyle(el).position !== 'fixed') continue;
-          const label = ((el as HTMLElement).innerText || el.getAttribute('aria-label') || '').trim();
+          /* ACCESSIBLE-NAME PRECEDENCE, not innerText-first. Fixed 2026-09-05.
+           *
+           * This read `innerText || aria-label`, which is backwards: the accname
+           * spec resolves aria-labelledby, then aria-label, then content. The
+           * error was not academic. components/Tip.tsx renders
+           *
+           *     <span role="button" tabIndex={0} aria-label={text}>ⓘ</span>
+           *
+           * so every Tip's accessible name is its own distinct tooltip text and
+           * its innerText is always "ⓘ". Reading content first meant the
+           * aria-label was never reached and EVERY Tip on a page collided with
+           * every other Tip. #846 was filed with five findings; three of them
+           * were this - /liq's liqfeed-header + wf-header, /dashboard's
+           * mr-eyebrow + edge-card-label, /markets' mkt-col-pressure. A screen
+           * reader announces those as "Liquidation feed…", "Whale trades…" and
+           * so on, correctly and distinctly.
+           *
+           * Worse than a false positive: acting on it would have made the UI
+           * worse, since the only way to satisfy the broken measurement is to
+           * give each ⓘ a different visible glyph. Dev Team caught it.
+           *
+           * The empty-string check on aria-label matters - `aria-label=""` does
+           * NOT name an element, and falling through to content is correct
+           * there. */
+          const labelledBy = (el.getAttribute('aria-labelledby') || '')
+            .split(/\s+/).filter(Boolean)
+            .map(id => document.getElementById(id)?.textContent?.trim() || '')
+            .filter(Boolean).join(' ');
+          const ariaLabel = (el.getAttribute('aria-label') || '').trim();
+          const label = (labelledBy || ariaLabel || (el as HTMLElement).innerText || '').trim();
           if (!label || label.length > 24) continue;            // prose, not a control label
           let n: Element | null = el, owner = '';
           while (n && !owner) {

--- a/qa/e2e/terminal-default.spec.ts
+++ b/qa/e2e/terminal-default.spec.ts
@@ -1,13 +1,27 @@
 import { test, expect } from '@playwright/test';
 
-/* TERMINAL SHIPS ON `/` ONLY (#719).
+/* TERMINAL IS THE DEFAULT, EVERYWHERE (#748).
  *
  * This is the first design change any real visitor sees. Everything here is a
  * user-visible contract, not an implementation detail:
  *
- *   `/`            terminal, for someone with no query param and no storage
- *   every app route  current, unchanged
+ *   `/`              terminal, for someone with no query param and no storage
+ *   every app route  terminal, on the same terms
  *   both escape hatches still work
+ *
+ * THIS FILE USED TO ASSERT THE OPPOSITE, and the correction is recorded rather
+ * than quietly swapped. It was written for #719, which shipped terminal on `/`
+ * alone and left every app route on the current design. #748 reversed that on
+ * the owner's instruction - "remove ?design terminal make terminal design
+ * default" - and `lib/designMode.ts` now ends `return 'terminal'` with
+ * `pathname` no longer an input to the resolver at all.
+ *
+ * The two tests that encoded #719's route split kept passing on `dev` for a day
+ * and then failed on the release candidate's CI run, which is the wrong order:
+ * the spec should have failed in the PR that changed the behaviour. It did not,
+ * because the browser suite runs on exactly one automatic trigger - a PR into
+ * `main`. That gap is real and is named in CI's own header comment; this file is
+ * one of the things that fell into it. See #844.
  *
  * `data-design` is the thing under test rather than any rendered pixel: it is
  * what the whole terminal stylesheet keys off, it is set before first paint by
@@ -27,7 +41,7 @@ async function designAttr(page: import('@playwright/test').Page): Promise<string
   return page.evaluate(() => document.documentElement.getAttribute('data-design'));
 }
 
-test.describe('#719 terminal on landing only', () => {
+test.describe('#748 terminal is the default on every route', () => {
   test.use({ storageState: { cookies: [], origins: [] } });
 
   test('/ renders terminal for a first-time visitor', async ({ page }) => {
@@ -35,10 +49,15 @@ test.describe('#719 terminal on landing only', () => {
     expect(await designAttr(page)).toBe('terminal');
   });
 
-  test('app routes stay on the current design', async ({ page }) => {
+  test('app routes render terminal too, on the same terms', async ({ page }) => {
+    /* The #719 version of this test asserted `.toBeNull()` here - that an app
+       route must NOT be terminal. Inverted for #748 rather than deleted,
+       because "every route agrees with `/`" is still a contract worth holding:
+       a route that opts itself out of the default would strand a visitor in a
+       design the rest of the app has left. */
     for (const route of APP_ROUTES) {
       await page.goto(route);
-      expect(await designAttr(page), `${route} must not be terminal by default`).toBeNull();
+      expect(await designAttr(page), `${route} must be terminal by default`).toBe('terminal');
     }
   });
 
@@ -66,7 +85,12 @@ test.describe('#719 terminal on landing only', () => {
   });
 
   test('?design=terminal still works on app routes, and sticks', async ({ page }) => {
-    // QA reviews deployed builds through this path.
+    /* QA reviews deployed builds through this path. After #748 the param names
+       the default rather than changing anything, so the ATTRIBUTE half of this
+       test would now pass with the param removed entirely. The half that still
+       earns its keep is the persisted write below: `?design=terminal` must
+       leave a stored 'terminal', because that is what pins a reviewer's session
+       if the default is ever moved back. */
     await page.goto('/dashboard?design=terminal');
     expect(await designAttr(page)).toBe('terminal');
 
@@ -169,20 +193,45 @@ test.describe('#719 terminal on landing only', () => {
     expect(landingNavHrefs.length, 'landing has no sign-in or sign-up link left').toBeGreaterThan(0);
   });
 
-  test('the boundary: / to an app route swaps the design, and says so', async ({ page }) => {
-    /* #719 asks what the user sees crossing from landing into the app. It is a
-       real design change mid-session and there is no hiding it - the owner's
-       decision IS that the two surfaces differ. What must not happen is a
-       BROKEN intermediate state, so this asserts the attribute is correct on
-       both sides of a client-side navigation rather than pretending the swap
-       is invisible. */
+  test('the boundary: / to an app route no longer swaps the design', async ({ page }) => {
+    /* THERE IS NO LONGER A BOUNDARY, AND THAT IS THE ASSERTION.
+     *
+     * Under #719 this test read the other way: crossing from `/` into an app
+     * route was a real design change mid-session, the owner's decision WAS that
+     * the two surfaces differ, and the test existed to prove the swap was clean
+     * rather than to pretend it was invisible.
+     *
+     * #748 removed the split, so the swap is the defect now. Kept as a test
+     * rather than deleted because the crossing is exactly where a per-route
+     * default would reappear if someone reintroduced one, and it would reappear
+     * silently - both sides render, both look deliberate, and only a visitor
+     * moving between them sees the flip. */
     await page.goto('/');
     expect(await designAttr(page)).toBe('terminal');
 
     await page.goto('/dashboard');
-    expect(await designAttr(page), 'crossing into the app must land on the current design').toBeNull();
+    expect(await designAttr(page), 'crossing into the app must stay on terminal - #748 retired the route split').toBe('terminal');
 
     await page.goBack();
-    expect(await designAttr(page), 'going back to / must return to terminal').toBe('terminal');
+    expect(await designAttr(page), 'going back to / must still be terminal').toBe('terminal');
+  });
+
+  test('the opt-out crosses the boundary too', async ({ page }) => {
+    /* The half that matters more than the default. A visitor who opts out on
+       `/` must stay opted out when they reach the app - otherwise the escape
+       hatch is only an escape from the landing page, and the first app route
+       silently puts them back. Not covered before #748, because before #748 an
+       app route was current-design regardless and this would have passed
+       vacuously. */
+    await page.goto('/?design=current');
+    expect(await designAttr(page)).toBeNull();
+
+    await expect
+      .poll(() => page.evaluate(() => { try { return localStorage.getItem('lhq-design-mode'); } catch { return null; } }),
+        { message: 'the opt-out was never persisted' })
+      .toBe('current');
+
+    await page.goto('/dashboard');
+    expect(await designAttr(page), 'the opt-out must survive crossing into the app').toBeNull();
   });
 });

--- a/qa/platform-audit.mjs
+++ b/qa/platform-audit.mjs
@@ -231,6 +231,57 @@ const PAGE_EVAL = ({ tokens, radiusExempt, emptySource }) => {
     radiusTotal: Object.values(radius).reduce((a,c)=>a+c,0),
     radiusTop: Object.entries(radius).sort((a,b)=>b[1]-a[1]).slice(0,3),
     contrastFails, worstContrast, subMin, empties, emptyLabels: [...new Set(emptyLabels)],
+
+    /* ── IS THE CONTROL REACHABLE. Added 2026-09-05, and the reason matters ──
+     *
+     * #845: /learn's logo and BOTH hero buttons, the primary CTA included, were
+     * painted over by the terminal app nav and could not be clicked. This file
+     * swept /learn on every audit and reported it CLEAN, because none of the
+     * checks above can see an unclickable control - contrast, overflow, radius,
+     * tap size and empty labels all pass on a button nobody can press.
+     *
+     * It was caught by the Playwright suite instead, which runs on exactly one
+     * trigger: a PR into main. The three releases before it - 2026-08-29,
+     * 09-02 and 09-03 - shipped with that suite disabled for cost, so nothing
+     * exercised a browser at all. A defect class that only one release-time
+     * gate can see is a defect class that ships whenever that gate is off.
+     *
+     * This check costs nothing extra: the sweep is already on the page with a
+     * laid-out DOM. It belongs here rather than only in the suite so it runs
+     * every audit, on every design, theme and viewport, for free.
+     *
+     * ATTRIBUTED BY THE COVERER, NOT COUNTED. A fixed bottom bar legitimately
+     * overlaps content on a scrolled page, so a raw count reports a healthy
+     * build as broken. `barCovered` is reported separately rather than dropped -
+     * the caller decides whether the bar belongs on that route, because on a
+     * marketing page it does NOT and that overlap IS the bug. Getting this
+     * backwards would have hidden #845 at 390 on the very routes under test. */
+    ...(() => {
+      const SEL = 'a[href], button, input, select, textarea, [role="button"], [role="link"], [tabindex]:not([tabindex="-1"])';
+      const covered = []; let barCovered = 0, probed = 0;
+      for (const el of document.querySelectorAll(SEL)) {
+        const b = el.getBoundingClientRect();
+        if (b.width < 1 || b.height < 1) continue;
+        if (b.bottom < 0 || b.top > innerHeight) continue;
+        const s = getComputedStyle(el);
+        if (s.display === 'none' || s.visibility === 'hidden' || s.opacity === '0') continue;
+        if (el.closest('[inert]')) continue;
+        probed++;
+        const x = Math.min(Math.max(b.left + b.width / 2, 1), innerWidth - 1);
+        const y = Math.min(Math.max(b.top + b.height / 2, 1), innerHeight - 1);
+        const hit = document.elementFromPoint(x, y);
+        /* Both directions: a button wrapping an icon hit-tests to the icon and a
+           link inside a styled wrapper hit-tests to the wrapper. Only an
+           UNRELATED element is a finding. Same rule as layout.spec.ts. */
+        if (!hit || hit === el || el.contains(hit) || hit.contains(el)) continue;
+        if (hit.closest('.mobile-tab-bar, .tnav-tabs')) { barCovered++; continue; }
+        const nameOf = n => n.tagName.toLowerCase()
+          + (typeof n.className === 'string' && n.className.trim()
+            ? '.' + n.className.trim().split(/\s+/).slice(0, 3).join('.') : '');
+        if (covered.length < 12) covered.push(`${nameOf(el)} < ${nameOf(hit)}`);
+      }
+      return { probed, coveredCount: covered.length, covered, barCovered };
+    })(),
   };
 };
 
@@ -246,12 +297,72 @@ for (const vp of VIEWPORTS) {
        exists and none should. Storing the string is still correct: it is what
        resolveDesignMode reads, and it maps to "attribute absent". */
     await ctx.addInitScript(([t, d]) => { try { localStorage.setItem('theme', t); localStorage.setItem('lhq-design-mode', d); } catch {} }, [theme, design]);
+    /* PIN CONSENT. Added 2026-09-05 with the coverage check, because without it
+     * that check measures the banner rather than the layout: the first
+     * instrumented run reported 60 covered controls and nearly every one was
+     * `< div.consent-bar`, `< p.consent-text` or `< button.consent-btn`.
+     *
+     * The banner legitimately covers the page until dismissed, so counting it is
+     * not a finding — it is the same reason contrast.spec.ts, layout.spec.ts and
+     * a11y.spec.ts all seed this key. `layout.spec.ts` keeps a dedicated
+     * first-visit sweep for the banner itself, which is where that question
+     * belongs. */
+    await ctx.addInitScript(() => { try { localStorage.setItem('lhq_analytics_consent_v1', 'denied'); } catch {} });
     const page = await ctx.newPage();
     page.on('pageerror', () => {});
+
+    /* A 4xx/5xx DURING A RUN INVALIDATES THE RUN. Added 2026-09-05 on Dev Team's
+     * finding, and it is the cheapest guard on this page.
+     *
+     * They spent an afternoon measuring against a local server whose
+     * `_next/static/chunks/*` were answering 500 with `text/plain`. The landing
+     * JS never executed, `.lp-loading` stayed up at 2.4s and at 15s alike, and
+     * every number that came back was well-formed and about a page that had not
+     * run. It only surfaced because a figure disagreed with a second instrument.
+     *
+     * A failed asset does not throw, does not appear in `pageerror`, and does
+     * not stop the sweep - it silently changes what is on screen. Same family as
+     * trap 13, where a broken fetch shim produced nine confident zeros: the
+     * measurement is fine and the SUBJECT is not what you think.
+     *
+     * So it is counted per route and reported, rather than left to be
+     * discovered. Requests the app makes to third parties are excluded - those
+     * fail all the time and are not this page's health. */
+    let badResponses = [];
+    page.on('response', (r) => {
+      try {
+        const u = r.url();
+        if (r.status() < 400 || !u.startsWith(BASE)) return;
+        /* DOCUMENTS AND ASSETS ONLY — NOT `/api/*`. Scoped on the first real run
+         * of this guard, which fired on 30 of 120 loads and was wrong on nearly
+         * all of them.
+         *
+         * What it caught: 19x `502 /api/proxy?type=premium-index`, 4x `502
+         * /api/ath`, and 4x `401 /api/price-alerts`. The 401 is the app working
+         * CORRECTLY — the sweep is signed out and that route is supposed to
+         * refuse. The 502s are upstream exchange failures wearing our own
+         * origin, which happen constantly and say nothing about the build.
+         *
+         * The failure this guard exists for is Dev Team's: `_next/static/chunks/*`
+         * answering 500, so the page's JS never executed while every measurement
+         * came back well-formed. That is a DOCUMENT/ASSET failure. An API route
+         * answering 401 or 502 leaves the page rendered and the measurement
+         * valid — it changes the DATA, which `empty` already counts.
+         *
+         * Scoped by resourceType rather than by URL shape, because the point is
+         * "did the page's own machinery load", not "did every request succeed".
+         * A guard that fires on healthy runs gets skimmed past within a day,
+         * which is worse than not having one. */
+        const kind = r.request().resourceType();
+        if (!['document', 'script', 'stylesheet', 'font'].includes(kind)) return;
+        badResponses.push(`${r.status()} ${kind} ${u.slice(BASE.length) || '/'}`);
+      } catch { /* response gone */ }
+    });
 
     for (const route of ROUTES) {
       const url = BASE + route + (route.includes('?') ? '&' : '?') + 'design=' + design;
       let rec = { route, viewport: vp, theme, design, error: null };
+      badResponses = [];
       try {
         await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 90000 });
         /* Dashboard double-mounts during the design-mode transition; wait for a
@@ -336,14 +447,14 @@ for (const vp of VIEWPORTS) {
           }
         }
         const data = await page.evaluate(PAGE_EVAL, { tokens: theme === 'light' ? LIGHT : DARK, radiusExempt: 24, emptySource: EMPTY_SOURCE });
-        rec = { ...rec, ...data };
+        rec = { ...rec, ...data, badResponses: [...badResponses] };
       } catch (e) {
         rec.error = String(e.message || e).slice(0, 70);
       }
       rows.push(rec);
       if (!JSON_OUT) {
         const f = rec.error ? `ERROR ${rec.error}` :
-          `ovf ${String(rec.overflow).padStart(4)}${rec.overflow === 0 && rec.widerThanViewport > 0 ? '(w' + rec.widerThanViewport + ')' : ''}  off ${String(rec.offDistinct).padStart(3)}  rad ${String(rec.radiusTotal).padStart(3)}  contrast ${String(rec.contrastFails).padStart(3)}  <24px ${String(rec.subMin).padStart(2)}  empty ${String(rec.empties).padStart(2)}` + (rec.unsettled ? '  UNSETTLED' : '');
+          `ovf ${String(rec.overflow).padStart(4)}${rec.overflow === 0 && rec.widerThanViewport > 0 ? '(w' + rec.widerThanViewport + ')' : ''}  off ${String(rec.offDistinct).padStart(3)}  rad ${String(rec.radiusTotal).padStart(3)}  contrast ${String(rec.contrastFails).padStart(3)}  <24px ${String(rec.subMin).padStart(2)}  empty ${String(rec.empties).padStart(2)}  covered ${String(rec.coveredCount).padStart(2)}${rec.barCovered ? '(bar' + rec.barCovered + ')' : ''}` + (rec.unsettled ? '  UNSETTLED' : '');
         const dcol = DESIGNS.length > 1 ? design.padEnd(9) + ' ' : '';
         console.log(`${dcol}${vp.padEnd(7)} ${theme.padEnd(5)} ${route.padEnd(18)} ${f}`);
         /* Name the empties. A bare count cannot be acted on - which field is
@@ -351,6 +462,19 @@ for (const vp of VIEWPORTS) {
            row into a bug report. */
         if (rec.emptyLabels && rec.emptyLabels.length) {
           console.log('              empty: ' + rec.emptyLabels.join(' | '));
+        }
+        /* Name the covered controls for the same reason the empties are named:
+           "3 covered" cannot be acted on, and "a.lp-btn-primary < header.tnav"
+           is a bug report. #845 was three lines like this one, and the audit
+           that swept that page every day printed none of them. */
+        if (rec.covered && rec.covered.length) {
+          for (const c of rec.covered) console.log('              covered: ' + c);
+        }
+        /* Printed, never swallowed. A row with a 500 behind it is not a result. */
+        if (rec.badResponses && rec.badResponses.length) {
+          console.log('              🔴 HTTP: ' + rec.badResponses.slice(0, 4).join(' | ')
+            + (rec.badResponses.length > 4 ? ` (+${rec.badResponses.length - 4} more)` : '')
+            + '  — this row measured a page that did not fully load');
         }
       }
     }
@@ -399,6 +523,17 @@ if (measured.length === 0) {
 
 console.log(`overflowing            ${measured.filter(r => r.overflow > 0).length} of ${measured.length}`);
 console.log(`with contrast failures ${measured.filter(r => r.contrastFails > 0).length}   (total ${sum('contrastFails')})`);
+/* SEPARATE LINE, not folded into a total. A control nobody can click is a
+   different severity from a low-contrast label, and #845 shipped because this
+   number did not exist. `bar` is counted apart because a fixed bottom bar
+   legitimately overlaps a scrolled page - it is context, not a pass. */
+console.log(`with covered controls  ${measured.filter(r => r.coveredCount > 0).length}   (total ${sum('coveredCount')}, plus ${sum('barCovered')} behind a fixed bottom bar)`);
+/* LAST, and loudest, because it invalidates everything above it rather than
+   adding to it. A sweep with 4xx/5xx in it did not measure the app. */
+const withBad = measured.filter(r => (r.badResponses || []).length);
+console.log(withBad.length
+  ? `🔴 loads with HTTP >= 400   ${withBad.length} of ${measured.length}   — THESE ROWS ARE NOT RESULTS, re-run before quoting any number above`
+  : `loads with HTTP >= 400  0 of ${measured.length}`);
 console.log(`with off-palette       ${measured.filter(r => r.offDistinct > 0).length}   (total distinct-instances ${sum('offDistinct')})`);
 console.log(`with radius violations ${measured.filter(r => r.radiusTotal > 0).length}   (total ${sum('radiusTotal')}, circular <=24px exempt per radius-ruling.md)`);
 console.log(`with sub-24px targets  ${measured.filter(r => r.subMin > 0).length}   (total ${sum('subMin')})`);


### PR DESCRIPTION
## Summary

Split out of the original #848 at Dev Team's request — this PR carries only `qa/` tooling. The onboarding doc and the permission-structure edits (`CLAUDE.md`, `CONTRIBUTING.md`) are separate PRs, because they are a different kind of decision and should not ride in on a review of test code.

QA-authored, `qa/` only, no app code. Closes the spec half of #844.

## What changed

Three specs called `page.goto` with no `?design=` and no seeded preference, so they swept whatever the app's default happened to be — correct until #748 changed that default. `platform-audit.mjs` gains a control-reachability check and an asset-scoped HTTP guard. `/arena` leaves `CONVERTED_ROUTES` because the component it names does not exist.

**`terminal-default.spec.ts`** (renamed from `landing-terminal-default.spec.ts`) — rewritten for #748. The two tests encoding #719's route split are inverted, not deleted; a new test covers the opt-out surviving the crossing from `/` into an app route, which could not have been written before #748.

**`clock.spec.ts`** — read `div.session-pill`, the current design's app bar. Terminal renders `.tnav-session` from the same `getCurrentWindow()`. Now asserts both, with a `data-design` poll before touching either selector.

**`contrast.spec.ts` + `_shared.ts`** — `BASELINE.contrast` is keyed by design. Terminal swept by default (what a visitor gets after #748); `QA_CONTRAST_DESIGN=current` sweeps the other. The two lists are not merged — a token failing in one design and passing in the other is a real difference.

**`layout.spec.ts`** — `KNOWN_OBSCURED` is keyed by design. Measured rather than renamed: terminal and current share 5 of the mobile entries and disagree on 5 more (`/alerts`, `/arena` only in terminal; `/funding`, `/scanner`, `/journal`, `/news`, `/playbook` only in current). A renamed copy would have asserted five overlaps that do not happen.

**`no-duplicate-controls.spec.ts`** — computed a control's accessible name as `innerText || aria-label`. Platform precedence is the reverse. `components/Tip.tsx` renders `<span role="button" aria-label={text}>ⓘ</span>`, so every tooltip's real name is distinct and its `innerText` is always `ⓘ` — content-first collided every Tip on a page with every other one. Re-run against `qa` with precedence corrected: 3 findings instead of 5, matching what Dev Team independently confirmed as real.

**`platform-audit.mjs`** — hit-tests every visible control and reports `coveredCount`/`covered` per row, attributed to the coverer so a legitimate fixed-bottom-bar overlap doesn't read as a finding. Also adds an HTTP-status guard: its first real run flagged 30 of 120 loads, nearly all a correct signed-out 401 or an upstream 502 wearing our own origin. Scoped to `document`/`script`/`stylesheet`/`font` — the asset classes whose failure actually changes what renders, which is the real failure mode (Dev Team's stale `.next` chunks returning 500).

**`qa/e2e/_design-tokens.ts`** — `/arena` removed from `CONVERTED_ROUTES`. `components/ArenaTerminal.tsx` does not exist; it was removed by an earlier revert and later CSS restoration never restored the component. Full cause recorded in the file itself. Tracked as #843/#853.

**`qa/README.md`** — traps 14, 15, 16. The routine sweep couldn't see an unclickable control (how #845 shipped invisible to daily audits); reading `innerText` before `aria-label` invents duplicate names a screen reader never announces; a list that looks like a rename is usually a different measurement (four instances in one afternoon, across two sessions).

## How to test (QA)

```
npx playwright test qa/e2e/terminal-default.spec.ts qa/e2e/clock.spec.ts \
  qa/e2e/layout.spec.ts qa/e2e/contrast.spec.ts --workers=1
node qa/platform-audit.mjs --base https://liquidity-hq-qa.onrender.com
```

Verified on deployed `qa` @ `d1fed3d`: 120/120 loads, 0 contrast failures, 0 overflow, 0 HTTP≥400, 9 real covered-control instances across 3 routes (all pre-existing, unrelated to this release).

## Risk level

**Low.** Test-only; nothing here can reach a user. Named honestly: the terminal contrast baseline and the layout baseline are each one recording sweep, and `installMarketFixtures` does not cover server-side fetches, so which states render still varies run to run — a new token there is case (a) until the diff says otherwise, not automatically a regression.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu
