### PR TITLE
fix(chart): the setup-quality tooltip is reachable from a keyboard (#850)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2133,11 +2133,18 @@ body.ticker-on .breaking-alert { top: calc(var(--appbar-h) + var(--strip-h) + 32
 .klc-ws-dot.live { background: var(--green); box-shadow: 0 0 5px var(--green); }
 .klc-ws-dot.err  { background: var(--red); }
 .sq-badge { display: inline-flex; align-items: center; }
-.sq-info  { position: relative; display: inline-flex; align-items: center; justify-content: center; min-width: 28px; min-height: 28px; margin: -4px; cursor: help; }
-@keyframes sq-fade { from { opacity: 0; transform: translateY(3px); } to { opacity: 1; transform: translateY(0); } }
-.sq-tooltip { display: none; position: absolute; bottom: calc(100% + 2px); right: 0; padding-bottom: 10px; z-index: 999; white-space: normal; }
-.sq-info:hover .sq-tooltip { display: block; animation: sq-fade 120ms ease; }
-.sq-tooltip::after { content: ''; position: absolute; bottom: 2px; right: 12px; border: 5px solid transparent; border-top: 6px solid var(--sq-bdr, rgba(251,191,36,0.28)); border-bottom: none; }
+/* `.sq-info`, `.sq-tooltip`, `.sq-info:hover .sq-tooltip`, `.sq-tooltip::after`
+   and `@keyframes sq-fade` were REMOVED here (#850), not left behind.
+
+   They styled a hover-only tooltip on the setup-quality badge that had no
+   tabIndex, no role and no aria-label — keyboard-dead, and invisible to
+   `no-duplicate-controls.spec.ts`, which selects on role and tabIndex. That
+   markup is now `<Tip>`, which owns its own panel styling.
+
+   Deleted rather than kept "in case", because this file already carries 194
+   terminal-scoped classes that no markup renders (see docs/HANDOVER.md §14),
+   and every one of them started as a rule whose component went away. A rule
+   with no markup is not harmless: it reads as evidence the feature exists. */
 /* Clickable price chips in chart toolbar */
 .klc-price-chip {
   font-size: var(--fs-data); font-weight: 700; letter-spacing: .03em; white-space: nowrap;

--- a/components/KLineProChart.tsx
+++ b/components/KLineProChart.tsx
@@ -7,6 +7,7 @@ import type { CombinedResult } from '@/lib/grok';
 import type { StrategySignal } from '@/lib/useEMAStrategy';
 import { detectStructureSignals, type PASignal } from '@/lib/priceAction';
 import { Warn } from '@/components/icons';
+import Tip from '@/components/Tip';
 import { useDesignMode } from '@/components/DesignModeProvider';
 import { barsAfter } from '@/lib/candles';
 import { LIQ_CLUSTER_LINES } from '@/lib/liqClusters';
@@ -2352,41 +2353,45 @@ export default function KLineProChart({ coin, tf, onTfChange, result, emaSignal,
               display: 'flex', alignItems: 'center', gap: 5,
             }}>
               {setupQuality.label}
-              <span className="sq-info" style={{ '--sq-bdr': setupQuality.bdr } as React.CSSProperties}>
-                {/* No `opacity` (#836) - eighth instance of the trap named
-                    above `.lp-footer-ack` in globals.css. Inherits the setup
-                    badge's colour, and 0.6 of any of the badge tones lands
-                    under AA on the badge's own tinted ground.
-
-                    NOT FIXED HERE, filed instead: this ⓘ is keyboard-dead.
-                    `.sq-info` is `cursor: help` with a hover-only tooltip -
-                    no tabIndex, no role, no Escape. `Tip.tsx` solved exactly
-                    this (role="button", tabIndex, aria-label, Enter/Space,
-                    Escape) and the fix here is to use it rather than to
-                    re-derive it. That is a behaviour change on the chart
-                    toolbar and does not belong in a contrast batch. */}
-                <span style={{ fontSize: '0.6875rem', lineHeight: 1 }}>ⓘ</span>
-                <div className="sq-tooltip">
-                  <div style={{
-                    width: 240,
-                    background: '#111',
-                    border: '1px solid rgba(255,255,255,0.12)',
-                    borderRadius: 10, padding: '12px 14px',
-                    boxShadow: '0 8px 32px rgba(0,0,0,0.65)',
-                    whiteSpace: 'normal',
-                  }}>
-                    <div style={{ fontSize: 'var(--fs-caption)', fontWeight: 600, color: 'rgba(255,255,255,0.9)', marginBottom: 6 }}>
+              {/* `Tip` rather than the hand-rolled `.sq-info` this used to be (#850).
+               *
+               * WHAT WAS WRONG: `.sq-info` was `cursor: help` with a
+               * `:hover`-only `.sq-tooltip` — no `tabIndex`, no `role`, no
+               * `aria-label`, no Escape. A keyboard user could not reach it, a
+               * screen reader announced nothing, and the glyph inside it meant
+               * `no-duplicate-controls.spec.ts` could not see it either: that
+               * spec selects on role and tabIndex, so an unnamed control with
+               * neither is not in its selector set at all. It is a worse defect
+               * than the duplicate names #846 was about, and invisible to the
+               * instrument that found those.
+               *
+               * WHY NOT RE-DERIVE IT HERE: Tip already solves this exact
+               * problem — role="button", tabIndex, aria-label, Enter/Space to
+               * toggle, Escape to dismiss, and a portalled panel that survives
+               * transformed ancestors. Writing a second keyboard implementation
+               * on the chart toolbar would be a second thing to keep correct.
+               *
+               * `body` keeps the three tiers of emphasis the hand-rolled panel
+               * had; `text` is the flat string a screen reader announces. The
+               * accessible name is the sentence, not the glyph. */}
+              <Tip
+                text={`${setupQuality.label}. ${setupQuality.detail} ${setupQuality.explanation}`}
+                width={240}
+                iconColor={setupQuality.color}
+                body={
+                  <>
+                    <div style={{ fontWeight: 600, color: 'rgba(255,255,255,0.9)', marginBottom: 6 }}>
                       {setupQuality.label}
                     </div>
-                    <div style={{ fontSize: 'var(--fs-caption)', color: 'rgba(255,255,255,0.38)', lineHeight: 1.55, marginBottom: 8 }}>
+                    <div style={{ color: 'rgba(255,255,255,0.38)', lineHeight: 1.55, marginBottom: 8 }}>
                       {setupQuality.detail}
                     </div>
-                    <div style={{ fontSize: 'var(--fs-caption)', color: 'rgba(255,255,255,0.72)', lineHeight: 1.7 }}>
+                    <div style={{ color: 'rgba(255,255,255,0.72)', lineHeight: 1.7 }}>
                       {setupQuality.explanation}
                     </div>
-                  </div>
-                </div>
-              </span>
+                  </>
+                }
+              />
             </span>
           </div>
         )}

--- a/components/Tip.tsx
+++ b/components/Tip.tsx
@@ -3,7 +3,20 @@ import { useState, useRef, useCallback, useEffect, useId } from 'react';
 import { createPortal } from 'react-dom';
 
 interface TipProps {
+  /** The accessible name, and the panel body unless `body` overrides it.
+   *  Stays a plain string: it is what `aria-label` announces, and a ReactNode
+   *  there would stringify to "[object Object]" for a screen reader. */
   text: string;
+  /* Optional rich panel content (#850). When present it replaces `text` in the
+     PANEL only — `aria-label` still announces `text`, so the accessible name is
+     unaffected and no existing call site changes behaviour.
+
+     Added for the chart's setup-quality tooltip, which had three tiers of
+     emphasis - a title, a dim sub-line and a brighter explanation - in
+     hand-rolled markup that was keyboard-dead. Collapsing it to one string to
+     fit this component would have traded a visual regression for the
+     accessibility fix; this takes both. */
+  body?: React.ReactNode;
   /* Optional. Tip usually wraps the label it explains, but where that label
      lives inside a <button> the Tip has to sit outside it - its trigger is a
      real focusable control, and a control inside a control is an
@@ -15,7 +28,7 @@ interface TipProps {
   iconColor?: string;
 }
 
-export default function Tip({ text, children, width = 230, iconColor = 'var(--txt3)' }: TipProps) {
+export default function Tip({ text, body, children, width = 230, iconColor = 'var(--txt3)' }: TipProps) {
   const [open, setOpen]   = useState(false);
   const [above, setAbove] = useState(false);
   const [coords, setCoords] = useState({ top: 0, bottom: 0, left: 0 });
@@ -147,7 +160,7 @@ export default function Tip({ text, children, width = 230, iconColor = 'var(--tx
             letterSpacing: 'normal',
           }}
         >
-          {text}
+          {body ?? text}
         </span>,
         document.body,
       )}


### PR DESCRIPTION
Closes #850.

## Summary

The chart's setup-quality badge carried a hand-rolled `ⓘ` tooltip that no keyboard could reach. It now uses `Tip`, which already solves this. `Tip` gained an optional `body` prop so the panel keeps its three tiers of emphasis, and the five orphaned `.sq-*` rules are deleted.

## What changed

| File | Change |
|---|---|
| `components/Tip.tsx` | optional `body?: ReactNode` — panel content only |
| `components/KLineProChart.tsx` | `.sq-info` markup → `<Tip>`, import added |
| `app/globals.css` | `.sq-info`, `.sq-tooltip`, `:hover`, `::after`, `@keyframes sq-fade` removed |

## Why

`.sq-info` was `cursor: help` with a `:hover`-only panel — **no `tabIndex`, no `role`, no `aria-label`, no Escape.** A keyboard user could not open it; a screen reader announced nothing.

**And it was invisible to the check that would have caught it.** `no-duplicate-controls.spec.ts` selects on role and tabIndex, so a control with neither is not in its selector set. That is why #846's sweep found five duplicate *names* on other screens and never saw an *unnamed* control here — which is the worse defect of the two.

**Not re-derived locally.** `Tip` already has `role="button"`, `tabIndex`, `aria-label`, Enter/Space to toggle, Escape to dismiss, and a portalled panel that survives transformed ancestors. A second keyboard implementation on the chart toolbar would be a second thing to keep correct.

**`body` is strictly additive.** `aria-label` still announces `text`, so the accessible name is a sentence rather than a glyph, and none of `Tip`'s **78 call sites across 39 files** change behaviour. Collapsing the panel to one string to fit the existing signature would have traded a visual regression for the accessibility fix.

**The CSS is deleted, not left behind.** `globals.css` already carries 194 terminal-scoped classes that no markup renders (`docs/HANDOVER.md` §14). Every one started as a rule whose component went away, and a rule with no markup reads as evidence the feature exists.

## How to test (QA)

On the qa environment, `/arena`:

1. **Wait for a setup-quality badge** beside the chart. It needs price within 0.8% of an S/R level with ≥2 touches, a squeeze score ≥50, and a direction — **it is not always there.**
2. **Tab to the `ⓘ`.** It should take focus and open the panel.
3. **Escape** closes it. **Enter** reopens it.
4. The panel still shows three lines — title, grey sub-line, brighter explanation.
5. **If no badge renders while you look, say so rather than passing it.**

## Verified

**The mechanism, rendered.** Driven from the keyboard only, on a `Tip` instance on `/liq`:

```
before anything       panel:false  expanded:false
after focus           panel:true   expanded:true   describedby:true
after Escape          panel:false  expanded:false
after Enter (reopen)  panel:true   expanded:true   describedby:true
after Escape again    panel:false  expanded:false
```

Gates: `npm run verify` — lint 0 errors · tsc 0 · 722/722 · build clean. Run in full because CI is off and the pre-push hook covers three of four.

> My first pass at that measurement reported **"Enter opens panel: false"** and would have been a confident bug report against a working component. `Tip`'s `onFocus` had already opened the panel, so Enter *toggled it shut* — and I read `aria-expanded` synchronously, before React re-rendered. The table above is the corrected run, with settle waits. Recorded because it is the same failure shape as the rest of this week and it nearly landed on the mechanism this fix depends on.

## Risk level

**Medium**, and the reason is what I could not reach rather than what I changed.

**The badge itself never rendered during testing.** `setupQuality` is data-gated on live market conditions. I confirmed the old markup is absent and no HTTP ≥400 occurred — but with the badge not rendering, *"0 `.sq-info` in the DOM"* is a clean zero from an instrument that could not reach the thing, and I am not offering it as evidence.

**So `body` is unrendered too.** The only call site using it is that badge. The prop is exercised by no test and by no observed render.

What is verified is the mechanism — `Tip` behaves correctly, and the badge inherits that when it appears. **This is not closed until someone sees a real setup-quality badge and Tabs to it.** Same shape as the grade-F badge in #836.

`Tip` is shared by 78 call sites, so the additive change is the part with blast radius; `body` defaults to `undefined` and `body ?? text` falls back to today's behaviour everywhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVjcfLMLXdmnkB3Nwwq43Y
