### PR TITLE
test(qa): /scanner belongs in the terminal mobile baseline too

### DIFF
--- a/qa/e2e/layout.spec.ts
+++ b/qa/e2e/layout.spec.ts
@@ -292,14 +292,36 @@ const KNOWN_OBSCURED_BY_DESIGN: Record<'current' | 'terminal', Record<string, st
      * are not the same set:
      *
      *   only in terminal   /alerts, /arena
-     *   only in current    /funding, /scanner, /journal, /news, /playbook
-     *   in both            /briefing, /calc, /dashboard, /faq, /offline
+     *   only in current    /funding, /journal, /news, /playbook
+     *   in both            /briefing, /calc, /dashboard, /faq, /offline, /scanner
      *
-     * Seven against ten, five shared. The two designs lay their pages out
+     * Eight against nine, six shared. The two designs lay their pages out
      * differently, so which control ends up under a fixed bar differs with
      * them - the bar being 4px taller in terminal is not the only variable.
      * A renamed copy of the other list would have asserted five overlaps that
-     * do not happen and missed two that do. */
+     * do not happen and missed two that do.
+     *
+     * /scanner WAS MISSING FROM THIS LIST, CORRECTED 2026-09-05, AFTER THIS
+     * COMMENT HAD ALREADY BEEN WRITTEN CLAIMING IT WAS "ONLY IN CURRENT". The
+     * release-candidate re-run failed on it - a coin-row button covered by
+     * nav.tnav-tabs at the natural rest state, before any scrolling.
+     *
+     * VERIFIED RATHER THAN ADDED ON FAITH. The spec's own error names the
+     * danger explicitly: "if your change added a fixed overlay, the fix is to
+     * reserve space for it, not to add the entry to KNOWN." So before adding
+     * it: scrolled to the true bottom (`scrollTop + clientHeight >=
+     * scrollHeight`, checked, not assumed) and re-swept every interactive
+     * element against the bar. Nothing was covered at max scroll. The overlap
+     * exists only in the first, unscrolled frame and clears the instant the
+     * page moves - same mechanism as the other six mobile entries here, not a
+     * new one.
+     *
+     * WHY THE ORIGINAL RECORDING SWEEP MISSED IT. /scanner's list length and
+     * row height depend on live coin data, so whether the last visible row on
+     * the first screen reaches far enough down to meet the bar varies run to
+     * run - the same data-dependent-ground shape as trap 12 and the grade-F
+     * badge. The comment above was written from one sweep and stated as a
+     * fact about the route rather than about that sweep. */
     mobile: [
       '/alerts: a.auth-gate-btn is covered by nav.tnav-tabs',
       '/arena: button.klc-tool-btn is covered by button.gchat-fab',
@@ -308,6 +330,7 @@ const KNOWN_OBSCURED_BY_DESIGN: Record<'current' | 'terminal', Record<string, st
       '/dashboard: button.sotd-refresh is covered by nav.tnav-tabs',
       '/faq: button is covered by nav.tnav-tabs',
       '/offline: button.pf-footer-expand is covered by nav.tnav-tabs',
+      '/scanner: button is covered by nav.tnav-tabs',
     ],
   },
 };


### PR DESCRIPTION
Follow-up to #857, which merged before this was caught. `KNOWN_OBSCURED_BY_DESIGN.terminal.mobile` gains `/scanner` and the comment above it — which wrongly claimed `/scanner` was 'only in current' — is corrected rather than left next to a list it no longer describes.

## Why

The release candidate's final re-run failed on it: a coin-row card covered by the fixed bottom bar at rest, before scrolling. Verified rather than assumed:

```
current   bar=mobile-tab-bar top=788   coin row bottom=972   overlap 184px
terminal  bar=tnav-tabs      top=784   coin row bottom=932   overlap 148px
```

Current's own baseline already carries this entry — not new, not caused by #845 (`/scanner` is an app route, that gate never touched it), not marginal in either design. Missing from terminal's list because `/scanner`'s row count/height are live data — same shape as trap 12.

Confirmed at true max scroll (checked, not assumed): nothing covered. Same accepted category as the other seven entries.

## How to test

`npx playwright test qa/e2e/layout.spec.ts --workers=1` on `qa` — both mobile tests pass.

## Risk level

Low. Test-only, one file, corrects a baseline that produced a false positive an hour after merge.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu