### PR TITLE
fix(ci): pre-push skips the gates on a deletion-only push

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -47,6 +47,39 @@
 # the PR, because nothing else will.
 set -e
 
+# DELETING A REF PUSHES NO CODE, SO THE GATES CANNOT SAY ANYTHING ABOUT IT.
+#
+# git feeds pre-push one line per ref on stdin:
+#     <local ref> <local sha> <remote ref> <remote sha>
+# and a DELETION carries an all-zeros local sha. If every ref in this push is a
+# deletion, there is nothing to gate.
+#
+# This is not a convenience. Deleting the 18 merged branches on 2026-09-06 ran
+# lint, tsc and 722 unit tests ONCE PER BRANCH - about 25 seconds each, roughly
+# seven minutes, to prove nothing about refs that carry no content.
+#
+# The cost is not the time. A gate that fires where it cannot possibly help is
+# how people learn to type `--no-verify` by reflex, and this file's own header
+# says a gate people disable protects nothing. Bypassing it fifteen times in a
+# row and telling nobody is exactly the "do it once quietly" mechanism that let
+# the deploy rows drift for two days.
+#
+# `saw_ref` matters: an EMPTY stdin must not look like a deletion. Without it a
+# push git gave no refs for would skip the gates silently, which is a worse
+# failure than the one being fixed.
+saw_ref=0
+only_deletions=1
+while read -r _local_ref local_sha _remote_ref _remote_sha; do
+  saw_ref=1
+  case "$local_sha" in
+    *[!0]*) only_deletions=0 ;;
+  esac
+done
+if [ "$saw_ref" = 1 ] && [ "$only_deletions" = 1 ]; then
+  printf '[pre-push] deletion only - no code pushed, gates skipped\n'
+  exit 0
+fi
+
 printf '[pre-push] lint\n'
 npm run lint
 


### PR DESCRIPTION
**PM Team / DevOps Team**

## Summary

The pre-push hook now exits early when every ref in a push is a deletion. Found by using it — I enabled `core.hooksPath` in my own clone this afternoon after discovering it was inert, then hit this within the hour deleting the 19 stale branches from #878.

## The problem

Deleting a ref **pushes no code**. Lint, typecheck and 722 unit tests cannot say anything about it. Deleting 18 merged branches ran the full gate **once per branch** — about 25 seconds each, roughly **seven minutes to prove nothing**.

**The time is not the point.** From this file's own header:

> *"a gate people disable protects nothing"*

A gate that fires where it cannot possibly help is exactly how people learn to type `--no-verify` by reflex. My alternative here was bypassing it fifteen times and telling nobody — the same **do-it-once-quietly** mechanism that let the deploy rows drift for two days, and that `CLAUDE.md` now records as *"the whole mechanism"*.

## The fix

`git` feeds pre-push one line per ref on stdin:

```
<local ref> <local sha> <remote ref> <remote sha>
```

A **deletion** carries an all-zeros local sha. If every ref is a deletion, exit 0.

## The subtlety worth reviewing

**An empty stdin must not look like a deletion.** Without a `saw_ref` guard, a push git gave no refs for would skip the gates **silently** — a worse failure than the one being fixed, and the same shape as the `head -6` truncation I reported as an absence earlier today.

## How to test

Three cases, all verified before pushing:

```bash
# 1. deletion-shaped → skips
printf '(delete) 0000000000000000000000000000000000000000 refs/heads/foo abc123\n' \
  | sh .githooks/pre-push
#    → [pre-push] deletion only - no code pushed, gates skipped

# 2. real push → runs the gates
printf 'refs/heads/x abc1234567890abcdef1234567890abcdef123456 refs/heads/x 0000000000000000000000000000000000000000\n' \
  | sh .githooks/pre-push
#    → [pre-push] lint …

# 3. EMPTY stdin → runs the gates (must NOT skip)
printf '' | sh .githooks/pre-push
#    → [pre-push] lint …
```

Plus `sh -n .githooks/pre-push` for syntax. **And this PR's own branch was pushed with the hook active** — case 2 in practice, gates ran.

## Risk level

**Low**, with the failure mode named: a bug here makes the gate skip when it should run. That is why case 3 exists and why the `saw_ref` guard is separate from the all-zeros check rather than folded into it.

The hook is unchanged for every push that carries content — same three gates, same order, same message.

## Context

Follows #869 (the hook reporting `BUILD NOT RUN` instead of "all gates passed") and #867. **Third defect found in this file in a day, and each was found by using it rather than reading it** — the message was wrong until someone quoted it in a handoff, the activation was inert until someone checked a second clone, and this fired until someone deleted enough refs to notice.

@Dev Team — yours to review. It is your gate in daily use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128SEKhetyzZqeE8BQ9kk3k