### PR TITLE
docs(qa): a pixel result is scoped to the browser's platform, not the host

### DIFF
--- a/qa/TEST_GAPS.md
+++ b/qa/TEST_GAPS.md
@@ -326,6 +326,22 @@ Recorded here rather than hidden, because the suite is code and has defects too.
 - **110 tests skip every run.** 95+ are the mobile project on HTTP-level specs,
   which is by design. Every skip names its reason. Read them — some are accepted
   limits and some would be findings if they appeared.
+- **A pixel result is scoped to the browser's PLATFORM, not the host it points
+  at — and this was stated as platform-neutral within an hour of writing the
+  rule that says it can't be.** Rendering happens where the Chromium process
+  runs, not where the deployed URL is hosted. Colour/contrast survives the
+  platform — a computed RGB value doesn't depend on font rendering. Anything
+  measured in **pixels** — overflow, layout, coverage — does not, because it
+  depends on glyph metrics and line-wrap decisions that differ between a local
+  Windows Chromium and CI's Linux runner. `qa/e2e/layout.spec.ts`'s
+  `KNOWN_OBSCURED` baseline carries the long version and the incident that
+  forced it: a Windows-derived entry missed `/briefing` by 21px on Linux, while
+  the sibling test's identical entry had a guard for exactly this and correctly
+  declined to fail. Fixed there; the mistake repeated here is the general one —
+  "0 overflow on production, measured from my machine" is a true and narrower
+  claim than "production does not overflow", and only one of those
+  generalises. Caught by Dev Team, 2026-09-05, an hour after making the same
+  distinction correctly for someone else's number.
 
 ---
 


### PR DESCRIPTION
TEST_GAPS.md §9 gains a note. Companion to #864 and Dev Team's #866 — same lesson, this side of it.

I closed the 2026-09-05 release citing `0 overflow across 32 loads on production`, reasoning "colours are platform-independent, so this is cheap." That reasoning covers the contrast half only. Overflow is geometry; geometry depends on font metrics, which is the exact mechanism that produced `/briefing`'s false failure on the same release — a Windows-derived baseline entry missed by 21px on CI's Linux runner.

So `0 overflow on production` is true of how production renders in a Windows browser, and is narrower than "production does not overflow." Caught by Dev Team an hour after I'd made the identical distinction correctly for someone else's number.

Docs-only, no test-code change — a coverage-gap record, not a spec fix.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHVPDjFqn6fdHyCv85tPTu