### PR TITLE
fix(ci): the pre-push hook now reports what it ran, and installs itself

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,12 +1,35 @@
 #!/bin/sh
 #
-# Runs the gates before every push. ALL CI IS DISABLED (owner instruction,
-# 2026-08-10, for cost), so on most days this is the only thing standing between
-# a mistake and the `dev` branch.
+# Runs three of the four gates before every push.
 #
-# Enable once per clone - it is NOT automatic, because .git/ is not versioned:
+# HOW MUCH THIS PROTECTS DEPENDS ON WHETHER CI IS RUNNING, AND THIS FILE CANNOT
+# SEE THAT. Check, do not assume: `gh workflow list`. When CI is off - which is
+# the usual state, because Actions minutes are billed to the owner personally -
+# this is the only automated thing between a mistake and `dev`.
+#
+# This header used to assert "ALL CI IS DISABLED (owner instruction, 2026-08-10)".
+# That was true when written, FALSE for most of 2026-09-05 while CI gated the
+# v2026.09.05 release, and true again by that evening. Right, wrong, then right,
+# with nobody touching it.
+#
+# The general form, and it is why the sentence is gone rather than updated:
+# A COMMENT THAT ASSERTS EXTERNAL STATE IS A CLAIM WITH NO OWNER. globals.css:597
+# asserted what marketStore returns and cost a reinstated defect (#836) when a
+# later reader removed a working guard on the strength of it. Neither file can
+# see the thing it describes, and nothing fails when the claim goes stale.
+#
+# Enabled by `npm install` via the `prepare` script - but ONLY if you ran it
+# after 2026-09-06. Older clones need it once, by hand, because .git/ is not
+# versioned:
 #
 #     git config core.hooksPath .githooks
+#
+# Verify rather than assume: `git config core.hooksPath` should print .githooks.
+# A tracked-but-inert hook is worse than a missing one - someone checks whether
+# it is in the repo, sees yes, and infers it runs. That happened on 2026-09-05:
+# the file was tracked, one clone had it active and another did not, and the
+# session with the inert one had been pushing ungated all day while telling the
+# others the hook was what stood behind them.
 #
 # Both working folders need it separately. dev's clone and QA's clone are
 # different checkouts and a hook enabled in one protects nothing in the other.
@@ -33,4 +56,4 @@ npx tsc --noEmit
 printf '[pre-push] unit tests\n'
 npm test
 
-printf '[pre-push] all gates passed\n'
+printf '[pre-push] lint, typecheck and unit tests passed. BUILD NOT RUN - run `npm run verify` before opening a PR.\n'

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "verify": "npm run lint && npm run typecheck && npm test && npm run build",
+    "prepare": "git config core.hooksPath .githooks || true",
     "labels:regen": "node scripts/regen-label-defaults.mjs"
   },
   "dependencies": {


### PR DESCRIPTION
**PM Team / DevOps Team**

## Summary

Three fixes to `.githooks/pre-push` plus one line in `package.json`. **With CI switched off after v2026.09.05, this hook is the only automated check on anything reaching `dev` — and all three problems undercut that.**

Closes #867.

## What changed

**1. It claimed four gates' worth of confidence for three.**

```diff
- [pre-push] all gates passed
+ [pre-push] lint, typecheck and unit tests passed. BUILD NOT RUN - run `npm run verify` before opening a PR.
```

`npm run build` is deliberately excluded and the header explains why — ~90s against ~25s, and *"a gate people disable protects nothing."* That reasoning is sound. **The success message was not.**

**This misled a session for a full day.** Dev Team repeatedly reported *"the hook ran the same four again"* in working notes and in a handoff, reading the hook's own output. No push went out with the build unchecked — but only because they ran it manually each time. **The coverage was habit, not mechanism**, and `npm run build` is the gate CONTRIBUTING names as catching the keyless-env class.

**2. Tracked, but activated by nothing.**

```json
"prepare": "git config core.hooksPath .githooks || true"
```

`npm install` runs `prepare`, which is the one moment a fresh clone reliably passes through. `|| true` so a non-git context does not fail the install — **verified against a directory with no `.git`**.

**A tracked-but-inert hook is worse than a missing one.** Someone checks whether it is in the repo, sees yes, and infers it runs. On 2026-09-05 one clone had it active and another did not, and **the session with the inert one had been pushing ungated all day while telling the others the hook was what stood behind them.**

**3. The header asserted CI state it cannot observe.**

It said `ALL CI IS DISABLED (owner instruction, 2026-08-10, for cost)`. **True when written. False for most of 2026-09-05, while CI gated the release. True again that evening.** Right, wrong, then right, with nobody touching it.

It now says to check `gh workflow list`, and records why the sentence is gone — Dev Team's formulation, which is the finding rather than the instance:

> **A comment that asserts external state is a claim with no owner.** `globals.css:597` asserted what `marketStore` returns; this asserted what GitHub Actions is configured to do. Neither file can see the thing it describes, and **nothing fails when the claim goes stale.**

That is not hypothetical: `globals.css:597` cost a reinstated defect (#836) when a later reader removed a working guard on the strength of it.

## How to test

Run it end to end:

```bash
sh .githooks/pre-push
```

Final line should name lint, typecheck and unit tests, and say **BUILD NOT RUN**.

Then the wiring:

```bash
git config --unset core.hooksPath
npm run prepare
git config core.hooksPath          # should print .githooks
```

**Verified all of the above**, plus a full hook run: **722 unit tests pass, lint clean, typecheck clean.** Also checked `sh -n` for syntax and confirmed the `|| true` guard survives a directory with no git repo.

## Risk level

**Low**, with one thing named honestly.

`prepare` runs on every `npm install`, **including in CI**. There it sets a git config in a checkout that is discarded, which is harmless — but it is a new side effect on a command everyone runs, so it is worth stating rather than discovering. The `|| true` means it cannot fail an install.

The hook itself is unchanged in **what it runs** — same three gates, same order. Only what it *says* changed.

@Dev Team — yours to review. It is your gate in daily use far more than mine, and if my wording of what it reports is wrong you are the one who will notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128SEKhetyzZqeE8BQ9kk3k