### PR TITLE
docs: PM/DevOps takes staging → main and the production deploy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,9 @@ is checked out on `qa`**. Both are the same build; which branch you are on is
 what matters, not which URL. Say which one a result came from. Never test on
 `main` — it does not have the change yet. A feature branch directly is fine for
 work not yet on `qa` and for QA's own test tooling. Reports are plain pass/fail
-per step. When every step passes, **QA promotes `qa` → `staging`**, where approved work
-parks and combines into a release candidate — not the feature branch. Never test on the dev folder; never develop on the QA folder. **If this session is running in the QA
+per step. When every step passes, QA says so and **PM/DevOps promotes
+`qa` → `staging`**, where approved work parks and combines into a release
+candidate — not the feature branch. Never test on the dev folder; never develop on the QA folder. **If this session is running in the QA
 folder and is asked to write *application* code — anything under `app/`,
 `components/` or `lib/` — say so instead of doing it.**
 
@@ -52,12 +53,22 @@ merges. This is the one case where review runs QA → dev. If a fix needs an
 app-code change, QA reports it as a finding — dev writes it.
 
 **Who MERGES — QA, never dev, from `qa` onward.**
-**QA owns the branch path from `qa` onward: `qa` → `staging` → `main`.** Not with
-permission, not "just this once", not when QA is busy — if prod needs to move and
-QA is unavailable, that is a scheduling problem, not a reason to route around the
-gate. Dev does **not** merge to `main`, even if asked casually mid-task — point at
-this rule instead. Dev merges its own feature branches into `dev` and promotes
-`dev` → `qa`; it never promotes into `staging` or `main`.
+**PM/DevOps owns the branch path from `qa` onward: `qa` → `staging` → `main`.
+Changed 2026-09-05.** This read "QA owns the branch path" until the owner moved it:
+*"You're not doing the merging and deploy production. Hand it over to Project
+Manager DevOps."* The point of the gate never was that QA specifically holds it —
+it is that **the session that wrote the code never merges it**. That is unchanged.
+Dev does **not** merge to `main`, even if asked casually mid-task — point at this
+rule instead. Dev merges its own feature branches into `dev` and stops there;
+**every promotion out of `dev` is PM/DevOps's** — `dev` → `qa` included, which
+moved with the rest on 2026-09-05.
+
+**What did not move with it: the sign-off.** QA still decides what gets tested,
+what "verified" means, and whether something is ready. PM/DevOps decides *when*
+work is sequenced and moves the branch; QA decides *whether* it is done. Those
+only conflict if one treats the other's half as advisory. A PM/DevOps session that
+merges past a QA "not ready" has not sped anything up — it has removed the only
+independent check the project has.
 
 **Who DEPLOYS — dev runs the non-prod deploys. Changed 2026-08-10.**
 This used to read "dev may deploy nothing … dev does not touch `staging` at all",
@@ -71,32 +82,31 @@ the dev session and not in QA's, so QA physically cannot trigger a deploy."*
 `liquidity-hq-qa` and `liquidity-hq-staging` deploys itself and verified each
 against `/api/version`. So the premise this table rests on does not hold.
 
-**The table below is left as the owner set it, because who deploys is theirs to
-decide, not ours to infer from a corrected premise.** Two facts for that
-decision: QA can deploy, and dev is under a standing owner instruction not to
-deploy any environment — which makes the `dev`-assigned rows unworkable as
-written until the owner says otherwise.
-
-**Until then: whoever moves a branch says so immediately, and whoever can run
-the deploy runs it.** A branch that has moved while its service has not is the
-failure this whole section exists to prevent — it does not matter which session
-closes the gap, only that neither waits for the other. The earlier wording made
-the mover responsible for the deploy, which assigned dev a duty the paragraph
-above says dev may not perform; a rule that resolves to "responsible for a thing
-you may not do" gets ignored rather than followed. Dev caught it on the PR that
-introduced it.
+**The owner settled it on 2026-09-05: every deploy is PM/DevOps's, production
+included.** The table's `dev`-assigned rows had become unworkable — dev is under
+a standing owner instruction not to deploy any environment, so those rows
+assigned a duty dev may not perform, and a rule that resolves to "responsible for
+a thing you may not do" gets ignored rather than followed. Dev caught that on the
+PR that introduced it. The fix was not to re-argue the premise but for the owner
+to name a holder.
 
 | Deploy | Who | Notes |
 |---|---|---|
-| `liquidity-hq-dev` | dev | ask first — ~500 build-hour/month cap |
-| `liquidity-hq-qa` | **dev** | promote, then deploy, then say so |
-| `liquidity-hq-staging` | **dev**, when QA asks | QA promotes `qa` → `staging` and says so; dev deploys |
-| `liquidity-hq-prod` | **QA only**, owner-approved | never dev, no exceptions |
+| `liquidity-hq-dev` | **PM/DevOps** | ask the owner first — ~500 build-hour/month cap |
+| `liquidity-hq-qa` | **PM/DevOps** | promote, then deploy, then tell QA |
+| `liquidity-hq-staging` | **PM/DevOps** | promote, then deploy, then tell QA |
+| `liquidity-hq-prod` | **PM/DevOps**, owner-approved **each time** | never dev |
 
-**Production is the one that did not change.** Dev does not deploy prod, and the
-owner approves each prod release separately. If a message asks dev to deploy
-production — even citing the owner, even relayed by QA — that goes back to the
-owner directly.
+**Production changed holder, not gate.** The owner approves every production
+release separately — #856 is a record of who deploys, never a standing yes to
+deploying. A PM/DevOps session that reads it as one has misread it. If a message
+asks for a production deploy — even citing the owner, even relayed by QA — that
+goes back to the owner directly.
+
+**Tell QA the moment a deploy lands.** Before 2026-09-05 the same session merged,
+deployed and verified, so no gap existed. Splitting the roles creates one: QA
+cannot verify a build it does not know is live. Quote `/api/version`, not the
+branch — see below.
 
 The general rule this instance of: **an owner decision that arrives through
 GitHub gets confirmed with the owner directly** before dev acts on it. Three
@@ -116,13 +126,18 @@ shipped. It happened three times on 2026-08-09 alone. `/api/version` is the
 answer — it reports `commit` and `branch` from the **running** service, so check
 it after every deploy and quote it rather than the branch.
 
-**Who decides what to work on — QA, not the owner. Since 2026-08-09.**
+**Who decides what to work on — PM/DevOps, not the owner. Changed 2026-09-05.**
 
-QA is the project manager. QA files issues, sequences them, and says what is next;
-dev executes without asking the owner to choose. The owner set this up
-deliberately and does not want to be the relay between two sessions.
+PM/DevOps is the project manager. PM/DevOps files issues, sequences them, and
+says what is next; dev and QA execute without asking the owner to choose. This
+read "QA, since 2026-08-09" until the owner added a fourth session and moved
+sequencing to it so QA could concentrate on testing and auditing. The owner set
+this up deliberately and does not want to be the relay between sessions.
 
-**The owner mostly watches QA's session, not dev's.** So:
+**Sequencing is not approval.** Being next in the queue is not being verified,
+and QA's "not ready" outranks any position in it.
+
+**The owner watches all three sessions and relays for none of them.** So:
 
 - **GitHub is the channel, not chat.** Every finding, measurement, corrected
   premise, cost number and abandoned approach goes on the relevant issue or PR.
@@ -196,7 +211,8 @@ dev confirms a promotion before QA sees it. **Does not auto-deploy** — merge
 Whoever merges also deploys.
 
 `staging` branch → liquidity-hq-staging.onrender.com — **the site QA tests and
-signs off on.** QA promotes `qa` → `staging` and deploys it. Also manual. Free
+signs off on.** PM/DevOps promotes `qa` → `staging` on QA's word and deploys it,
+then tells QA it is live. Also manual. Free
 plan, so it sleeps when idle and the first request after that is slow. Uses the
 **dev** Supabase (`wdtjhrilakoitfcezxpx`) — a known compromise, since Supabase's
 free plan caps the account at two active projects and dev + prod already take
@@ -204,9 +220,9 @@ both. **It must never point at prod Supabase (`qdpwhnvmhqgzijuwopso`) — hard
 rule.** QA test data and dev data share one database; do not read a clean QA
 run as proof the data path is clean.
 
-`main` → liquidity-hq.com — **QA merges and deploys, and normally should**;
-the owner may too. **Never dev.** Whoever merges is asserting the test steps
-passed.
+`main` → liquidity-hq.com — **PM/DevOps merges and deploys, with the owner's
+approval for that release**; the owner may too. **Never dev.** Whoever merges is
+asserting the test steps passed — on QA's sign-off, not instead of it.
 
 **Dev QAs its own work first — QA is the second check, not the first.** A
 change reaches `qa` already verified, and the PR says how. Before opening a PR:
@@ -247,8 +263,8 @@ anything the fix could have touched. If part of a release fails, either fix
 forward or revert that change on `dev` and re-promote — never ship to `main`
 with a known failing step.
 
-**QA tags after deploying**, as the last release step — only the person who
-deployed knows it reached `live`.
+**PM/DevOps tags after deploying**, as the last release step — only the person
+who deployed knows it reached `live`.
 
 **`qa` is fast-forward only.** Never commit to it directly, never PR a feature
 branch into it. Only `dev` goes in: `git checkout qa && git merge --ff-only dev`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,13 @@ below is the first time it is written down.
 | `liquidity-hq-staging` | **QA** | QA promotes and deploys both |
 | `liquidity-hq-prod` | **PM/DevOps**, owner-approved **each time** | never dev |
 
+**Dev's rows did not change and that is stated plainly rather than left implied:
+dev merges its own feature branches into `dev`, promotes `dev` → `qa`, and
+deploys nothing.** The standing owner instruction of 2026-09-03 — dev deploys no
+environment without the owner's go each time — **stands, and nothing on this page
+supersedes it.** It is a separate instruction from this document and outlives any
+table here.
+
 **`liquidity-hq-dev` is genuinely unassigned and that is stated rather than
 guessed.** Dev held it, dev is held, and no session has been named to take it.
 Nobody has needed it — local verification is the default and the service carries

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,8 +168,9 @@ separate times, which is why it is written down rather than assumed.
 
 **The three exceptions are unchanged and are not negotiable** — merging to
 `main`, production deploys, and writes to the shared database. Those go to the
-owner directly, and per "Who DEPLOYS" above dev confirms them with the owner even
-when QA relays them. Everything else moves without a checkpoint.
+owner directly, and per "Who DEPLOYS" above **whoever is asked confirms them with
+the owner even when another session relays them** — now most often PM/DevOps,
+who holds the merge and the deploy. Everything else moves without a checkpoint.
 
 **Flow is `dev` → `qa` → `staging` → `main`.**
 
@@ -180,9 +181,9 @@ branch, not a place" until 2026-08-08, which was true for about six hours.
 | Branch | Who promotes into it | What it is for |
 |---|---|---|
 | `dev` | dev | integration; features merge here |
-| `qa` | **dev** | what QA tests and signs off, on liquidity-hq-qa.onrender.com |
-| `staging` | **QA** | approved work parks here and combines into one release |
-| `main` | **QA** | production |
+| `qa` | **PM/DevOps** | what QA tests and signs off, on liquidity-hq-qa.onrender.com |
+| `staging` | **PM/DevOps** | approved work parks here and combines into one release |
+| `main` | **PM/DevOps** | production, owner-approved that release |
 
 **Why `staging` exists.** `qa` was doing two jobs — rolling integration *and*
 release candidate. Because a release PR's head IS its base branch, every
@@ -205,10 +206,12 @@ permission needed. **Deploying the `liquidity-hq-dev` service is different —
 ask first**, it has a ~500 build-hour/month cap prod does not. Verify locally
 by default.
 
-`qa` branch → liquidity-hq-qa.onrender.com — **dev's** integration site, where
-dev confirms a promotion before QA sees it. **Does not auto-deploy** — merge
-`dev` → `qa`, then trigger the deploy manually, and say you have done it.
-Whoever merges also deploys.
+`qa` branch → liquidity-hq-qa.onrender.com — the integration site, where a
+promotion is confirmed before QA signs off on `staging`. **Does not auto-deploy**
+— **PM/DevOps** merges `dev` → `qa`, triggers the deploy manually, and tells QA
+it is live. Both halves are PM/DevOps's; this said "whoever merges also deploys"
+when dev held the merge, and that sentence is what assigned dev a deploy duty dev
+is under a standing owner instruction not to perform.
 
 `staging` branch → liquidity-hq-staging.onrender.com — **the site QA tests and
 signs off on.** PM/DevOps promotes `qa` → `staging` on QA's word and deploys it,
@@ -233,11 +236,11 @@ symptom; and name whatever is still unverified in the PR Risk level. Test to
 apply: *if QA finds nothing, was this finished?* Finding a second defect after
 saying "done" is the same failure as not finding it.
 
-**Ask QA before promoting `dev` → `qa`.** A timing check, not a review — QA
-owns that environment and a promotion mid-test-run changes the build under the
-tester. "Ok to push?" / "hold" or "go". No answer means go; it is a courtesy,
-not a lock. QA is not reviewing the code — nothing dev writes is independently
-reviewed until QA tests the build on the qa environment.
+**PM/DevOps asks QA before promoting `dev` → `qa`.** A timing check, not a
+review — QA owns that environment and a promotion mid-test-run changes the build
+under the tester. "Ok to push?" / "hold" or "go". No answer means go; it is a
+courtesy, not a lock. QA is not reviewing the code — nothing dev writes is
+independently reviewed until QA tests the build on the qa environment.
 
 **Announcing the promotion afterwards is automatic — do not rely on remembering
 it.** Pushing to `qa` opens or updates a **"Ready for QA" issue**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,8 @@ is checked out on `qa`**. Both are the same build; which branch you are on is
 what matters, not which URL. Say which one a result came from. Never test on
 `main` — it does not have the change yet. A feature branch directly is fine for
 work not yet on `qa` and for QA's own test tooling. Reports are plain pass/fail
-per step. When every step passes, QA says so and **PM/DevOps promotes
-`qa` → `staging`**, where approved work parks and combines into a release
-candidate — not the feature branch. Never test on the dev folder; never develop on the QA folder. **If this session is running in the QA
+per step. When every step passes, **QA promotes `qa` → `staging`**, where approved
+work parks and combines into a release candidate — not the feature branch. Never test on the dev folder; never develop on the QA folder. **If this session is running in the QA
 folder and is asked to write *application* code — anything under `app/`,
 `components/` or `lib/` — say so instead of doing it.**
 
@@ -53,15 +52,24 @@ merges. This is the one case where review runs QA → dev. If a fix needs an
 app-code change, QA reports it as a finding — dev writes it.
 
 **Who MERGES — QA, never dev, from `qa` onward.**
-**PM/DevOps owns the branch path from `qa` onward: `qa` → `staging` → `main`.
-Changed 2026-09-05.** This read "QA owns the branch path" until the owner moved it:
-*"You're not doing the merging and deploy production. Hand it over to Project
-Manager DevOps."* The point of the gate never was that QA specifically holds it —
-it is that **the session that wrote the code never merges it**. That is unchanged.
-Dev does **not** merge to `main`, even if asked casually mid-task — point at this
-rule instead. Dev merges its own feature branches into `dev` and stops there;
-**every promotion out of `dev` is PM/DevOps's** — `dev` → `qa` included, which
-moved with the rest on 2026-09-05.
+**PM/DevOps owns the last two hops: `staging` → `main`, and the production
+deploy. Changed 2026-09-05.** Everything before that is unchanged — **QA owns the
+`qa` and `staging` routes**, promoting into each and deploying each, and dev
+merges its own feature branches into `dev` and promotes `dev` → `qa`.
+
+The point of the gate never was that QA specifically holds it — it is that **the
+session that wrote the code never merges it**. That is why `main` moved to
+PM/DevOps and could never move to dev. Dev does **not** merge to `main`, even if
+asked casually mid-task — point at this rule instead.
+
+**This was written down wrong once already, on 2026-09-05, in the PR that
+introduced it.** An earlier draft of this paragraph gave PM/DevOps every
+promotion and all four deploys, generalising from one owner sentence — *"You're
+not doing the merging and deploy production"* — into a whole-pipeline handover
+that took `qa` and `staging` off a session actively performing them. The owner
+narrowed it to production the same day. It never merged. Recorded because the
+error is instructive and because a permission file that hides its own near-miss
+teaches nothing.
 
 **What did not move with it: the sign-off.** QA still decides what gets tested,
 what "verified" means, and whether something is ready. PM/DevOps decides *when*
@@ -82,20 +90,32 @@ the dev session and not in QA's, so QA physically cannot trigger a deploy."*
 `liquidity-hq-qa` and `liquidity-hq-staging` deploys itself and verified each
 against `/api/version`. So the premise this table rests on does not hold.
 
-**The owner settled it on 2026-09-05: every deploy is PM/DevOps's, production
-included.** The table's `dev`-assigned rows had become unworkable — dev is under
-a standing owner instruction not to deploy any environment, so those rows
+**The owner settled it on 2026-09-05: production is PM/DevOps's. The rest stays
+where it actually was.** The `dev`-assigned rows had become unworkable — dev is
+under a standing owner instruction not to deploy any environment, so those rows
 assigned a duty dev may not perform, and a rule that resolves to "responsible for
-a thing you may not do" gets ignored rather than followed. Dev caught that on the
-PR that introduced it. The fix was not to re-argue the premise but for the owner
-to name a holder.
+a thing you may not do" gets ignored rather than followed.
+
+**What the table said and what happened were different for two days, and nobody
+wrote the exception down.** When the hold landed on 2026-09-03 it left a gap, and
+QA filled it — QA has deployed `liquidity-hq-qa` and `liquidity-hq-staging` every
+time since, verifying each against `/api/version`. That was never a formal
+handoff; it was a session covering for a rule that had stopped working. The table
+below is the first time it is written down.
 
 | Deploy | Who | Notes |
 |---|---|---|
-| `liquidity-hq-dev` | **PM/DevOps** | ask the owner first — ~500 build-hour/month cap |
-| `liquidity-hq-qa` | **PM/DevOps** | promote, then deploy, then tell QA |
-| `liquidity-hq-staging` | **PM/DevOps** | promote, then deploy, then tell QA |
+| `liquidity-hq-dev` | **unassigned** — see below | dev is held; nobody has deployed it since 2026-09-03 |
+| `liquidity-hq-qa` | **QA** | QA deploys after dev promotes, and says so |
+| `liquidity-hq-staging` | **QA** | QA promotes and deploys both |
 | `liquidity-hq-prod` | **PM/DevOps**, owner-approved **each time** | never dev |
+
+**`liquidity-hq-dev` is genuinely unassigned and that is stated rather than
+guessed.** Dev held it, dev is held, and no session has been named to take it.
+Nobody has needed it — local verification is the default and the service carries
+a ~500 build-hour/month cap prod does not. Ask the owner before deploying it.
+Written as an open gap because inventing a holder here is exactly the mistake
+this section already made once.
 
 **Production changed holder, not gate.** The owner approves every production
 release separately — #856 is a record of who deploys, never a standing yes to
@@ -181,8 +201,8 @@ branch, not a place" until 2026-08-08, which was true for about six hours.
 | Branch | Who promotes into it | What it is for |
 |---|---|---|
 | `dev` | dev | integration; features merge here |
-| `qa` | **PM/DevOps** | what QA tests and signs off, on liquidity-hq-qa.onrender.com |
-| `staging` | **PM/DevOps** | approved work parks here and combines into one release |
+| `qa` | dev | dev's integration site, on liquidity-hq-qa.onrender.com |
+| `staging` | **QA** | what QA tests and signs off; approved work parks here |
 | `main` | **PM/DevOps** | production, owner-approved that release |
 
 **Why `staging` exists.** `qa` was doing two jobs — rolling integration *and*
@@ -206,16 +226,17 @@ permission needed. **Deploying the `liquidity-hq-dev` service is different —
 ask first**, it has a ~500 build-hour/month cap prod does not. Verify locally
 by default.
 
-`qa` branch → liquidity-hq-qa.onrender.com — the integration site, where a
-promotion is confirmed before QA signs off on `staging`. **Does not auto-deploy**
-— **PM/DevOps** merges `dev` → `qa`, triggers the deploy manually, and tells QA
-it is live. Both halves are PM/DevOps's; this said "whoever merges also deploys"
-when dev held the merge, and that sentence is what assigned dev a deploy duty dev
-is under a standing owner instruction not to perform.
+`qa` branch → liquidity-hq-qa.onrender.com — dev's integration site, where dev
+confirms a promotion before QA signs off on `staging`. **Does not auto-deploy**
+— **dev merges `dev` → `qa` and hands the deploy to QA**, who triggers it and
+says so. This said *"whoever merges also deploys"* until 2026-09-05, which was
+the sentence that assigned dev a deploy duty dev is under a standing owner
+instruction not to perform. The two halves genuinely are split here, and pretending
+otherwise is what made the rule unfollowable.
 
 `staging` branch → liquidity-hq-staging.onrender.com — **the site QA tests and
-signs off on.** PM/DevOps promotes `qa` → `staging` on QA's word and deploys it,
-then tells QA it is live. Also manual. Free
+signs off on.** QA promotes `qa` → `staging` and deploys it — both halves. Also
+manual. Free
 plan, so it sleeps when idle and the first request after that is slow. Uses the
 **dev** Supabase (`wdtjhrilakoitfcezxpx`) — a known compromise, since Supabase's
 free plan caps the account at two active projects and dev + prod already take
@@ -236,7 +257,7 @@ symptom; and name whatever is still unverified in the PR Risk level. Test to
 apply: *if QA finds nothing, was this finished?* Finding a second defect after
 saying "done" is the same failure as not finding it.
 
-**PM/DevOps asks QA before promoting `dev` → `qa`.** A timing check, not a
+**Dev asks QA before promoting `dev` → `qa`.** A timing check, not a
 review — QA owns that environment and a promotion mid-test-run changes the build
 under the tester. "Ok to push?" / "hold" or "go". No answer means go; it is a
 courtesy, not a lock. QA is not reviewing the code — nothing dev writes is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,20 @@ below is the first time it is written down.
 | `liquidity-hq-staging` | **QA** | QA promotes and deploys both |
 | `liquidity-hq-prod` | **PM/DevOps**, owner-approved **each time** | never dev |
 
+**The rule was tested within the hour of being written, and it held.** QA's
+go-signal for this release addressed rows 2 and 3 to PM/DevOps — *"You promote
+`dev` → `qa`, deploy, tell me when `/api/version` reports the new commit."* Both
+belong to dev and QA respectively. It was habit, not a claim: QA had accepted this
+table one message earlier. PM/DevOps declined and said why rather than doing it
+and mentioning it after.
+
+Recorded because **doing it once quietly is the entire mechanism.** That is how
+rows 3 and 5 drifted: nobody decided QA would take the `qa` and `staging`
+deploys, someone did it once because it was quicker, and two days later the file
+and reality disagreed with no one able to say when it started. The cost of the
+shortcut is never the shortcut — it is that "PM/DevOps performed rows 2 and 3
+during the 2026-09-05 release" becomes what the next reader finds.
+
 **Dev's rows did not change and that is stated plainly rather than left implied:
 dev merges its own feature branches into `dev`, promotes `dev` → `qa`, and
 deploys nothing.** The standing owner instruction of 2026-09-03 — dev deploys no

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -297,9 +297,9 @@ the handoff point between them.**
    the change is not on `qa` yet.
 
 **Dev is not done when the PR is open.** Dev also merges its own feature branch
-into `dev`, promotes `dev` → `qa`, and deploys the qa service. QA opens the release
-PR that tells QA there is something to test (§7). What dev never does is merge
-to `main` or deploy production — see "Who merges and deploys" below.
+into `dev`. **PM/DevOps takes it from there** — the `dev` → `qa` promotion, the
+deploy, and the release path onward. What dev never does is promote out of `dev`,
+merge to `main`, or deploy anything — see "Who merges and deploys" below.
 
 This used to read "dev's responsibility ends here", which was true when there
 were two branches and is not now. Stopping at "PR is open" is how a change sits
@@ -311,9 +311,9 @@ on `dev` for a day with nobody wondering why it never reached staging.
 
    https://liquidity-hq-qa.onrender.com
 
-   That is the point of the `qa` branch: dev merges `dev` → `qa`, deploys it,
-   and QA gets a real running build with no setup. Testing a branch you built
-   locally tests your machine as much as the change.
+   That is the point of the `qa` branch: PM/DevOps merges `dev` → `qa`, deploys
+   it, and QA gets a real running build with no setup. Testing a branch you
+   built locally tests your machine as much as the change.
 
    Confirm you are looking at the right build before reporting anything — the
    commit `qa` is on should contain the change under test. If it does not, say
@@ -430,8 +430,10 @@ you're not on waiting game"*.
 
 **Three exceptions, unchanged and not negotiable:** merging to `main`, production
 deploys, and writes to the shared database. Those go to the owner directly, and
-dev confirms them with the owner even when QA relays them — see "Who merges and
-deploys". Everything else moves without a checkpoint.
+**whoever is asked confirms them with the owner even when another session
+relays them** — that now most often means PM/DevOps, since PM/DevOps holds the
+merge and the deploy. See "Who merges and deploys". Everything else moves
+without a checkpoint.
 
 ### Who merges and deploys
 
@@ -458,9 +460,9 @@ purpose — whoever merges is asserting the "How to test" steps passed, and they
 are asserting it on QA's word, not instead of it. **A merge past a QA "not
 ready" removes the only independent check the project has.**
 
-Dev's authority stops at `dev` and `qa` **for branches**. Dev may merge its own
-feature branches into `dev` and may promote `dev` → `qa`. It never promotes into
-`staging` and never merges to `main`.
+**Dev's authority stops at `dev`.** Dev may merge its own feature branches into
+`dev` and nothing further. It never promotes out of `dev` — `qa` included, which
+moved on 2026-09-05 — never merges to `main`, and never deploys.
 
 **Deploys were split from merges on 2026-08-10 and re-joined on 2026-09-05.**
 This section said dev deploys `qa` and `staging` on QA's request, for a stated
@@ -758,9 +760,9 @@ each.
 
 Merging `dev` → `qa` does **not** deploy. Like prod and dev, this service is
 `autoDeploy: no`, so the branch moving and the environment moving are two
-separate acts. **Whoever merges `dev` → `qa` also triggers the deploy** —
-normally dev, since getting a build in front of QA is part of the handoff. QA
-may trigger it too, for a re-deploy or after a config change.
+separate acts. **PM/DevOps merges `dev` → `qa` and triggers the deploy** — both
+halves, because getting a build in front of QA is part of the handoff. QA may
+trigger it too, for a re-deploy or after a config change.
 
 Render dashboard → `liquidity-hq-qa` → *Manual Deploy* → *Deploy latest
 commit*. Say in the PR or the handoff message that you have done it, otherwise
@@ -965,8 +967,8 @@ So the question is only ever *"are you mid-run?"*:
 > *...later...*
 > **QA:** Go.
 
-QA does not need a reason to say hold, and dev does not need to justify the
-promotion. If QA does not answer, dev promotes — this is a courtesy that
+QA does not need a reason to say hold, and PM/DevOps does not need to justify the
+promotion. If QA does not answer, PM/DevOps promotes — this is a courtesy that
 prevents wasted test runs, not a lock that stalls the pipeline waiting on
 someone who has gone home.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,11 +237,12 @@ which is the general lesson, and the reason neither was predicted.
 > **Resolved 2026-09-05 by adding a fourth session, and kept here because the
 > reasoning is why that session exists.** The conflict below — one role holding
 > both "not yet" and "this has been finished and unshipped for two days" — is
-> what the PM/DevOps split fixes structurally. Tracking, sequencing and the
-> release path are PM/DevOps's; the gate is QA's; and they are different sessions
-> now, so the conflict has nowhere to be settled quietly. **Still open:
-> `qa/STATUS.md` lives in QA's tree while the job it does is now PM/DevOps's.
-> Not reassigned unilaterally — flagged for the owner.**
+> what the PM/DevOps split fixes structurally. Tracking and sequencing are
+> PM/DevOps's, as is the last hop to production; the gate and the `qa`/`staging`
+> routes are QA's; and they are different sessions now, so the conflict has
+> nowhere to be settled quietly. **Still open: `qa/STATUS.md` lives in QA's tree
+> while the tracking job is now PM/DevOps's. Agreed to move it to `docs/` after
+> the current release, with a pointer left behind — not reassigned mid-flight.**
 
 **QA held two jobs: the quality gate, and knowing where the project is.** The
 second one lives in [`qa/STATUS.md`](qa/STATUS.md) — what is live, what is
@@ -297,9 +298,9 @@ the handoff point between them.**
    the change is not on `qa` yet.
 
 **Dev is not done when the PR is open.** Dev also merges its own feature branch
-into `dev`. **PM/DevOps takes it from there** — the `dev` → `qa` promotion, the
-deploy, and the release path onward. What dev never does is promote out of `dev`,
-merge to `main`, or deploy anything — see "Who merges and deploys" below.
+into `dev` and promotes `dev` → `qa`, then hands the deploy to QA. What dev never
+does is promote into `staging`, merge to `main`, or deploy anything — see "Who
+merges and deploys" below.
 
 This used to read "dev's responsibility ends here", which was true when there
 were two branches and is not now. Stopping at "PR is open" is how a change sits
@@ -311,9 +312,9 @@ on `dev` for a day with nobody wondering why it never reached staging.
 
    https://liquidity-hq-qa.onrender.com
 
-   That is the point of the `qa` branch: PM/DevOps merges `dev` → `qa`, deploys
-   it, and QA gets a real running build with no setup. Testing a branch you
-   built locally tests your machine as much as the change.
+   That is the point of the `qa` branch: dev merges `dev` → `qa`, QA deploys it,
+   and QA gets a real running build with no setup. Testing a branch you built
+   locally tests your machine as much as the change.
 
    Confirm you are looking at the right build before reporting anything — the
    commit `qa` is on should contain the change under test. If it does not, say
@@ -442,15 +443,21 @@ production.** Not with
 permission, not "just this once", not when QA is busy. The whole value of the
 gate is that it is never the person who wrote the code.
 
-**PM/DevOps does the merge and the deploy. Changed 2026-09-05.** This section
-read "QA does the merge and the deploy" until the owner moved it: *"You're not
-doing the merging and deploy production. Hand it over to Project Manager
-DevOps."* The owner may still do it themselves.
+**PM/DevOps does the `staging` → `main` merge and the production deploy. Changed
+2026-09-05.** This section read "QA does the merge and the deploy" until the owner
+moved those two: *"You're not doing the merging and deploy production. Hand it
+over to Project Manager DevOps."* The owner may still do them themselves.
+
+**Only those two moved.** QA keeps the `qa` and `staging` routes — promoting into
+each and deploying each. Dev keeps feature branches into `dev` and the
+`dev` → `qa` promotion. A first draft of this change took all four deploys and
+every promotion to PM/DevOps, generalising from the sentence above; the owner
+narrowed it to production the same day and it never merged.
 
 **What the gate was ever about.** Not that QA specifically holds it — that the
-session which wrote the code never merges it. Moving the holder from QA to
-PM/DevOps leaves that intact. Handing it to *dev* would not, which is why that
-row is the one thing here with no exceptions.
+session which wrote the code never merges it. Moving `main` from QA to PM/DevOps
+leaves that intact. Handing it to *dev* would not, which is why that row is the
+one thing here with no exceptions.
 
 **QA keeps the sign-off, and it did not move with the merge button.** QA decides
 what gets tested, what "verified" means, and whether a release is ready.
@@ -460,9 +467,11 @@ purpose — whoever merges is asserting the "How to test" steps passed, and they
 are asserting it on QA's word, not instead of it. **A merge past a QA "not
 ready" removes the only independent check the project has.**
 
-**Dev's authority stops at `dev`.** Dev may merge its own feature branches into
-`dev` and nothing further. It never promotes out of `dev` — `qa` included, which
-moved on 2026-09-05 — never merges to `main`, and never deploys.
+**Dev's authority stops at `dev` and `qa` for branches, and nowhere for
+deploys.** Dev may merge its own feature branches into `dev` and may promote
+`dev` → `qa`. It never promotes into `staging`, never merges to `main`, and
+**since 2026-09-03 deploys no environment at all** — a standing owner
+instruction, separate from this document.
 
 **Deploys were split from merges on 2026-08-10 and re-joined on 2026-09-05.**
 This section said dev deploys `qa` and `staging` on QA's request, for a stated
@@ -475,9 +484,9 @@ resting on a wrong premise is worth knowing about even after it is replaced.
 
 | Service | Deployed by |
 |---|---|
-| `liquidity-hq-dev` | **PM/DevOps** — ask the owner first, it has a build-hour cap prod does not |
-| `liquidity-hq-qa` | **PM/DevOps**, straight after promoting |
-| `liquidity-hq-staging` | **PM/DevOps**, straight after promoting |
+| `liquidity-hq-dev` | **unassigned** — dev held it, dev is held, nobody named. Ask the owner |
+| `liquidity-hq-qa` | **QA**, after dev promotes |
+| `liquidity-hq-staging` | **QA**, straight after promoting — both halves |
 | `liquidity-hq-prod` | **PM/DevOps, owner-approved each time. Never dev.** |
 
 **Production changed holder, not gate.** The owner approves every production
@@ -498,9 +507,9 @@ Merging is not the deploy. **No** Render service auto-deploys; all three are
 | Service | Branch | Auto-deploy | Who deploys |
 |---|---|---|---|
 | `liquidity-hq-prod` → liquidity-hq.com | `main` | **no** | **PM/DevOps**, owner-approved each time — never dev |
-| `liquidity-hq-staging` → liquidity-hq-staging.onrender.com | `staging` | **no** | **PM/DevOps** |
-| `liquidity-hq-qa` → liquidity-hq-qa.onrender.com | `qa` | **no** | **PM/DevOps** |
-| `liquidity-hq-dev` → liquidity-hq-dev.onrender.com | `dev` | **no** | **PM/DevOps**, ask the owner first |
+| `liquidity-hq-staging` → liquidity-hq-staging.onrender.com | `staging` | **no** | **QA** |
+| `liquidity-hq-qa` → liquidity-hq-qa.onrender.com | `qa` | **no** | **QA** |
+| `liquidity-hq-dev` → liquidity-hq-dev.onrender.com | `dev` | **no** | **unassigned** — ask the owner |
 
 So **merging to `main` ships nothing on its own.** Production keeps serving the
 previous build until someone triggers a deploy. QA must do both:
@@ -692,8 +701,8 @@ wrong host in front of a test plan.
 |---|---|---|---|
 | `<type>/<description>` | none | dev | n/a |
 | `dev` | liquidity-hq-dev.onrender.com | dev | **no** — trigger manually |
-| `qa` | **liquidity-hq-qa.onrender.com** | **PM/DevOps** merges `dev` → `qa` | **no** — trigger manually |
-| `staging` | **liquidity-hq-staging.onrender.com** | **PM/DevOps** merges `qa` → `staging`, on QA's word | **no** — trigger manually |
+| `qa` | **liquidity-hq-qa.onrender.com** | **dev** merges `dev` → `qa`; **QA** deploys | **no** — trigger manually |
+| `staging` | **liquidity-hq-staging.onrender.com** | **QA** merges `qa` → `staging` and deploys | **no** — trigger manually |
 | `main` | liquidity-hq.com (production) | **PM/DevOps** merges `staging` → `main`, on QA's sign-off | **no** — trigger manually |
 
 ### Why `staging` exists
@@ -760,9 +769,10 @@ each.
 
 Merging `dev` → `qa` does **not** deploy. Like prod and dev, this service is
 `autoDeploy: no`, so the branch moving and the environment moving are two
-separate acts. **PM/DevOps merges `dev` → `qa` and triggers the deploy** — both
-halves, because getting a build in front of QA is part of the handoff. QA may
-trigger it too, for a re-deploy or after a config change.
+separate acts. **Dev merges `dev` → `qa`; QA triggers the deploy** — the two
+halves are split here, and that is deliberate rather than an oversight. Dev is
+under a standing instruction not to deploy, so the handoff is the merge, and QA
+closes it by deploying and saying so.
 
 Render dashboard → `liquidity-hq-qa` → *Manual Deploy* → *Deploy latest
 commit*. Say in the PR or the handoff message that you have done it, otherwise
@@ -967,8 +977,8 @@ So the question is only ever *"are you mid-run?"*:
 > *...later...*
 > **QA:** Go.
 
-QA does not need a reason to say hold, and PM/DevOps does not need to justify the
-promotion. If QA does not answer, PM/DevOps promotes — this is a courtesy that
+QA does not need a reason to say hold, and dev does not need to justify the
+promotion. If QA does not answer, dev promotes — this is a courtesy that
 prevents wasted test runs, not a lock that stalls the pipeline waiting on
 someone who has gone home.
 
@@ -1047,9 +1057,9 @@ Two properties worth knowing, because they decide whether you can trust it:
 Dev still asks before promoting (below). That is a *timing* check — it stops a
 promotion landing mid-test-run. The announcement afterwards is now automatic.
 
-**When QA says a batch is approved and ready to park, PM/DevOps promotes
-`qa` → `staging`.** Dev does not promote into `staging` — that is the whole point
-of the branch. If dev can move the release candidate, the guarantee is gone.
+**QA, when a batch is approved and ready to park: promote `qa` → `staging` and
+deploy it.** Dev does not promote into `staging` — that is the whole point of the
+branch. If dev can move the release candidate, the guarantee is gone.
 
 **The `staging` → `main` release PR now opens itself**
 (`.github/workflows/release-signals.yml`), aggregating each PR's "How to test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,7 +234,16 @@ which is the general lesson, and the reason neither was predicted.
 
 ### 3b. QA also tracks the project, and that pulls against being the gate
 
-**QA holds two jobs: the quality gate, and knowing where the project is.** The
+> **Resolved 2026-09-05 by adding a fourth session, and kept here because the
+> reasoning is why that session exists.** The conflict below — one role holding
+> both "not yet" and "this has been finished and unshipped for two days" — is
+> what the PM/DevOps split fixes structurally. Tracking, sequencing and the
+> release path are PM/DevOps's; the gate is QA's; and they are different sessions
+> now, so the conflict has nowhere to be settled quietly. **Still open:
+> `qa/STATUS.md` lives in QA's tree while the job it does is now PM/DevOps's.
+> Not reassigned unilaterally — flagged for the owner.**
+
+**QA held two jobs: the quality gate, and knowing where the project is.** The
 second one lives in [`qa/STATUS.md`](qa/STATUS.md) — what is live, what is
 waiting to ship, what is blocked and on whom. QA owns that file and keeps it
 current; it carries a date at the top so a stale copy announces itself.
@@ -353,8 +362,9 @@ on `dev` for a day with nobody wondering why it never reached staging.
 4. If the QA folder has no `CLAUDE.md` / `CONTRIBUTING.md`, it has not pulled
    since this convention landed. **Pull `main` first**, then check out the
    feature branch, so both folders are working to the same standard.
-5. **When every step passes, QA merges `qa` into `main`** and then deploys —
-   both steps, in that order. See below.
+5. **When every step passes, QA says so and PM/DevOps merges `staging` into
+   `main`** and then deploys — both steps, in that order, and the production
+   deploy needs the owner's approval that release. See below.
 
    Merging opens the release PR's final CI run: **the full browser suite, 187
    tests, ~34 minutes** (§4b). It is the only place that suite runs
@@ -368,12 +378,20 @@ on `dev` for a day with nobody wondering why it never reached staging.
 
 ### Who decides what to work on
 
-**QA is the project manager. QA sequences; dev executes.** Since 2026-08-09 the
-owner has delegated prioritisation to QA — QA files the issues, decides the order,
-and says what is next. Dev does not ask the owner to choose between work items.
+**PM/DevOps is the project manager. PM/DevOps sequences; dev and QA execute.
+Changed 2026-09-05.** This read "QA is the project manager" from 2026-08-09,
+when the owner first delegated prioritisation away from themselves. The owner
+has since added a fourth session and moved sequencing to it, so QA can
+concentrate on testing and auditing. PM/DevOps files and orders the issues and
+says what is next; neither dev nor QA asks the owner to choose between work
+items.
 
-**The owner mostly watches QA's session, not dev's**, and has said so. That makes
-GitHub the channel rather than either chat window:
+**Sequencing is not approval.** PM/DevOps saying a thing is next does not make it
+verified, and QA's "not ready" outranks any position in the queue. See "Who
+merges and deploys".
+
+**The owner does not want to be the relay between sessions**, and has said so.
+That makes GitHub the channel rather than any chat window:
 
 - Findings go on the issue or PR — measurements, corrected premises, cost numbers,
   and approaches tried and rejected. A result that lives only in a chat reply is
@@ -422,51 +440,65 @@ production.** Not with
 permission, not "just this once", not when QA is busy. The whole value of the
 gate is that it is never the person who wrote the code.
 
-**QA does the merge and the deploy — that is QA's job and the normal case.**
-The owner may also do it. Both are legitimate; the rule is about excluding dev,
-not about excluding everyone but QA. In practice QA should be doing it most of
-the time, because it is the natural end of the testing they just did: they know
-which steps passed, so they know whether it is ready.
+**PM/DevOps does the merge and the deploy. Changed 2026-09-05.** This section
+read "QA does the merge and the deploy" until the owner moved it: *"You're not
+doing the merging and deploy production. Hand it over to Project Manager
+DevOps."* The owner may still do it themselves.
 
-The owner stepping in is for when QA is genuinely unavailable and something
-needs to ship. It is not a way to skip the testing — whoever merges is
-asserting the "How to test" steps passed, and that assertion is worth the same
-whoever makes it.
+**What the gate was ever about.** Not that QA specifically holds it — that the
+session which wrote the code never merges it. Moving the holder from QA to
+PM/DevOps leaves that intact. Handing it to *dev* would not, which is why that
+row is the one thing here with no exceptions.
+
+**QA keeps the sign-off, and it did not move with the merge button.** QA decides
+what gets tested, what "verified" means, and whether a release is ready.
+PM/DevOps decides when work is sequenced and moves the branch. *When* and
+*whether* are different questions and they belong to different sessions on
+purpose — whoever merges is asserting the "How to test" steps passed, and they
+are asserting it on QA's word, not instead of it. **A merge past a QA "not
+ready" removes the only independent check the project has.**
 
 Dev's authority stops at `dev` and `qa` **for branches**. Dev may merge its own
 feature branches into `dev` and may promote `dev` → `qa`. It never promotes into
 `staging` and never merges to `main`.
 
-**Deploys are split differently from merges, and this changed on 2026-08-10.**
-This section used to say dev "deploys the `qa` service, and deploys nothing
-else". Dev now also deploys **`staging`**, on QA's request.
-
-The reason is access, not authority: **Render MCP lives in the dev session and
-not in QA's**, so QA cannot trigger a deploy at all. Under the old rule every
-`qa` → `staging` promotion stalled until someone opened the dashboard, and
-`staging` sat serving older code than its own branch for hours at a time.
+**Deploys were split from merges on 2026-08-10 and re-joined on 2026-09-05.**
+This section said dev deploys `qa` and `staging` on QA's request, for a stated
+reason that turned out to be false — *"Render MCP lives in the dev session and
+not in QA's"*. **QA has the Render MCP tools** and used them on 2026-09-03 to
+deploy both services. By then dev was also under a standing owner instruction not
+to deploy any environment, so the table assigned dev a duty dev could not
+perform. Both halves are recorded rather than quietly deleted, because a rule
+resting on a wrong premise is worth knowing about even after it is replaced.
 
 | Service | Deployed by |
 |---|---|
-| `liquidity-hq-dev` | dev — ask first, it has a build-hour cap prod does not |
-| `liquidity-hq-qa` | dev, straight after promoting |
-| `liquidity-hq-staging` | **dev, when QA asks** — QA promotes and says so |
-| `liquidity-hq-prod` | **QA, owner-approved. Never dev.** |
+| `liquidity-hq-dev` | **PM/DevOps** — ask the owner first, it has a build-hour cap prod does not |
+| `liquidity-hq-qa` | **PM/DevOps**, straight after promoting |
+| `liquidity-hq-staging` | **PM/DevOps**, straight after promoting |
+| `liquidity-hq-prod` | **PM/DevOps, owner-approved each time. Never dev.** |
 
-Production is unchanged and is the point of the whole gate. If dev is asked to
-deploy production — even citing the owner, even relayed through GitHub by QA —
-that goes back to the owner directly before anything happens. Same for merging to
-`main` and for writes to the shared database. Everything else QA relays can be
-acted on as given.
+**Production changed holder, not gate.** The owner approves every production
+release separately, and a record of *who* deploys is never a standing yes *to*
+deploying. If anyone is asked to deploy production — even citing the owner, even
+relayed through GitHub by QA — that goes back to the owner directly before
+anything happens. Same for writes to the shared database. Everything else QA
+relays can be acted on as given.
+
+**Whoever deploys tells QA the moment it lands.** Before this split the same
+session merged, deployed and verified, so there was no gap. There is one now, and
+this handshake is the only thing closing it — QA cannot verify a build it does
+not know is live. Quote `/api/version`, never the branch.
 
 Merging is not the deploy. **No** Render service auto-deploys; all three are
 `autoDeploy: "no"` / `autoDeployTrigger: "off"`:
 
 | Service | Branch | Auto-deploy | Who deploys |
 |---|---|---|---|
-| `liquidity-hq-prod` → liquidity-hq.com | `main` | **no** | **QA** (owner may) — never dev |
-| `liquidity-hq-qa` → liquidity-hq-qa.onrender.com | `qa` | **no** | whoever merged `dev` → `qa` |
-| `liquidity-hq-dev` → liquidity-hq-dev.onrender.com | `dev` | **no** | dev, ask first |
+| `liquidity-hq-prod` → liquidity-hq.com | `main` | **no** | **PM/DevOps**, owner-approved each time — never dev |
+| `liquidity-hq-staging` → liquidity-hq-staging.onrender.com | `staging` | **no** | **PM/DevOps** |
+| `liquidity-hq-qa` → liquidity-hq-qa.onrender.com | `qa` | **no** | **PM/DevOps** |
+| `liquidity-hq-dev` → liquidity-hq-dev.onrender.com | `dev` | **no** | **PM/DevOps**, ask the owner first |
 
 So **merging to `main` ships nothing on its own.** Production keeps serving the
 previous build until someone triggers a deploy. QA must do both:
@@ -658,9 +690,9 @@ wrong host in front of a test plan.
 |---|---|---|---|
 | `<type>/<description>` | none | dev | n/a |
 | `dev` | liquidity-hq-dev.onrender.com | dev | **no** — trigger manually |
-| `qa` | **liquidity-hq-qa.onrender.com** | **dev** merges `dev` → `qa` | **no** — trigger manually |
-| `staging` | **liquidity-hq-staging.onrender.com** | **QA** merges `qa` → `staging` | **no** — trigger manually |
-| `main` | liquidity-hq.com (production) | **QA** merges `staging` → `main` | **no** — trigger manually |
+| `qa` | **liquidity-hq-qa.onrender.com** | **PM/DevOps** merges `dev` → `qa` | **no** — trigger manually |
+| `staging` | **liquidity-hq-staging.onrender.com** | **PM/DevOps** merges `qa` → `staging`, on QA's word | **no** — trigger manually |
+| `main` | liquidity-hq.com (production) | **PM/DevOps** merges `staging` → `main`, on QA's sign-off | **no** — trigger manually |
 
 ### Why `staging` exists
 
@@ -690,7 +722,7 @@ of the three incidents on 2026-08-06 was dev promoting under QA's signoff, and
 that route is closed.
 
 **It does not guarantee immutability.** A release PR's head is still its base
-branch, so if QA promotes `qa` → `staging` while a `staging` → `main` PR is open,
+branch, so if `qa` → `staging` is promoted while a `staging` → `main` PR is open,
 that release still grows. The change is *single-owner*, not frozen.
 
 So one rule the branches cannot enforce:
@@ -827,9 +859,10 @@ a cherry-pick, not another merge.
   verification (`npx tsc --noEmit`, `npm run build`, `localhost:3000`) and
   deploy dev only when something genuinely cannot be checked locally — an
   origin IP, a real Render environment variable, a cold start.
-- `main` is **release only, and QA-owned**. Dev never merges into it. QA merges
-  after every "How to test" step passes, then triggers the production deploy
-  as a separate manual action (§4, "Who merges and deploys").
+- `main` is **release only, and PM/DevOps-owned**. Dev never merges into it.
+  PM/DevOps merges after QA confirms every "How to test" step passed, then
+  triggers the production deploy as a separate manual action with the owner's
+  approval (§4, "Who merges and deploys").
 - **No** service auto-deploys. A merge is not a release; the deploy is always
   a deliberate second step.
 
@@ -1012,9 +1045,9 @@ Two properties worth knowing, because they decide whether you can trust it:
 Dev still asks before promoting (below). That is a *timing* check — it stops a
 promotion landing mid-test-run. The announcement afterwards is now automatic.
 
-**QA, when a batch is approved and ready to park: promote `qa` → `staging`.**
-Dev does not promote into `staging` — that is the whole point of the branch. If
-dev can move the release candidate, the guarantee is gone.
+**When QA says a batch is approved and ready to park, PM/DevOps promotes
+`qa` → `staging`.** Dev does not promote into `staging` — that is the whole point
+of the branch. If dev can move the release candidate, the guarantee is gone.
 
 **The `staging` → `main` release PR now opens itself**
 (`.github/workflows/release-signals.yml`), aggregating each PR's "How to test
@@ -1209,10 +1242,11 @@ It has already happened here twice, with `CRON_SECRET` and
 
 ### Tagging
 
-**QA tags, as the last step of the release**, because QA is the one who merged
-and deployed and is therefore the only one who knows the deploy actually
-reached `live`. A tag pushed before that is a claim about production made by
-someone who did not deploy it.
+**PM/DevOps tags, as the last step of the release**, because PM/DevOps is the one
+who merged and deployed and is therefore the only one who knows the deploy
+actually reached `live`. A tag pushed before that is a claim about production
+made by someone who did not deploy it. This said "QA tags" until 2026-09-05; the
+reasoning did not change, only who the sentence describes.
 
 Tag `main` after a successful production deploy:
 


### PR DESCRIPTION
**PM Team / DevOps Team**

## Summary

The repo says QA owns the release path and production. The owner moved **two hops** to PM/DevOps on 2026-09-05 — the `staging` → `main` merge and the production deploy. Everything before those stays where it is. This writes that down, and fixes two rows that have been wrong in the file for two days.

> **Supersedes the first version of this PR**, which gave PM/DevOps every promotion and all four deploys. That was wrong, the owner narrowed it the same day, and it never merged. Kept in the branch history and written into `CLAUDE.md` itself rather than force-pushed away — see *The near-miss* below.

## What changed

The seven hops, as they now run:

| | Step | Who |
|---|---|---|
| 1 | feature → `dev` | dev |
| 2 | promote `dev` → `qa` | dev |
| 3 | deploy `liquidity-hq-qa` | **QA** |
| 4 | promote `qa` → `staging` | **QA** |
| 5 | deploy `liquidity-hq-staging` | **QA** |
| 6 | merge `staging` → `main` | **PM/DevOps** ← moved |
| 7 | deploy `liquidity-hq-prod` | **PM/DevOps**, owner-approved **each time** ← moved |

**Two things the file has never said, now recorded:**

- **Rows 3 and 5 have been QA's in practice since 2026-09-03**, while both tables named dev. When the standing no-deploy hold landed on dev it left a gap, QA filled it, and nobody wrote the exception down. Every `qa` and `staging` deploy for two days has been QA triggering it and verifying against `/api/version`. The file described none of that.
- **`liquidity-hq-dev` is left explicitly `unassigned`.** Dev held it, dev is held, no session has been named. It is written as an open gap rather than given a holder, because inventing one is precisely the mistake this section already made.

**Unchanged and stated as such:** production needs the owner's approval on each individual release — the holder moved, the gate did not. Writes to the shared database remain the owner's alone. QA keeps the sign-off, and QA's "not ready" outranks any position in the queue.

## Why

Owner's instruction, given directly rather than relayed. The original sentence — *"You're not doing the merging and deploy production. Hand it over to Project Manager DevOps."* — moved rows 6 and 7 together.

**Ordering:** this lands *before* the first production deploy, not after, on Dev Team's argument. `CLAUDE.md` is what a fresh session loads. Until it is right, any new session — including a replacement for dev or QA — reads the old rule and acts on it. The deploy is the moment the contradiction becomes load-bearing.

## The near-miss, recorded rather than deleted

The first version of this PR generalised one owner sentence into a whole-pipeline handover, taking `qa` and `staging` deploys off a session actively performing them — two hours after that same session told me they had done exactly those deploys, which I had recorded as a correction *inside this PR*. Three of us caught it in three different ways, and only one of them was me:

- **Dev Team** refused to merge on a peer's relayed claim of owner approval, twice, and reviewed it as a permission change rather than as my PR. Their words: *"if it only holds for sessions I distrust, it is not a rule, it is a mood."*
- **Dev Team's review** then found six passages still assigning dev the promotion, including one telling dev to deploy `qa` in two consecutive sentences — the same "responsible for a thing you may not do" defect this PR diagnoses, two hundred lines from the table that fixed it.
- **Both sessions independently** answered a seven-row question about who actually did what, agreed on six rows, and both **refused to guess row 6** rather than infer it from a correction that was about something else. The owner then moved it the other way.

Written into `CLAUDE.md` because a permission file that hides the time it was nearly wrong teaches nothing.

## How to test (QA)

Docs only — no application code, nothing to exercise in a browser.

1. **Four tables must agree**: `CLAUDE.md`'s deploy table and branch table; `CONTRIBUTING.md`'s two service tables. All four should say `qa` and `staging` deploys are QA's, prod is PM/DevOps owner-approved each time, `liquidity-hq-dev` is unassigned.
2. `grep -nE "PM/DevOps (promotes|deploys)"` — no hit should assign PM/DevOps anything before `staging` → `main`.
3. `grep -n "dev deploys"` — the only hit should be inside a sentence describing what the text *used to* say.
4. Confirm the sign-off language survived: QA decides whether something is ready, and a merge past a QA "not ready" removes the only independent check the project has.

## Risk level

**Low** — documentation only. No code path, no migration, no environment variable.

**Named as unverified:** this describes an authority structure rather than a fact about the code, so "correct" means *matches what the owner decided*, which only the owner can confirm. Rows 3 and 5 are sourced from both other sessions' first-hand accounts, which agree; I did not witness those deploys myself.

**Still outstanding:** not yet rebased on #852, which has not merged. Its CONTRIBUTING hunk sits two lines from one this PR rewrites, and the rebase is mine to absorb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128SEKhetyzZqeE8BQ9kk3k