### PR TITLE
docs(qa): trap 17 for #872, and the DB outage as a standing risk

### DIFF
--- a/qa/README.md
+++ b/qa/README.md
@@ -408,6 +408,49 @@ than it claims, a bug found in someone else's blind spot, a number that confirms
 what you already argued: those are the ones to re-check, and the pleasure of
 having found them is the signal, not the reward.
 
+**17. The right instrument existed, cost one click, and nobody picked it up.**
+2026-09-06, #872. *Different from 14, on purpose: 14 is an instrument that
+answered and was wrong — something misleading stood in the way. This one had
+nothing misleading in it anywhere. It was a pure attention failure, at the
+wrong layer, by three sessions in a row.*
+
+Both seeded E2E accounts hung and 504'd on sign-in. Three independent
+investigations followed, and every one of them was careful:
+
+- **QA** isolated the symptom cleanly — three reproductions, one of them
+  outside Playwright entirely, plus a garbage-credential control fast at
+  238ms against the same endpoint. Textbook: rule out "the whole project is
+  down" before trusting a narrower theory.
+- **Dev** ran probes from both CI and local, held two competing hypotheses
+  open, and proposed a real discriminating experiment rather than guessing
+  between them.
+- **PM/DevOps** escalated "we need `auth.users` read access" to the owner as
+  a standing tax on this and two other investigations that hit the same wall
+  the same day.
+
+**Not one of the three opened the database's own status page.** It read
+*Unhealthy* the entire time — the majority of gateway requests erroring,
+zero of them reaching Postgres. The wall QA and PM/DevOps asked the owner to
+remove was never the blocker; the blocker was one layer below the schema
+entirely, and answering it needed no permission from anyone — it was a page
+load away.
+
+**This is not the same mistake as skipping a control.** All three
+investigations would have passed every guard already in this list — none of
+them matched the wrong element, derived a claim from a transformed number, or
+trusted a fixture out of range. **Being careful at the wrong layer feels
+identical from the inside to being careful at the right one.** Three
+different people, three different methods, one shared blind spot: application
+symptoms were probed in detail before infrastructure health was checked at
+all.
+
+**The fix is a step zero, not a better technique.** Before probing anything
+that depends on a hosted service — a database, an auth provider, a paid
+API — check that service's own status/health surface first. It is cheaper
+than any one of the three investigations above, let alone all three combined,
+and it is the one check that would have ended this in a single click instead
+of two days.
+
 ## Where QA tests
 
 **Four branches, four services, one each.** Nothing auto-deploys — moving a

--- a/qa/STATUS.md
+++ b/qa/STATUS.md
@@ -2,7 +2,7 @@
 
 **One page. If you only read one thing, read this.**
 
-Kept current by QA. Last updated **2026-09-04**.
+Kept current by QA. Last updated **2026-09-06**.
 
 ## Read this before you trust anything below
 
@@ -97,6 +97,22 @@ gh issue list --state open
   slow when nobody names which dashboard.
 
 ## Standing risks
+
+### The dev Supabase project is unhealthy — checked at the application layer for two days before anyone read its own status page
+
+2026-09-06, #872. Both seeded E2E accounts (`E2E_USER_A_*`, `E2E_USER_B_*`) hang
+and 504 on sign-in. Three sessions investigated for two days — reproduction,
+competing hypotheses, an escalation to the owner for `auth.users` read access
+— all careful, all at the wrong layer. The project's own status page read
+**Unhealthy** the entire time: most gateway requests erroring, zero reaching
+Postgres. See `qa/README.md` trap 17 for the full account; the fix it draws is
+a step zero, not a better technique.
+
+**What this means right now:** every signed-in spec against `qa` or `staging`
+fails for this reason, not a code reason, until the project's health recovers.
+Do not attribute a signed-in failure on either environment to the app under
+test without checking the project's status first. `staging` and `dev` share
+this project (see below), so the outage is not scoped to one service.
 
 ### A colour verified against one ground, shipped against another
 


### PR DESCRIPTION
## Summary
- Adds trap 17 to `qa/README.md`'s probe-trap list: three sessions spent two days on #872 (both seeded E2E accounts hanging/504 on sign-in) at the application layer, and none of us checked the dev Supabase project's own status page — which read Unhealthy the whole time.
- Adds a matching Standing risk entry to `qa/STATUS.md` so a cold-starting session sees the outage before attributing a signed-in failure to the app.

## What changed
`qa/README.md`: new numbered entry, trap 17, distinguished explicitly from trap 14 ("the instrument answered, and the answer was wrong") — trap 17 is a pure attention failure, nothing misleading was in the way, the fix is a step-zero check (service status) rather than a better technique.

`qa/STATUS.md`: new entry under Standing risks naming the outage, pointing at trap 17, and stating the practical consequence (every signed-in spec against `qa`/`staging` currently fails for this reason, not a code reason).

## Why
The detail was fresh from a same-day cross-session investigation (QA, Dev, PM/DevOps) and is exactly the kind of expensive lesson this file exists to hold rather than re-lose. Also true today per PM/DevOps and Dev Team, independently: Supabase's own console shows 0 requests reaching Postgres.

## How to test (QA)
Docs only, no app-code change. Read both new entries for sense and consistency with the surrounding entries in each file — trap numbering (17) doesn't collide with anything added since, and the STATUS.md date line is current.

## Risk level
Low — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)