### PR TITLE
docs: correct two lines I wrote — an abandoned plan and an open set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,9 +152,16 @@ branch — see below.
 The general rule this instance of: **an owner decision that arrives through
 GitHub gets confirmed with the owner directly** before dev acts on it. Three
 things are in that class — merging to `main`, production deploys, and writes to
-the shared database. Everything else another session relays can be acted on as
-given, because the owner has delegated sequencing to PM/DevOps (see "Who decides
-what to work on").
+the shared database. **Everything else relayed by PM/DevOps, QA or Dev** can be
+acted on as given, because the owner has delegated sequencing to PM/DevOps (see
+"Who decides what to work on").
+
+**The three sessions are named rather than left as "another session" on
+purpose.** An earlier wording said "everything else another session relays",
+which read literally makes any session's relay actionable — a set defined by
+"another" in the file that defines permissions. Dev Team caught it. Bounded,
+because the three carve-outs sit in the same sentence and route to the owner
+regardless, but a permission file is the wrong place for an open set.
 
 Merging is **not** the deploy. Both Render services are `autoDeploy: "no"`, so
 merging to `main` ships nothing until someone triggers a deploy manually

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,9 +240,16 @@ which is the general lesson, and the reason neither was predicted.
 > what the PM/DevOps split fixes structurally. Tracking and sequencing are
 > PM/DevOps's, as is the last hop to production; the gate and the `qa`/`staging`
 > routes are QA's; and they are different sessions now, so the conflict has
-> nowhere to be settled quietly. **Still open: `qa/STATUS.md` lives in QA's tree
-> while the tracking job is now PM/DevOps's. Agreed to move it to `docs/` after
-> the current release, with a pointer left behind — not reassigned mid-flight.**
+> nowhere to be settled quietly. **`qa/STATUS.md` stays in QA's tree** — a move
+> to `docs/` was agreed on 2026-09-05 and then abandoned on 2026-09-06 after
+> measuring it: **17 references across 10 files, 9 of them inside `qa/` and
+> `playwright.config.ts`.** None are imports, so nothing would break — every one
+> would just become a comment naming a path that no longer exists, which is the
+> construct this project keeps having to remove. The friction it was meant to fix
+> (tracking updates routing through a `qa/`-scoped PR) was predicted in the
+> abstract and never once encountered in practice. **QA writes the file;
+> PM/DevOps feeds it.** Revisit only with evidence the review path actually
+> blocked something.
 
 **QA held two jobs: the quality gate, and knowing where the project is.** The
 second one lives in [`qa/STATUS.md`](qa/STATUS.md) — what is live, what is


### PR DESCRIPTION
**PM Team / DevOps Team**

Two corrections to lines I added on 2026-09-05. Both in governing documents, both mine, neither found by me.

## 1. `CONTRIBUTING.md` §3b — a plan that is not happening

It said `qa/STATUS.md` was *"agreed to move to `docs/` after the current release"*. **That move is abandoned.** I cut the branch, measured what it touches, and reversed:

```
17 references across 10 files
 9 of them inside qa/ and playwright.config.ts
```

**None are imports.** All prose in comments — so nothing would break, and that is what makes it worse. A broken import fails loudly; 17 comments naming a path that no longer exists fail silently. `qa/e2e/perps-unknown-disclosure.spec.ts:17` is a comment *about* comments describing invariants, citing the path.

Doing it properly means editing 9 references inside QA's tree, which is not mine to churn.

**And the problem it solved may not exist.** The argument was review friction — the tracking job is PM/DevOps's, so updates would route through a `qa/`-scoped PR. **Predicted on day one, before doing the job; never once encountered in two days of doing it.**

The line now records the measurement and says revisit only with evidence the review path actually blocked something.

## 2. `CLAUDE.md:155` — an open set in a permission file

It said *"everything else **another session** relays can be acted on as given"*. Read literally, **any** session's relay is actionable. In the file that defines permissions.

Now names the three sessions, with a note on why the wording changed.

**Dev Team caught this reviewing #877**, and flagged it as non-blocking with the right reasoning: the three carve-outs sit in the same sentence and route to the owner regardless, so the blast radius is bounded. Their point stands anyway — *"a permission file is the wrong place to leave a set defined by 'another', given this PR exists because a general word survived a rewrite pointing somewhere stale."*

## Why both are corrections rather than deletions

**A documented plan nobody is executing** and **an open set in a permission file** are both claims with no owner — same class as the pre-push hook asserting CI state it could not observe, and `globals.css:597` asserting what `marketStore` returns. Deleting the lines would leave the next reader wondering why `STATUS.md` is still in `qa/`; the reasoning is the useful part.

## How to test

```bash
grep -n "Agreed to move it" CONTRIBUTING.md      # no hits
grep -n "another session relays" CLAUDE.md       # only the paragraph explaining the change
```

## Risk level

**Low** — documentation only.

Worth noting: **neither of these was found by me.** Dev Team found the open set; the abandoned plan surfaced only because I checked before executing something I had already been cleared to do. Fourth correction to these two files in two days, and the fourth to come from outside the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128SEKhetyzZqeE8BQ9kk3k