### PR TITLE
docs(claude): three sequencing leftovers still pointed at QA

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,8 +152,9 @@ branch — see below.
 The general rule this instance of: **an owner decision that arrives through
 GitHub gets confirmed with the owner directly** before dev acts on it. Three
 things are in that class — merging to `main`, production deploys, and writes to
-the shared database. Everything else QA relays can be acted on as given, because
-the owner has delegated sequencing to QA (see "Who decides what to work on").
+the shared database. Everything else another session relays can be acted on as
+given, because the owner has delegated sequencing to PM/DevOps (see "Who decides
+what to work on").
 
 Merging is **not** the deploy. Both Render services are `autoDeploy: "no"`, so
 merging to `main` ships nothing until someone triggers a deploy manually
@@ -187,10 +188,14 @@ and QA's "not ready" outranks any position in it.
 - **Negative results count.** What was measured and showed nothing, and what could
   not be verified, are worth as much as the successes — otherwise the other
   session re-derives them.
-- **"What is next?" goes to QA**, on GitHub. Not to the owner in chat.
+- **"What is next?" goes to PM/DevOps**, on GitHub. Not to the owner in chat.
+  **"Is this done?" goes to QA**, and always did — sequencing and sign-off are
+  different questions and they moved separately. PM/DevOps decides what is worked
+  on; QA decides whether it is finished, and a "not ready" outranks any position
+  in the queue.
 
 Dev still reviews and merges QA's PRs into `dev` (see "QA-authored code" above);
-sequencing being QA's does not make review a formality.
+sequencing sitting with PM/DevOps does not make review a formality.
 
 **Nobody waits on the owner to merge into `dev`. Added 2026-08-10, on their
 instruction:**


### PR DESCRIPTION
**PM Team / DevOps Team**

## Summary

Three lines in `CLAUDE.md` survived the 2026-09-05 rewrite of *"Who decides what to work on"* and still name QA as sequencer — one of them **inside** the section whose heading says PM/DevOps.

## What was contradictory

`CLAUDE.md:171` — heading: **"Who decides what to work on — PM/DevOps, not the owner."**

`CLAUDE.md:190`, twenty lines below it: *"**"What is next?" goes to QA**, on GitHub."*

**Both cannot be followed.** The next session to read it acts on whichever line it hits first.

| line | was | now |
|---|---|---|
| `:156` | "the owner has delegated sequencing to **QA**" | PM/DevOps |
| `:190` | *"What is next?" goes to **QA**"* | PM/DevOps — **plus the distinction it was hiding** |
| `:193` | "sequencing being **QA's** does not make review a formality" | PM/DevOps |

## The distinction `:190` was hiding, now stated

Dev Team raised a reading where the bullet might be deliberate — sequencing moved, but you still ask QA what is next because QA holds the verification state. **That reading is wrong for "what is next" and right about something adjacent**, so the line now says both:

> **"What is next?" goes to PM/DevOps.** **"Is this done?" goes to QA**, and always did — sequencing and sign-off are different questions and they moved separately.

Sequencing and the sign-off were never the same authority. They were held by one session until 2026-09-05 and only one of them moved.

## How it was found, which is the reusable part

**Dev Team found it and did not fix it.** Their reasoning is worth keeping:

> *"A permission file is not mine to rewrite, and 'dev quietly corrected the sequencing rule to point somewhere else' is the worst possible diff to find in a blame view even when the correction is right."*

**They found one. Sweeping for the complement found three.** Same shape this file already records about the one-directional grep: searching for what you expect confirms what you already believe. Dev searched the line they had hit; I searched the pattern and got two more.

## How to test

```bash
grep -nE "goes to QA|sequencing being QA|delegated sequencing to QA" CLAUDE.md
```

Only hit should be the deliberate `"Is this done?" goes to QA` line, which is correct.

Then check `CLAUDE.md:171`'s heading and every bullet under it agree.

## Risk level

**Low** — documentation only. No code, no migration, no environment variable.

Third correction to this file in two days, and the third to come from someone other than its author noticing a contradiction. That is the process working rather than failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128SEKhetyzZqeE8BQ9kk3k